### PR TITLE
fix kubeconfig to use correct cluster name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ kubeconfig
 /bazel-genfiles
 /bazel-out
 /bazel-testlogs
+
+# vscode
+.vscode

--- a/pkg/cloud/aws/services/certificates/certificates.go
+++ b/pkg/cloud/aws/services/certificates/certificates.go
@@ -143,7 +143,7 @@ func NewSelfSignedCACert(key *rsa.PrivateKey) (*x509.Certificate, error) {
 }
 
 // NewKubeconfig creates a new Kubeconfig where endpoint is the ELB endpoint.
-func NewKubeconfig(endpoint string, caCert *x509.Certificate, caKey *rsa.PrivateKey) (*api.Config, error) {
+func NewKubeconfig(clusterName, endpoint string, caCert *x509.Certificate, caKey *rsa.PrivateKey) (*api.Config, error) {
 	cfg := &Config{
 		CommonName:   "kubernetes-admin",
 		Organization: []string{"system:masters"},
@@ -160,8 +160,6 @@ func NewKubeconfig(endpoint string, caCert *x509.Certificate, caKey *rsa.Private
 		return nil, errors.Wrap(err, "unable to sign certificate")
 	}
 
-	// TODO: make this configurable.
-	clusterName := "test1"
 	userName := "kubernetes-admin"
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
 

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -90,7 +90,7 @@ func (d *Deployer) GetKubeConfig(cluster *clusterv1.Cluster, _ *clusterv1.Machin
 
 	server := fmt.Sprintf("https://%s:6443", dnsName)
 
-	cfg, err := certificates.NewKubeconfig(server, cert, key)
+	cfg, err := certificates.NewKubeconfig(cluster.Name, server, cert, key)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate a kubeconfig")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR removes the hard-coded cluster name when generating the kubeconfig for the target cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #455 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._ No

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```