### PR TITLE
fix gazelle parameters

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 # Update the excludes if you get "unrecognised import path"
 
 # gazelle:prefix sigs.k8s.io/cluster-api-provider-aws
-# gazelle:build_file_name BUILD,BUILD.bazel
+# gazelle:build_file_name BUILD.bazel,BUILD
 # gazelle:proto disable_global
 # gazelle:exclude vendor/github.com/golang/mock/mockgen/tests/vendor_dep
 # gazelle:exclude vendor/golang.org/x/tools/cmd/bundle/testdata


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuck@heptio.com>

**What this PR does / why we need it**:
This makes gazelle prefer `BUILD.bazel` to `BUILD` which is good for case insensitive operating systems.

New files will be BUILD.bazel while older BUILD files will still be respected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #343 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```