### PR TITLE
Add state filtering for subnets

### DIFF
--- a/pkg/cloud/aws/services/ec2/filters.go
+++ b/pkg/cloud/aws/services/ec2/filters.go
@@ -109,6 +109,13 @@ func (s *Service) filterVPCStates(states ...string) *ec2.Filter {
 	}
 }
 
+func (s *Service) filterSubnetsStates(states ...string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String("state"),
+		Values: aws.StringSlice(states),
+	}
+}
+
 // Add additional cluster tag filters, to match on our tags
 func (s *Service) addFilterTags(clusterName string, filters []*ec2.Filter) []*ec2.Filter {
 	filters = append(filters, s.filterCluster(clusterName))

--- a/pkg/cloud/aws/services/ec2/subnets.go
+++ b/pkg/cloud/aws/services/ec2/subnets.go
@@ -133,6 +133,7 @@ func (s *Service) describeVpcSubnets(clusterName string, vpcID string) (v1alpha1
 		Filters: []*ec2.Filter{
 			s.filterVpc(vpcID),
 			s.filterCluster(clusterName),
+			s.filterSubnetsStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
 		},
 	})
 

--- a/pkg/cloud/aws/services/ec2/subnets_test.go
+++ b/pkg/cloud/aws/services/ec2/subnets_test.go
@@ -72,6 +72,10 @@ func TestReconcileSubnets(t *testing.T) {
 								Name:   aws.String("tag-key"),
 								Values: []*string{aws.String("kubernetes.io/cluster/test-cluster")},
 							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
 						},
 					})).
 					Return(&ec2.DescribeSubnetsOutput{
@@ -148,6 +152,10 @@ func TestReconcileSubnets(t *testing.T) {
 							{
 								Name:   aws.String("tag-key"),
 								Values: []*string{aws.String("kubernetes.io/cluster/test-cluster")},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
 							},
 						},
 					})).


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Adds a filter to the describe method making sure subnets are either pending or available

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #165 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```