### PR TITLE
Lookup AMIs instead of hardcoding them.

### DIFF
--- a/envfile.example
+++ b/envfile.example
@@ -3,6 +3,3 @@ export AWS_REGION=us-west-2
 export AWS_ACCESS_KEY_ID=""
 export AWS_SECRET_ACCESS_KEY=""
 export SSH_KEY_NAME=""
-
-# use a dev image instead of the released image
-export MANAGER_IMAGE=""

--- a/pkg/cloud/aws/services/ec2/ami.go
+++ b/pkg/cloud/aws/services/ec2/ami.go
@@ -16,43 +16,53 @@ limitations under the License.
 
 package ec2
 
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/klog"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+)
+
+func amiName(platform, platformVersion, kubernetesVersion string) string {
+	return fmt.Sprintf("ami-%s-%s-%s-00-??????????", platform, platformVersion, strings.TrimPrefix(kubernetesVersion, "v"))
+}
+
 // defaultAMILookup returns the default AMI based on region
-func (s *Service) defaultAMILookup(region string) string {
-	//TODO(chuckha) Replace this function with a method to filter public images.
-	switch region {
-	case "ap-northeast-1":
-		return "ami-06525773f0332c0ca"
-	case "ap-northeast-2":
-		return "ami-0914a816a80ab8779"
-	case "ap-south-1":
-		return "ami-04b17f6875b4d9c29"
-	case "ap-southeast-1":
-		return "ami-0ccaa193408259c82"
-	case "ap-southeast-2":
-		return "ami-0385d030f1b7df12c"
-	case "ca-central-1":
-		return "ami-031ca32942ffbe25f"
-	case "eu-central-1":
-		return "ami-078f9fe8bdaa81aa8"
-	case "eu-west-1":
-		return "ami-09547cd6f9856a79b"
-	case "eu-west-2":
-		return "ami-08efe1a8b5f18f381"
-	case "eu-west-3":
-		return "ami-042c578ede4ff3f33"
-	case "sa-east-1":
-		return "ami-0dd7e2894db509204"
-	case "us-east-1":
-		return "ami-026e9f3a713727945"
-	case "us-east-2":
-		return "ami-0ec6d3241fb7776fe"
-	case "us-west-1":
-		return "ami-06ec1c533176de131"
-	case "us-west-2":
-		return "ami-0cfa2d1fa5cc93615"
-	default:
-		return "unknown region"
+func (s *Service) defaultAMILookup(platform, platformVersion, kubernetesVersion string) (string, error) {
+	describeImageInput := &ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("name"),
+				Values: []*string{aws.String(amiName(platform, platformVersion, kubernetesVersion))},
+			},
+			{
+				Name:   aws.String("architecture"),
+				Values: []*string{aws.String("x86_64")},
+			},
+			{
+				Name:   aws.String("state"),
+				Values: []*string{aws.String("available")},
+			},
+			{
+				Name:   aws.String("virtualization-type"),
+				Values: []*string{aws.String("hvm")},
+			},
+		},
 	}
+
+	out, err := s.scope.EC2.DescribeImages(describeImageInput)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find ami: %q", amiName(platform, platformVersion, kubernetesVersion))
+	}
+	if len(out.Images) == 0 {
+		return "", errors.Errorf("found no AMIs with the name: %q", amiName(platform, platformVersion, kubernetesVersion))
+	}
+	klog.V(2).Infof("Using AMI: %q", aws.StringValue(out.Images[0].ImageId))
+	return aws.StringValue(out.Images[0].ImageId), nil
 }
 
 func (s *Service) defaultBastionAMILookup(region string) string {

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -106,11 +106,15 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 		Role:        aws.String(machine.Role()),
 	})
 
+	var err error
 	// Pick image from the machine configuration, or use a default one.
 	if machine.MachineConfig.AMI.ID != nil {
 		input.ImageID = *machine.MachineConfig.AMI.ID
 	} else {
-		input.ImageID = s.defaultAMILookup(machine.Region())
+		input.ImageID, err = s.defaultAMILookup("ubuntu", "18.04", machine.Machine.Spec.Versions.Kubelet)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Pick subnet from the machine configuration, or default to the first private available.

--- a/pkg/cloud/aws/services/ec2/instances_test.go
+++ b/pkg/cloud/aws/services/ec2/instances_test.go
@@ -302,6 +302,15 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				m.
+					DescribeImages(gomock.Any()).
+					Return(&ec2.DescribeImagesOutput{
+						Images: []*ec2.Image{
+							{
+								Name: aws.String("ami-1"),
+							},
+						},
+					}, nil)
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{


### PR DESCRIPTION
This is a first pass at looking up AMIs instead of hardcoding
a big case statement basd on region.

Fixes #138

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR looks up AMIs for control plane nodes instead of relying on hardcoded case statement.

This logic requires coordination with the build/ directory because it uses the name to look up the actual AMI. There may be improvements and we want to implement this logic with the bastion hosts (I think) as well.

The goal is to iterate from here, this may not be perfect but until we release new images with a different title, this will work.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```