### PR TITLE
Adds an install script

### DIFF
--- a/hack/install-build.sh
+++ b/hack/install-build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+install bazel-bin/cmd/clusterctl/darwin_amd64_pure_stripped/clusterctl /usr/local/bin
+if [ $? -eq 0 ]; then
+    echo -e "\033[0;32m[$(date)]\033[0;0m Installed clusterctl"
+else
+    echo -e "\033[0;31m[$(date)]\033[0;0m failed to install clusterctl"
+fi
+install bazel-bin/cmd/clusterawsadm/darwin_amd64_pure_stripped/clusterawsadm /usr/local/bin
+if [ $? -eq 0 ]; then
+    echo -e "\033[0;32m[$(date)]\033[0;0m Installed clusterawsadm"
+else
+    echo -e "\033[0;31m[$(date)]\033[0;0m failed to install clusterawsadm"
+fi
+
+


### PR DESCRIPTION
This script installs the bazel built binaries into `/usr/local/bin`.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adds a script to install binaries that bazel builds. This is a minor helper for devs when they don't want to manually type the path to the new built binaries every time. It has colorized output for easy scanning of success/failure.

**Special notes for your reviewer**:
Totally cool if this is not useful or if there is a better pattern people use. Would be happy with any feedback.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```