### PR TITLE
Example improvements

### DIFF
--- a/clusterctl/examples/aws/provider-components.yaml.template
+++ b/clusterctl/examples/aws/provider-components.yaml.template
@@ -4,12 +4,18 @@ metadata:
   name: clusterapi-controllers
   labels:
     api: clusterapi
+    controllers: "true"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      api: clusterapi
+      controllers: "true"
   template:
     metadata:
       labels:
         api: clusterapi
+        controllers: "true"
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/cmd/cluster-controller/Makefile
+++ b/cmd/cluster-controller/Makefile
@@ -37,6 +37,10 @@ endif
 NAME = aws-cluster-controller
 TAG = 0.0.1
 
+ifndef DEV_TAG
+DEV_TAG = $(TAG)-dev
+endif
+
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..
 
@@ -49,7 +53,7 @@ fix_gcs_permissions:
 	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
 dev_image:
-	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..
+	docker build -t "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)" -f ./Dockerfile ../..
 
 dev_push: dev_image
-	docker push "$(DEV_PREFIX)/$(NAME):$(TAG)-dev"
+	docker push "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)"

--- a/cmd/machine-controller/Makefile
+++ b/cmd/machine-controller/Makefile
@@ -37,6 +37,10 @@ endif
 NAME = aws-machine-controller
 TAG = 0.0.1
 
+ifndef DEV_TAG
+DEV_TAG = $(TAG)-dev
+endif
+
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..
 
@@ -49,7 +53,7 @@ fix_gcs_permissions:
 	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
 dev_image:
-	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..
+	docker build -t "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)" -f ./Dockerfile ../..
 
 dev_push: dev_image
-	docker push "$(DEV_PREFIX)/$(NAME):$(TAG)-dev"
+	docker push "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)"


### PR DESCRIPTION
Happy to extract those into separate PRs, but as they were tiny in bundled those changes.

**Fix example spec**

When running `clusterctl` two deployments will be created `clusterapi-apiserver` and `clusterapi-controllers`. Both have the label `api: clusterapi`, so add another label to the controllers to match only controller pods (the apiserver deployment has already the additional label `apiserver: true`)

**Allow to override dev image tags**

I found it a bit cumbersome to manually edit the tag when recreating the controllers, instead `export DEV_TAG` can now be used to modify the tag.

**Clarify example generation**

I tried to run `./clusterctl/examples/aws/generate-yaml.sh`, which failed as the script can only be executed inside `./clusterctl/examples/aws`