### PR TITLE
clusterctl: fatal on empty kubeconfig

### DIFF
--- a/clusterctl/main.go
+++ b/clusterctl/main.go
@@ -26,6 +26,9 @@ import (
 
 func main() {
 	cfg := config.GetConfigOrDie()
+	if cfg == nil {
+		glog.Fatal("unable to get kubeconfig")
+	}
 
 	codec, err := v1alpha1.NewCodec()
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:

`kubernetes-sigs/controller-runtime` uses `NullLogger`, so `log.Error` was being ignored.

https://github.com/kubernetes-sigs/controller-runtime/blob/ddf0390deebe496cb449b1b8540031da9236afa2/pkg/runtime/log/null.go#L27-L28

https://github.com/kubernetes-sigs/controller-runtime/blob/8d93cc75ed7086e85ec7de09332a3bfd8603a959/pkg/client/config/config.go#L91


This PR adds an additional error message, rather than proceeding to panic that's not helpful for debugging.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1059e58]

goroutine 1 [running]:
sigs.k8s.io/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset.NewForConfig(0x0, 0x0, 0x0, 0x217fb6b)
	/Users/leegyuho/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/clientset.go:64 +0x4e
```

After

```
F1011 15:23:36.800569    6129 main.go:30] unable to get kubeconfig
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```