### PR TITLE
clusterctl: Remove grabbing kubeconfig on start

### DIFF
--- a/clusterctl/main.go
+++ b/clusterctl/main.go
@@ -14,36 +14,13 @@
 package main
 
 import (
-	"github.com/golang/glog"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
-	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
-
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/cluster"
 )
 
 func main() {
-	cfg := config.GetConfigOrDie()
-	if cfg == nil {
-		glog.Fatal("unable to get kubeconfig")
-	}
-
-	codec, err := v1alpha1.NewCodec()
-	if err != nil {
-		glog.Fatal(err)
-	}
-
-	cs, err := clientset.NewForConfig(cfg)
-	if err != nil {
-		glog.Fatal(err)
-	}
-
-	clusterActuator, _ := cluster.NewActuator(cluster.ActuatorParams{
-		Codec:          codec,
-		ClustersGetter: cs.ClusterV1alpha1(),
-	})
+	clusterActuator, _ := cluster.NewActuator(cluster.ActuatorParams{})
 
 	common.RegisterClusterProvisioner("aws", clusterActuator)
 	cmd.Execute()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

clusterctl attempts to get a kube-client on startup instead of using a parameter.

We don't need a kube-client to get the cluster actuator going in the context of the CLI 
steps.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #247

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```