### PR TITLE
Fix NPE when deleting not yet created machine

### DIFF
--- a/cloud/aws/actuators/machine/actuator.go
+++ b/cloud/aws/actuators/machine/actuator.go
@@ -123,6 +123,11 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 		return errors.Wrap(err, "failed to get instance")
 	}
 
+	// The machine hasn't been created yet
+	if instance == nil {
+		return nil
+	}
+
 	// Check the instance state. If it's already shutting down or terminated,
 	// do nothing. Otherwise attempt to delete it.
 	// This decision is based on the ec2-instance-lifecycle graph at

--- a/cloud/aws/actuators/machine/actuator_test.go
+++ b/cloud/aws/actuators/machine/actuator_test.go
@@ -109,6 +109,33 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestDeleteNotExisting(t *testing.T) {
+	codec, err := v1alpha1.NewCodec()
+	if err != nil {
+		t.Fatalf("failed to create a codec: %v", err)
+	}
+
+	ap := machine.ActuatorParams{
+		Codec:           codec,
+		MachinesService: &machines{},
+		EC2Service:      &ec2{},
+	}
+
+	actuator, err := machine.NewActuator(ap)
+	if err != nil {
+		t.Fatalf("failed to create an actuator: %v", err)
+	}
+
+	// Get some empty cluster and machine structs.
+	testCluster := &clusterv1.Cluster{}
+	testMachine := &clusterv1.Machine{}
+
+	// Delete the machine.
+	if err := actuator.Delete(testCluster, testMachine); err != nil {
+		t.Fatalf("failed to delete machine: %v", err)
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	codec, err := v1alpha1.NewCodec()
 	if err != nil {


### PR DESCRIPTION
`InstanceIfExists` can also return `nil` if the call succeeded, but no instance has been found.

This allows to delete not yet started machines.