### PR TITLE
Add a make target for generating the binaries for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ kubeconfig
 /bazel-genfiles
 /bazel-out
 /bazel-testlogs
+
+# release builds
+clusterctl-*-amd64
+clusterawsadm-*-amd64

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,13 @@ clusterawsadm: check-install vendor
 cluster-api-dev-helper: check-install vendor
 	CGO_ENABLED=0 go install $(GOFLAGS) sigs.k8s.io/cluster-api-provider-aws/hack/cluster-api-dev-helper
 
+# Build the release binaries
+build-release-binaries: check-install vendor
+	GOOS=linux CGO_ENABLED=0 go build -o clusterctl-linux-amd64 $(GOFLAGS) sigs.k8s.io/cluster-api-provider-aws/cmd/clusterctl
+	GOOS=linux CGO_ENABLED=0 go build -o clusterawsadm-linux-amd64 $(GOFLAGS) sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm
+	GOOS=darwin CGO_ENABLED=0 go build -o clusterctl-darwin-amd64 $(GOFLAGS) sigs.k8s.io/cluster-api-provider-aws/cmd/clusterctl
+	GOOS=darwin CGO_ENABLED=0 go build -o clusterawsadm-darwin-amd64 $(GOFLAGS) sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm
+
 # Run tests
 test: generate fmt vet
 	go test -v -tags=integration ./pkg/... ./cmd/...


### PR DESCRIPTION
Adds a make target for generating the binaries needed for cutting a release of cluster-api-provider-aws.