### PR TITLE
Bump cluster-api version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -835,7 +835,7 @@
   revision = "0317810137be915b9cf888946c6e115c1bfac693"
 
 [[projects]]
-  digest = "1:c647740824ccb1788a07484325a66ece6ff75b214b3560d02fbe5231666fc9b1"
+  digest = "1:ab6454ea7baa47e6d15292dd5c70dab3e749ac8b94644e8b3c8d09fde8073ae8"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "cmd/clusterctl/clientcmd",
@@ -861,7 +861,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "0173ea2753b7cca0fad8b05e04545edd7a61b0c8"
+  revision = "f03f47c17d09c4765a1bfdd204f8d814196cb3d8"
 
 [[projects]]
   digest = "1:f67de7bec51b31c93bce558098ac8c144e598248a6c91016dc7dca668558353d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  revision = "0173ea2753b7cca0fad8b05e04545edd7a61b0c8"
+  revision = "f03f47c17d09c4765a1bfdd204f8d814196cb3d8"
 
 # For dependency below: Refer to issue https://github.com/golang/dep/issues/1799
 [[override]]

--- a/vendor/sigs.k8s.io/cluster-api/Dockerfile
+++ b/vendor/sigs.k8s.io/cluster-api/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.10.3 as builder
+FROM golang:1.11.2 as builder
 
 # Copy in the go src
 WORKDIR $GOPATH/src/sigs.k8s.io/cluster-api

--- a/vendor/sigs.k8s.io/cluster-api/Gopkg.lock
+++ b/vendor/sigs.k8s.io/cluster-api/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v0.28.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -222,6 +230,14 @@
   revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -318,6 +334,51 @@
   pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  digest = "1:93a746f1060a8acbcf69344862b2ceced80f854170e1caae089b2834c5fbf7f4"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:db712fde5d12d6cdbdf14b777f0c230f4ff5ab0be8e35b239fc319953ed577a4"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "4724e9255275ce38f7179b2478abeae4e28c904f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d39e7c7677b161c2dd4c635a2ac196460608c7d8ba5337cc8cae5825a2681f8f"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
+  revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
 
 [[projects]]
   digest = "1:6a4a11ba764a56d2758899ec6f3848d24698d48442ebce85ee7a3f63284526cd"
@@ -536,7 +597,7 @@
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:728c0c37966b7a6c8980fab69a3d690cc0996e206804a55052318858d00f1e17"
+  digest = "1:26a67eb988225c6a0600c1af0b35e795ac4d23a9c40a7aa178fa2adc0670f1f7"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -551,10 +612,12 @@
     "authorization/v1beta1",
     "autoscaling/v1",
     "autoscaling/v2beta1",
+    "autoscaling/v2beta2",
     "batch/v1",
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
@@ -571,11 +634,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "2d6f90ab1293a1fb871cf149423ebb72aa7423aa"
-  version = "kubernetes-1.11.2"
+  revision = "b503174bad5991eb66f18247f52e41c3258f6348"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
-  digest = "1:145647b653ff6a6882bbc2c4701ebcbce7be643007231d545560e4ce612ad5cb"
+  digest = "1:d9e9a6062217111c1b7c548a47bd67b2b518c8da05d124dbca74e246565c76a6"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -585,11 +648,11 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "408db4a50408e2149acbd657bceb2480c13cb0a4"
-  version = "kubernetes-1.11.2"
+  revision = "0cd23ebeb6882bd1cdc2cb15fc7b2d72e8a86a5b"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
-  digest = "1:6a8fca786f4e263fac02cb6cfe8f0decfee526aede3969d301e18fcef167cd38"
+  digest = "1:37113933623d6702a851b11c9a7534adb99961c1bf3cc8bd3b354402fd7243fe"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -623,6 +686,7 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
+    "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/rand",
     "pkg/util/runtime",
@@ -639,8 +703,8 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
-  version = "kubernetes-1.11.2"
+  revision = "eddba98df674a16931d2d4ba75edc3a389bf633a"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
   branch = "master"
@@ -651,7 +715,7 @@
   revision = "cf5eff4f5e8f6019796cb18c69918b9f2f09e6db"
 
 [[projects]]
-  digest = "1:2094148c7308a9ddab4ad3c355c343a55d8b6c265417cebe42e74a594916dd9d"
+  digest = "1:b2820d12e324fc54ce0a4f330719c6858a5dfafbe053f2cb48ff299aed4538d1"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -670,10 +734,12 @@
     "kubernetes/typed/authorization/v1beta1",
     "kubernetes/typed/autoscaling/v1",
     "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta2",
     "kubernetes/typed/batch/v1",
     "kubernetes/typed/batch/v1beta1",
     "kubernetes/typed/batch/v2alpha1",
     "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1beta1",
     "kubernetes/typed/core/v1",
     "kubernetes/typed/events/v1beta1",
     "kubernetes/typed/extensions/v1beta1",
@@ -723,8 +789,8 @@
     "util/workqueue",
   ]
   pruneopts = "UT"
-  revision = "1f13a808da65775f22cbf47862c4e5898d8f4ca1"
-  version = "kubernetes-1.11.2"
+  revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
   branch = "master"
@@ -785,7 +851,7 @@
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
-  digest = "1:f67de7bec51b31c93bce558098ac8c144e598248a6c91016dc7dca668558353d"
+  digest = "1:9204bf9bd9c82866f4f077f1c859da5f49e928f3ac48640ac8f87c1604cd555c"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -793,15 +859,18 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller",
     "pkg/envtest",
     "pkg/envtest/printer",
     "pkg/event",
     "pkg/handler",
     "pkg/internal/controller",
+    "pkg/internal/controller/metrics",
     "pkg/internal/recorder",
     "pkg/leaderelection",
     "pkg/manager",
+    "pkg/metrics",
     "pkg/patch",
     "pkg/predicate",
     "pkg/reconcile",
@@ -812,29 +881,37 @@
     "pkg/runtime/signals",
     "pkg/source",
     "pkg/source/internal",
+    "pkg/webhook",
     "pkg/webhook/admission",
     "pkg/webhook/admission/types",
+    "pkg/webhook/internal/cert",
+    "pkg/webhook/internal/cert/generator",
+    "pkg/webhook/internal/cert/writer",
+    "pkg/webhook/internal/cert/writer/atomic",
     "pkg/webhook/types",
   ]
   pruneopts = "UT"
-  revision = "5fd1e9e9fac5261e9ad9d47c375afc014fc31d21"
-  version = "v0.1.7"
+  revision = "c63ebda0bf4be5f0a8abd4003e4ea546032545ba"
+  version = "v0.1.8"
 
 [[projects]]
-  digest = "1:41e7c89bdceb653e2235a7b5627d23af65fa22fb4dad368bf49eb2857e23bac2"
+  digest = "1:946a62b07e59b9abd1f475a5b5c8d590255c1d40627f386d34fd073d3de9ecb8"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "cmd/controller-gen",
     "pkg/crd/generator",
     "pkg/crd/util",
-    "pkg/generate/rbac",
     "pkg/internal/codegen",
     "pkg/internal/codegen/parse",
+    "pkg/internal/general",
+    "pkg/rbac",
     "pkg/util",
+    "pkg/webhook",
+    "pkg/webhook/internal",
   ]
   pruneopts = "UT"
-  revision = "38b2f3f497ed6b8ea5d2844ecf00c28ac4b5c2c4"
-  version = "v0.1.6"
+  revision = "950a0e88e4effb864253b3c7504b326cc83b9d11"
+  version = "v0.1.8"
 
 [[projects]]
   branch = "master"
@@ -905,6 +982,7 @@
     "k8s.io/klog",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/envtest",
     "sigs.k8s.io/controller-runtime/pkg/handler",

--- a/vendor/sigs.k8s.io/cluster-api/Makefile
+++ b/vendor/sigs.k8s.io/cluster-api/Makefile
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+.DEFAULT_GOAL:=help
+
 # Default timeout for starting/stopping the Kubebuilder test controlplane
 export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
@@ -21,49 +26,52 @@ IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:latest
 
 all: test manager clusterctl
 
-# Run tests
-test: generate fmt vet manifests verify
-	go test -v -tags=integration ./pkg/... ./cmd/...
-#	go test -v -tags=integration ./pkg/... ./cmd/... -coverprofile cover.out
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-# Build manager binary
-manager: generate fmt vet
+.PHONY: gazelle
+gazelle: ## Run Bazel Gazelle
+	(which bazel && ./hack/update-bazel.sh) || true
+
+.PHONY: test
+test: verify generate fmt vet manifests ## Run tests
+	go test -v -tags=integration ./pkg/... ./cmd/...
+
+.PHONY: manager
+manager: generate fmt vet ## Build manager binary
 	go build -o bin/manager sigs.k8s.io/cluster-api/cmd/manager
 
-# Build clusterctl binary
-clusterctl: generate fmt vet
+.PHONY: clusterctl
+clusterctl: generate fmt vet ## Build clusterctl binary
 	go build -o bin/clusterctl sigs.k8s.io/cluster-api/cmd/clusterctl
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet
+.PHONY: run
+run: generate fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run ./cmd/manager/main.go
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests
+.PHONY: deploy
+deploy: manifests ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 	kustomize build config/default | kubectl apply -f -
 
-# Generate manifests e.g. CRD, RBAC etc.
-manifests:
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
-	@# Kubebuilder CRD generation can't handle intstr.IntOrString properly:
-	@# https://github.com/kubernetes-sigs/kubebuilder/issues/442
-	sed -i -e 's/maxSurge:/maxSurge: {}/g' -e '/maxSurge:/{n;d};' config/crds/cluster_v1alpha1_machinedeployment.yaml
-	sed -i -e 's/maxUnavailable:/maxUnavailable: {}/g' -e '/maxUnavailable:/{n;d};' config/crds/cluster_v1alpha1_machinedeployment.yaml
 
-# Run go fmt against code
-fmt:
+.PHONY: manifests
+manifests: ## Generate manifests e.g. CRD, RBAC etc.
+	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
+
+.PHONY: fmt
+fmt: ## Run go fmt against code
 	go fmt ./pkg/... ./cmd/...
 
-# Run go vet against code
-vet:
+.PHONY: vet
+vet: ## Run go vet against code
 	go vet ./pkg/... ./cmd/...
 
-# Generate code
-generate: clientset
+.PHONY: generate
+generate: clientset gazelle ## Generate code
 	go generate ./pkg/... ./cmd/...
 
-# Generate a typed clientset
-clientset:
+.PHONY: clientset
+clientset: ## Generate a typed clientset
 	rm -rf pkg/client
 	cd ./vendor/k8s.io/code-generator/cmd && go install ./client-gen ./lister-gen ./informer-gen
 	$$GOPATH/bin/client-gen --clientset-name clientset --input-base sigs.k8s.io/cluster-api/pkg/apis \
@@ -78,16 +86,18 @@ clientset:
 		--output-package sigs.k8s.io/cluster-api/pkg/client/informers_generated \
 		--go-header-file=./hack/boilerplate.go.txt
 
-# Build the docker image
-docker-build: generate fmt vet manifests
+.PHONY: docker-build
+docker-build: generate fmt vet manifests ## Build the docker image
 	docker build . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
 
+.PHONY: docker-push
+docker-push: ## Push the docker image
+	docker push ${IMG}
+
+.PHONY: verify
 verify:
 	./hack/verify_boilerplate.py
 	./hack/verify_clientset.sh
-
-# Push the docker image
-docker-push:
-	docker push ${IMG}
+	./hack/verify-bazel.sh

--- a/vendor/sigs.k8s.io/cluster-api/WORKSPACE
+++ b/vendor/sigs.k8s.io/cluster-api/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f87fa87475ea107b3c69196f39c82b7bbf58fe27c62a338684c20ca17d1d8613",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.2/rules_go-0.16.2.tar.gz"],
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz",
+    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
 )
 
 http_archive(
@@ -16,7 +16,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(
+    go_version = "1.11.4",
+)
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 

--- a/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -87,7 +87,7 @@ type client struct {
 	closeFn         func() error
 }
 
-// New creates and returns a Client, the kubeconfig argument is expected to be the string represenation
+// New creates and returns a Client, the kubeconfig argument is expected to be the string representation
 // of a valid kubeconfig.
 func New(kubeconfig string) (*client, error) {
 	f, err := createTempFile(kubeconfig)

--- a/vendor/sigs.k8s.io/cluster-api/config/crds/cluster_v1alpha1_machinedeployment.yaml
+++ b/vendor/sigs.k8s.io/cluster-api/config/crds/cluster_v1alpha1_machinedeployment.yaml
@@ -48,8 +48,14 @@ spec:
               properties:
                 rollingUpdate:
                   properties:
-                    maxSurge: {}
-                    maxUnavailable: {}
+                    maxSurge:
+                      oneOf:
+                      - type: string
+                      - type: integer
+                    maxUnavailable:
+                      oneOf:
+                      - type: string
+                      - type: integer
                   type: object
                 type:
                   type: string

--- a/vendor/sigs.k8s.io/cluster-api/config/default/kustomization.yaml
+++ b/vendor/sigs.k8s.io/cluster-api/config/default/kustomization.yaml
@@ -20,6 +20,7 @@ namePrefix: cluster-api-
 resources:
 - ../crds/cluster_v1alpha1_cluster.yaml
 - ../crds/cluster_v1alpha1_machine.yaml
+- ../crds/cluster_v1alpha1_machineclass.yaml
 - ../crds/cluster_v1alpha1_machinedeployment.yaml
 - ../crds/cluster_v1alpha1_machineset.yaml
 - ../rbac/rbac_role.yaml

--- a/vendor/sigs.k8s.io/cluster-api/docs/book/appendices/keps/0003-cluster-api.md
+++ b/vendor/sigs.k8s.io/cluster-api/docs/book/appendices/keps/0003-cluster-api.md
@@ -1,1 +1,1 @@
-{% include "git+https://github.com/kubernetes/community.git/keps/sig-cluster-lifecycle/0003-cluster-api.md" %}
+{% include "git+https://github.com/kubernetes/enhancements.git/keps/sig-cluster-lifecycle/0003-cluster-api.md" %}

--- a/vendor/sigs.k8s.io/cluster-api/hack/verify-bazel.sh
+++ b/vendor/sigs.k8s.io/cluster-api/hack/verify-bazel.sh
@@ -18,6 +18,8 @@ set -o nounset
 set -o pipefail
 set -o verbose
 
+if ! which bazel &>/dev/null; then echo "Bazel not available, skipping validation"; exit; fi
+
 diff=$(bazel run //:gazelle -- update -mode diff -external vendored)
 
 if [[ -n "${diff}" ]]; then

--- a/vendor/sigs.k8s.io/cluster-api/hack/verify_clientset.sh
+++ b/vendor/sigs.k8s.io/cluster-api/hack/verify_clientset.sh
@@ -38,7 +38,7 @@ make clientset
 
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
-diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
+diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" -x '*.bazel' -x 'BUILD' || ret=$?
 cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
 if [[ $ret -eq 0 ]]
 then

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common/consts.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common/consts.go
@@ -100,6 +100,6 @@ type MachineDeploymentStrategyType string
 
 const (
 	// Replace the old MachineSet by new one using rolling update
-	// i.e gradually scale down the old MachineSet and scale up the new one.
+	// i.e. gradually scale down the old MachineSet and scale up the new one.
 	RollingUpdateMachineDeploymentStrategyType MachineDeploymentStrategyType = "RollingUpdate"
 )

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -66,7 +66,7 @@ type ClusterNetworkingConfig struct {
 	// The network ranges from which service VIPs are allocated.
 	Services NetworkRanges `json:"services"`
 
-	// The network ranges from which POD networks are allocated.
+	// The network ranges from which Pod networks are allocated.
 	Pods NetworkRanges `json:"pods"`
 
 	// Domain name for services.

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 )
 
-// Finalizer is set on PreareForCreate callback
+// Finalizer is set on PrepareForCreate callback
 const MachineFinalizer = "machine.cluster.k8s.io"
 
 // +genclient
@@ -74,7 +74,7 @@ type MachineSpec struct {
 
 	// To populate in the associated Node for dynamic kubelet config. This
 	// field already exists in Node, so any updates to it in the Machine
-	// spec will be automatially copied to the linked NodeRef from the
+	// spec will be automatically copied to the linked NodeRef from the
 	// status. The rest of dynamic kubelet config support should then work
 	// as-is.
 	// +optional
@@ -160,7 +160,7 @@ type MachineStatus struct {
 	LastOperation *LastOperation `json:"lastOperation,omitempty"`
 
 	// Phase represents the current phase of machine actuation.
-	// Eg. Pending, Running, Terminating, Failed etc.
+	// E.g. Pending, Running, Terminating, Failed etc.
 	// +optional
 	Phase *string `json:"phase,omitempty"`
 }
@@ -174,11 +174,11 @@ type LastOperation struct {
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`
 
 	// State is the current status of the last performed operation.
-	// Eg.Processing, Failed, Successful etc
+	// E.g. Processing, Failed, Successful etc
 	State *string `json:"state,omitempty"`
 
 	// Type is the type of operation which was last performed.
-	// Eg. Create, Delete, Update etc
+	// E.g. Create, Delete, Update etc
 	Type *string `json:"type,omitempty"`
 }
 

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -120,7 +120,7 @@ type MachineSetStatus struct {
 	// These fields should not be set for transitive errors that a
 	// controller faces that are expected to be fixed automatically over
 	// time (like service outages), but instead indicate that something is
-	// fundamentally wrong with the MachineTemplates's spec or the configuration of
+	// fundamentally wrong with the MachineTemplate's spec or the configuration of
 	// the machine controller, and that manual intervention is required. Examples
 	// of terminal errors would be invalid combinations of settings in the
 	// spec, values that are unsupported by the machine controller, or the

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/cluster/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/cluster/controller.go
@@ -97,6 +97,9 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 			klog.Infof("failed to add finalizer to cluster object %v due to error %v.", name, err)
 			return reconcile.Result{}, err
 		}
+
+		// Since adding the finalizer updates the object return to avoid later update issues
+		return reconcile.Result{}, nil
 	}
 
 	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machine/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machine/controller.go
@@ -98,8 +98,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	ctx := context.TODO()
 	// Fetch the Machine instance
 	m := &clusterv1.Machine{}
-	err := r.Get(ctx, request.NamespacedName, m)
-	if err != nil {
+	if err := r.Client.Get(ctx, request.NamespacedName, m); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
@@ -118,10 +117,13 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	if m.ObjectMeta.DeletionTimestamp.IsZero() &&
 		!util.Contains(m.ObjectMeta.Finalizers, clusterv1.MachineFinalizer) {
 		m.Finalizers = append(m.Finalizers, clusterv1.MachineFinalizer)
-		if err = r.Update(ctx, m); err != nil {
+		if err := r.Client.Update(ctx, m); err != nil {
 			klog.Infof("failed to add finalizer to machine object %v due to error %v.", name, err)
 			return reconcile.Result{}, err
 		}
+
+		// Since adding the finalizer updates the object return to avoid later update issues
+		return reconcile.Result{}, nil
 	}
 
 	if !m.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -137,6 +139,10 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 		klog.Infof("reconciling machine object %v triggers delete.", name)
 		if err := r.delete(ctx, m); err != nil {
 			klog.Errorf("Error deleting machine object %v; %v", name, err)
+			if requeueErr, ok := err.(*controllerError.RequeueAfterError); ok {
+				klog.Infof("Actuator returned requeue-after error: %v", requeueErr)
+				return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
+			}
 			return reconcile.Result{}, err
 		}
 
@@ -162,8 +168,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 	if exist {
 		klog.Infof("Reconciling machine object %v triggers idempotent update.", name)
-		err := r.update(ctx, m)
-		if err != nil {
+		if err := r.update(ctx, m); err != nil {
 			if requeueErr, ok := err.(*controllerError.RequeueAfterError); ok {
 				klog.Infof("Actuator returned requeue-after error: %v", requeueErr)
 				return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
@@ -185,39 +190,38 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	return reconcile.Result{}, nil
 }
 
-func (c *ReconcileMachine) create(ctx context.Context, machine *clusterv1.Machine) error {
-	cluster, err := c.getCluster(ctx, machine)
+func (r *ReconcileMachine) create(ctx context.Context, machine *clusterv1.Machine) error {
+	cluster, err := r.getCluster(ctx, machine)
 	if err != nil {
 		return err
 	}
 
-	return c.actuator.Create(ctx, cluster, machine)
+	return r.actuator.Create(ctx, cluster, machine)
 }
 
-func (c *ReconcileMachine) update(ctx context.Context, new_machine *clusterv1.Machine) error {
-	cluster, err := c.getCluster(ctx, new_machine)
+func (r *ReconcileMachine) update(ctx context.Context, new_machine *clusterv1.Machine) error {
+	cluster, err := r.getCluster(ctx, new_machine)
 	if err != nil {
 		return err
 	}
 
 	// TODO: Assume single master for now.
 	// TODO: Assume we never change the role for the machines. (Master->Node, Node->Master, etc)
-	return c.actuator.Update(ctx, cluster, new_machine)
+	return r.actuator.Update(ctx, cluster, new_machine)
 }
 
-func (c *ReconcileMachine) delete(ctx context.Context, machine *clusterv1.Machine) error {
-	cluster, err := c.getCluster(ctx, machine)
+func (r *ReconcileMachine) delete(ctx context.Context, machine *clusterv1.Machine) error {
+	cluster, err := r.getCluster(ctx, machine)
 	if err != nil {
 		return err
 	}
 
-	return c.actuator.Delete(ctx, cluster, machine)
+	return r.actuator.Delete(ctx, cluster, machine)
 }
 
-func (c *ReconcileMachine) getCluster(ctx context.Context, machine *clusterv1.Machine) (*clusterv1.Cluster, error) {
+func (r *ReconcileMachine) getCluster(ctx context.Context, machine *clusterv1.Machine) (*clusterv1.Cluster, error) {
 	clusterList := clusterv1.ClusterList{}
-	err := c.Client.List(ctx, client.InNamespace(machine.Namespace), &clusterList)
-	if err != nil {
+	if err := r.Client.List(ctx, client.InNamespace(machine.Namespace), &clusterList); err != nil {
 		return nil, err
 	}
 
@@ -231,17 +235,17 @@ func (c *ReconcileMachine) getCluster(ctx context.Context, machine *clusterv1.Ma
 	}
 }
 
-func (c *ReconcileMachine) isDeleteAllowed(machine *clusterv1.Machine) bool {
-	if c.nodeName == "" || machine.Status.NodeRef == nil {
+func (r *ReconcileMachine) isDeleteAllowed(machine *clusterv1.Machine) bool {
+	if r.nodeName == "" || machine.Status.NodeRef == nil {
 		return true
 	}
-	if machine.Status.NodeRef.Name != c.nodeName {
+	if machine.Status.NodeRef.Name != r.nodeName {
 		return true
 	}
 	node := &corev1.Node{}
-	err := c.Client.Get(context.Background(), client.ObjectKey{Name: c.nodeName}, node)
+	err := r.Client.Get(context.Background(), client.ObjectKey{Name: r.nodeName}, node)
 	if err != nil {
-		klog.Infof("unable to determine if controller's node is associated with machine '%v', error getting node named '%v': %v", machine.Name, c.nodeName, err)
+		klog.Infof("unable to determine if controller's node is associated with machine '%v', error getting node named '%v': %v", machine.Name, r.nodeName, err)
 		return true
 	}
 	// When the UID of the machine's node reference and this controller's actual node match then then the request is to

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/controller.go
@@ -95,8 +95,18 @@ func (r *ReconcileMachineDeployment) getMachineSetsForDeployment(d *v1alpha1.Mac
 	// List all MachineSets to find those we own but that no longer match our
 	// selector.
 	machineSets := &v1alpha1.MachineSetList{}
-	err := r.List(context.Background(), client.InNamespace(d.Namespace), machineSets)
-	if err != nil {
+	listOptions := &client.ListOptions{
+		Namespace: d.Namespace,
+		// This is set so the fake client can be used for unit test. See:
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/168
+		Raw: &metav1.ListOptions{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       "MachineSet",
+			},
+		},
+	}
+	if err := r.Client.List(context.Background(), listOptions, machineSets); err != nil {
 		return nil, err
 	}
 
@@ -194,8 +204,18 @@ func (r *ReconcileMachineDeployment) getMachineDeploymentsForMachineSet(ms *v1al
 	}
 
 	dList := &v1alpha1.MachineDeploymentList{}
-	err := r.Client.List(context.Background(), client.InNamespace(ms.Namespace), dList)
-	if err != nil {
+	listOptions := &client.ListOptions{
+		Namespace: ms.Namespace,
+		// This is set so the fake client can be used for unit test. See:
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/168
+		Raw: &metav1.ListOptions{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       "MachineDeployment",
+			},
+		},
+	}
+	if err := r.Client.List(context.Background(), listOptions, dList); err != nil {
 		klog.Warningf("failed to list machine deployments, %v", err)
 		return nil
 	}
@@ -230,8 +250,18 @@ func (r *ReconcileMachineDeployment) getMachineMapForDeployment(d *v1alpha1.Mach
 		return nil, err
 	}
 	machines := &v1alpha1.MachineList{}
-	err = r.List(context.Background(), client.InNamespace(d.Namespace).MatchingLabels(selector), machines)
-	if err != nil {
+	listOptions := &client.ListOptions{
+		Namespace: d.Namespace,
+		// This is set so the fake client can be used for unit test. See:
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/168
+		Raw: &metav1.ListOptions{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       "Machine",
+			},
+		},
+	}
+	if err = r.Client.List(context.Background(), listOptions.MatchingLabels(selector), machines); err != nil {
 		return nil, err
 	}
 	// Group Machines by their controller (if it's in msList).

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/rolling.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/rolling.go
@@ -34,6 +34,12 @@ func (r *ReconcileMachineDeployment) rolloutRolling(d *v1alpha1.MachineDeploymen
 	if err != nil {
 		return err
 	}
+	// newMS can be nil in case there is already a MachineSet associated with this deployment,
+	// but there are only either changes in annotations or MinReadySeconds. Or in other words,
+	// this can be nil if there are changes, but no replacement of existing machines is needed.
+	if newMS == nil {
+		return nil
+	}
 	allMSs := append(oldMSs, newMS)
 
 	// Scale up, if we can.

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/sync.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/sync.go
@@ -389,7 +389,7 @@ func (r *ReconcileMachineDeployment) scaleMachineSetOperation(ms *clusterv1alpha
 	return scaled, err
 }
 
-// cleanupDeployment is responsible for cleaning up a deployment ie. retains all but the latest N old machine sets
+// cleanupDeployment is responsible for cleaning up a deployment i.e. retains all but the latest N old machine sets
 // where N=d.Spec.RevisionHistoryLimit. Old machine sets are older versions of the machinetemplate of a deployment kept
 // around by default 1) for historical reasons and 2) for the ability to rollback a deployment.
 func (r *ReconcileMachineDeployment) cleanupDeployment(oldMSs []*clusterv1alpha1.MachineSet, deployment *clusterv1alpha1.MachineDeployment) error {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/util/util.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/util/util.go
@@ -503,7 +503,7 @@ func DeploymentComplete(deployment *v1alpha1.MachineDeployment, newStatus *v1alp
 }
 
 // NewMSNewReplicas calculates the number of replicas a deployment's new MS should have.
-// When one of the followings is true, we're rolling out the deployment; otherwise, we're scaling it.
+// When one of the following is true, we're rolling out the deployment; otherwise, we're scaling it.
 // 1) The new MS is saturated: newMS's replicas == deployment's replicas
 // 2) Max number of machines allowed is reached: deployment's replicas + maxSurge == all MSs' replicas
 func NewMSNewReplicas(deployment *v1alpha1.MachineDeployment, allMSs []*v1alpha1.MachineSet, newMS *v1alpha1.MachineSet) (int32, error) {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go
@@ -50,7 +50,7 @@ var stateConfirmationInterval = 100 * time.Millisecond
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
 	r := newReconciler(mgr)
-	return add(mgr, r, r.MachineSetToMachines)
+	return add(mgr, r, r.MachineToMachineSets)
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -100,7 +100,7 @@ type ReconcileMachineSet struct {
 	scheme *runtime.Scheme
 }
 
-func (r *ReconcileMachineSet) MachineSetToMachines(o handler.MapObject) []reconcile.Request {
+func (r *ReconcileMachineSet) MachineToMachineSets(o handler.MapObject) []reconcile.Request {
 	result := []reconcile.Request{}
 	m := &clusterv1alpha1.Machine{}
 	key := client.ObjectKey{Namespace: o.Meta.GetNamespace(), Name: o.Meta.GetName()}
@@ -294,7 +294,7 @@ func (c *ReconcileMachineSet) createMachine(machineSet *clusterv1alpha1.MachineS
 	return machine
 }
 
-// shoudExcludeMachine returns true if the machine should be filtered out, false otherwise.
+// shouldExcludeMachine returns true if the machine should be filtered out, false otherwise.
 func shouldExcludeMachine(machineSet *clusterv1alpha1.MachineSet, machine *clusterv1alpha1.Machine) bool {
 	// Ignore inactive machines.
 	if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/machine.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/machine.go
@@ -18,7 +18,6 @@ package machineset
 
 import (
 	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog"
@@ -33,7 +32,19 @@ func (c *ReconcileMachineSet) getMachineSetsForMachine(m *v1alpha1.Machine) []*v
 	}
 
 	msList := &v1alpha1.MachineSetList{}
-	err := c.Client.List(context.Background(), &client.ListOptions{Namespace: m.Namespace}, msList)
+	listOptions := &client.ListOptions{
+		Namespace: m.Namespace,
+		// This is set so the fake client can be used for unit test. See:
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/168
+		Raw: &metav1.ListOptions{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       "MachineSet",
+			},
+		},
+	}
+
+	err := c.Client.List(context.Background(), listOptions, msList)
 	if err != nil {
 		klog.Errorf("Failed to list machine sets, %v", err)
 		return nil


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR keeps CAPA up to date with CAPI. It recently moved to depend on k8s 1.12.3 things and we want to eventually get to 1.13. This is just a step in that direction. Shoutout to @vincepri for doing the 1.12 migration work on CAPI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #467 but only vaguely

**Special notes for your reviewer**:
I created a whole cluster with this commit.

```release-note
NONE
```