### PR TITLE
services/ec2/instances: Add some more glogging to methods

### DIFF
--- a/cloud/aws/services/ec2/instances.go
+++ b/cloud/aws/services/ec2/instances.go
@@ -31,6 +31,7 @@ import (
 // InstanceIfExists returns the existing instance or nothing if it doesn't exist.
 func (s *Service) InstanceIfExists(instanceID *string) (*v1alpha1.Instance, error) {
 	glog.V(2).Infof("Looking for instance %q", *instanceID)
+
 	input := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{instanceID},
 	}
@@ -52,6 +53,7 @@ func (s *Service) InstanceIfExists(instanceID *string) (*v1alpha1.Instance, erro
 
 // CreateInstance runs an ec2 instance.
 func (s *Service) CreateInstance(machine *clusterv1.Machine, config *v1alpha1.AWSMachineProviderConfig, clusterStatus *v1alpha1.AWSClusterProviderStatus) (*v1alpha1.Instance, error) {
+	glog.V(2).Info("Attempting to create an instance")
 
 	input := &v1alpha1.Instance{
 		Type:       config.InstanceType,
@@ -106,6 +108,8 @@ func (s *Service) CreateInstance(machine *clusterv1.Machine, config *v1alpha1.AW
 // TerminateInstance terminates an EC2 instance.
 // Returns nil on success, error in all other cases.
 func (s *Service) TerminateInstance(instanceID *string) error {
+	glog.V(2).Infof("Attempting to terminate instance %q", *instanceID)
+
 	input := &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{
 			instanceID,
@@ -122,6 +126,8 @@ func (s *Service) TerminateInstance(instanceID *string) error {
 
 // CreateOrGetMachine will either return an existing instance or create and return an instance.
 func (s *Service) CreateOrGetMachine(machine *clusterv1.Machine, status *v1alpha1.AWSMachineProviderStatus, config *v1alpha1.AWSMachineProviderConfig, clusterStatus *v1alpha1.AWSClusterProviderStatus) (*v1alpha1.Instance, error) {
+	glog.V(2).Info("Attempting to create or get machine")
+
 	// instance id exists, try to get it
 	if status.InstanceID != nil {
 		glog.V(2).Infof("Looking up instance %q", *status.InstanceID)
@@ -141,6 +147,7 @@ func (s *Service) CreateOrGetMachine(machine *clusterv1.Machine, status *v1alpha
 	}
 
 	// otherwise let's create it
+	glog.V(2).Info("Instance did not exist, attempting to creating it")
 	return s.CreateInstance(machine, config, clusterStatus)
 }
 
@@ -197,6 +204,8 @@ func (s *Service) runInstance(i *v1alpha1.Instance) (*v1alpha1.Instance, error) 
 // UpdateInstanceSecurityGroups modifies the security groups of the given
 // EC2 instance.
 func (s *Service) UpdateInstanceSecurityGroups(instanceID *string, securityGroups []*string) error {
+	glog.V(2).Infof("Attempting to update security groups on instance %q", *instanceID)
+
 	input := &ec2.ModifyInstanceAttributeInput{
 		InstanceId: instanceID,
 		Groups:     securityGroups,
@@ -215,8 +224,12 @@ func (s *Service) UpdateInstanceSecurityGroups(instanceID *string, securityGroup
 // We may not always have to perform each action, so we check what we're
 // receiving to avoid calling AWS if we don't need to.
 func (s *Service) UpdateResourceTags(resourceID *string, create map[string]string, remove map[string]string) error {
+	glog.V(2).Infof("Attempting to update tags on resource %q", *resourceID)
+
 	// If we have anything to create or update
 	if len(create) > 0 {
+		glog.V(2).Infof("Attempting to create tags on resource %q", *resourceID)
+
 		// Convert our create map into an array of *ec2.Tag
 		createTagsInput := mapToTags(create)
 
@@ -235,6 +248,8 @@ func (s *Service) UpdateResourceTags(resourceID *string, create map[string]strin
 
 	// If we have anything to remove
 	if len(remove) > 0 {
+		glog.V(2).Infof("Attempting to delete tags on resource %q", *resourceID)
+
 		// Convert our remove map into an array of *ec2.Tag
 		removeTagsInput := mapToTags(remove)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Adds more `glog` calls to the `services/ec2/instances` methods, improving debugability as we can more easily see where calls originated during errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #173 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```