### PR TITLE
Fix up the getting started guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ clean:
 
 # Manifests.
 cmd/clusterctl/examples/aws/out/:
-	./cmd/clusterctl/examples/aws/generate-yaml.sh
+	MANAGER_IMAGE=${MANAGER_IMAGE} ./cmd/clusterctl/examples/aws/generate-yaml.sh
 
 cmd/clusterctl/examples/aws/out/credentials: cmd/clusterctl/examples/aws/out/ clusterawsadm
 	clusterawsadm alpha bootstrap generate-aws-default-profile > cmd/clusterctl/examples/aws/out/credentials

--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -110,7 +110,9 @@ func createStackCmd() *cobra.Command {
 		Long:  "Create a new AWS CloudFormation stack using the bootstrap template",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			stackName := "cluster-api-provider-aws-sigs-k8s-io"
-			sess, err := session.NewSession()
+			sess, err := session.NewSessionWithOptions(session.Options{
+				SharedConfigState: session.SharedConfigEnable,
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/clusterctl/examples/aws/generate-yaml.sh
+++ b/cmd/clusterctl/examples/aws/generate-yaml.sh
@@ -7,7 +7,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 OUTPUT_DIR=${DIR}/out
 
 # Manager image.
-export MANAGER_IMAGE="${MANAGER_IMAGE:-gcr.io/k8s-cluster-api/aws-cluster-controller:0.0.1}"
+export MANAGER_IMAGE="${MANAGER_IMAGE:-gcr.io/cluster-api-provider-aws/cluster-api-aws-controller:latest}"
 
 # Machine settings.
 export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,8 @@
 - [jq][jq]
 - [PowerShell AWS Tools][aws_powershell]
 - [Go](https://golang.org/dl/)
+- make
+- gettext
 
 ## Prerequisites
 
@@ -201,44 +203,16 @@ $ENV:AWS_SECRET_ACCESS_KEY=$awsCredentials.SecretAccessKey
 
 ## Deploying a cluster
 
-### Starting Minikube
-For security reasons, it's best to start a Minikube instance before using
-clusterctl to store your AWS credentials.
-
-``` shell
-minikube start
-```
-
-Then write the AWS credentials into the Minikube instance for use by Cluster API:
-
-``` shell
-minikube ssh 'mkdir -p .aws'
-clusterawsadm alpha bootstrap generate-aws-default-profile | minikube ssh 'cat > .aws/credentials'
-[default]
-aws_access_key_id = AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-region = eu-west-1
-
-
-^C
-```
-
-**NOTE**:
-> This will print the AWS credentials to the screen and then hang
-> (due to a restriction in Minikube).
-> This is OK, and you can cancel with Ctrl+C, but make sure to do this privately.
-
 ### Generating cluster manifests
 
-The shell script `generate-yaml.sh` can be used to generate the
+There is a make target `manifests` that can be used to generate the
 cluster manifests.
 
 ```bash
-cd ./cmd/clusterctl/examples/aws/
-./generate-yaml.sh
+make manifests
 ```
 
-Then edit `out/cluster.yaml` and `out/machine.yaml` for your SSH key and AWS
+Then edit `cmd/clusterctl/examples/aws/out/cluster.yaml` and `cmd/clusterctl/examples/aws/out/machine.yaml` for AWS
 region and any other customisations you want to make.
 
 ### Starting Cluster API
@@ -252,10 +226,9 @@ You can now start the Cluster API controllers and deploy a new cluster in AWS:
 
 ```bash
 clusterctl create cluster -v2 --provider aws \
-  -m ./out/machines.yaml \
-  -c ./out/cluster.yaml \
-  -p ./out/provider-components.yaml \
-  --existing-bootstrap-cluster-kubeconfig ~/.kube/config
+  -m ./cmd/clusterctl/examples/aws/out/machines.yaml \
+  -c ./cmd/clusterctl/examples/aws/out/cluster.yaml \
+  -p ./cmd/clusterctl/examples/aws/out/provider-components.yaml
 
 I1018 01:21:12.079384   16367 clusterdeployer.go:94] Creating bootstrap cluster
 I1018 01:21:12.106882   16367 clusterdeployer.go:111] Applying Cluster API stack to bootstrap cluster
@@ -272,10 +245,9 @@ I1018 01:21:12.524912   16367 clusterdeployer.go:123] Creating master  in namesp
 
 ```powershell
 clusterctl create cluster -v2 --provider aws `
-  -m ./config/samples/out/machines.yaml `
-  -c ./config/samples/out/cluster.yaml `
-  -p ./config/samples/out/provider-components.yaml `
-  --existing-bootstrap-cluster-kubeconfig ~/.kube/config
+  -m ./cmd/clusterctl/examples/aws/out/machines.yaml `
+  -c ./cmd/clusterctl/examples/aws/out/cluster.yaml `
+  -p ./cmd/clusterctl/examples/aws/out/provider-components.yaml
 
 I1018 01:21:12.079384   16367 clusterdeployer.go:94] Creating bootstrap cluster
 I1018 01:21:12.106882   16367 clusterdeployer.go:111] Applying Cluster API stack to bootstrap cluster

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -323,14 +323,14 @@ func (a *Actuator) storeMachineStatus(machine *clusterv1.Machine, status *v1alph
 
 	ext, err := v1alpha1.EncodeMachineStatus(status)
 	if err != nil {
-		return fmt.Errorf("failed to update machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+		return fmt.Errorf("failed to encode machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
 	}
 
 	machine.Status.ProviderStatus = ext
 
 	if updateResource {
 		if _, err := machinesClient.Update(machine); err != nil {
-			return fmt.Errorf("failed to update machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+			return fmt.Errorf("failed to update machine for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
 		}
 	} else {
 		if _, err := machinesClient.UpdateStatus(machine); err != nil {

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -129,12 +129,12 @@ func (a *Actuator) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 
 	machine.Annotations["cluster-api-provider-aws"] = "true"
 
-	if err := a.storeMachineStatus(machine, status); err != nil {
-		glog.Errorf("failed to store provider status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
-	}
-
 	if err := a.reconcileLBAttachment(cluster, machine, i); err != nil {
 		return errors.Wrap(err, "failed to reconcile LB attachment")
+	}
+
+	if err := a.storeMachineStatus(machine, status, true); err != nil {
+		glog.Errorf("failed to store provider status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
 	}
 
 	return nil
@@ -223,10 +223,6 @@ func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 		return errors.Wrap(err, "failed to get machine status")
 	}
 
-	if err := a.storeMachineStatus(machine, status); err != nil {
-		glog.Errorf("failed to store provider status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
-	}
-
 	clusterConfig, err := a.clusterProviderConfig(cluster)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster provider config")
@@ -263,10 +259,13 @@ func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 		return errors.Wrap(err, "failed to ensure tags")
 	}
 
-	// We need to update the machine since annotations may have changed.
 	if securityGroupsChanged || tagsChanged {
-		if err := a.updateMachine(machine); err != nil {
-			return errors.Wrap(err, "failed to update machine")
+		if err := a.storeMachineStatus(machine, status, true); err != nil {
+			glog.Errorf("failed to store provider status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+		}
+	} else {
+		if err := a.storeMachineStatus(machine, status, false); err != nil {
+			glog.Errorf("failed to store provider status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
 		}
 	}
 
@@ -319,17 +318,7 @@ func (a *Actuator) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 	return true, nil
 }
 
-func (a *Actuator) updateMachine(machine *clusterv1.Machine) error {
-	machinesClient := a.machinesGetter.Machines(machine.Namespace)
-
-	if _, err := machinesClient.Update(machine); err != nil {
-		return fmt.Errorf("failed to update machine: %v", err)
-	}
-
-	return nil
-}
-
-func (a *Actuator) storeMachineStatus(machine *clusterv1.Machine, status *v1alpha1.AWSMachineProviderStatus) error {
+func (a *Actuator) storeMachineStatus(machine *clusterv1.Machine, status *v1alpha1.AWSMachineProviderStatus, updateResource bool) error {
 	machinesClient := a.machinesGetter.Machines(machine.Namespace)
 
 	ext, err := v1alpha1.EncodeMachineStatus(status)
@@ -338,8 +327,15 @@ func (a *Actuator) storeMachineStatus(machine *clusterv1.Machine, status *v1alph
 	}
 
 	machine.Status.ProviderStatus = ext
-	if _, err := machinesClient.UpdateStatus(machine); err != nil {
-		return fmt.Errorf("failed to update machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+
+	if updateResource {
+		if _, err := machinesClient.Update(machine); err != nil {
+			return fmt.Errorf("failed to update machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+		}
+	} else {
+		if _, err := machinesClient.UpdateStatus(machine); err != nil {
+			return fmt.Errorf("failed to update machine status for machine %q in namespace %q: %v", machine.Name, machine.Namespace, err)
+		}
 	}
 
 	return nil

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -278,6 +278,8 @@ func (s *Service) runInstance(i *v1alpha1.Instance) (*v1alpha1.Instance, error) 
 		return nil, errors.Errorf("no instance returned for reservation %v", out.GoString())
 	}
 
+	s.EC2.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{InstanceIds: []*string{out.Instances[0].InstanceId}})
+
 	return fromSDKTypeToInstance(out.Instances[0]), nil
 }
 

--- a/pkg/cloud/aws/services/ec2/instances_test.go
+++ b/pkg/cloud/aws/services/ec2/instances_test.go
@@ -260,6 +260,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.EXPECT().
+					WaitUntilInstanceRunning(gomock.Any()).
+					Return(nil)
 			},
 			check: func(instance *v1alpha1.Instance, err error) {
 				if err != nil {


### PR DESCRIPTION
Fixes: #294 

- [clusterawsadm] enable sharedconfig usage 
- Update getting started guide for current workflow
- Update the default manager image for the `make manifests` target
- additional post-crd fixup to machine actuator