### PR TITLE
Fix looped package installation deprecation

### DIFF
--- a/images/ansible/roles/common/tasks/debian.yml
+++ b/images/ansible/roles/common/tasks/debian.yml
@@ -30,13 +30,11 @@
 - name: install baseline dependencies
   apt:
     force_apt_get: True
-    name: "{{ item }}"
+    name: "{{ common_debs }}"
     state: latest
-  with_items: "{{ common_debs }}"
 
 - name: install extra debs
   apt:
     force_apt_get: True
-    name: "{{ item }}"
+    name: "{{ common_extra_debs }}"
     state: latest
-  with_items: "{{ common_extra_debs }}"

--- a/images/ansible/roles/common/tasks/redhat.yml
+++ b/images/ansible/roles/common/tasks/redhat.yml
@@ -35,10 +35,8 @@
 
 - name: install baseline dependencies
   yum:
-    name: "{{ item }}"
-  with_items: "{{ common_rpms }}"
+    name: "{{ common_rpms }}"
 
 - name: install extra rpms
   yum:
-    name: "{{ item }}"
-  with_items: "{{ common_extra_rpms }}"
+    name: "{{ common_extra_rpms }}"

--- a/images/ansible/roles/kubernetes/tasks/debian.yml
+++ b/images/ansible/roles/kubernetes/tasks/debian.yml
@@ -25,9 +25,10 @@
 
 - name: install kubernetes packages
   apt:
-    name: "{{ item }}"
-  with_items:
-    - "kubelet={{ kubernetes_version | kube_platform_version('debian') }}"
-    - "kubeadm={{ kubernetes_version | kube_platform_version('debian') }}"
-    - "kubectl={{ kubernetes_version | kube_platform_version('debian') }}"
-    - "kubernetes-cni={{kubernetes_cni_version | kube_platform_version('debian') }}"
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - "kubelet={{ kubernetes_version | kube_platform_version('debian') }}"
+      - "kubeadm={{ kubernetes_version | kube_platform_version('debian') }}"
+      - "kubectl={{ kubernetes_version | kube_platform_version('debian') }}"
+      - "kubernetes-cni={{kubernetes_cni_version | kube_platform_version('debian') }}"

--- a/images/ansible/roles/kubernetes/tasks/redhat.yml
+++ b/images/ansible/roles/kubernetes/tasks/redhat.yml
@@ -22,10 +22,11 @@
 
 - name: install the kubernetes yum packages
   yum:
-    name: "{{ item }}"
+    name: "{{ packages }}"
     allow_downgrade: True
-  with_items:
-    - "kubelet-{{ kubernetes_version | kube_platform_version('redhat') }}"
-    - "kubeadm-{{ kubernetes_version | kube_platform_version('redhat') }}"
-    - "kubectl-{{ kubernetes_version | kube_platform_version('redhat') }}"
-    - "kubernetes-cni-{{kubernetes_cni_version | kube_platform_version('redhat')}}"
+  vars:
+    packages:
+      - "kubelet-{{ kubernetes_version | kube_platform_version('redhat') }}"
+      - "kubeadm-{{ kubernetes_version | kube_platform_version('redhat') }}"
+      - "kubectl-{{ kubernetes_version | kube_platform_version('redhat') }}"
+      - "kubernetes-cni-{{kubernetes_cni_version | kube_platform_version('redhat')}}"

--- a/images/ansible/roles/providers/tasks/aws.yml
+++ b/images/ansible/roles/providers/tasks/aws.yml
@@ -14,7 +14,8 @@
 ---
 - name: install aws clients
   pip:
-    name: "{{ item }}"
-  with_items:
-    - https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-    - awscli
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+      - awscli


### PR DESCRIPTION
**What this PR does / why we need it**:
Installing packages in a loop is deprecated in Ansible 2.7.0 (possibly earlier) and will be removed in v2.11. This is the recommended method going forward.

**Release note**:
```release-note
NONE
```