### PR TITLE
Cluster and machine actuator updates status

### DIFF
--- a/pkg/apis/awsprovider/v1alpha1/register.go
+++ b/pkg/apis/awsprovider/v1alpha1/register.go
@@ -97,7 +97,6 @@ func EncodeMachineStatus(status *AWSMachineProviderStatus) (*runtime.RawExtensio
 
 	return &runtime.RawExtension{
 		Raw: rawBytes,
-		//Object: ??,
 	}, nil
 }
 
@@ -115,6 +114,5 @@ func EncodeClusterStatus(status *AWSClusterProviderStatus) (*runtime.RawExtensio
 
 	return &runtime.RawExtension{
 		Raw: rawBytes,
-		//Object: ??,
 	}, nil
 }

--- a/pkg/apis/awsprovider/v1alpha1/register.go
+++ b/pkg/apis/awsprovider/v1alpha1/register.go
@@ -81,3 +81,40 @@ func MachineStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSMachi
 
 	return status, nil
 }
+
+func EncodeMachineStatus(status *AWSMachineProviderStatus) (*runtime.RawExtension, error) {
+	if status == nil {
+		return &runtime.RawExtension{}, nil
+	}
+
+	var rawBytes []byte
+	var err error
+
+	//  TODO: use apimachinery conversion https://godoc.org/k8s.io/apimachinery/pkg/runtime#Convert_runtime_Object_To_runtime_RawExtension
+	if rawBytes, err = yaml.Marshal(status); err != nil {
+		return nil, err
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+		//Object: ??,
+	}, nil
+}
+
+func EncodeClusterStatus(status *AWSClusterProviderStatus) (*runtime.RawExtension, error) {
+	if status == nil {
+		return &runtime.RawExtension{}, nil
+	}
+	var rawBytes []byte
+	var err error
+
+	//  TODO: use apimachinery conversion https://godoc.org/k8s.io/apimachinery/pkg/runtime#Convert_runtime_Object_To_runtime_RawExtension
+	if rawBytes, err = yaml.Marshal(status); err != nil {
+		return nil, err
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+		//Object: ??,
+	}, nil
+}

--- a/pkg/cloud/aws/actuators/cluster/actuator_test.go
+++ b/pkg/cloud/aws/actuators/cluster/actuator_test.go
@@ -146,6 +146,10 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
+	clusters.ci.EXPECT().
+		UpdateStatus(gomock.AssignableToTypeOf(cluster)).
+		Return(cluster, nil)
+
 	services.ec2.EXPECT().
 		ReconcileNetwork("test", gomock.AssignableToTypeOf(&providerv1.Network{})).
 		Return(nil)

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -129,6 +129,10 @@ func (a *Actuator) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 
 	machine.Annotations["cluster-api-provider-aws"] = "true"
 
+	if err := a.storeMachineStatus(machine, status); err != nil {
+		glog.Errorf("failed to store provider status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+	}
+
 	if err := a.reconcileLBAttachment(cluster, machine, i); err != nil {
 		return errors.Wrap(err, "failed to reconcile LB attachment")
 	}
@@ -217,6 +221,10 @@ func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 	status, err := a.machineProviderStatus(machine)
 	if err != nil {
 		return errors.Wrap(err, "failed to get machine status")
+	}
+
+	if err := a.storeMachineStatus(machine, status); err != nil {
+		glog.Errorf("failed to store provider status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
 	}
 
 	clusterConfig, err := a.clusterProviderConfig(cluster)
@@ -316,6 +324,22 @@ func (a *Actuator) updateMachine(machine *clusterv1.Machine) error {
 
 	if _, err := machinesClient.Update(machine); err != nil {
 		return fmt.Errorf("failed to update machine: %v", err)
+	}
+
+	return nil
+}
+
+func (a *Actuator) storeMachineStatus(machine *clusterv1.Machine, status *v1alpha1.AWSMachineProviderStatus) error {
+	machinesClient := a.machinesGetter.Machines(machine.Namespace)
+
+	ext, err := v1alpha1.EncodeMachineStatus(status)
+	if err != nil {
+		return fmt.Errorf("failed to update machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+	}
+
+	machine.Status.ProviderStatus = ext
+	if _, err := machinesClient.UpdateStatus(machine); err != nil {
+		return fmt.Errorf("failed to update machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Currently, updated status for cluster and machine don't get stored so the actuators work is not saved. This PR saves the status for both cluster and machine.

In this PR:
* add methods to encode ClusterProviderStatus and MachineProviderStatus
* add methods to store cluster and machine status
* store cluster and machine status in actuator function
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 288

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```