### PR TITLE
Improve user experience when generating manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ clean: ## Remove all generated files
 reset-bazel: ## Deep cleaning for bazel
 	bazel clean --expunge
 
+.PHONY: cmd/clusterctl/examples/aws/out
 cmd/clusterctl/examples/aws/out:
 	./cmd/clusterctl/examples/aws/generate-yaml.sh
 


### PR DESCRIPTION
This makes the out taret a phony so make will always try to
run the script regardless if the directory is clean or not.
The script provides useful error messages that the user can
act upon.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR improves the UX for users getting started. This introduces errors and actions to fix the errors instead of silently ignoring a script and creating confusion for users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #540 

**Special notes for your reviewer**:

```release-note
NONE
```