### PR TITLE
Improve NAT logging & filtering

### DIFF
--- a/pkg/cloud/aws/services/ec2/account.go
+++ b/pkg/cloud/aws/services/ec2/account.go
@@ -14,6 +14,8 @@
 package ec2
 
 import (
+	"sort"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 )
@@ -45,5 +47,6 @@ func (s *Service) getAvailableZones() ([]string, error) {
 		zones = append(zones, *zone.ZoneName)
 	}
 
+	sort.Strings(zones)
 	return zones, nil
 }

--- a/pkg/cloud/aws/services/ec2/filters.go
+++ b/pkg/cloud/aws/services/ec2/filters.go
@@ -88,6 +88,13 @@ func (s *Service) filterAvailable() *ec2.Filter {
 	}
 }
 
+func (s *Service) filterNATGatewayStates(states ...string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String("state"),
+		Values: aws.StringSlice(states),
+	}
+}
+
 func (s *Service) filterInstanceStates(states ...string) *ec2.Filter {
 	return &ec2.Filter{
 		Name:   aws.String("instance-state-name"),

--- a/pkg/cloud/aws/services/ec2/natgateways.go
+++ b/pkg/cloud/aws/services/ec2/natgateways.go
@@ -94,7 +94,7 @@ func (s *Service) describeNatGatewaysBySubnet(vpcID string) (map[string]*ec2.Nat
 	describeNatGatewayInput := &ec2.DescribeNatGatewaysInput{
 		Filter: []*ec2.Filter{
 			s.filterVpc(vpcID),
-			s.filterAvailable(),
+			s.filterNATGatewayStates(ec2.NatGatewayStatePending, ec2.NatGatewayStateAvailable),
 		},
 	}
 
@@ -143,7 +143,6 @@ func (s *Service) createNatGateway(clusterName string, subnetID string) (*ec2.Na
 	}
 
 	glog.Infof("NAT gateway %q for subnet ID %q is now available", *out.NatGateway.NatGatewayId, subnetID)
-
 	return out.NatGateway, nil
 }
 
@@ -211,5 +210,5 @@ func (s *Service) getNatGatewayForSubnet(subnets v1alpha1.Subnets, sn *v1alpha1.
 		return gws[0], nil
 	}
 
-	return "", errors.Errorf("no nat gateways are available in availability zone %q for subnet %q", sn.AvailabilityZone, sn.ID)
+	return "", errors.Errorf("no nat gateways available in %q for private subnet %q, current state: %+v", sn.AvailabilityZone, sn.ID, azGateways)
 }

--- a/pkg/cloud/aws/services/ec2/natgateways_test.go
+++ b/pkg/cloud/aws/services/ec2/natgateways_test.go
@@ -100,7 +100,7 @@ func TestReconcileNatGateways(t *testing.T) {
 								},
 								{
 									Name:   aws.String("state"),
-									Values: []*string{aws.String("available")},
+									Values: []*string{aws.String("pending"), aws.String("available")},
 								},
 							},
 						}),
@@ -177,7 +177,7 @@ func TestReconcileNatGateways(t *testing.T) {
 								},
 								{
 									Name:   aws.String("state"),
-									Values: []*string{aws.String("available")},
+									Values: []*string{aws.String("pending"), aws.String("available")},
 								},
 							},
 						}),
@@ -253,7 +253,7 @@ func TestReconcileNatGateways(t *testing.T) {
 								},
 								{
 									Name:   aws.String("state"),
-									Values: []*string{aws.String("available")},
+									Values: []*string{aws.String("pending"), aws.String("available")},
 								},
 							},
 						}),

--- a/pkg/cloud/aws/services/ec2/network.go
+++ b/pkg/cloud/aws/services/ec2/network.go
@@ -70,14 +70,17 @@ func (s *Service) DeleteNetwork(clusterName string, network *v1alpha1.Network) (
 		return err
 	}
 
+	// NAT Gateways.
 	if err := s.deleteNatGateways(clusterName, network.Subnets, &network.VPC); err != nil {
 		return err
 	}
 
+	// EIPs.
 	if err := s.releaseAddresses(clusterName); err != nil {
 		return err
 	}
 
+	// Internet Gateways.
 	if err := s.deleteInternetGateways(clusterName, network); err != nil {
 		return err
 	}

--- a/pkg/cloud/aws/services/ec2/routetables_test.go
+++ b/pkg/cloud/aws/services/ec2/routetables_test.go
@@ -140,7 +140,7 @@ func TestReconcileRouteTables(t *testing.T) {
 					DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 			},
-			err: errors.New(`no nat gateways are available in availability zone "us-east-1a"`),
+			err: errors.New(`no nat gateways available in "us-east-1a"`),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR improves NAT gateway logs and the filtering when describing NAT gateways. Also makes sure to always return a sorted list of AZs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #241

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```