### PR TITLE
Default network configuration

### DIFF
--- a/cloud/aws/services/ec2/network.go
+++ b/cloud/aws/services/ec2/network.go
@@ -16,6 +16,21 @@ package ec2
 import "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
 
 func (s *Service) ReconcileNetwork(network *v1alpha1.Network) (err error) {
+	if network == nil {
+		network = &v1alpha1.Network{}
+	}
+
+	if network.VPC == nil {
+		network.VPC = &v1alpha1.VPC{
+			ID:        "",
+			CidrBlock: "",
+		}
+	}
+
+	if network.Subnets == nil {
+		network.Subnets = []*v1alpha1.Subnet{}
+	}
+
 	// VPC.
 	if err := s.reconcileVPC(network.VPC); err != nil {
 		return err


### PR DESCRIPTION
When running through the setup described [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws#running-clusterctl) I encountered a NPE as the examples don't set any network configuration.

This sets some empty values if nothing is defined, which triggers the defaults to be used.