### PR TITLE
VPC Teardown

### DIFF
--- a/cloud/aws/actuators/cluster/actuator_test.go
+++ b/cloud/aws/actuators/cluster/actuator_test.go
@@ -103,6 +103,10 @@ func TestReconcile(t *testing.T) {
 							aws.String("1234"),
 						},
 					},
+					&ec2.Filter{
+						Name:   aws.String("tag-key"),
+						Values: []*string{aws.String("kubernetes.io/cluster/test")},
+					},
 				},
 			}).
 			Return(&ec2.DescribeSubnetsOutput{
@@ -144,6 +148,10 @@ func TestReconcile(t *testing.T) {
 						Name:   aws.String("attachment.vpc-id"),
 						Values: []*string{aws.String("1234")},
 					},
+					&ec2.Filter{
+						Name:   aws.String("tag-key"),
+						Values: []*string{aws.String("kubernetes.io/cluster/test")},
+					},
 				},
 			}).
 			Return(&ec2.DescribeInternetGatewaysOutput{
@@ -159,6 +167,15 @@ func TestReconcile(t *testing.T) {
 		me.EXPECT().
 			AllocateAddress(&ec2.AllocateAddressInput{Domain: aws.String("vpc")}).
 			Return(&ec2.AllocateAddressOutput{AllocationId: aws.String("scarf")}, nil),
+		me.EXPECT().
+			CreateTags(&ec2.CreateTagsInput{
+				Resources: aws.StringSlice([]string{"scarf"}),
+				Tags: []*ec2.Tag{&ec2.Tag{
+					Key:   aws.String("kubernetes.io/cluster/test"),
+					Value: aws.String("owned"),
+				}},
+			}).
+			Return(nil, nil),
 		me.EXPECT().
 			CreateNatGateway(&ec2.CreateNatGatewayInput{
 				AllocationId: aws.String("scarf"),
@@ -189,6 +206,10 @@ func TestReconcile(t *testing.T) {
 						Values: []*string{
 							aws.String("1234"),
 						},
+					},
+					&ec2.Filter{
+						Name:   aws.String("tag-key"),
+						Values: []*string{aws.String("kubernetes.io/cluster/test")},
 					},
 				},
 			}).Return(&ec2.DescribeRouteTablesOutput{}, nil),

--- a/cloud/aws/services/ec2/account.go
+++ b/cloud/aws/services/ec2/account.go
@@ -14,7 +14,6 @@
 package ec2
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 )
@@ -34,12 +33,7 @@ func (s *Service) getRegion() string {
 
 func (s *Service) getAvailableZones() ([]string, error) {
 	out, err := s.EC2.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("state"),
-				Values: []*string{aws.String("available")},
-			},
-		},
+		Filters: []*ec2.Filter{s.filterAvailable()},
 	})
 
 	if err != nil {

--- a/cloud/aws/services/ec2/bastion.go
+++ b/cloud/aws/services/ec2/bastion.go
@@ -88,10 +88,9 @@ func (s *Service) describeBastionInstance(clusterName string, status *v1alpha1.A
 				Name:   aws.String(fmt.Sprintf("tag:%s", TagNameAWSClusterAPIRole)),
 				Values: []*string{aws.String(TagValueBastionRole)},
 			},
+			s.filterCluster(clusterName),
 		},
 	}
-
-	input.Filters = s.addTagFilters(clusterName, input.Filters)
 
 	out, err := s.EC2.DescribeInstances(input)
 	if err != nil {

--- a/cloud/aws/services/ec2/eips.go
+++ b/cloud/aws/services/ec2/eips.go
@@ -16,10 +16,12 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/services/wait"
 )
 
-func (s *Service) allocateAddress() (string, error) {
+func (s *Service) allocateAddress(clusterName string) (string, error) {
 	out, err := s.EC2.AllocateAddress(&ec2.AllocateAddressInput{
 		Domain: aws.String("vpc"),
 	})
@@ -28,5 +30,48 @@ func (s *Service) allocateAddress() (string, error) {
 		return "", errors.Wrapf(err, "failed to create Elastic IP address")
 	}
 
+	if err := s.createTags(clusterName, *out.AllocationId, ResourceLifecycleOwned, nil); err != nil {
+		return "", errors.Wrapf(err, "failed to tag elastic IP %q", *out.AllocationId)
+	}
+
 	return *out.AllocationId, nil
+}
+
+func (s *Service) releaseAddresses(clusterName string) error {
+	out, err := s.EC2.DescribeAddresses(&ec2.DescribeAddressesInput{
+		Filters: []*ec2.Filter{s.filterCluster(clusterName)},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to describe elastic IPs %q", err)
+	}
+
+	for _, ip := range out.Addresses {
+		if ip.AssociationId != nil {
+			return errors.Errorf("failed to release elastic IP %q with allocation ID %q: Still associated with association ID %q", *ip.PublicIp, *ip.AllocationId, *ip.AssociationId)
+		}
+
+		delete := func() (bool, error) {
+			_, err := s.EC2.ReleaseAddress(&ec2.ReleaseAddressInput{
+				AllocationId: ip.AllocationId,
+			})
+
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+
+		retryableErrors := []string{
+			errorAuthFailure,
+			errorInUseIPAddress,
+		}
+
+		err := wait.WaitForWithRetryable(wait.NewBackoff(), delete, retryableErrors)
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to release elastic IP %q: %q", *ip.AllocationId, err)
+		}
+		glog.Infof("released elastic IP %q with allocation ID %q", *ip.PublicIp, *ip.AllocationId)
+	}
+	return nil
 }

--- a/cloud/aws/services/ec2/errors.go
+++ b/cloud/aws/services/ec2/errors.go
@@ -19,6 +19,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+const (
+	errorAuthFailure        = "AuthFailure"
+	errorInUseIPAddress     = "InvalidIPAddress.InUse"
+	errorGroupNotFound      = "InvalidGroup.NotFound"
+	errorPermissionNotFound = "InvalidPermission.NotFound"
+)
+
 var _ error = &EC2Error{}
 
 // EC2Error is an error exposed to users of this library.

--- a/cloud/aws/services/ec2/filters.go
+++ b/cloud/aws/services/ec2/filters.go
@@ -1,0 +1,51 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+const (
+	filterNameTagKey        = "tag-key"
+	filterNameVpcID         = "vpc-id"
+	filterNameState         = "state"
+	filterNameVpcAttachment = "attachment.vpc-id"
+)
+
+// Returns an EC2 filter using the Cluster API per-cluster tag
+func (s *Service) filterCluster(clusterName string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String(filterNameTagKey),
+		Values: aws.StringSlice([]string{s.clusterTagKey(clusterName)}),
+	}
+}
+
+// Returns an EC2 filter for the specified VPC ID
+func (s *Service) filterVpc(vpcID string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String(filterNameVpcID),
+		Values: aws.StringSlice([]string{vpcID}),
+	}
+}
+
+// Returns an EC2 filter for the specified VPC ID
+func (s *Service) filterVpcAttachment(vpcID string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String(filterNameVpcAttachment),
+		Values: aws.StringSlice([]string{vpcID}),
+	}
+}
+
+// Returns an EC2 filter for the state to be available
+func (s *Service) filterAvailable() *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String(filterNameState),
+		Values: aws.StringSlice([]string{stateAvailable}),
+	}
+}
+
+// Add additional cluster tag filters, to match on our tags
+func (s *Service) addFilterTags(clusterName string, filters []*ec2.Filter) []*ec2.Filter {
+	filters = append(filters, s.filterCluster(clusterName))
+	return filters
+}

--- a/cloud/aws/services/ec2/natgateways_test.go
+++ b/cloud/aws/services/ec2/natgateways_test.go
@@ -100,6 +100,10 @@ func TestReconcileNatGateways(t *testing.T) {
 									Name:   aws.String("vpc-id"),
 									Values: []*string{aws.String(subnetsVPCID)},
 								},
+								{
+									Name:   aws.String("state"),
+									Values: []*string{aws.String("available")},
+								},
 							},
 						}),
 						gomock.Any()).Return(nil)
@@ -124,6 +128,16 @@ func TestReconcileNatGateways(t *testing.T) {
 					WaitUntilNatGatewayAvailable(&ec2.DescribeNatGatewaysInput{
 						NatGatewayIds: []*string{aws.String("natgateway")},
 					}).Return(nil)
+
+				m.EXPECT().
+					CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+						Resources: aws.StringSlice([]string{ElasticIPAllocationID}),
+						Tags: []*ec2.Tag{&ec2.Tag{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						}},
+					})).
+					Return(nil, nil)
 
 				m.EXPECT().
 					CreateTags(gomock.Eq(&ec2.CreateTagsInput{
@@ -172,6 +186,10 @@ func TestReconcileNatGateways(t *testing.T) {
 									Name:   aws.String("vpc-id"),
 									Values: []*string{aws.String(subnetsVPCID)},
 								},
+								{
+									Name:   aws.String("state"),
+									Values: []*string{aws.String("available")},
+								},
 							},
 						}),
 						gomock.Any()).Do(func(_, y interface{}) {
@@ -202,6 +220,16 @@ func TestReconcileNatGateways(t *testing.T) {
 					WaitUntilNatGatewayAvailable(&ec2.DescribeNatGatewaysInput{
 						NatGatewayIds: []*string{aws.String("natgateway")},
 					}).Return(nil)
+
+				m.EXPECT().
+					CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+						Resources: aws.StringSlice([]string{ElasticIPAllocationID}),
+						Tags: []*ec2.Tag{&ec2.Tag{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						}},
+					})).
+					Return(nil, nil)
 
 				m.EXPECT().
 					CreateTags(gomock.Eq(&ec2.CreateTagsInput{
@@ -241,6 +269,10 @@ func TestReconcileNatGateways(t *testing.T) {
 								{
 									Name:   aws.String("vpc-id"),
 									Values: []*string{aws.String(subnetsVPCID)},
+								},
+								{
+									Name:   aws.String("state"),
+									Values: []*string{aws.String("available")},
 								},
 							},
 						}),

--- a/cloud/aws/services/ec2/network.go
+++ b/cloud/aws/services/ec2/network.go
@@ -51,6 +51,45 @@ func (s *Service) ReconcileNetwork(clusterName string, network *v1alpha1.Network
 		return err
 	}
 
-	glog.V(2).Info("Renconcile network completed successfully")
+	glog.V(2).Info("Reconciled network completed successfully")
+	return nil
+}
+
+func (s *Service) DeleteNetwork(clusterName string, network *v1alpha1.Network) (err error) {
+	glog.V(2).Info("Deleting network")
+
+	// Security groups.
+	if err := s.deleteSecurityGroups(clusterName, network); err != nil {
+		return err
+	}
+
+	// Routing tables.
+	if err := s.deleteRouteTables(clusterName, network); err != nil {
+		return err
+	}
+
+	if err := s.deleteNatGateways(clusterName, network.Subnets, &network.VPC); err != nil {
+		return err
+	}
+
+	if err := s.releaseAddresses(clusterName); err != nil {
+		return err
+	}
+
+	if err := s.deleteInternetGateways(clusterName, network); err != nil {
+		return err
+	}
+
+	// Subnets.
+	if err := s.deleteSubnets(clusterName, network); err != nil {
+		return err
+	}
+
+	// VPC.
+	if err := s.deleteVPC(&network.VPC); err != nil {
+		return err
+	}
+
+	glog.V(2).Info("Deleted network completed successfully")
 	return nil
 }

--- a/cloud/aws/services/ec2/service.go
+++ b/cloud/aws/services/ec2/service.go
@@ -17,6 +17,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
 
+const (
+	stateAvailable = "available"
+	stateDeleting  = "deleting"
+	stateDeleted   = "deleted"
+	statePending   = "pending"
+	stateFailed    = "failed"
+)
+
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
 // One alternative is to have a large list of functions from the ec2 client.

--- a/cloud/aws/services/ec2/subnets_test.go
+++ b/cloud/aws/services/ec2/subnets_test.go
@@ -68,6 +68,10 @@ func TestReconcileSubnets(t *testing.T) {
 								Name:   aws.String("vpc-id"),
 								Values: []*string{aws.String(subnetsVPCID)},
 							},
+							{
+								Name:   aws.String("tag-key"),
+								Values: []*string{aws.String("kubernetes.io/cluster/test-cluster")},
+							},
 						},
 					})).
 					Return(&ec2.DescribeSubnetsOutput{
@@ -146,6 +150,10 @@ func TestReconcileSubnets(t *testing.T) {
 							{
 								Name:   aws.String("vpc-id"),
 								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("tag-key"),
+								Values: []*string{aws.String("kubernetes.io/cluster/test-cluster")},
 							},
 						},
 					})).

--- a/cloud/aws/services/ec2/tags.go
+++ b/cloud/aws/services/ec2/tags.go
@@ -75,15 +75,6 @@ func (s *Service) createTags(clusterName string, resourceID string, lifecycle Re
 	return errors.Wrapf(err, "failed to tag resource %q in cluster %q", resourceID, clusterName)
 }
 
-// Add additional cluster tag filters, to match on our tags
-func (s *Service) addTagFilters(clusterName string, filters []*ec2.Filter) []*ec2.Filter {
-	filters = append(filters, &ec2.Filter{
-		Name:   aws.String("tag-key"),
-		Values: aws.StringSlice([]string{s.clusterTagKey(clusterName)}),
-	})
-	return filters
-}
-
 // buildTags builds tags including the cluster tag
 func (s *Service) buildTags(clusterName string, lifecycle ResourceLifecycle, additionalTags map[string]string) map[string]string {
 	tags := make(map[string]string)

--- a/cloud/aws/services/wait/wait.go
+++ b/cloud/aws/services/wait/wait.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	aMW "k8s.io/apimachinery/pkg/util/wait"
+)
+
+/*
+ Ideally, this entire file would be replaced with returning a retryable
+ error and letting the actuator requeue deletion. Unfortunately, since
+ the retry behaviour is not tunable, with a max retry limit of 10, we
+ implement waits manually here.
+*/
+
+// Values based loosely on https://github.com/Netflix/edda/blob/master/src/main/scala/com/netflix/edda/Crawler.scala#L159
+
+func NewBackoff() aMW.Backoff {
+
+	duration, _ := time.ParseDuration("2s")
+	return aMW.Backoff{
+		Duration: duration,
+		Factor:   1.5,
+		Jitter:   1.0,
+		Steps:    100,
+	}
+}
+
+// WaitForWithRetryable repeats a condition check with exponential backoff.
+//
+// It takes a list of string slice of AWS API errors that can be considered as retriable.
+//
+// It checks the condition up to Steps times.
+//
+// If Jitter is greater than zero, a random amount of each duration is added
+// (between duration and duration*(1+jitter)).
+//
+// If it receives a RequestLimitExceeded or Throttling error, then we
+// multiply the delay by the specified factor.
+//
+// If the condition never returns true, ErrWaitTimeout is returned. All other
+// errors terminate immediately.
+func WaitForWithRetryable(backoff aMW.Backoff, condition aMW.ConditionFunc, retryableErrors []string) error {
+	duration := backoff.Duration
+	for i := 0; i < backoff.Steps; i++ {
+		if i != 0 {
+			adjusted := duration
+			if backoff.Jitter > 0.0 {
+				adjusted = aMW.Jitter(duration, backoff.Jitter)
+			}
+			time.Sleep(adjusted)
+			duration = time.Duration(float64(duration) * backoff.Factor)
+		}
+		ok, err := condition()
+		if ok {
+			return nil
+		}
+		if err != nil {
+			awserr, ok := err.(awserr.Error)
+			if !ok {
+				return err
+			}
+			isRetryable := false
+			for _, r := range retryableErrors {
+				if awserr.Code() == r {
+					isRetryable = true
+				}
+			}
+			if !isRetryable {
+				return err
+			}
+		}
+	}
+	return aMW.ErrWaitTimeout
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Tears down all VPC related resources, pretty much in the reverse order that it was created.

**Which issue(s) this PR fixes** 
Supports #39, #41, #43, #56, #59, #61, #60, #62

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

For resources that take some time to delete, like NAT gateways, was originally going
to return a retryable error for the actuator to requeue. Unfortunately, the re queuing behaviour is not tunable, and is based on constant retries within a short interval up to a maximum of 10.

This PR therefore implements a waiter based on that within API Machinery, but with an
additional helper to handle errors given by the AWS SDK.

This also provides a better UX for end-users as errors are really about something going
wrong rather than dealing with eventual consistency.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```