### PR TITLE
clusterctl: remove unused "NewActuator" call

### DIFF
--- a/clusterctl/main.go
+++ b/clusterctl/main.go
@@ -45,7 +45,6 @@ func main() {
 		ClustersGetter: cs.ClusterV1alpha1(),
 	})
 
-	cluster.NewActuator(cluster.ActuatorParams{})
 	common.RegisterClusterProvisioner("aws", clusterActuator)
 	cmd.Execute()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Previous line already calls `clusterActuator, _ := cluster.NewActuator(cluster.ActuatorParams{`. 
Remove `NewActuator` call that was never used.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```