### PR TITLE
Return a VPC only if it's available or pending

### DIFF
--- a/pkg/cloud/aws/services/ec2/bastion.go
+++ b/pkg/cloud/aws/services/ec2/bastion.go
@@ -57,6 +57,7 @@ func (s *Service) ReconcileBastion(clusterName, keyName string, status *v1alpha1
 	if keyName == "" {
 		keyName = defaultSSHKeyName
 	}
+
 	spec := s.getDefaultBastion(clusterName, status.Region, status.Network, keyName)
 
 	// Describe bastion instance, if any.

--- a/pkg/cloud/aws/services/ec2/filters.go
+++ b/pkg/cloud/aws/services/ec2/filters.go
@@ -95,6 +95,13 @@ func (s *Service) filterInstanceStates(states ...string) *ec2.Filter {
 	}
 }
 
+func (s *Service) filterVPCStates(states ...string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String("state"),
+		Values: aws.StringSlice(states),
+	}
+}
+
 // Add additional cluster tag filters, to match on our tags
 func (s *Service) addFilterTags(clusterName string, filters []*ec2.Filter) []*ec2.Filter {
 	filters = append(filters, s.filterCluster(clusterName))

--- a/pkg/cloud/aws/services/ec2/vpc_test.go
+++ b/pkg/cloud/aws/services/ec2/vpc_test.go
@@ -44,10 +44,17 @@ func TestReconcileVPC(t *testing.T) {
 						VpcIds: []*string{
 							aws.String("vpc-exists"),
 						},
+						Filters: []*ec2.Filter{
+							{
+								Name:   aws.String("state"),
+								Values: aws.StringSlice([]string{ec2.VpcStatePending, ec2.VpcStateAvailable}),
+							},
+						},
 					})).
 					Return(&ec2.DescribeVpcsOutput{
 						Vpcs: []*ec2.Vpc{
 							{
+								State:     aws.String("available"),
 								VpcId:     aws.String("vpc-exists"),
 								CidrBlock: aws.String("10.0.0.0/8"),
 							},
@@ -65,6 +72,12 @@ func TestReconcileVPC(t *testing.T) {
 						VpcIds: []*string{
 							aws.String("vpc-new"),
 						},
+						Filters: []*ec2.Filter{
+							{
+								Name:   aws.String("state"),
+								Values: aws.StringSlice([]string{ec2.VpcStatePending, ec2.VpcStateAvailable}),
+							},
+						},
 					})).
 					Return(&ec2.DescribeVpcsOutput{}, nil)
 
@@ -72,6 +85,7 @@ func TestReconcileVPC(t *testing.T) {
 					CreateVpc(gomock.AssignableToTypeOf(&ec2.CreateVpcInput{})).
 					Return(&ec2.CreateVpcOutput{
 						Vpc: &ec2.Vpc{
+							State:     aws.String("available"),
 							VpcId:     aws.String("vpc-new"),
 							CidrBlock: aws.String("10.1.0.0/16"),
 						},


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This should fix the reconcile in case the VPC doesn't exist anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```