### PR TITLE
Add security groups to new instances

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1051,6 +1051,7 @@
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ec2",
     "github.com/aws/aws-sdk-go/service/ec2/ec2iface",
+    "github.com/aws/aws-sdk-go/service/elb",
     "github.com/aws/aws-sdk-go/service/elb/elbiface",
     "github.com/golang/glog",
     "github.com/golang/mock/gomock",

--- a/cloud/aws/actuators/machine/actuator.go
+++ b/cloud/aws/actuators/machine/actuator.go
@@ -96,7 +96,12 @@ func (a *Actuator) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 
 	status.InstanceID = &i.ID
 	status.InstanceState = aws.String(string(i.State))
-	// TODO: Set the machine.Status.NodeRef after the node has initialized
+
+	if machine.Annotations == nil {
+		machine.Annotations = map[string]string{}
+	}
+	machine.Annotations["cluster-api-provider-aws"] = "true"
+
 	return a.updateStatus(machine, status)
 }
 
@@ -151,12 +156,7 @@ func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 		return errors.Wrap(err, "failed to get machine status")
 	}
 
-	err = a.updateStatus(machine, status)
-	if err != nil {
-		return errors.Wrap(err, "failed to update machine status")
-	}
-
-	return nil
+	return a.updateStatus(machine, status)
 }
 
 // Exists test for the existence of a machine and is invoked by the Machine Controller

--- a/cloud/aws/providerconfig/v1alpha1/types.go
+++ b/cloud/aws/providerconfig/v1alpha1/types.go
@@ -355,4 +355,10 @@ type Instance struct {
 
 	// Indicates whether the instance is optimized for Amazon EBS I/O.
 	EBSOptimized *bool `json:"ebsOptimized"`
+
+	// UserData defines the Base64-encoded user data to make available to the instance.
+	UserData *string
+
+	// SecurityGroupIDs are one or more security group IDs this instance belongs to.
+	SecurityGroupIDs []*string
 }


### PR DESCRIPTION
* Fetch the IP with the deployer (needs fixing)
* Apply a startup script to control plane nodes

Signed-off-by: Chuck Ha <chuck@heptio.com>


**What this PR does / why we need it**:
This PR adds security groups to newly created nodes

It adds annotations to newly created nodes so clusterctl is happy. I expect these to change.

The deployer gets the IP of the node being created. This will also change 100% especially as we move into private subnet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to  #31

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```