### PR TITLE
Add initial Bazel support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,4 @@
+build --workspace_status_command=./hack/print-workspace-status.sh
+run --workspace_status_command=./hack/print-workspace-status.sh
+
+test --features=race --test_output=errors

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,19 @@ vendor
 .env
 envfile
 minikube.kubeconfig
+
 kubeconfig
 
 # binaries
 cmd/cluster-controller/cluster-controller
 cmd/machine-controller/machine-controller
+
+
+# bazel
+/bazel-bin
+/bazel-cluster-api-provider-aws
+/bazel-genfiles
+/bazel-out
+/bazel-testlogs
+
+

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,9 +17,8 @@ filegroup(
     name = "all-images",
     srcs = [
         "//clusterctl:clusterctl-image",
-        "//cmd/cluster-controller:cluster-controller-image",
         "//cmd/clusterawsadm:clusterawsadm-image",
-        "//cmd/machine-controller:machine-controller-image",
+        "//cmd/manager:manager-image",
     ],
 )
 
@@ -27,8 +26,7 @@ filegroup(
     name = "all-images-dev",
     srcs = [
         "//clusterctl:clusterctl-image-dev",
-        "//cmd/cluster-controller:cluster-controller-image-dev",
         "//cmd/clusterawsadm:clusterawsadm-image-dev",
-        "//cmd/machine-controller:machine-controller-image-dev",
+        "//cmd/manager:manager-image-dev",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix sigs.k8s.io/cluster-api-provider-aws
+# gazelle:build_file_name BUILD,BUILD.bazel
+# gazelle:proto disable_global
+# gazelle:exclude vendor/golang.org/x/tools/go/ssa/interp/testdata
+# gazelle:exclude vendor/golang.org/x/tools/go/internal/gccgoimporter/testdata
+# gazelle:exclude vendor/golang.org/x/tools/go/internal/gcimporter/testdata
+# gazelle:exclude vendor/golang.org/x/tools/go/loader/testdata
+# gazelle:exclude vendor/golang.org/x/tools/cmd/fiximports/testdata
+gazelle(
+    name = "gazelle",
+    command = "fix",
+)
+
+filegroup(
+    name = "all-images",
+    srcs = [
+        "//clusterctl:clusterctl-image",
+        "//cmd/cluster-controller:cluster-controller-image",
+        "//cmd/clusterawsadm:clusterawsadm-image",
+        "//cmd/machine-controller:machine-controller-image",
+    ],
+)
+
+filegroup(
+    name = "all-images-dev",
+    srcs = [
+        "//clusterctl:clusterctl-image-dev",
+        "//cmd/cluster-controller:cluster-controller-image-dev",
+        "//cmd/clusterawsadm:clusterawsadm-image-dev",
+        "//cmd/machine-controller:machine-controller-image-dev",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,59 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "7519e9e1c716ae3c05bd2d984a42c3b02e690c5df728dc0a84b23f90c355c5a1",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.4/rules_go-0.15.4.tar.gz"],
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "c0a5739d12c6d05b6c1ad56f2200cb0b57c5a70e03ebd2f7b87ce88cabf09c7b",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.14.0/bazel-gazelle-0.14.0.tar.gz"],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "29d109605e0d6f9c892584f07275b8c9260803bf0c6fcb7de2623b2bedc910bd",
+    strip_prefix = "rules_docker-0.5.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.5.1.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+container_pull(
+    name = "golang-image",
+    registry = "registry.hub.docker.com",
+    repository = "library/golang",
+    tag = "1.10-alpine",
+)

--- a/build/rules.bzl
+++ b/build/rules.bzl
@@ -1,0 +1,67 @@
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:push.bzl", "container_push")
+load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
+
+def cluster_api_binary(name):
+    go_image(
+        name = name + "-amd64",
+        base = "@golang-image//image",
+        embed = [":go_default_library"],
+        goarch = "amd64",
+        goos = "linux",
+        # goos = select(
+        #   "@io_bazel_rules_go//go/platform:linux": "linux",
+        #   "//conditions:default": fail("only building on Linux supported. Try again with --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 ")
+        # )
+        pure = "on",
+    )
+
+    tags = [
+        "{GIT_COMMIT}",
+        "{GIT_VERSION}",
+        "{BUILD_TIMESTAMP}",
+        "latest",
+    ]
+
+    container_bundle(
+        name = name + "-image",
+        images = {
+            "{registry}/aws-{name}:{tag}".format(
+                registry = "$(STABLE_DOCKER_REPO)",
+                name = name,
+                tag = tag,
+            ): ":{name}-amd64".format(name = name)
+            for tag in tags
+        },
+        stamp = True,
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+    )
+
+    docker_push(
+        name = name + "-push-dev",
+        bundle = ":{name}-image-dev".format(name = name),
+        tags = ["manual"],
+    )
+
+    container_bundle(
+        name = name + "-image-dev",
+        images = {
+            "{registry}/aws-{name}:{tag}".format(
+                registry = "$(dev_registry)/$(dev_repository)",
+                name = name,
+                tag = tag,
+            ): ":{name}-amd64".format(name = name)
+            for tag in tags
+        },
+        stamp = True,
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+    )
+
+    docker_push(
+        name = name + "-push",
+        bundle = ":{name}-image".format(name = name),
+        tags = ["manual"],
+    )

--- a/clusterctl/BUILD
+++ b/clusterctl/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/clusterctl",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/actuators/cluster:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/cmd:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/config:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "clusterctl",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/clusterctl/BUILD
+++ b/clusterctl/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//build:rules.bzl", "cluster_api_binary")
 
 go_library(
     name = "go_default_library",
@@ -21,3 +22,5 @@ go_binary(
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
+
+cluster_api_binary(name = "clusterctl")

--- a/cmd/clusterawsadm/BUILD
+++ b/cmd/clusterawsadm/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm",
+    visibility = ["//visibility:private"],
+    deps = ["//cmd/clusterawsadm/cmd:go_default_library"],
+)
+
+go_binary(
+    name = "clusterawsadm",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/clusterawsadm/BUILD
+++ b/cmd/clusterawsadm/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//build:rules.bzl", "cluster_api_binary")
 
 go_library(
     name = "go_default_library",
@@ -13,3 +14,5 @@ go_binary(
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
+
+cluster_api_binary(name = "clusterawsadm")

--- a/cmd/clusterawsadm/client/BUILD
+++ b/cmd/clusterawsadm/client/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["client.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset:go_default_library",
+    ],
+)

--- a/cmd/clusterawsadm/cmd/BUILD
+++ b/cmd/clusterawsadm/cmd/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["root.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/clusterawsadm/cmd/alpha:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)

--- a/cmd/clusterawsadm/cmd/alpha/BUILD
+++ b/cmd/clusterawsadm/cmd/alpha/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["alpha.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/alpha",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/clusterawsadm/cmd/alpha/bootstrap:go_default_library",
+        "//cmd/clusterawsadm/cmd/alpha/ec2:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)

--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/BUILD
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["bootstrap.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/alpha/bootstrap",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cloud/aws/services/cloudformation:go_default_library",
+        "//pkg/cloud/aws/services/sts:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/cloudformation:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/sts:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)

--- a/cmd/clusterawsadm/cmd/alpha/ec2/BUILD
+++ b/cmd/clusterawsadm/cmd/alpha/ec2/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ec2.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/alpha/ec2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/clusterawsadm/client:go_default_library",
+        "//pkg/cloud/aws/services/ec2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)

--- a/cmd/manager/BUILD
+++ b/cmd/manager/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/manager",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/apis:go_default_library",
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/actuators/cluster:go_default_library",
+        "//pkg/cloud/aws/actuators/machine:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/controller/cluster:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/controller/machine:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/config:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/runtime/log:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "manager",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/manager/BUILD
+++ b/cmd/manager/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//build:rules.bzl", "cluster_api_binary")
 
 go_library(
     name = "go_default_library",
@@ -27,3 +28,5 @@ go_binary(
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
+
+cluster_api_binary(name = "manager")

--- a/hack/cluster-api-dev-helper/BUILD
+++ b/hack/cluster-api-dev-helper/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/hack/cluster-api-dev-helper",
+    visibility = ["//visibility:private"],
+    deps = ["//hack/cluster-api-dev-helper/cmd:go_default_library"],
+)
+
+go_binary(
+    name = "cluster-api-dev-helper",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/hack/cluster-api-dev-helper/cmd/BUILD
+++ b/hack/cluster-api-dev-helper/cmd/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "exec.go",
+        "minikube.go",
+        "root.go",
+        "testing.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/hack/cluster-api-dev-helper/cmd",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/spf13/cobra:go_default_library"],
+)

--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GIT_COMMIT="$(git describe --always --dirty --abbrev=14)"
+
+if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+    GIT_TREE_STATE="clean"
+else
+    GIT_TREE_STATE="dirty"
+fi
+
+# stolen from k8s.io/hack/lib/version.sh
+# Use git describe to find the version based on tags.
+if GIT_VERSION=$(git describe --tags --abbrev=14 2>/dev/null); then
+    # This translates the "git describe" to an actual semver.org
+    # compatible semantic version that looks something like this:
+    #   v1.1.0-alpha.0.6+84c76d1142ea4d
+    #
+    # TODO: We continue calling this "git version" because so many
+    # downstream consumers are expecting it there.
+    DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+    if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\-\2/")
+    elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+        # We have distance to base tag (v1.1.0-1-gCommitHash)
+        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/-\1/")
+    fi
+    if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+        # git describe --dirty only considers changes to existing files, but
+        # that is problematic since new untracked .go files affect the build,
+        # so use our idea of "dirty" from git status instead.
+        GIT_VERSION+="-dirty"
+    fi
+
+
+    # Try to match the "git describe" output to a regex to try to extract
+    # the "major" and "minor" versions and whether this is the exact tagged
+    # version or whether the tree is between two tagged versions.
+    if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+        GIT_MAJOR=${BASH_REMATCH[1]}
+        GIT_MINOR=${BASH_REMATCH[2]}
+    fi
+
+    # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+    if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+        echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+        echo "Please see more details here: https://semver.org"
+        exit 1
+    fi
+fi
+
+
+cat <<EOF
+STABLE_DOCKER_REPO ${DOCKER_REPO_OVERRIDE:-gcr.io/cluster-api}
+GIT_COMMIT ${GIT_COMMIT-}
+GIT_TREE_STATE ${GIT_TREE_STATE-}
+GIT_MAJOR ${GIT_MAJOR-}
+GIT_MINOR ${GIT_MINOR-}
+GIT_VERSION ${GIT_VERSION-}
+EOF

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+cd $KUBE_ROOT
+# bazel run //:gazelle -- update-repos -from_file=Gopkg.lock
+find $KUBE_ROOT/vendor -name 'BUILD' -delete
+bazel run //:gazelle

--- a/pkg/apis/BUILD
+++ b/pkg/apis/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["apis.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/apis",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library"],
+)

--- a/pkg/apis/awsproviderconfig/BUILD
+++ b/pkg/apis/awsproviderconfig/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["group.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/apis/awsproviderconfig/v1alpha1/BUILD
+++ b/pkg/apis/awsproviderconfig/v1alpha1/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "register.go",
+        "types.go",
+        "zz_generated.deepcopy.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/runtime/scheme:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/actuators/cluster/BUILD
+++ b/pkg/cloud/aws/actuators/cluster/BUILD
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "actuator.go",
+        "interfaces.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/cluster",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/services:go_default_library",
+        "//pkg/cloud/aws/services/certificates:go_default_library",
+        "//pkg/cloud/aws/services/ec2:go_default_library",
+        "//pkg/cloud/aws/services/elb:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/controller/error:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["actuator_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/actuators/cluster/mock_clusteriface:go_default_library",
+        "//pkg/cloud/aws/services:go_default_library",
+        "//pkg/cloud/aws/services/mocks:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/actuators/cluster/mock_clusteriface/BUILD
+++ b/pkg/cloud/aws/actuators/cluster/mock_clusteriface/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/cluster/mock_clusteriface",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/actuators/machine/BUILD
+++ b/pkg/cloud/aws/actuators/machine/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "actuator.go",
+        "security_groups.go",
+        "tags.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/services:go_default_library",
+        "//pkg/cloud/aws/services/ec2:go_default_library",
+        "//pkg/cloud/aws/services/elb:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/controller/error:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/actuators/machine/mock_machineiface/BUILD
+++ b/pkg/cloud/aws/actuators/machine/mock_machineiface/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/mock_machineiface",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/BUILD
+++ b/pkg/cloud/aws/services/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["interfaces.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/awserrors/BUILD
+++ b/pkg/cloud/aws/services/awserrors/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["errors.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/awserrors",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library"],
+)

--- a/pkg/cloud/aws/services/certificates/BUILD
+++ b/pkg/cloud/aws/services/certificates/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["certificates.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/certificates",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/cloudformation/BUILD
+++ b/pkg/cloud/aws/services/cloudformation/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "bootstrap.go",
+        "cloudformation.go",
+        "service.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/cloudformation",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cloud/aws/services/awserrors:go_default_library",
+        "//pkg/cloud/aws/services/iam:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/cloudformation:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface:go_default_library",
+        "//vendor/github.com/awslabs/goformation/cloudformation:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/ec2/BUILD
+++ b/pkg/cloud/aws/services/ec2/BUILD
@@ -1,0 +1,61 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "account.go",
+        "ami.go",
+        "bastion.go",
+        "console.go",
+        "eips.go",
+        "errors.go",
+        "filters.go",
+        "gateways.go",
+        "instances.go",
+        "natgateways.go",
+        "network.go",
+        "routetables.go",
+        "securitygroups.go",
+        "service.go",
+        "subnets.go",
+        "tags.go",
+        "vpc.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/ec2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/services/awserrors:go_default_library",
+        "//pkg/cloud/aws/services/wait:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2/ec2iface:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "gateways_test.go",
+        "instances_test.go",
+        "natgateways_test.go",
+        "routetables_test.go",
+        "subnets_test.go",
+        "vpc_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/services/ec2/mock_ec2iface:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/ec2/mock_ec2iface/BUILD
+++ b/pkg/cloud/aws/services/ec2/mock_ec2iface/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/ec2/mock_ec2iface",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/request:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/elb/BUILD
+++ b/pkg/cloud/aws/services/elb/BUILD
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "errors.go",
+        "loadbalancer.go",
+        "service.go",
+        "tags.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/elb",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/services/awserrors:go_default_library",
+        "//pkg/cloud/aws/services/wait:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elb/elbiface:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["service_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/cloud/aws/services/elb/mock_elbiface:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/elb/mock_elbiface/BUILD
+++ b/pkg/cloud/aws/services/elb/mock_elbiface/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/elb/mock_elbiface",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/request:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/iam/BUILD
+++ b/pkg/cloud/aws/services/iam/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["types.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/iam",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/cloud/aws/services/mocks/BUILD
+++ b/pkg/cloud/aws/services/mocks/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "ec2.go",
+        "elb.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/mocks",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/awsproviderconfig/v1alpha1:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/sts/BUILD
+++ b/pkg/cloud/aws/services/sts/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "identity.go",
+        "service.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/sts",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/sts:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/sts/stsiface:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+    ],
+)

--- a/pkg/cloud/aws/services/wait/BUILD
+++ b/pkg/cloud/aws/services/wait/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["wait.go"],
+    importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/wait",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cloud/aws/services/awserrors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+    ],
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

We're looking to build cluster-api-provider-aws with Bazel. This pull request adds the first pass of support for that.

**Special notes for your reviewer**:

What works right now:

* tests:
```shell
bazel test //pkg/... //cmd/...
```
* building and pushing docker images
```
bazel run --define=dev_repository=liz-heptio --define=dev_registry=gcr.io  //clusterctl:clusterctl-push-dev
```
* updating the BUILD files
```
bazel run //:gazelle
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```