### PR TITLE
[clusterawsadm] Do not return error if stack update successful

### DIFF
--- a/cloud/aws/services/awserrors/errors.go
+++ b/cloud/aws/services/awserrors/errors.go
@@ -24,3 +24,11 @@ func Code(err error) (string, bool) {
 	}
 	return "", false
 }
+
+// Message returns the AWS error message as a string
+func Message(err error) string {
+	if awserr, ok := err.(awserr.Error); ok {
+		return awserr.Message()
+	}
+	return ""
+}


### PR DESCRIPTION
Currently clusterawsadm returns an error if the stack already exists even if the update is successful, this change will only return an error if the update fails.

/assign @randomvariable 
/assign @vincepri 