### PR TITLE
Update machines.yaml.template with TypeMeta

### DIFF
--- a/cmd/clusterctl/examples/aws/machines.yaml.template
+++ b/cmd/clusterctl/examples/aws/machines.yaml.template
@@ -1,3 +1,5 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineList
 items:
   - apiVersion: "cluster.k8s.io/v1alpha1"
     kind: Machine


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the machines.yaml we were generating was missing TypeMeta information, which would cause issues with any external tooling (IDE plugins, kustomize, etc).