### PR TITLE
Containerd 1.2.1

### DIFF
--- a/build/amis/ansible/roles/containerd/defaults/main.yml
+++ b/build/amis/ansible/roles/containerd/defaults/main.yml
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-containerd_version: "1.2.0"
-containerd_sha256: ee076c6260de140f9aa6dee30b0e360abfb80af252d271e697982d1209ca5dee
+containerd_version: "1.2.1"
+containerd_sha256: 329d44850685f8b511779c00763df50dd24257b3a1c594aff57e77bcee1b1269

--- a/build/amis/ansible/roles/containerd/tasks/main.yml
+++ b/build/amis/ansible/roles/containerd/tasks/main.yml
@@ -42,3 +42,8 @@
     daemon_reload: yes
     enabled: True
     state: started
+
+- name: delete tarball
+  file:
+    path: /tmp/containerd.tar.gz
+    state: absent


### PR DESCRIPTION
**What this PR does / why we need it**:

- installs latest containerd (1.2.1)
- deletes containerd tarball after installation

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```