### PR TITLE
[DO NOT MERGE] 1.13 config update

### DIFF
--- a/pkg/cloud/aws/services/userdata/controlplane.go
+++ b/pkg/cloud/aws/services/userdata/controlplane.go
@@ -26,13 +26,14 @@ HOSTNAME="$(curl http://169.254.169.254/latest/meta-data/local-hostname)"
 
 cat >/tmp/kubeadm.yaml <<EOF
 ---
-apiVersion: kubeadm.k8s.io/v1alpha3
+apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-apiServerCertSANs:
-  - "$PRIVATE_IP"
-  - "{{.ELBAddress}}"
-apiServerExtraArgs:
-  cloud-provider: aws
+apiServer:
+  certSANs:
+    - "$PRIVATE_IP"
+    - "{{.ELBAddress}}"
+  extraArgs:
+    cloud-provider: aws
 controlPlaneEndpoint: "{{.ELBAddress}}:6443"
 clusterName: "{{.ClusterName}}"
 networking:
@@ -41,7 +42,7 @@ networking:
   serviceSubnet: "{{.ServiceSubnet}}"
 kubernetesVersion: "{{.KubernetesVersion}}"
 ---
-apiVersion: kubeadm.k8s.io/v1alpha3
+apiVersion: kubeadm.k8s.io/v1beta1
 kind: InitConfiguration
 nodeRegistration:
   name: ${HOSTNAME}

--- a/pkg/cloud/aws/services/userdata/node.go
+++ b/pkg/cloud/aws/services/userdata/node.go
@@ -36,14 +36,16 @@ HOSTNAME="$(curl http://169.254.169.254/latest/meta-data/local-hostname)"
 
 cat >/tmp/kubeadm-node.yaml <<EOF
 ---
-apiVersion: kubeadm.k8s.io/v1alpha3
+apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
-token: {{.BootstrapToken}}
-discoveryTokenAPIServers:
-- "{{.ELBAddress}}:6443"
-discoveryFile: /tmp/cluster-info.yaml
+discovery:
+  bootstrapToken:
+    token: "{{.BootstrapToken}}"
+    apiServerEndpoint: "{{.ELBAddress}}:6443"
+  file:
+    kubeConfigPath: /tmp/cluster-info.yaml
 nodeRegistration:
-  name: ${HOSTNAME}
+  name: "${HOSTNAME}"
   criSocket: /var/run/containerd/containerd.sock
   kubeletExtraArgs:
     cloud-provider: aws


### PR DESCRIPTION
Merge after 1.13 releases and we rebuild the AMIs and update the AMI list.

Signed-off-by: Chuck Ha <chuck@heptio.com>

**What this PR does / why we need it**:
This PR bumps the kubeadm configs to v1beta1. To be used with 1.13

It was tested with kubernetes v1.13.0-rc.1 and bootstrapped successfully.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #412 

**Special notes for your reviewer**:

/hold
Holding until 1.13 is released and AMIs are updated.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
Uses v1beta1 for kubeadm config types. 
```