### PR TITLE
Fix issue where public subnet isn't marked public

### DIFF
--- a/cloud/aws/services/ec2/subnets.go
+++ b/cloud/aws/services/ec2/subnets.go
@@ -98,6 +98,9 @@ LoopExisting:
 			return err
 		}
 
+		glog.V(2).Infof("Created new subnet %q in VPC %q with cidr %q and availability zone %q",
+			nsn.ID, nsn.VpcID, nsn.CidrBlock, nsn.AvailabilityZone)
+
 		nsn.DeepCopyInto(subnet)
 	}
 
@@ -166,15 +169,12 @@ func (s *Service) createSubnet(clusterName string, sn *v1alpha1.Subnet) (*v1alph
 		}
 	}
 
-	glog.V(2).Infof("Created new subnet %q in VPC %q with cidr %q and availability zone %q",
-		*out.Subnet.SubnetId, *out.Subnet.VpcId, *out.Subnet.CidrBlock, *out.Subnet.AvailabilityZone)
-
 	return &v1alpha1.Subnet{
 		ID:               *out.Subnet.SubnetId,
 		VpcID:            *out.Subnet.VpcId,
 		AvailabilityZone: *out.Subnet.AvailabilityZone,
 		CidrBlock:        *out.Subnet.CidrBlock,
-		IsPublic:         *out.Subnet.MapPublicIpOnLaunch,
+		IsPublic:         sn.IsPublic,
 	}, nil
 }
 

--- a/cloud/aws/services/ec2/subnets_test.go
+++ b/cloud/aws/services/ec2/subnets_test.go
@@ -90,11 +90,10 @@ func TestReconcileSubnets(t *testing.T) {
 					})).
 					Return(&ec2.CreateSubnetOutput{
 						Subnet: &ec2.Subnet{
-							VpcId:               aws.String(subnetsVPCID),
-							SubnetId:            aws.String("subnet-2"),
-							CidrBlock:           aws.String("10.1.0.0/16"),
-							AvailabilityZone:    aws.String("us-east-1a"),
-							MapPublicIpOnLaunch: aws.Bool(true),
+							VpcId:            aws.String(subnetsVPCID),
+							SubnetId:         aws.String("subnet-2"),
+							CidrBlock:        aws.String("10.1.0.0/16"),
+							AvailabilityZone: aws.String("us-east-1a"),
 						},
 					}, nil)
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes an issue where public subnets wouldn't be seen as such. This only happens during the creation step.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
The log line has been moved mostly to be consistent with other parts of the codebase.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```