### PR TITLE
Rev manager image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ FASTBUILD ?= n ## Set FASTBUILD=y (case-sensitive) to skip some slow tasks
 ## Image URL to use all building/pushing image targets
 STABLE_DOCKER_REPO ?= gcr.io/cluster-api-provider-aws
 MANAGER_IMAGE_NAME ?= cluster-api-aws-controller
-MANAGER_IMAGE_TAG ?= 0.0.2
+MANAGER_IMAGE_TAG ?= 0.0.3
 MANAGER_IMAGE ?= $(STABLE_DOCKER_REPO)/$(MANAGER_IMAGE_NAME):$(MANAGER_IMAGE_TAG)
 DEV_DOCKER_REPO ?= gcr.io/$(shell gcloud config get-value project)
 DEV_MANAGER_IMAGE ?= $(DEV_DOCKER_REPO)/$(MANAGER_IMAGE_NAME):$(MANAGER_IMAGE_TAG)

--- a/cmd/clusterctl/examples/aws/generate-yaml.sh
+++ b/cmd/clusterctl/examples/aws/generate-yaml.sh
@@ -25,7 +25,7 @@ ENVSUBST=${ENVSUBST:-envsubst}
 export CLUSTER_NAME="test1"
 
 # Manager image.
-export MANAGER_IMAGE="${MANAGER_IMAGE:-gcr.io/cluster-api-provider-aws/cluster-api-aws-controller:0.0.2}"
+export MANAGER_IMAGE="${MANAGER_IMAGE:-gcr.io/cluster-api-provider-aws/cluster-api-aws-controller:0.0.3}"
 export MANAGER_IMAGE_PULL_POLICY=${MANAGER_IMAGE_PULL_POLICY:-IfNotPresent}
 
 # Machine settings.


### PR DESCRIPTION
**What this PR does / why we need it**:

Rev the manager image in preparation to cut a release.