### PR TITLE
Cleans up clusterctl workflow

### DIFF
--- a/pkg/cloud/aws/actuators/cluster/actuator.go
+++ b/pkg/cloud/aws/actuators/cluster/actuator.go
@@ -164,18 +164,18 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster) error {
 }
 
 // GetIP returns the IP of a machine, but this is going away.
-func (a *Actuator) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
-	if cluster.Status.ProviderStatus == nil {
-		return "", errors.New("ProviderStatus is nil, cannot get IP")
-	}
-	// Load provider status.
-	status, err := providerv1.ClusterStatusFromProviderStatus(cluster.Status.ProviderStatus)
-	if err != nil {
-		return "", errors.Errorf("failed to load cluster provider status: %v", err)
-	}
+func (a *Actuator) GetIP(cluster *clusterv1.Cluster, _ *clusterv1.Machine) (string, error) {
+	if cluster.Status.ProviderStatus != nil {
 
-	if status.Network.APIServerELB.DNSName != "" {
-		return status.Network.APIServerELB.DNSName, nil
+		// Load provider status.
+		status, err := providerv1.ClusterStatusFromProviderStatus(cluster.Status.ProviderStatus)
+		if err != nil {
+			return "", errors.Errorf("failed to load cluster provider status: %v", err)
+		}
+
+		if status.Network.APIServerELB.DNSName != "" {
+			return status.Network.APIServerELB.DNSName, nil
+		}
 	}
 
 	// Load provider config.


### PR DESCRIPTION
Tries to get the cluster IP from several places instead
of failing after the first attempt.

Signed-off-by: Chuck Ha <chuck@heptio.com>

**What this PR does / why we need it**:
This PR lets clusterctl end with exit code 0 as shown here:

```
...
I1025 18:00:24.754193   11903 clusterdeployer.go:175] Done provisioning cluster. You can now access your cluster with kubectl --kubeconfig kubeconfig
I1025 18:00:24.756865   11903 clusterdeployer.go:223] Cleaning up bootstrap cluster.
 salazar:cluster-api-provider-aws cha$ $?
-bash: 0: command not found
```

This PR also refactors the actuator tests into test tables.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #313 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```