### PR TITLE
Adds utilities to speed up dev process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,10 @@ vendor
 *.swp
 
 # envfile
+.env
 envfile
 minikube.kubeconfig
+
+# binaries
+cmd/cluster-controller/cluster-controller
+cmd/machine-controller/machine-controller

--- a/cmd/cluster-controller/Dockerfile.minikube
+++ b/cmd/cluster-controller/Dockerfile.minikube
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
-set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
-cd "${REPO_ROOT}" && make vendor
-go build  "${REPO_ROOT}"/...
+
+# Final container
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates openssh-server && rm -rf /var/lib/apt/lists/*
+
+# We don't care about reproducability whilst developing, so copy our local binary
+COPY cluster-controller .

--- a/cmd/cluster-controller/Makefile
+++ b/cmd/cluster-controller/Makefile
@@ -57,3 +57,6 @@ dev_image:
 
 dev_push: dev_image
 	docker push "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)"
+
+minikube_build:
+	eval $$(minikube docker-env) && docker build -t "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)" -f ./Dockerfile.minikube .

--- a/cmd/machine-controller/Dockerfile.minikube
+++ b/cmd/machine-controller/Dockerfile.minikube
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
-set -o pipefail
+# Final container
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates openssh-server && rm -rf /var/lib/apt/lists/*
 
-REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
-cd "${REPO_ROOT}" && make vendor
-go build  "${REPO_ROOT}"/...
+# We don't care about reproducability whilst developing, so copy our local binary
+COPY machine-controller .

--- a/cmd/machine-controller/Makefile
+++ b/cmd/machine-controller/Makefile
@@ -57,3 +57,6 @@ dev_image:
 
 dev_push: dev_image
 	docker push "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)"
+
+minikube_build:
+	eval $$(minikube docker-env) && docker build -t "$(DEV_PREFIX)/$(NAME):$(DEV_TAG)" -f ./Dockerfile.minikube .

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,6 +12,8 @@
     - [Using images on Google Cloud](#using-images-on-google-cloud)
   - [Using AWS Elastic Container Registry](#using-aws-elastic-container-registry)
     - [Using images on Elastic Container Registry](#using-images-on-elastic-container-registry)
+    - [Using Minikube only](#using-minikube-only)
+- [cluster-api-dev-helper](#cluster-api-dev-helper)
 
 <!-- /TOC -->
 
@@ -84,6 +86,27 @@ Then generate the [example configuration](getting-started.md#generating-cluster-
 
 You will also need to configure minikube or your bootstrap cluster with credentials to access ECR, using [image pull secrets][image_pull_secrets]
 or another mechanism.
+
+#### Using Minikube only
+
+You can also build and test using only the local storage on the minikube VM,
+using:
+
+``` bash
+make minikube_build FASTBUILD=true
+```
+
+## cluster-api-dev-helper
+
+Some command development tasks have been put into a cluster-api-dev-helper
+utility in the /hack directory.
+
+To install it, run:
+
+``` bash
+make cluster-api-dev-helper-bin FASTBUILD=true
+```
+
 
 <!-- References -->
 

--- a/hack/cluster-api-dev-helper/cmd/exec.go
+++ b/hack/cluster-api-dev-helper/cmd/exec.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"log"
+	"os"
+	"os/exec"
+)
+
+func runShellWithWait(cmd string) {
+	runCommandWithWait("sh", "-c", cmd)
+}
+
+func runCommandWithWait(cmd string, args ...string) bool {
+	command := runCommand(cmd, args...)
+	if err := command.Wait(); err != nil {
+		log.Println(err)
+	}
+	return command.ProcessState.Success()
+}
+
+func runShell(cmd string) *exec.Cmd {
+	return runCommand("sh", "-c", cmd)
+}
+
+func runCommand(cmd string, args ...string) *exec.Cmd {
+	command := exec.Command(cmd, args...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Start(); err != nil {
+		log.Println(err)
+	}
+	return command
+}

--- a/hack/cluster-api-dev-helper/cmd/minikube.go
+++ b/hack/cluster-api-dev-helper/cmd/minikube.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func defineMinikubeCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "minikube",
+		Short: "minikube helper commands",
+		Long:  `minikube helper commands`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(cmd.Help())
+		},
+	}
+
+	defineMinikubeFixLibVirtNetworkCmd(newCmd)
+	defineMinikubeClean(newCmd)
+	defineMinikubeKVMDestroy(newCmd)
+	defineMinikubeSetup(newCmd)
+	defineMinikubeReset(newCmd)
+
+	parent.AddCommand(newCmd)
+}
+
+func defineMinikubeFixLibVirtNetworkCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "fix-libvirt-network",
+		Short: "Make the KVM minikube network permanent using LibVirt",
+		Long:  `Make the KVM minikube network permanent using LibVirt. Requires virsh`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runCommandWithWait("virsh", "-c", "qemu:///system", "net-autostart", "minikube-net")
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineMinikubeClean(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Clean up .minikube directory",
+		Long:  `Clean up .minikube directory, deleting machines`,
+		Run: func(cmd *cobra.Command, args []string) {
+			minikubeClean()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineMinikubeKVMDestroy(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "kvm-destroy",
+		Short: "Destroy the KVM VM backing minikube",
+		Long:  `Destroy the KVM VM backing minikube`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runCommandWithWait("virsh", "-c", "qemu:///system", "destroy", "minikube")
+			runCommandWithWait("virsh", "-c", "qemu:///system", "undefine", "--remove-all-storage", "--delete-snapshots", "minikube")
+			runCommandWithWait("virsh", "-c", "qemu:///system", "net-undefine", "minikube-net")
+			minikubeClean()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineMinikubeSetup(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Set up minikube for use with Cluster API",
+		Long:  `Set up minikube for use with Cluster API`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runCommandWithWait("minikube", "config", "set", "bootstrapper", "kubeadm")
+			runCommandWithWait("minikube", "config", "set", "kubernetes-version", "v1.9.4")
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineMinikubeReset(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Remove Cluster API specific minikube configuration",
+		Long:  `Remove Cluster API specific minikube configuration`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runCommandWithWait("minikube", "config", "unset", "kubernetes-version")
+			runCommandWithWait("minikube", "config", "unset", "bootstrapper")
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func minikubeClean() {
+	runCommandWithWait("sh", "-c", "rm -rf $HOME/.minikube/machines")
+	runCommandWithWait("sh", "-c", "rm -rf $HOME/.minikube/profiles")
+	runCommandWithWait("sh", "-c", "rm -rf $HOME/.minikube/certs")
+	runCommandWithWait("sh", "-c", "rm -rf $HOME/.minikube/*.pem")
+}

--- a/hack/cluster-api-dev-helper/cmd/root.go
+++ b/hack/cluster-api-dev-helper/cmd/root.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func defineRootCmd() {
+	rootCmd := &cobra.Command{
+		Use:   "cluster-api-dev-helper",
+		Short: "Cluster API Development Helpers",
+		Long:  `A lot of hacks to help with developing Cluster API`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(cmd.Help())
+		},
+	}
+
+	defineTestingCmd(rootCmd)
+	defineMinikubeCmd(rootCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// Execute bootstraps Cobra
+func Execute() {
+	defineRootCmd()
+}

--- a/hack/cluster-api-dev-helper/cmd/testing.go
+++ b/hack/cluster-api-dev-helper/cmd/testing.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func defineTestingCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "testing",
+		Short: "Test Cluster API",
+		Long:  `Commands to help test Cluster API`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(cmd.Help())
+		},
+	}
+
+	defineTestingStartCmd(newCmd)
+	defineTestingLogsCmd(newCmd)
+	defineTestingDestroyAllCmd(newCmd)
+	defineTestingDeleteClustersCmd(newCmd)
+	defineTestingDestroyClustersCmd(newCmd)
+	defineTestingDeleteMachinesCmd(newCmd)
+	defineTestingDestroyMachinesCmd(newCmd)
+	defineTestingClusterLogs(newCmd)
+	defineTestingMachineLogs(newCmd)
+
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingStartCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "start-with-existing-context",
+		Short: "Start tests with an existing kubeconfig context",
+		Long:  `Start tests with an existing kubeconfig context. Expects to be run in the repository using Go 1.11`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var wg sync.WaitGroup
+			a := runShell(`go run ./clusterctl create cluster -v2  \
+				-m ./clusterctl/examples/aws/out/machines.yaml \
+				-c ./clusterctl/examples/aws/out/cluster.yaml \
+				-p ./clusterctl/examples/aws/out/provider-components.yaml \
+				--provider aws \
+				--existing-bootstrap-cluster-kubeconfig ~/.kube/config`)
+			wg.Add(2)
+			go clusterLogs(&wg)
+			go machineLogs(&wg)
+			a.Wait()
+		},
+	}
+
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingLogsCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "controller-logs",
+		Short: "Start tailing controller logs",
+		Long:  `Start tailing controller logs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go clusterLogs(&wg)
+			go machineLogs(&wg)
+			wg.Wait()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingDestroyAllCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "destroy-all",
+		Short: "Destroys Cluster API without finalizers",
+		Long:  `Destroys Cluster API without finalizers`,
+		Run: func(cmd *cobra.Command, args []string) {
+			destroyMachines()
+			destroyClusters()
+			destroyControlPlane()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingDeleteClustersCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "delete-clusters",
+		Short: "Delete all clusters and tail logs",
+		Long:  `Delete all clusters and tail logs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go clusterLogs(&wg)
+			runShell("kubectl delete clusters --all --wait=true")
+			wg.Wait()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingDestroyClustersCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "destroy-clusters",
+		Short: "Forcefully destroy clusters",
+		Long:  `Forcefully destroy clusters`,
+		Run: func(cmd *cobra.Command, args []string) {
+			destroyClusters()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingDeleteMachinesCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "delete-machines",
+		Short: "Delete all machines and tail logs",
+		Long:  `Delete all machines and tail logs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go machineLogs(&wg)
+			runShell("kubectl delete machines --all --wait=true")
+			wg.Wait()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingDestroyMachinesCmd(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "destroy-machines",
+		Short: "Forcefully destroy machines",
+		Long:  `Forcefully destroy machines`,
+		Run: func(cmd *cobra.Command, args []string) {
+			destroyMachines()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingClusterLogs(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "cluster-controller-logs",
+		Short: "Tail cluster controller logs",
+		Long:  `Tail cluster controller logs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go clusterLogs(&wg)
+			wg.Wait()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func defineTestingMachineLogs(parent *cobra.Command) {
+	newCmd := &cobra.Command{
+		Use:   "machine-controller-logs",
+		Short: "Tail cluster controller logs",
+		Long:  `Tail cluster controller logs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go machineLogs(&wg)
+			wg.Wait()
+		},
+	}
+	parent.AddCommand(newCmd)
+}
+
+func destroyMachines() {
+	runShellWithWait("kubectl get machine -o name | xargs kubectl patch -p '{\"metadata\":{\"finalizers\":null}}'")
+	runShellWithWait("kubectl delete machines --force=true --grace-period 0 --all --wait=true")
+}
+
+func destroyClusters() {
+	runShellWithWait("kubectl patch cluster test1 -p '{\"metadata\":{\"finalizers\":null}}'")
+	runShellWithWait("kubectl delete clusters --force=true --grace-period 0 --all --wait=true")
+}
+
+func destroyControlPlane() {
+	runShellWithWait("kubectl delete deployment clusterapi-apiserver --force=true --grace-period 0 --wait=true")
+	runShellWithWait("kubectl delete deployment clusterapi-controllers --force=true --grace-period 0 --wait=true")
+	runShellWithWait("kubectl delete statefulsets etcd-clusterapi --force=true --grace-period 0 --wait=true")
+}
+
+func clusterLogs(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		b := runShell("kubectl get po -o name | grep clusterapi-controllers | xargs kubectl logs -c aws-cluster-controller -f")
+		b.Wait()
+		time.Sleep(5 * 1000 * 1000 * 1000)
+	}
+}
+
+func machineLogs(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		c := runShell("kubectl get po -o name | grep clusterapi-controllers | xargs kubectl logs -c aws-machine-controller -f")
+		c.Wait()
+		time.Sleep(5 * 1000 * 1000 * 1000)
+	}
+}

--- a/hack/cluster-api-dev-helper/main.go
+++ b/hack/cluster-api-dev-helper/main.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is a load of hacks, and should eventually be deleted.
+
+package main
+
+import (
+	"sigs.k8s.io/cluster-api-provider-aws/hack/cluster-api-dev-helper/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

cluster-api-dev-helper encodes a few common development tasks
such as stand up and teardown within minikube, tailing logs etc...

minikube_build adds a faster development experience by utilising
the Docker endpoint in Minikube so images do not need to be pushed
to an external repository.

Signed-off-by: Naadir Jeewa <naadir@randomvariable.co.uk>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Some of this will be superseded by #136 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```