### PR TITLE
NAT Gateway reconciliation

### DIFF
--- a/cloud/aws/services/ec2/natgateways.go
+++ b/cloud/aws/services/ec2/natgateways.go
@@ -1,0 +1,96 @@
+// Copyright © 2018 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
+)
+
+func (s *Service) reconcileNatGateways(subnets v1alpha1.Subnets, vpc *v1alpha1.VPC) error {
+	if len(subnets.FilterPrivate()) == 0 {
+		return nil
+	}
+
+	existing, err := s.describeNatGatewaysBySubnet(vpc.ID)
+	if err != nil {
+		return err
+	}
+
+	for _, sn := range subnets.FilterPublic() {
+		if sn.ID == "" {
+			continue
+		}
+		if _, ok := existing[sn.ID]; ok {
+			continue
+		}
+
+		_, err := s.createNatGateway(sn.ID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) describeNatGatewaysBySubnet(vpcID string) (map[string]*ec2.NatGateway, error) {
+	describeNatGatewayInput := ec2.DescribeNatGatewaysInput{
+		Filter: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(vpcID)},
+			},
+		},
+	}
+
+	gateways := make(map[string]*ec2.NatGateway)
+
+	err := s.EC2.DescribeNatGatewaysPages(
+		&describeNatGatewayInput,
+		func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool {
+			for _, r := range page.NatGateways {
+				gateways[*r.SubnetId] = r
+			}
+			return !lastPage
+		})
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to describe NAT gateways with VPC ID %q", vpcID)
+	}
+	return gateways, nil
+}
+
+func (s *Service) createNatGateway(subnetID string) (*ec2.NatGateway, error) {
+
+	ip, err := s.allocateAddress()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create IP address for NAT gateway for subnet ID %q", subnetID)
+	}
+
+	out, err := s.EC2.CreateNatGateway(&ec2.CreateNatGatewayInput{
+		SubnetId:     aws.String(subnetID),
+		AllocationId: aws.String(ip),
+	})
+
+	err = s.EC2.WaitUntilNatGatewayAvailable(&ec2.DescribeNatGatewaysInput{
+		NatGatewayIds: []*string{out.NatGateway.NatGatewayId},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create NAT gateway for subnet ID %q", subnetID)
+	}
+
+	return out.NatGateway, nil
+}

--- a/cloud/aws/services/ec2/natgateways_test.go
+++ b/cloud/aws/services/ec2/natgateways_test.go
@@ -1,0 +1,296 @@
+// Copyright © 2018 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:generate mockgen -destination=../mocks/mock_doer.go -package=mocks github.com/sgreben/testing-with-gomock/doer Doer
+
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/services/ec2/mock_ec2iface"
+)
+
+const (
+	ElasticIPAllocationID = "elastic-ip-allocation-id"
+)
+
+func TestReconcileNatGateways(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testCases := []struct {
+		name   string
+		input  []*v1alpha1.Subnet
+		expect func(m *mock_ec2iface.MockEC2API)
+	}{
+		{
+			name: "single private subnet exists, should create no NAT gateway",
+			input: []*v1alpha1.Subnet{
+				{
+					ID:               "subnet-1",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         false,
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2API) {
+
+				m.EXPECT().
+					DescribeNatGatewaysPages(
+						gomock.Eq(&ec2.DescribeNatGatewaysInput{
+							Filter: []*ec2.Filter{
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(subnetsVPCID)},
+								},
+							},
+						}),
+						gomock.Any()).
+					Return(nil)
+
+				m.EXPECT().CreateNatGateway(gomock.Any()).Times(0)
+			},
+		},
+		{
+			name: "no private subnet exists, should create no NAT gateway",
+			input: []*v1alpha1.Subnet{
+				{
+					ID:               "subnet-1",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         true,
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2API) {
+
+				m.EXPECT().
+					DescribeNatGatewaysPages(gomock.Any(), gomock.Any()).Times(0)
+
+				m.EXPECT().CreateNatGateway(gomock.Any()).Times(0)
+			},
+		},
+		{
+			name: "public & private subnet exists, should create 1 NAT gateway",
+			input: []*v1alpha1.Subnet{
+				{
+					ID:               "subnet-1",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         true,
+				},
+				{
+					ID:               "subnet-2",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.12.0/24",
+					IsPublic:         false,
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2API) {
+
+				m.EXPECT().
+					DescribeNatGatewaysPages(
+						gomock.Eq(&ec2.DescribeNatGatewaysInput{
+							Filter: []*ec2.Filter{
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(subnetsVPCID)},
+								},
+							},
+						}),
+						gomock.Any()).Return(nil)
+
+				m.EXPECT().
+					AllocateAddress(&ec2.AllocateAddressInput{Domain: aws.String("vpc")}).
+					Return(&ec2.AllocateAddressOutput{
+						AllocationId: aws.String(ElasticIPAllocationID),
+					}, nil)
+
+				m.EXPECT().
+					CreateNatGateway(&ec2.CreateNatGatewayInput{
+						AllocationId: aws.String(ElasticIPAllocationID),
+						SubnetId:     aws.String("subnet-1"),
+					}).Return(&ec2.CreateNatGatewayOutput{
+					NatGateway: &ec2.NatGateway{
+						NatGatewayId: aws.String("natgateway"),
+					},
+				}, nil)
+
+				m.EXPECT().
+					WaitUntilNatGatewayAvailable(&ec2.DescribeNatGatewaysInput{
+						NatGatewayIds: []*string{aws.String("natgateway")},
+					}).Return(nil)
+
+			},
+		},
+		{
+			name: "two public & 1 private subnet, and one NAT gateway exists",
+			input: []*v1alpha1.Subnet{
+				{
+					ID:               "subnet-1",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         true,
+				},
+				{
+					ID:               "subnet-2",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.12.0/24",
+					IsPublic:         false,
+				},
+				{
+					ID:               "subnet-3",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1b",
+					CidrBlock:        "10.0.13.0/24",
+					IsPublic:         true,
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2API) {
+
+				m.EXPECT().
+					DescribeNatGatewaysPages(
+						gomock.Eq(&ec2.DescribeNatGatewaysInput{
+							Filter: []*ec2.Filter{
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(subnetsVPCID)},
+								},
+							},
+						}),
+						gomock.Any()).Do(func(_, y interface{}) {
+					funct := y.(func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool)
+					funct(&ec2.DescribeNatGatewaysOutput{NatGateways: []*ec2.NatGateway{&ec2.NatGateway{
+						NatGatewayId: aws.String("gateway"),
+						SubnetId:     aws.String("subnet-1"),
+					}}}, true)
+				}).Return(nil)
+
+				m.EXPECT().
+					AllocateAddress(&ec2.AllocateAddressInput{Domain: aws.String("vpc")}).
+					Return(&ec2.AllocateAddressOutput{
+						AllocationId: aws.String(ElasticIPAllocationID),
+					}, nil)
+
+				m.EXPECT().
+					CreateNatGateway(&ec2.CreateNatGatewayInput{
+						AllocationId: aws.String(ElasticIPAllocationID),
+						SubnetId:     aws.String("subnet-3"),
+					}).Return(&ec2.CreateNatGatewayOutput{
+					NatGateway: &ec2.NatGateway{
+						NatGatewayId: aws.String("natgateway"),
+					},
+				}, nil)
+
+				m.EXPECT().
+					WaitUntilNatGatewayAvailable(&ec2.DescribeNatGatewaysInput{
+						NatGatewayIds: []*string{aws.String("natgateway")},
+					}).Return(nil)
+
+			},
+		},
+		{
+			name: "public & private subnet, and one NAT gateway exists",
+			input: []*v1alpha1.Subnet{
+				{
+					ID:               "subnet-1",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         true,
+				},
+				{
+					ID:               "subnet-2",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.12.0/24",
+					IsPublic:         false,
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2API) {
+
+				m.EXPECT().
+					DescribeNatGatewaysPages(
+						gomock.Eq(&ec2.DescribeNatGatewaysInput{
+							Filter: []*ec2.Filter{
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(subnetsVPCID)},
+								},
+							},
+						}),
+						gomock.Any()).Do(func(_, y interface{}) {
+					funct := y.(func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool)
+					funct(&ec2.DescribeNatGatewaysOutput{NatGateways: []*ec2.NatGateway{&ec2.NatGateway{
+						NatGatewayId: aws.String("gateway"),
+						SubnetId:     aws.String("subnet-1"),
+					}}}, true)
+				}).Return(nil)
+
+				m.EXPECT().AllocateAddress(gomock.Any()).Times(0)
+
+				m.EXPECT().CreateNatGateway(gomock.Any()).Times(0)
+			},
+		},
+		{
+			name: "public & private subnet declared, but doesn't exist yet",
+			input: []*v1alpha1.Subnet{
+				{
+					ID:               "",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         true,
+				},
+				{
+					ID:               "",
+					VpcID:            subnetsVPCID,
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.12.0/24",
+					IsPublic:         false,
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2API) {
+
+				m.EXPECT().
+					DescribeNatGatewaysPages(gomock.Any(), gomock.Any()).Times(1)
+
+				m.EXPECT().AllocateAddress(gomock.Any()).Times(0)
+
+				m.EXPECT().CreateNatGateway(gomock.Any()).Times(0)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ec2Mock := mock_ec2iface.NewMockEC2API(mockCtrl)
+			tc.expect(ec2Mock)
+
+			s := NewService(ec2Mock)
+			if err := s.reconcileNatGateways(tc.input, &v1alpha1.VPC{ID: subnetsVPCID}); err != nil {
+				t.Fatalf("got an unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #35 

Roughly, the approach will be for creation (after subnet reconciliation):

1. Loop over all subnets in provider config
2. Exit if all subnets are public
3. Loop over public subnets and ensure there is A NAT gateway managed by us in there.
4. Loop over routing tables and ensure one exists for each AZ corresponding to the NAT gateway
5. Loop over private subnets
  a. Check the route table is the one we manage
  b. If not, associate it

