### PR TITLE
Fix subnet create

### DIFF
--- a/cloud/aws/services/ec2/subnets.go
+++ b/cloud/aws/services/ec2/subnets.go
@@ -149,6 +149,7 @@ func (s *Service) createSubnet(sn *v1alpha1.Subnet) (*v1alpha1.Subnet, error) {
 			MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 				Value: aws.Bool(true),
 			},
+			SubnetId: out.Subnet.SubnetId,
 		}
 
 		if _, err := s.EC2.ModifySubnetAttribute(attReq); err != nil {

--- a/cloud/aws/services/ec2/subnets_test.go
+++ b/cloud/aws/services/ec2/subnets_test.go
@@ -103,6 +103,7 @@ func TestReconcileSubnets(t *testing.T) {
 						MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 							Value: aws.Bool(true),
 						},
+						SubnetId: aws.String("subnet-2"),
 					}).
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil)
 
@@ -181,6 +182,7 @@ func TestReconcileSubnets(t *testing.T) {
 						MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 							Value: aws.Bool(true),
 						},
+						SubnetId: aws.String("subnet-2"),
 					}).
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(secondSubnet)


### PR DESCRIPTION
`ModifySubnetAttributeInput` requires `SubnetId` to be set https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#ModifySubnetAttributeInput