### PR TITLE
fix check-install for empty GOPATH

### DIFF
--- a/scripts/check-install.sh
+++ b/scripts/check-install.sh
@@ -19,7 +19,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-WORKINGDIR=$(pwd)
+GOPATH="$(go env GOPATH)"
+WORKINGDIR="$(pwd)"
 EXPECTEDDIR="${GOPATH}/src/sigs.k8s.io/cluster-api-provider-aws"
 
 if [ "${WORKINGDIR}" != "${EXPECTEDDIR}" ]; then


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuck@heptio.com>

**What this PR does / why we need it**:
`scripts/check-install.sh` fails when GOPATH is not set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```