### PR TITLE
[WIP] Change up error handling

### DIFF
--- a/pkg/apis/awsprovider/v1alpha1/BUILD
+++ b/pkg/apis/awsprovider/v1alpha1/BUILD
@@ -15,6 +15,7 @@ go_library(
     importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1",
     visibility = ["//visibility:public"],
     deps = [
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/apis/awsprovider/v1alpha1/register.go
+++ b/pkg/apis/awsprovider/v1alpha1/register.go
@@ -25,6 +25,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -50,7 +51,7 @@ func ClusterConfigFromProviderConfig(providerConfig clusterv1.ProviderConfig) (*
 		return &config, nil
 	}
 	if err := yaml.Unmarshal(providerConfig.Value.Raw, &config); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return &config, nil
 }
@@ -63,7 +64,7 @@ func ClusterStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSClust
 
 	status := new(AWSClusterProviderStatus)
 	if err := yaml.Unmarshal(extension.Raw, status); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return status, nil
@@ -73,7 +74,7 @@ func ClusterStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSClust
 func MachineConfigFromProviderConfig(providerConfig clusterv1.ProviderConfig) (*AWSMachineProviderConfig, error) {
 	var config AWSMachineProviderConfig
 	if err := yaml.Unmarshal(providerConfig.Value.Raw, &config); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return &config, nil
 }
@@ -86,7 +87,7 @@ func MachineStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSMachi
 
 	status := new(AWSMachineProviderStatus)
 	if err := yaml.Unmarshal(extension.Raw, status); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return status, nil
@@ -103,7 +104,7 @@ func EncodeMachineStatus(status *AWSMachineProviderStatus) (*runtime.RawExtensio
 
 	//  TODO: use apimachinery conversion https://godoc.org/k8s.io/apimachinery/pkg/runtime#Convert_runtime_Object_To_runtime_RawExtension
 	if rawBytes, err = json.Marshal(status); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return &runtime.RawExtension{
@@ -122,7 +123,7 @@ func EncodeClusterStatus(status *AWSClusterProviderStatus) (*runtime.RawExtensio
 
 	//  TODO: use apimachinery conversion https://godoc.org/k8s.io/apimachinery/pkg/runtime#Convert_runtime_Object_To_runtime_RawExtension
 	if rawBytes, err = json.Marshal(status); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return &runtime.RawExtension{
@@ -141,7 +142,7 @@ func EncodeClusterConfig(status *AWSClusterProviderConfig) (*runtime.RawExtensio
 
 	//  TODO: use apimachinery conversion https://godoc.org/k8s.io/apimachinery/pkg/runtime#Convert_runtime_Object_To_runtime_RawExtension
 	if rawBytes, err = json.Marshal(status); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return &runtime.RawExtension{

--- a/pkg/cloud/aws/actuators/cluster/actuator.go
+++ b/pkg/cloud/aws/actuators/cluster/actuator.go
@@ -47,12 +47,20 @@ func NewActuator(params ActuatorParams) *Actuator {
 	return res
 }
 
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
 // Reconcile reconciles a cluster and is invoked by the Cluster Controller
 func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 	klog.Infof("Reconciling cluster %v", cluster.Name)
 
 	scope, err := actuators.NewScope(actuators.ScopeParams{Cluster: cluster, Client: a.client})
 	if err != nil {
+		klog.Error(err)
+		if errst, ok := err.(stackTracer); ok {
+			klog.Errorf("%+v", errst)
+		}
 		return err
 	}
 

--- a/pkg/deployer/BUILD.bazel
+++ b/pkg/deployer/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/cloud/aws/services/certificates:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
     ],
 )


### PR DESCRIPTION
This is open for feedback, it's a WIP so it doesn't accidentally get merged.

Signed-off-by: Chuck Ha <chuck@heptio.com>

**What this PR does / why we need it**:
This PR is an example of how I'd like to change up the error handling in this project. It is a little bit weird because we depend on thirdparty tools that don't adhere to this idea.

The general take here is that we wrap up errors with a stack at the edge of our program. So anytime we call out to clusterapi, the standard library, whatever. If we're calling internal to our workspace then we don't have to do anything simply return the error exactly as is since we already know it will be wrapped with a stack trace at that point.

Then at the top level we log stack traces when errors occur. This is actually a little weird for this application because it's running in a loop so it's likely that logs will have lots of stacktraces embedded in them. I think that's ok though because we get extra context around the error and what happened.

**Special notes for your reviewer**:
Would love to hear your feedback on this style of error logging.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
/cc @randomvariable 