### PR TITLE
Fix subnet discovery, reconcile route tables, add logs

### DIFF
--- a/cloud/aws/providerconfig/v1alpha1/types.go
+++ b/cloud/aws/providerconfig/v1alpha1/types.go
@@ -14,6 +14,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -174,6 +176,11 @@ type VPC struct {
 	CidrBlock string `json:"cidrBlock"`
 }
 
+// String returns a string representation of the VPC.
+func (v *VPC) String() string {
+	return fmt.Sprintf("id=%s", v.ID)
+}
+
 // Subnet defines an AWS subnet attached to a VPC.
 type Subnet struct {
 	ID string `json:"id"`
@@ -184,6 +191,11 @@ type Subnet struct {
 	IsPublic         bool    `json:"public"`
 	RouteTableID     *string `json:"routeTableId"`
 	NatGatewayID     *string `json:"natGatewayId"`
+}
+
+// String returns a string representation of the subnet.
+func (s *Subnet) String() string {
+	return fmt.Sprintf("id=%s/az=%s", s.ID, s.AvailabilityZone)
 }
 
 // Subnets is a slice of Subnet.

--- a/cloud/aws/services/ec2/gateways.go
+++ b/cloud/aws/services/ec2/gateways.go
@@ -16,11 +16,14 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
 )
 
 func (s *Service) reconcileInternetGateways(in *v1alpha1.Network) error {
+	glog.V(2).Infof("Reconciling internet gateways")
+
 	igs, err := s.describeVpcInternetGateways(&in.VPC)
 	if IsNotFound(err) {
 		ig, err := s.createInternetGateway(&in.VPC)

--- a/cloud/aws/services/ec2/network.go
+++ b/cloud/aws/services/ec2/network.go
@@ -13,9 +13,13 @@
 
 package ec2
 
-import "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
+import (
+	"github.com/golang/glog"
+	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
+)
 
 func (s *Service) ReconcileNetwork(network *v1alpha1.Network) (err error) {
+	glog.V(2).Info("Reconciling network")
 
 	// VPC.
 	if err := s.reconcileVPC(&network.VPC); err != nil {
@@ -23,7 +27,7 @@ func (s *Service) ReconcileNetwork(network *v1alpha1.Network) (err error) {
 	}
 
 	// Subnets.
-	if err := s.reconcileSubnets(network.Subnets, &network.VPC); err != nil {
+	if err := s.reconcileSubnets(network); err != nil {
 		return err
 	}
 
@@ -37,5 +41,11 @@ func (s *Service) ReconcileNetwork(network *v1alpha1.Network) (err error) {
 		return err
 	}
 
+	// Routing tables.
+	if err := s.reconcileRouteTables(network); err != nil {
+		return err
+	}
+
+	glog.V(2).Info("Renconcile network completed successfully")
 	return nil
 }

--- a/cloud/aws/services/ec2/subnets_test.go
+++ b/cloud/aws/services/ec2/subnets_test.go
@@ -33,17 +33,20 @@ func TestReconcileSubnets(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		input  []*v1alpha1.Subnet
+		input  *v1alpha1.Network
 		expect func(m *mock_ec2iface.MockEC2API)
 	}{
 		{
 			name: "single private subnet exists, should create public with defaults",
-			input: []*v1alpha1.Subnet{
-				{
-					ID:               "subnet-1",
-					AvailabilityZone: "us-east-1a",
-					CidrBlock:        "10.0.10.0/24",
-					IsPublic:         false,
+			input: &v1alpha1.Network{
+				VPC: v1alpha1.VPC{ID: subnetsVPCID},
+				Subnets: []*v1alpha1.Subnet{
+					{
+						ID:               "subnet-1",
+						AvailabilityZone: "us-east-1a",
+						CidrBlock:        "10.0.10.0/24",
+						IsPublic:         false,
+					},
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2API) {
@@ -111,16 +114,19 @@ func TestReconcileSubnets(t *testing.T) {
 		},
 		{
 			name: "no subnet exist, create private and public",
-			input: []*v1alpha1.Subnet{
-				{
-					AvailabilityZone: "us-east-1a",
-					CidrBlock:        "10.1.0.0/16",
-					IsPublic:         false,
-				},
-				{
-					AvailabilityZone: "us-east-1b",
-					CidrBlock:        "10.2.0.0/16",
-					IsPublic:         true,
+			input: &v1alpha1.Network{
+				VPC: v1alpha1.VPC{ID: subnetsVPCID},
+				Subnets: []*v1alpha1.Subnet{
+					{
+						AvailabilityZone: "us-east-1a",
+						CidrBlock:        "10.1.0.0/16",
+						IsPublic:         false,
+					},
+					{
+						AvailabilityZone: "us-east-1b",
+						CidrBlock:        "10.2.0.0/16",
+						IsPublic:         true,
+					},
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2API) {
@@ -197,7 +203,7 @@ func TestReconcileSubnets(t *testing.T) {
 			tc.expect(ec2Mock)
 
 			s := NewService(ec2Mock)
-			if err := s.reconcileSubnets(tc.input, &v1alpha1.VPC{ID: subnetsVPCID}); err != nil {
+			if err := s.reconcileSubnets(tc.input); err != nil {
 				t.Fatalf("got an unexpected error: %v", err)
 			}
 		})

--- a/cloud/aws/services/ec2/vpc.go
+++ b/cloud/aws/services/ec2/vpc.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
 )
@@ -27,9 +28,10 @@ const (
 )
 
 func (s *Service) reconcileVPC(in *v1alpha1.VPC) error {
+	glog.V(2).Infof("Reconciling VPC")
+
 	vpc, err := s.describeVPC(in.ID)
 	if IsNotFound(err) {
-
 		// Create a new vpc.
 		vpc, err = s.createVPC(in)
 		if err != nil {
@@ -41,6 +43,7 @@ func (s *Service) reconcileVPC(in *v1alpha1.VPC) error {
 	}
 
 	vpc.DeepCopyInto(in)
+	glog.V(2).Infof("Working on VPC %q", in.ID)
 	return nil
 }
 
@@ -64,7 +67,7 @@ func (s *Service) createVPC(v *v1alpha1.VPC) (*v1alpha1.VPC, error) {
 	}
 
 	// TODO(vincepri): tag vpc with https://docs.aws.amazon.com/sdk-for-go/api/service/resourcegroupstaggingapi/#ResourceGroupsTaggingAPI.TagResources
-
+	glog.V(2).Infof("Created new VPC %q with cidr %q", *out.Vpc.VpcId, *out.Vpc.CidrBlock)
 	return &v1alpha1.VPC{
 		ID:        *out.Vpc.VpcId,
 		CidrBlock: *out.Vpc.CidrBlock,
@@ -81,6 +84,7 @@ func (s *Service) deleteVPC(v *v1alpha1.VPC) error {
 		return errors.Wrapf(err, "failed to delete vpc %q", v.ID)
 	}
 
+	glog.V(2).Infof("Deleted VPC %q", v.ID)
 	return nil
 }
 

--- a/clusterctl/examples/aws/provider-components.yaml.template
+++ b/clusterctl/examples/aws/provider-components.yaml.template
@@ -67,7 +67,7 @@ spec:
         args:
         - --kubeconfig=/etc/kubernetes/admin.conf
         - --leader-elect
-        - -v1
+        - -v2
         resources:
           requests:
             cpu: 200m
@@ -98,7 +98,7 @@ spec:
         args:
         - --kubeconfig=/etc/kubernetes/admin.conf
         - --leader-elect
-        - -v1
+        - -v2
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

- Add much needed logs throughout the reconcile loop.
- Forces to store the state in the cluster actuator with defer.
- Fixes subnet discovery which caused the first iteration to fail.
- Actually reconcile routing tables.
- Complete cluster actuator tests.
- Fix NPE in route table association.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```