### PR TITLE
minor cli message

### DIFF
--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -120,6 +120,7 @@ func createStackCmd() *cobra.Command {
 		Long:  "Create a new AWS CloudFormation stack using the bootstrap template",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			stackName := "cluster-api-provider-aws-sigs-k8s-io"
+			fmt.Printf("Attempting to create CloudFormation stack %s", stackName)
 			sess, err := session.NewSessionWithOptions(session.Options{
 				SharedConfigState: session.SharedConfigEnable,
 			})


### PR DESCRIPTION
Signed-off-by: Ruben Orduz <rdodev@vmware.com>

**What this PR does / why we need it**:
Currently `clusterawsadm alpha bootstrap  create-stack` is silent unless there's an error or completes successfully. This PR is minor UX message so they user knows actions are about to take place.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
On cluster boostrap creation the CLI will now let the user know it will attempt to create a bootstrap stack.
```