### PR TITLE
Fixes examples(-dev) makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,11 @@ cmd/clusterctl/examples/aws/out/credentials: cmd/clusterctl/examples/aws/out ## 
 
 .PHONY: examples
 examples: ## Generate example output
-	$(MAKE) cmd/clusterctl/examples/aws/out IMAGE=${MANAGER_IMAGE}
+	$(MAKE) cmd/clusterctl/examples/aws/out MANAGER_IMAGE=${MANAGER_IMAGE}
 
 .PHONY: examples-dev
 examples-dev: ## Generate example output with developer image
-	$(MAKE) cmd/clusterctl/examples/aws/out IMAGE=${DEV_MANAGER_IMAGE}
+	$(MAKE) cmd/clusterctl/examples/aws/out MANAGER_IMAGE=${DEV_MANAGER_IMAGE}
 
 .PHONY: manifests
 manifests: cmd/clusterctl/examples/aws/out/credentials ## Generate manifests for clusterctl


### PR DESCRIPTION
The generated kustomize patch now uses the correct dev image.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR makes `make examples-dev` work as expected.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```