### PR TITLE
Makefile: Ensure out directory exists for release-binaries target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ cluster-api-dev-helper: dep-ensure ## Build cluster-api-dev-helper binary
 release-binaries: ## Build release binaries
 	bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/clusterctl //cmd/clusterawsadm
 	bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //cmd/clusterctl //cmd/clusterawsadm
+	mkdir -p out
 	install bazel-bin/cmd/clusterawsadm/darwin_amd64_pure_stripped/clusterawsadm out/clusterawsadm-darwin-amd64
 	install bazel-bin/cmd/clusterawsadm/linux_amd64_pure_stripped/clusterawsadm out/clusterawsadm-linux-amd64
 	install bazel-bin/cmd/clusterctl/darwin_amd64_pure_stripped/clusterctl out/clusterctl-darwin-amd64
@@ -131,6 +132,7 @@ clean: ## Remove all generated files
 	rm -f kubeconfig
 	rm -f minikube.kubeconfig
 	rm -f bazel-*
+	rm -rf out/
 
 .PHONY: reset-bazel
 reset-bazel: ## Deep cleaning for bazel


### PR DESCRIPTION
**What this PR does / why we need it**:
In a fresh `cluster-api-provider-aws` checkout, the `release-binaries` make target would fail due to the `out` directory not existing yet.
This PR ensures that the directory exists before we attempt to use it, it also cleans it up in the `clean` target.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```