### PR TITLE
Fix status update error on first run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,10 +178,10 @@ kind-reset: ## Destroys the "capa" kind cluster.
 	kind delete cluster --name=capa
 
 kind-create-cluster: kind ## Invokes `clusterctl create cluster ...` using the kind "capa" cluster as bootstrap.
-	clusterctl create cluster -v 3 --provider aws -e $(kind get kubeconfig-path --name=capa) -m ./cmd/clusterctl/examples/aws/out/machines.yaml -c ./cmd/clusterctl/examples/aws/out/cluster.yaml -p ./cmd/clusterctl/examples/aws/out/provider-components.yaml -a ./cmd/clusterctl/examples/aws/out/addons.yaml
+	clusterctl create cluster -v 3 --provider aws -e $(shell kind get kubeconfig-path --name=capa) -m ./cmd/clusterctl/examples/aws/out/machines.yaml -c ./cmd/clusterctl/examples/aws/out/cluster.yaml -p ./cmd/clusterctl/examples/aws/out/provider-components.yaml -a ./cmd/clusterctl/examples/aws/out/addons.yaml
 
 kind-delete-cluster: kind ## Invokes `clusterctl delete cluster ...` using the kind "capa" cluster as bootstrap.
-	clusterctl delete cluster -e $(kind get kubeconfig-path) --cluster test1 --cluster-namespace default --kubeconfig ./kubeconfig -p ./cmd/clusterctl/examples/aws/out/provider-components.yaml
+	clusterctl delete cluster -e $(shell kind get kubeconfig-path --name=capa) --cluster test1 --cluster-namespace default --kubeconfig ./kubeconfig -p ./cmd/clusterctl/examples/aws/out/provider-components.yaml
 
 ifneq ($(FASTBUILD),y)
 

--- a/pkg/cloud/aws/actuators/BUILD.bazel
+++ b/pkg/cloud/aws/actuators/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/elb/elbiface:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",

--- a/pkg/cloud/aws/actuators/machine_scope.go
+++ b/pkg/cloud/aws/actuators/machine_scope.go
@@ -107,8 +107,6 @@ func (m *MachineScope) storeMachineStatus() error {
 }
 
 func (m *MachineScope) Close() {
-	defer m.Scope.Close()
-
 	if m.MachineClient == nil {
 		return
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes the status update error that happens when the actuator runs. It'll fetch the latest cluster object from the api and update the status.

Further investigation is needed for the other issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #430

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```