### PR TITLE
Don't assume compilining machine has envsubst

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,6 +117,12 @@ go_repository(
     commit = "4ed3216f3ec431b140b1d899130a69fc671678f4",  # v1.12.1
 )
 
+go_repository(
+    name = "com_github_a8m_envsubst",
+    importpath = "github.com/a8m/envsubst",
+    commit = "41dec2456c86b2a9fa51a22a808b7084b8d52c64", # v1.1.0
+)
+
 # for @io_k8s_kubernetes
 http_archive(
     name = "io_kubernetes_build",

--- a/cmd/clusterctl/examples/aws/BUILD
+++ b/cmd/clusterctl/examples/aws/BUILD
@@ -12,11 +12,15 @@ genrule(
          "out/aws_manager_image_patch.yaml"
    ],
     cmd = " ".join([
+        "ENVSUBST=$(location @com_github_a8m_envsubst//cmd/envsubst:envsubst)",
         "MANAGER_IMAGE=$$(cat $(location //cmd/manager:manager-amd64.digest))",
         "OUTPUT_DIR=$(@D)/out",
         "DIR=.",
         "$(location :generate-yaml.sh) -f",
     ]),
-   tools = [":generate-yaml.sh"],
+   tools = [
+       ":generate-yaml.sh",
+       "@com_github_a8m_envsubst//cmd/envsubst:envsubst",
+   ],
    visibility = [ "//visibility:public" ],
 )

--- a/cmd/clusterctl/examples/aws/generate-yaml.sh
+++ b/cmd/clusterctl/examples/aws/generate-yaml.sh
@@ -5,6 +5,7 @@ set -o nounset
 # Directories.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 OUTPUT_DIR=${OUTPUT_DIR:-${DIR}/out}
+ENVSUBST=${ENVSUBST:-envsubst}
 
 # Manager image.
 export MANAGER_IMAGE="${MANAGER_IMAGE:-gcr.io/cluster-api-provider-aws/cluster-api-aws-controller:latest}"
@@ -65,13 +66,13 @@ fi
 
 mkdir -p ${OUTPUT_DIR}
 
-envsubst < $CLUSTER_TEMPLATE_FILE > "${CLUSTER_GENERATED_FILE}"
+$ENVSUBST < $CLUSTER_TEMPLATE_FILE > "${CLUSTER_GENERATED_FILE}"
 echo "Done generating ${CLUSTER_GENERATED_FILE}"
 
-envsubst < $MACHINES_TEMPLATE_FILE > "${MACHINES_GENERATED_FILE}"
+$ENVSUBST < $MACHINES_TEMPLATE_FILE > "${MACHINES_GENERATED_FILE}"
 echo "Done generating ${MACHINES_GENERATED_FILE}"
 
-envsubst < $MANAGER_PATCH_TEMPLATE_FILE > "${MANAGER_PATCH_GENERATED_FILE}"
+$ENVSUBST < $MANAGER_PATCH_TEMPLATE_FILE > "${MANAGER_PATCH_GENERATED_FILE}"
 echo "Done generating ${MANAGER_PATCH_GENERATED_FILE}"
 
 cp  ${DIR}/addons.yaml ${ADDONS_FILE}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Some of the k8s images don't have `envsubst` on them. To fix this, pull in an external Golang envsubst program, and use it if it's available.

**Special notes for your reviewer**:



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```