### PR TITLE
Use interfaces in machine actuator

### DIFF
--- a/cloud/aws/actuators/machine/security_groups.go
+++ b/cloud/aws/actuators/machine/security_groups.go
@@ -16,6 +16,7 @@ package machine
 // should not need to import the ec2 sdk here
 import (
 	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
+	service "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/services"
 
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -32,7 +33,7 @@ const (
 // Returns bool, error
 // Bool indicates if changes were made or not, allowing the caller to decide
 // if the machine should be updated.
-func (a *Actuator) ensureSecurityGroups(machine *clusterv1.Machine, instanceID *string, additionalSecurityGroups []v1alpha1.AWSResourceReference, instanceSecurityGroups map[string]string) (bool, error) {
+func (a *Actuator) ensureSecurityGroups(ec2svc service.EC2MachineInterface, machine *clusterv1.Machine, instanceID *string, additionalSecurityGroups []v1alpha1.AWSResourceReference, instanceSecurityGroups map[string]string) (bool, error) {
 	// Get the SecurityGroup annotations
 	annotation, err := a.machineAnnotationJSON(machine, SecurityGroupsLastAppliedAnnotation)
 	if err != nil {
@@ -48,7 +49,7 @@ func (a *Actuator) ensureSecurityGroups(machine *clusterv1.Machine, instanceID *
 	)
 	if changed {
 		// Finally, update the instance with our new security groups.
-		err := a.ec2.UpdateInstanceSecurityGroups(instanceID, groupIDs)
+		err := ec2svc.UpdateInstanceSecurityGroups(instanceID, groupIDs)
 		if err != nil {
 			return false, err
 		}

--- a/cloud/aws/controllers/machine/controller.go
+++ b/cloud/aws/controllers/machine/controller.go
@@ -16,9 +16,6 @@ package machine
 import (
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -40,8 +37,6 @@ import (
 	machineactuator "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/actuators/machine"
 	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/controllers/machine/options"
 	"sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig/v1alpha1"
-	ec2svc "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/services/ec2"
-	elbsvc "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/services/elb"
 )
 
 const (
@@ -65,20 +60,9 @@ func Start(server *options.Server, shutdown <-chan struct{}) {
 		glog.Fatalf("Could not create codec: %v", err)
 	}
 
-	// Requires setting environment variables:
-	// AWS_REGION=us-west-2,
-	// AWS_ACCESS_KEY_ID=
-	// AWS_SECRET_ACCESS_KEY=
-	sess := session.Must(session.NewSession())
-	ec2client := ec2.New(sess)
-	elbclient := elb.New(sess)
-
 	params := machineactuator.ActuatorParams{
 		MachinesGetter: client.ClusterV1alpha1(),
-		EC2Service:     ec2svc.NewService(ec2client),
-		ELBService:     elbsvc.NewService(elbclient),
 		Codec:          codec,
-		//		ClusterClient: client.ClusterV1alpha1().Clusters(corev1.NamespaceDefault),
 	}
 
 	actuator, err := machineactuator.NewActuator(params)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Start the use of interface based services. The code looks a little uglier than before, although I believe this is a good start for a large refactor, where clients/actuators revolve around a single context / cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#144 

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```