### PR TITLE
Do not bail early in Machine create

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -212,13 +212,6 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 		return errors.Wrap(err, "failed to get cluster provider config")
 	}
 
-	// status.InstanceID is nil, so don't do this
-	if status.InstanceID == nil {
-		// Instance was never created
-		klog.Infof("Machine %v does not exist", machine.Name)
-		return nil
-	}
-
 	ec2svc := a.ec2(clusterConfig)
 
 	instance, err := ec2svc.InstanceIfExists(status.InstanceID)

--- a/pkg/cloud/aws/services/userdata/node.go
+++ b/pkg/cloud/aws/services/userdata/node.go
@@ -37,9 +37,9 @@ HOSTNAME="$(curl http://169.254.169.254/latest/meta-data/local-hostname)"
 cat >/tmp/kubeadm-node.yaml <<EOF
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
-kind: NodeConfiguration
+kind: JoinConfiguration
 token: {{.BootstrapToken}}
-discoveryTokenAPIServers: 
+discoveryTokenAPIServers:
 - "{{.ELBAddress}}:6443"
 discoveryFile: /tmp/cluster-info.yaml
 nodeRegistration:


### PR DESCRIPTION
* Fix kubeadm type to successfully join a node

Signed-off-by: Chuck Ha <chuck@heptio.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes the error when a node is joining:

```no kind "NodeConfiguration" is registered for version "kubeadm.k8s.io/v1alpha3" in scheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go:31"```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```