### PR TITLE
Fix NPE in machine actuator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,11 @@ endif
 
 # Dependency managemnt.
 vendor:
-	dep version || go get -u github.com/golang/dep/cmd/dep
+	${GOPATH}/bin/dep version || go get -u github.com/golang/dep/cmd/dep
 	${GOPATH}/bin/dep ensure
 
 check-install:
 	./scripts/check-install.sh
-
-depend-update:
-	dep version || go get -u github.com/golang/dep/cmd/dep
-	${GOPATH}/bin/dep ensure -update
 
 # Generate code.
 generate: vendor

--- a/cmd/clusterawsadm/client/client.go
+++ b/cmd/clusterawsadm/client/client.go
@@ -57,13 +57,16 @@ func homeDir() string {
 
 func MachineInstanceID(name string) (string, error) {
 	c := NewClient()
+
 	m, err := c.ClusterV1alpha1().Machines("default").Get(name, v1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
-	status, err := providerv1.MachineStatusFromBytes(m.Status.ProviderStatus.Raw)
+
+	status, err := providerv1.MachineStatusFromProviderStatus(m.Status.ProviderStatus)
 	if err != nil {
 		return "", err
 	}
+
 	return *status.InstanceID, nil
 }

--- a/pkg/apis/awsprovider/v1alpha1/register.go
+++ b/pkg/apis/awsprovider/v1alpha1/register.go
@@ -52,11 +52,13 @@ func ClusterStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSClust
 	if extension == nil {
 		return &AWSClusterProviderStatus{}, nil
 	}
-	var status AWSClusterProviderStatus
-	if err := yaml.Unmarshal(extension.Raw, &status); err != nil {
+
+	status := new(AWSClusterProviderStatus)
+	if err := yaml.Unmarshal(extension.Raw, status); err != nil {
 		return nil, err
 	}
-	return &status, nil
+
+	return status, nil
 }
 
 func MachineConfigFromProviderConfig(providerConfig clusterv1.ProviderConfig) (*AWSMachineProviderConfig, error) {
@@ -67,10 +69,15 @@ func MachineConfigFromProviderConfig(providerConfig clusterv1.ProviderConfig) (*
 	return &config, nil
 }
 
-func MachineStatusFromBytes(raw []byte) (*AWSMachineProviderStatus, error) {
-	var status AWSMachineProviderStatus
-	if err := yaml.Unmarshal(raw, &status); err != nil {
+func MachineStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSMachineProviderStatus, error) {
+	if extension == nil {
+		return &AWSMachineProviderStatus{}, nil
+	}
+
+	status := new(AWSMachineProviderStatus)
+	if err := yaml.Unmarshal(extension.Raw, status); err != nil {
 		return nil, err
 	}
-	return &status, nil
+
+	return status, nil
 }

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -17,14 +17,12 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/golang/glog"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // InstanceByTags returns the existing instance or nothing if it doesn't exist.


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes a NPE in the machine actuator caused by the machine state to be empty on bootstrap. It also removes the state update, which is tracked in the follow-up issue #288.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #287 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```