### PR TITLE
Machine Actuator: Implement immutable state checking for Update method

### DIFF
--- a/pkg/cloud/aws/actuators/machine/BUILD.bazel
+++ b/pkg/cloud/aws/actuators/machine/BUILD.bazel
@@ -37,6 +37,8 @@ go_test(
     srcs = ["actuator_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/awsprovider/v1alpha1:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/controller/machine:go_default_library",

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -261,33 +261,33 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 	return nil
 }
 
-// immutableSateChanged checks that no immutable fields have been updated in an
+// immutableStateChanged checks that no immutable fields have been updated in an
 // Update request.
 // Returns a bool indicating if an attempt to change immutable state occurred.
 //  - true:  An attempt to change immutable state occurred.
 //  - false: Immutable state was untouched.
-func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, instanceDescription *v1alpha1.Instance) bool {
+func immutableStateChanged(machineSpec *v1alpha1.AWSMachineProviderSpec, instance *v1alpha1.Instance) bool {
 	// Instance Type
-	if machineConfig.InstanceType != instanceDescription.Type {
+	if machineSpec.InstanceType != instance.Type {
 		return true
 	}
 
 	// IAM Profile
-	if machineConfig.IAMInstanceProfile != instanceDescription.IAMProfile {
+	if machineSpec.IAMInstanceProfile != instance.IAMProfile {
 		return true
 	}
 
 	// SSH Key Name
-	if machineConfig.KeyName != aws.StringValue(instanceDescription.KeyName) {
+	if machineSpec.KeyName != aws.StringValue(instance.KeyName) {
 		return true
 	}
 
 	// Subnet ID
-	// machineConfig.Subnet is an AWSResourceReference and could technically be
+	// machineSpec.Subnet is a *AWSResourceReference and could technically be
 	// a *string, ARN or Filter. However, elsewhere in the code it is only used
 	// as a *string, so do the same here.
-	if machineConfig.Subnet != nil {
-		if aws.StringValue(machineConfig.Subnet.ID) != instanceDescription.SubnetID {
+	if machineSpec.Subnet != nil {
+		if aws.StringValue(machineSpec.Subnet.ID) != instance.SubnetID {
 			return true
 		}
 	}
@@ -300,13 +300,11 @@ func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, insta
 	// the length of the PublicIP string. Anything >0 is assumed to mean it does
 	// have a public IP.
 	instanceHasPublicIP := false
-	if len(aws.StringValue(instanceDescription.PublicIP)) > 0 {
+	if len(aws.StringValue(instance.PublicIP)) > 0 {
 		instanceHasPublicIP = true
 	}
 
-	// Check the value of the machineConfig against the instanceDescription
-	// If these values don't match, a changed occurred.
-	if aws.BoolValue(machineConfig.PublicIP) != instanceHasPublicIP {
+	if aws.BoolValue(machineSpec.PublicIP) != instanceHasPublicIP {
 		return true
 	}
 

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -267,22 +267,19 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 //  - true:  An attempt to change immutable state occured.
 //  - false: Immutable state was untouched.
 func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, instanceDescription *v1alpha1.Instance) bool {
-	// State change tracking.
-	changed := false
-
 	// Instance Type
 	if machineConfig.InstanceType != instanceDescription.Type {
-		changed = true
+		return true
 	}
 
 	// IAM Profile
 	if machineConfig.IAMInstanceProfile != instanceDescription.IAMProfile {
-		changed = true
+		return true
 	}
 
 	// SSH Key Name
 	if machineConfig.KeyName != aws.StringValue(instanceDescription.KeyName) {
-		changed = true
+		return true
 	}
 
 	// Subnet ID
@@ -291,7 +288,7 @@ func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, insta
 	// as a *string, so do the same here.
 	if machineConfig.Subnet != nil {
 		if aws.StringValue(machineConfig.Subnet.ID) != instanceDescription.SubnetID {
-			changed = true
+			return true
 		}
 	}
 
@@ -310,10 +307,11 @@ func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, insta
 	// Check the value of the machineConfig against the instanceDescription
 	// If these values don't match, a changed occurred.
 	if aws.BoolValue(machineConfig.PublicIP) != instanceHasPublicIP {
-		changed = true
+		return true
 	}
 
-	return changed
+	// No immutable state changes found.
+	return false
 }
 
 // Update updates a machine and is invoked by the Machine Controller.

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -263,8 +263,8 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 // immutableSateChanged checks that no immutable fields have been updated in an
 // Update request.
-// Returns a bool indicating if an attempt to change immutable state occured.
-//  - true:  An attempt to change immutable state occured.
+// Returns a bool indicating if an attempt to change immutable state occurred.
+//  - true:  An attempt to change immutable state occurred.
 //  - false: Immutable state was untouched.
 func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, instanceDescription *v1alpha1.Instance) bool {
 	// Instance Type

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -336,7 +336,6 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	// We can now compare the various AWS state to the state we were passed.
 	// We will check immutable state first, in order to fail quickly before
 	// moving on to state that we can mutate.
-	// TODO: Implement immutable state check.
 	if a.isMachineOutdated(scope.MachineConfig, instanceDescription) {
 		return errors.Errorf("found attempt to change immutable state")
 	}

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -285,6 +285,16 @@ func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, insta
 		changed = true
 	}
 
+	// Subnet ID
+	// machineConfig.Subnet is an AWSResourceReference and could technically be
+	// a *string, ARN or Filter. However, elsewhere in the code it is only used
+	// as a *string, so do the same here.
+	if machineConfig.Subnet != nil {
+		if aws.StringValue(machineConfig.Subnet.ID) != instanceDescription.SubnetID {
+			changed = true
+		}
+	}
+
 	// PublicIP check is a little more complicated as the machineConfig is a
 	// simple bool indicating if the instance should have a public IP or not,
 	// while the instanceDescription contains the public IP assigned to the
@@ -302,11 +312,6 @@ func immutableStateChanged(machineConfig *v1alpha1.AWSMachineProviderSpec, insta
 	if aws.BoolValue(machineConfig.PublicIP) != instanceHasPublicIP {
 		changed = true
 	}
-
-	// The subnet ID should also be checked here, but appears to be more
-	// complicated, as instanceDescription only contains SubnetID while the
-	// machineConfig can contain an ID, ARN or Filter for finding the correct
-	// SubnetID.
 
 	return changed
 }

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -261,12 +261,12 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 	return nil
 }
 
-// immutableStateChanged checks that no immutable fields have been updated in an
+// isMachineOudated checks that no immutable fields have been updated in an
 // Update request.
 // Returns a bool indicating if an attempt to change immutable state occurred.
 //  - true:  An attempt to change immutable state occurred.
 //  - false: Immutable state was untouched.
-func immutableStateChanged(machineSpec *v1alpha1.AWSMachineProviderSpec, instance *v1alpha1.Instance) bool {
+func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpec, instance *v1alpha1.Instance) bool {
 	// Instance Type
 	if machineSpec.InstanceType != instance.Type {
 		return true
@@ -337,7 +337,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	// We will check immutable state first, in order to fail quickly before
 	// moving on to state that we can mutate.
 	// TODO: Implement immutable state check.
-	if immutableStateChanged(scope.MachineConfig, instanceDescription) {
+	if a.isMachineOutdated(scope.MachineConfig, instanceDescription) {
 		return errors.Errorf("found attempt to change immutable state")
 	}
 

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -421,6 +421,30 @@ func TestImmutableStateChange(t *testing.T) {
 			},
 			expectedValue: true,
 		},
+		{
+			name: "subnetid is unchanged",
+			machineConfig: v1alpha1.AWSMachineProviderSpec{
+				Subnet: &v1alpha1.AWSResourceReference{
+					ID: aws.String("subnet-abcdef"),
+				},
+			},
+			instanceDescription: v1alpha1.Instance{
+				SubnetID: "subnet-abcdef",
+			},
+			expectedValue: false,
+		},
+		{
+			name: "subnetid is changed",
+			machineConfig: v1alpha1.AWSMachineProviderSpec{
+				Subnet: &v1alpha1.AWSResourceReference{
+					ID: aws.String("subnet-123456"),
+				},
+			},
+			instanceDescription: v1alpha1.Instance{
+				SubnetID: "subnet-abcdef",
+			},
+			expectedValue: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -445,8 +445,10 @@ func TestImmutableStateChange(t *testing.T) {
 		},
 	}
 
+	testActuator := NewActuator(ActuatorParams{})
+
 	for _, tc := range testCases {
-		changed := immutableStateChanged(&tc.machineSpec, &tc.instance)
+		changed := testActuator.isMachineOutdated(&tc.machineSpec, &tc.instance)
 
 		if tc.expected != changed {
 			t.Fatalf("[%s] Expected MachineSpec [%+v], NOT Equal Instance [%+v]",

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -405,7 +405,6 @@ func TestImmutableStateChange(t *testing.T) {
 				PublicIP: aws.Bool(false),
 			},
 			instanceDescription: v1alpha1.Instance{
-				// This IP chosen from RFC5737 TEST-NET-1
 				PublicIP: aws.String(""),
 			},
 			expectedValue: false,
@@ -416,7 +415,6 @@ func TestImmutableStateChange(t *testing.T) {
 				PublicIP: aws.Bool(true),
 			},
 			instanceDescription: v1alpha1.Instance{
-				// This IP chosen from RFC5737 TEST-NET-1
 				PublicIP: aws.String(""),
 			},
 			expectedValue: true,

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -448,7 +448,6 @@ func TestImmutableStateChange(t *testing.T) {
 	for _, tc := range testCases {
 		changed := immutableStateChanged(&tc.machineConfig, &tc.instanceDescription)
 
-		// true case: values changed
 		if tc.expectedValue != changed {
 			t.Fatalf("[%s] Expected Machine Config [%+v], NOT Equal Instance Description [%+v]",
 				tc.name, tc.machineConfig, tc.instanceDescription)

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -312,145 +312,145 @@ func TestMachineEqual(t *testing.T) {
 
 func TestImmutableStateChange(t *testing.T) {
 	testCases := []struct {
-		name                string
-		machineConfig       v1alpha1.AWSMachineProviderSpec
-		instanceDescription v1alpha1.Instance
-		expectedValue       bool
+		name        string
+		machineSpec v1alpha1.AWSMachineProviderSpec
+		instance    v1alpha1.Instance
+		expected    bool
 	}{
 		{
 			name: "instance type is unchanged",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				InstanceType: "t2.micro",
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				Type: "t2.micro",
 			},
-			expectedValue: false,
+			expected: false,
 		},
 		{
 			name: "instance type is changed",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				InstanceType: "m5.large",
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				Type: "t2.micro",
 			},
-			expectedValue: true,
+			expected: true,
 		},
 		{
 			name: "iam profile is unchanged",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				IAMInstanceProfile: "test-profile",
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				IAMProfile: "test-profile",
 			},
-			expectedValue: false,
+			expected: false,
 		},
 		{
 			name: "iam profile is changed",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				IAMInstanceProfile: "test-profile-updated",
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				IAMProfile: "test-profile",
 			},
-			expectedValue: true,
+			expected: true,
 		},
 		{
 			name: "keyname is unchanged",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				KeyName: "SSHKey",
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				KeyName: aws.String("SSHKey"),
 			},
-			expectedValue: false,
+			expected: false,
 		},
 		{
 			name: "keyname is changed",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				KeyName: "SSHKey2",
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				KeyName: aws.String("SSHKey"),
 			},
-			expectedValue: true,
+			expected: true,
 		},
 		{
 			name: "instance with public ip is unchanged",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				PublicIP: aws.Bool(true),
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				// This IP chosen from RFC5737 TEST-NET-1
 				PublicIP: aws.String("192.0.2.1"),
 			},
-			expectedValue: false,
+			expected: false,
 		},
 		{
 			name: "instance with public ip is changed",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				PublicIP: aws.Bool(false),
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				// This IP chosen from RFC5737 TEST-NET-1
 				PublicIP: aws.String("192.0.2.1"),
 			},
-			expectedValue: true,
+			expected: true,
 		},
 		{
 			name: "instance without public ip is unchanged",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				PublicIP: aws.Bool(false),
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				PublicIP: aws.String(""),
 			},
-			expectedValue: false,
+			expected: false,
 		},
 		{
 			name: "instance without public ip is changed",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				PublicIP: aws.Bool(true),
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				PublicIP: aws.String(""),
 			},
-			expectedValue: true,
+			expected: true,
 		},
 		{
 			name: "subnetid is unchanged",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				Subnet: &v1alpha1.AWSResourceReference{
 					ID: aws.String("subnet-abcdef"),
 				},
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				SubnetID: "subnet-abcdef",
 			},
-			expectedValue: false,
+			expected: false,
 		},
 		{
 			name: "subnetid is changed",
-			machineConfig: v1alpha1.AWSMachineProviderSpec{
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				Subnet: &v1alpha1.AWSResourceReference{
 					ID: aws.String("subnet-123456"),
 				},
 			},
-			instanceDescription: v1alpha1.Instance{
+			instance: v1alpha1.Instance{
 				SubnetID: "subnet-abcdef",
 			},
-			expectedValue: true,
+			expected: true,
 		},
 	}
 
 	for _, tc := range testCases {
-		changed := immutableStateChanged(&tc.machineConfig, &tc.instanceDescription)
+		changed := immutableStateChanged(&tc.machineSpec, &tc.instance)
 
-		if tc.expectedValue != changed {
-			t.Fatalf("[%s] Expected Machine Config [%+v], NOT Equal Instance Description [%+v]",
-				tc.name, tc.machineConfig, tc.instanceDescription)
+		if tc.expected != changed {
+			t.Fatalf("[%s] Expected MachineSpec [%+v], NOT Equal Instance [%+v]",
+				tc.name, tc.machineSpec, tc.instance)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements erroring on a machine update if the incoming configuration attempts to change immutable machine state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #33 

**Special notes for your reviewer**:
Currently need to implement the Subnet checks.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```