### PR TITLE
Fix security group duplicate rule bug

### DIFF
--- a/pkg/apis/awsprovider/v1alpha1/types.go
+++ b/pkg/apis/awsprovider/v1alpha1/types.go
@@ -16,6 +16,7 @@ package v1alpha1
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -294,7 +295,7 @@ type IngressRule struct {
 	CidrBlocks []string `json:"cidrBlocks"`
 
 	// The security group id to allow access from. Cannot be specified with CidrBlocks.
-	SourceSecurityGroupID *string `json:"sourceSecurityGroupId"`
+	SourceSecurityGroupIDs []string `json:"sourceSecurityGroupIds"`
 }
 
 // String returns a string representation of the ingress rule.
@@ -310,6 +311,10 @@ func (i IngressRules) Difference(o IngressRules) (out IngressRules) {
 	for _, x := range i {
 		found := false
 		for _, y := range o {
+			sort.Strings(x.CidrBlocks)
+			sort.Strings(y.CidrBlocks)
+			sort.Strings(x.SourceSecurityGroupIDs)
+			sort.Strings(y.SourceSecurityGroupIDs)
 			if reflect.DeepEqual(x, y) {
 				found = true
 				break

--- a/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
@@ -339,10 +339,10 @@ func (in *IngressRule) DeepCopyInto(out *IngressRule) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.SourceSecurityGroupID != nil {
-		in, out := &in.SourceSecurityGroupID, &out.SourceSecurityGroupID
-		*out = new(string)
-		**out = **in
+	if in.SourceSecurityGroupIDs != nil {
+		in, out := &in.SourceSecurityGroupIDs, &out.SourceSecurityGroupIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes an issue where the rules attached to a security group were recreated on every reconcile call. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```