### PR TITLE
Add region cluster configuration parameter

### DIFF
--- a/cloud/aws/actuators/cluster/actuator.go
+++ b/cloud/aws/actuators/cluster/actuator.go
@@ -77,6 +77,9 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) (reterr error) {
 		return errors.Errorf("failed to load cluster provider status: %v", err)
 	}
 
+	// Store some config parameters in the status.
+	status.Region = config.Region
+
 	// Always defer storing the cluster status. In case any of the calls below fails or returns an error
 	// the cluster state might have partial changes that should be stored.
 	defer func() {

--- a/cloud/aws/actuators/cluster/actuator.go
+++ b/cloud/aws/actuators/cluster/actuator.go
@@ -17,45 +17,45 @@ import (
 	"fmt"
 
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
+	ec2svc "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/services/ec2"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 )
-
-type ec2Svc interface {
-	ReconcileNetwork(string, *providerconfigv1.Network) error
-}
-
-type codec interface {
-	DecodeFromProviderConfig(clusterv1.ProviderConfig, runtime.Object) error
-	DecodeProviderStatus(*runtime.RawExtension, runtime.Object) error
-	EncodeProviderStatus(runtime.Object) (*runtime.RawExtension, error)
-}
 
 // Actuator is responsible for performing cluster reconciliation
 type Actuator struct {
 	codec          codec
 	clustersGetter client.ClustersGetter
-	ec2            ec2Svc
+	ec2Getter      EC2Getter
 }
 
 // ActuatorParams holds parameter information for Actuator
 type ActuatorParams struct {
 	Codec          codec
 	ClustersGetter client.ClustersGetter
-	EC2Service     ec2Svc
+	EC2Getter      EC2Getter
 }
 
 // NewActuator creates a new Actuator
 func NewActuator(params ActuatorParams) (*Actuator, error) {
-	return &Actuator{
+	res := &Actuator{
 		codec:          params.Codec,
 		clustersGetter: params.ClustersGetter,
-		ec2:            params.EC2Service,
-	}, nil
+		ec2Getter:      params.EC2Getter,
+	}
+
+	if res.ec2Getter == nil {
+		res.ec2Getter = new(defaultEC2Getter)
+	}
+
+	return res, nil
 }
 
 // Reconcile reconciles a cluster and is invoked by the Cluster Controller
@@ -64,6 +64,12 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) (reterr error) {
 
 	// Get a cluster api client for the namespace of the cluster.
 	clusterClient := a.clustersGetter.Clusters(cluster.Namespace)
+
+	// Load provider config.
+	config, err := a.loadProviderConfig(cluster)
+	if err != nil {
+		return errors.Errorf("failed to load cluster provider config: %v", err)
+	}
 
 	// Load provider status.
 	status, err := a.loadProviderStatus(cluster)
@@ -80,7 +86,10 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) (reterr error) {
 		}
 	}()
 
-	if err := a.ec2.ReconcileNetwork(cluster.Name, &status.Network); err != nil {
+	// Load ec2 client.
+	svc := ec2svc.NewService(a.ec2Getter.EC2(config))
+
+	if err := svc.ReconcileNetwork(cluster.Name, &status.Network); err != nil {
 		return errors.Errorf("unable to reconcile network: %v", err)
 	}
 
@@ -117,4 +126,10 @@ func (a *Actuator) storeProviderStatus(clusterClient client.ClusterInterface, cl
 	}
 
 	return nil
+}
+
+type defaultEC2Getter struct{}
+
+func (d *defaultEC2Getter) EC2(clusterConfig *providerconfigv1.AWSClusterProviderConfig) ec2iface.EC2API {
+	return ec2.New(session.Must(session.NewSession()), aws.NewConfig().WithRegion(clusterConfig.Region))
 }

--- a/cloud/aws/actuators/cluster/interfaces.go
+++ b/cloud/aws/actuators/cluster/interfaces.go
@@ -1,0 +1,36 @@
+// Copyright © 2018 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"k8s.io/apimachinery/pkg/runtime"
+	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// EC2Getter has a single method that returns an ec2 client.
+type EC2Getter interface {
+	EC2(*providerconfigv1.AWSClusterProviderConfig) ec2iface.EC2API
+}
+
+type ec2SvcIface interface {
+	ReconcileNetwork(string, *providerconfigv1.Network) error
+}
+
+type codec interface {
+	DecodeFromProviderConfig(clusterv1.ProviderConfig, runtime.Object) error
+	DecodeProviderStatus(*runtime.RawExtension, runtime.Object) error
+	EncodeProviderStatus(runtime.Object) (*runtime.RawExtension, error)
+}

--- a/cloud/aws/controllers/cluster/controller.go
+++ b/cloud/aws/controllers/cluster/controller.go
@@ -19,8 +19,6 @@ package cluster
 import (
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +40,6 @@ import (
 	clusteractuator "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/actuators/cluster"
 	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/controllers/cluster/options"
 	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
-	ec2svc "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/services/ec2"
 )
 
 const (
@@ -64,17 +61,9 @@ func Start(server *options.Server, shutdown <-chan struct{}) {
 		glog.Fatalf("Could not create codec: %v", err)
 	}
 
-	// Requires setting environment variables:
-	// AWS_REGION=us-west-2,
-	// AWS_ACCESS_KEY_ID=
-	// AWS_SECRET_ACCESS_KEY=
-	sess := session.Must(session.NewSession())
-	ec2client := ec2.New(sess)
-
 	params := clusteractuator.ActuatorParams{
 		Codec:          codec,
 		ClustersGetter: clients.ClusterV1alpha1(),
-		EC2Service:     ec2svc.NewService(ec2client),
 	}
 
 	actuator, err := clusteractuator.NewActuator(params)

--- a/cloud/aws/providerconfig/v1alpha1/types.go
+++ b/cloud/aws/providerconfig/v1alpha1/types.go
@@ -161,6 +161,7 @@ type AWSMachineProviderCondition struct {
 type AWSClusterProviderStatus struct {
 	metav1.TypeMeta `json:",inline"`
 
+	Region  string  `json:"region"`
 	Network Network `json:"network"`
 }
 

--- a/cloud/aws/providerconfig/v1alpha1/types.go
+++ b/cloud/aws/providerconfig/v1alpha1/types.go
@@ -102,6 +102,9 @@ type Filter struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type AWSClusterProviderConfig struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// The AWS Region the cluster lives in.
+	Region string `json:"region"`
 }
 
 // AWSMachineProviderStatus is the type that will be embedded in a Machine.Status.ProviderStatus field.

--- a/cloud/aws/services/ec2/ami.go
+++ b/cloud/aws/services/ec2/ami.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package ec2
 
-// DefaultAMILookup returns the default AMI based on region
+// defaultAMILookup returns the default AMI based on region
 func (s *Service) defaultAMILookup(region string) string {
 	//TODO(chuckha) Replace this function with a method to filter public images.
 	switch region {

--- a/clusterctl/examples/aws/cluster.yaml.template
+++ b/clusterctl/examples/aws/cluster.yaml.template
@@ -13,4 +13,5 @@ spec:
     value:
       apiVersion: "awsproviderconfig/v1alpha1"
       kind: "AWSClusterProviderConfig"
+      region: "${AWS_REGION}"
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds the region parameter to the cluster configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #144 

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The cluster configuration has a new required parameter, `region` which corresponds to the AWS region the cluster lives in.
```