### PR TITLE
Add permissions for ELB to create service linked roles

### DIFF
--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/BUILD
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cloud/aws/services/cloudformation:go_default_library",
+        "//pkg/cloud/aws/services/iam:go_default_library",
         "//pkg/cloud/aws/services/sts:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/cloudformation:go_default_library",

--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -28,6 +28,7 @@ import (
 	awssts "github.com/aws/aws-sdk-go/service/sts"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/cloudformation"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/iam"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/sts"
 )
 
@@ -106,7 +107,7 @@ Instructions for obtaining the AWS account ID can be found on https://docs.aws.a
 				return err
 			}
 
-			fmt.Print(string(j))
+			fmt.Print(iam.ProcessPolicyDocument(string(j)))
 			return nil
 		},
 	}

--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -191,6 +191,19 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 			{
 				Effect: iam.EffectAllow,
 				Resource: iam.Resources{fmt.Sprintf(
+					"arn:aws:iam::%s:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing",
+					accountID),
+				},
+				Action: iam.Actions{
+					"iam:CreateServiceLinkedRole",
+				},
+				Condition: iam.Conditions{
+					"StringLike": map[string]string{"iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"},
+				},
+			},
+			{
+				Effect: iam.EffectAllow,
+				Resource: iam.Resources{fmt.Sprintf(
 					"arn:aws:iam::%s:role/%s",
 					accountID,
 					iam.NewManagedName("*"),

--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -340,7 +340,7 @@ func (s *Service) ReconcileBootstrapStack(stackName string, accountID string) er
 		return errors.Wrap(err, "failed to generate AWS CloudFormation YAML")
 	}
 
-	if err := s.createStack(stackName, string(yaml)); err != nil {
+	if err := s.createStack(stackName, iam.ProcessPolicyDocument(string(yaml))); err != nil {
 		if code, _ := awserrors.Code(errors.Cause(err)); code == "AlreadyExistsException" {
 			klog.Infof("AWS Cloudformation stack %q already exists, updating", stackName)
 			updateErr := s.updateStack(stackName, string(yaml))

--- a/pkg/cloud/aws/services/iam/types.go
+++ b/pkg/cloud/aws/services/iam/types.go
@@ -82,10 +82,7 @@ type Resources []string
 type PrincipalID []string
 
 // Conditions is the map of all conditions in the statement entry.
-type Conditions map[string]ConditionValues
-
-// ConditionValues are a list of condition values in a condition statement
-type ConditionValues []string
+type Conditions map[string]interface{}
 
 // JSON is the JSON output of the policy document
 func (p *PolicyDocument) JSON() (string, error) {

--- a/pkg/cloud/aws/services/iam/types.go
+++ b/pkg/cloud/aws/services/iam/types.go
@@ -19,6 +19,7 @@ package iam
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -63,7 +64,13 @@ type StatementEntry struct {
 	Effect       string     `json:"Effect"`
 	Action       Actions    `json:"Action"`
 	Resource     Resources  `json:",omitempty"`
-	Condition    Conditions `json:",omitempty"`
+
+	// Condition is currently called IAMConditions to pass through
+	// GoFormation's template processing without being replaced
+	// with an intrinsic function. If you use a Condition statement,
+	// run the resultant stringified template through ProcessPolicyDocument
+	// to change back IAMCondition to Condition.
+	Condition Conditions `json:"IAMConditions,omitempty"`
 }
 
 // Statements is the list of StatementEntries
@@ -90,11 +97,18 @@ func (p *PolicyDocument) JSON() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(b), nil
+	return ProcessPolicyDocument(string(b)), nil
 }
 
 // NewManagedName creates an IAM acceptable name prefixed with this Cluster API
 // implementation's prefix.
 func NewManagedName(prefix string) string {
 	return fmt.Sprintf("%s.%s", prefix, IAMSuffix)
+}
+
+// ProcessPolicyDocument replaces IAMConditions in serialised StatementEntry
+// objects with Condition as per the AWS IAM policy schema as a work-around for
+// https://github.com/awslabs/goformation/issues/157
+func ProcessPolicyDocument(p string) string {
+	return strings.Replace(p, "IAMConditions", "Condition", 1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #422 

Permits ELB, as an Amazon-managed service, to create a role to access EC2 in the customer's account, which is needed to attach the control plane instances to a load balancer.

**Special notes for your reviewer**:

In order to test this, ELB will create a `AWSServiceRoleForElasticLoadBalancing` using these IAM permissions. If all ELBs are deleted, then this role can be deleted and then the account is reusable for testing this feature.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
clusterawsadm: IAM policies have been extended to allow AWS ELB to create the AWSServiceRoleForElasticLoadBalancing IAM role if it does not exist in an account.
```