### PR TITLE
Update cluster-api to latest master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -836,7 +836,7 @@
   revision = "0317810137be915b9cf888946c6e115c1bfac693"
 
 [[projects]]
-  digest = "1:e0646c498fb25588240aa66b7e4ef58da6d4b59037d6c7774eca3aa9bbaf2cab"
+  digest = "1:bc7ad2011ba9c3cf2d231d4fd3d240cb8af4afa0f0ff738d5795be78483791ab"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "cmd/clusterctl/clientcmd",
@@ -863,7 +863,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "ca1e293c506a5ca10f46fefa86dd22e48d358430"
+  revision = "2aa88253578695ddb71aee8e6f36b83f31c4bd38"
 
 [[projects]]
   digest = "1:f67de7bec51b31c93bce558098ac8c144e598248a6c91016dc7dca668558353d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  revision = "ca1e293c506a5ca10f46fefa86dd22e48d358430"
+  revision = "2aa88253578695ddb71aee8e6f36b83f31c4bd38"
 
 # For dependency below: Refer to issue https://github.com/golang/dep/issues/1799
 [[override]]

--- a/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing/BUILD.bazel
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["existingcluster.go"],
+    srcs = ["cluster.go"],
     importmap = "sigs.k8s.io/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing",
     importpath = "sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing",
     visibility = ["//visibility:public"],

--- a/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing/cluster.go
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing/cluster.go
@@ -25,36 +25,36 @@ import (
 
 // Represents an existing cluster being used for bootstrapping, should not be able to
 // actually delete or create, but can point to actual kubeconfig file.
-type ExistingCluster struct {
+type Cluster struct {
 	kubeconfigPath string
 	kubeconfigFile string
 }
 
-// NewExistingCluster creates a new existing k8s bootstrap cluster object
+// New creates a new existing k8s bootstrap cluster object
 // We should clean up any lingering resources when clusterctl is complete.
 // TODO https://github.com/kubernetes-sigs/cluster-api/issues/448
-func NewExistingCluster(kubeconfigPath string) (*ExistingCluster, error) {
+func New(kubeconfigPath string) (*Cluster, error) {
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 		return nil, errors.Errorf("file at %s does not exist", kubeconfigPath)
 	}
 
-	return &ExistingCluster{kubeconfigPath: kubeconfigPath}, nil
+	return &Cluster{kubeconfigPath: kubeconfigPath}, nil
 }
 
 // Create implements clusterdeployer.ClusterProvisioner interface
-func (e *ExistingCluster) Create() error {
+func (e *Cluster) Create() error {
 	// noop
 	return nil
 }
 
 // Delete implements clusterdeployer.ClusterProvisioner interface
-func (e *ExistingCluster) Delete() error {
+func (e *Cluster) Delete() error {
 	// noop
 	return nil
 }
 
 // GetKubeconfig implements clusterdeployer.ClusterProvisioner interface
-func (e *ExistingCluster) GetKubeconfig() (string, error) {
+func (e *Cluster) GetKubeconfig() (string, error) {
 
 	if e.kubeconfigFile == "" {
 		b, err := ioutil.ReadFile(e.kubeconfigPath)

--- a/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -99,7 +99,13 @@ func (k *Kind) getKubeConfigPath() (string, error) {
 	for _, opt := range k.options {
 		args = append(args, fmt.Sprintf("--%v", opt))
 	}
-	return k.exec(args...)
+
+	out, err := k.exec(args...)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(out), nil
 }
 
 func (k *Kind) exec(args ...string) (string, error) {

--- a/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
@@ -38,7 +38,7 @@ func Get(o Options) (ClusterProvisioner, error) {
 		return minikube.WithOptions(o.ExtraFlags), nil
 	default:
 		if o.KubeConfig != "" {
-			return existing.NewExistingCluster(o.KubeConfig)
+			return existing.New(o.KubeConfig)
 		}
 
 		return nil, errors.New("no bootstrap provisioner specified, you can specify `--bootstrap-cluster-kubeconfig` to use an existing Kubernetes cluster or `--bootstrap-type` to use a built-in ephemeral cluster.")


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR updates cluster-api upstream dependency to the latest master, which fixes an issue with kind bootstrapper returning kubeconfig path with a newline.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```