### PR TITLE
Fix possible race condition between machine and cluster actuator

### DIFF
--- a/pkg/cloud/aws/services/ec2/instances_test.go
+++ b/pkg/cloud/aws/services/ec2/instances_test.go
@@ -273,9 +273,15 @@ func TestCreateInstance(t *testing.T) {
 							ID: "2",
 						},
 					},
+					APIServerELB: v1alpha1.ClassicELB{
+						DNSName: "test-apiserver.us-east-1.aws",
+					},
 				},
 			},
-			clusterConfig: &v1alpha1.AWSClusterProviderSpec{},
+			clusterConfig: &v1alpha1.AWSClusterProviderSpec{
+				CACertificate: []byte("x"),
+				CAPrivateKey:  []byte("y"),
+			},
 			cluster: clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test1",


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```