### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ clean: ## Remove all generated files
 	rm -f bazel-*
 
 cmd/clusterctl/examples/aws/out/:
-	MANAGER_IMAGE=${IMAGE} ./cmd/clusterctl/examples/aws/generate-yaml.sh
+	./cmd/clusterctl/examples/aws/generate-yaml.sh
 
 cmd/clusterctl/examples/aws/out/credentials: cmd/clusterctl/examples/aws/out/ clusterawsadm ## Generate k8s secret for AWS credentials
 	clusterawsadm alpha bootstrap generate-aws-default-profile > cmd/clusterctl/examples/aws/out/credentials


### PR DESCRIPTION
**What this PR does / why we need it**:
This does not need to override MANAGER_IMAGE because that can
be done when invoking the Makefile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```