### PR TITLE
cluster-api-dev-helper: Make compatible with CRDs

### DIFF
--- a/hack/cluster-api-dev-helper/cmd/minikube.go
+++ b/hack/cluster-api-dev-helper/cmd/minikube.go
@@ -84,7 +84,7 @@ func defineMinikubeSetup(parent *cobra.Command) {
 		Long:  `Set up minikube for use with Cluster API`,
 		Run: func(cmd *cobra.Command, args []string) {
 			runCommandWithWait("minikube", "config", "set", "bootstrapper", "kubeadm")
-			runCommandWithWait("minikube", "config", "set", "kubernetes-version", "v1.9.4")
+			runCommandWithWait("minikube", "config", "set", "kubernetes-version", "v1.12.1")
 		},
 	}
 	parent.AddCommand(newCmd)

--- a/hack/cluster-api-dev-helper/cmd/testing.go
+++ b/hack/cluster-api-dev-helper/cmd/testing.go
@@ -38,8 +38,6 @@ func defineTestingCmd(parent *cobra.Command) {
 	defineTestingDestroyClustersCmd(newCmd)
 	defineTestingDeleteMachinesCmd(newCmd)
 	defineTestingDestroyMachinesCmd(newCmd)
-	defineTestingClusterLogs(newCmd)
-	defineTestingMachineLogs(newCmd)
 	defineTestingRestartControllerCmd(newCmd)
 	defineTestingApplyControllerManifestsCmd(newCmd)
 
@@ -53,15 +51,14 @@ func defineTestingStartCmd(parent *cobra.Command) {
 		Long:  `Start tests with an existing kubeconfig context. Expects to be run in the repository using Go 1.11`,
 		Run: func(cmd *cobra.Command, args []string) {
 			var wg sync.WaitGroup
-			a := runShell(`go run ./clusterctl create cluster -v2  \
+			a := runShell(`go run ./clusterctl create cluster -v4  \
 				-m ./clusterctl/examples/aws/out/machines.yaml \
 				-c ./clusterctl/examples/aws/out/cluster.yaml \
 				-p ./clusterctl/examples/aws/out/provider-components.yaml \
 				--provider aws \
-				--existing-bootstrap-cluster-kubeconfig ~/.kube/config`)
-			wg.Add(2)
-			go clusterLogs(&wg)
-			go machineLogs(&wg)
+				--existing-bootstrap-cluster-kubeconfig /home/naadir/.kube/config`)
+			wg.Add(1)
+			go controllerLogs(&wg)
 			a.Wait()
 		},
 	}
@@ -76,9 +73,8 @@ func defineTestingLogsCmd(parent *cobra.Command) {
 		Long:  `Start tailing controller logs`,
 		Run: func(cmd *cobra.Command, args []string) {
 			var wg sync.WaitGroup
-			wg.Add(2)
-			go clusterLogs(&wg)
-			go machineLogs(&wg)
+			wg.Add(1)
+			go controllerLogs(&wg)
 			wg.Wait()
 		},
 	}
@@ -107,7 +103,7 @@ func defineTestingDeleteClustersCmd(parent *cobra.Command) {
 		Run: func(cmd *cobra.Command, args []string) {
 			var wg sync.WaitGroup
 			wg.Add(1)
-			go clusterLogs(&wg)
+			go controllerLogs(&wg)
 			runShell("kubectl delete clusters --all --wait=true")
 			wg.Wait()
 		},
@@ -135,7 +131,7 @@ func defineTestingDeleteMachinesCmd(parent *cobra.Command) {
 		Run: func(cmd *cobra.Command, args []string) {
 			var wg sync.WaitGroup
 			wg.Add(1)
-			go machineLogs(&wg)
+			go controllerLogs(&wg)
 			runShell("kubectl delete machines --all --wait=true")
 			wg.Wait()
 		},
@@ -150,36 +146,6 @@ func defineTestingDestroyMachinesCmd(parent *cobra.Command) {
 		Long:  `Forcefully destroy machines`,
 		Run: func(cmd *cobra.Command, args []string) {
 			destroyMachines()
-		},
-	}
-	parent.AddCommand(newCmd)
-}
-
-func defineTestingClusterLogs(parent *cobra.Command) {
-	newCmd := &cobra.Command{
-		Use:   "cluster-controller-logs",
-		Short: "Tail cluster controller logs",
-		Long:  `Tail cluster controller logs`,
-		Run: func(cmd *cobra.Command, args []string) {
-			var wg sync.WaitGroup
-			wg.Add(1)
-			go clusterLogs(&wg)
-			wg.Wait()
-		},
-	}
-	parent.AddCommand(newCmd)
-}
-
-func defineTestingMachineLogs(parent *cobra.Command) {
-	newCmd := &cobra.Command{
-		Use:   "machine-controller-logs",
-		Short: "Tail cluster controller logs",
-		Long:  `Tail cluster controller logs`,
-		Run: func(cmd *cobra.Command, args []string) {
-			var wg sync.WaitGroup
-			wg.Add(1)
-			go machineLogs(&wg)
-			wg.Wait()
 		},
 	}
 	parent.AddCommand(newCmd)
@@ -210,25 +176,24 @@ func defineTestingApplyControllerManifestsCmd(parent *cobra.Command) {
 }
 
 func destroyMachines() {
-	runShellWithWait("kubectl get machine -o name | xargs kubectl patch -p '{\"metadata\":{\"finalizers\":null}}'")
+	runShellWithWait("kubectl get machine -o name | xargs kubectl patch -p '{\"metadata\":{\"finalizers\":null}}' --type=merge")
 	runShellWithWait("kubectl delete machines --force=true --grace-period 0 --all --wait=true")
 }
 
 func destroyClusters() {
-	runShellWithWait("kubectl patch cluster test1 -p '{\"metadata\":{\"finalizers\":null}}'")
+	runShellWithWait("kubectl patch cluster test1 -p '{\"metadata\":{\"finalizers\":null}}' --type=merge")
 	runShellWithWait("kubectl delete clusters --force=true --grace-period 0 --all --wait=true")
 }
 
 func destroyControlPlane() {
-	runShellWithWait("kubectl delete deployment clusterapi-apiserver --force=true --grace-period 0 --wait=true")
 	runShellWithWait("kubectl delete deployment clusterapi-controllers --force=true --grace-period 0 --wait=true")
-	runShellWithWait("kubectl delete statefulsets etcd-clusterapi --force=true --grace-period 0 --wait=true")
+	runShellWithWait("kubectl delete crds --all --force=true --grace-period 0 --wait=true")
 }
 
-func clusterLogs(wg *sync.WaitGroup) {
+func controllerLogs(wg *sync.WaitGroup) {
 	defer wg.Done()
 	for {
-		b := runShell("kubectl get po -o name | grep clusterapi-controllers | xargs kubectl logs -c aws-cluster-controller -f")
+		b := runShell("kubectl get po -o name | grep clusterapi-controllers | xargs kubectl logs -c cluster-api-aws-controller -f")
 		b.Wait()
 		time.Sleep(5 * 1000 * 1000 * 1000)
 	}
@@ -236,13 +201,4 @@ func clusterLogs(wg *sync.WaitGroup) {
 
 func restartControllers() {
 	runShellWithWait("kubectl get po -o name | grep clusterapi-controllers | xargs kubectl delete")
-}
-
-func machineLogs(wg *sync.WaitGroup) {
-	defer wg.Done()
-	for {
-		c := runShell("kubectl get po -o name | grep clusterapi-controllers | xargs kubectl logs -c aws-machine-controller -f")
-		c.Wait()
-		time.Sleep(5 * 1000 * 1000 * 1000)
-	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Converts all the dev hacks to work with our new shiny CRD version


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #247 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```