### PR TITLE
More reliable public subnet detection

### DIFF
--- a/pkg/apis/awsprovider/v1alpha1/awsclusterproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1alpha1/awsclusterproviderconfig_types.go
@@ -122,18 +122,18 @@ type SubnetSpec struct {
 	// AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
-	// IsPublic defines the subnet as a public subnet. Refer to the AWS documentation for further information.
+	// IsPublic defines the subnet as a public subnet. A subnet is considered public when it has a direct route to and from the internet via an internet gateway.
 	// +optional
-	IsPublic bool `json:"isPublic,omitempty"`
+	IsPublic bool `json:"isPublic"`
 
 	// RouteTableID is the routing table id associated with the subnet.
 	// +optional
 	RouteTableID *string `json:"routeTableId"`
 
 	// NatGatewayID is the NAT gateway id associated with the subnet.
-	// Ignored if the subnet is public.
+	// Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the nat gateway resides. It is then used to determe routes for private subnets in the same AZ as the public subnet.
 	// +optional
-	NatGatewayID *string `json:"natGatewayId"`
+	NatGatewayID *string `json:"natGatewayId,omitempty"`
 
 	// Tags is a collection of tags describing the resource.
 	Tags tags.Map `json:"tags,omitempty"`

--- a/pkg/apis/awsprovider/v1alpha1/awsclusterproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1alpha1/awsclusterproviderconfig_types.go
@@ -122,7 +122,7 @@ type SubnetSpec struct {
 	// AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
-	// IsPublic defines the subnet as a public subnet. A subnet is considered public when it has a direct route to and from the internet via an internet gateway.
+	// IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.
 	// +optional
 	IsPublic bool `json:"isPublic"`
 

--- a/pkg/cloud/aws/services/ec2/routetables.go
+++ b/pkg/cloud/aws/services/ec2/routetables.go
@@ -155,11 +155,16 @@ func (s *Service) deleteRouteTables() error {
 }
 
 func (s *Service) describeVpcRouteTables() ([]*ec2.RouteTable, error) {
+	filters := []*ec2.Filter{
+		filter.EC2.VPC(s.scope.VPC().ID),
+	}
+
+	if !s.scope.VPC().IsProvided() {
+		filters = append(filters, filter.EC2.Cluster(s.scope.Name()))
+	}
+
 	out, err := s.scope.EC2.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
-		Filters: []*ec2.Filter{
-			filter.EC2.VPC(s.scope.VPC().ID),
-			filter.EC2.Cluster(s.scope.Name()),
-		},
+		Filters: filters,
 	})
 
 	if err != nil {

--- a/pkg/cloud/aws/services/ec2/subnets_test.go
+++ b/pkg/cloud/aws/services/ec2/subnets_test.go
@@ -139,21 +139,6 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
-					Return(&ec2.DescribeInternetGatewaysOutput{
-						InternetGateways: []*ec2.InternetGateway{
-							{
-								InternetGatewayId: aws.String("igw-0"),
-								Attachments: []*ec2.InternetGatewayAttachment{
-									{
-										State: aws.String(ec2.AttachmentStatusAttached),
-										VpcId: aws.String(subnetsVPCID),
-									},
-								},
-							},
-						},
-					}, nil)
-
 				m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String(defaultPublicSubnetCidr),
@@ -238,21 +223,6 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}),
 					gomock.Any()).Return(nil)
-
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
-					Return(&ec2.DescribeInternetGatewaysOutput{
-						InternetGateways: []*ec2.InternetGateway{
-							{
-								InternetGatewayId: aws.String("igw-0"),
-								Attachments: []*ec2.InternetGatewayAttachment{
-									{
-										State: aws.String(ec2.AttachmentStatusAttached),
-										VpcId: aws.String(subnetsVPCID),
-									},
-								},
-							},
-						},
-					}, nil)
 
 				firstSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
@@ -360,21 +330,6 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}),
 					gomock.Any()).Return(nil)
-
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
-					Return(&ec2.DescribeInternetGatewaysOutput{
-						InternetGateways: []*ec2.InternetGateway{
-							{
-								InternetGatewayId: aws.String("igw-0"),
-								Attachments: []*ec2.InternetGatewayAttachment{
-									{
-										State: aws.String(ec2.AttachmentStatusAttached),
-										VpcId: aws.String(subnetsVPCID),
-									},
-								},
-							},
-						},
-					}, nil)
 
 				firstSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
@@ -521,21 +476,6 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}),
 					gomock.Any()).Return(nil)
-
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
-					Return(&ec2.DescribeInternetGatewaysOutput{
-						InternetGateways: []*ec2.InternetGateway{
-							{
-								InternetGatewayId: aws.String("igw-0"),
-								Attachments: []*ec2.InternetGatewayAttachment{
-									{
-										State: aws.String(ec2.AttachmentStatusAttached),
-										VpcId: aws.String(subnetsVPCID),
-									},
-								},
-							},
-						},
-					}, nil)
 
 				m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
@@ -703,21 +643,6 @@ func TestDiscoverSubnets(t *testing.T) {
 						},
 					}),
 					gomock.Any()).Return(nil)
-
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
-					Return(&ec2.DescribeInternetGatewaysOutput{
-						InternetGateways: []*ec2.InternetGateway{
-							{
-								InternetGatewayId: aws.String("igw-0"),
-								Attachments: []*ec2.InternetGatewayAttachment{
-									{
-										State: aws.String(ec2.AttachmentStatusAttached),
-										VpcId: aws.String(subnetsVPCID),
-									},
-								},
-							},
-						},
-					}, nil)
 
 			},
 			expect: []*v1alpha1.SubnetSpec{

--- a/pkg/cloud/aws/services/ec2/subnets_test.go
+++ b/pkg/cloud/aws/services/ec2/subnets_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package ec2
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -110,6 +112,43 @@ func TestReconcileSubnets(t *testing.T) {
 										Key:   aws.String("Name"),
 										Value: aws.String("test-cluster-subnet-private"),
 									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/routable"),
+										Value: aws.String("private"),
+									},
+								},
+							},
+						},
+					}, nil)
+
+				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{}, nil)
+
+				m.DescribeNatGatewaysPages(
+					gomock.Eq(&ec2.DescribeNatGatewaysInput{
+						Filter: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
+						},
+					}),
+					gomock.Any()).Return(nil)
+
+				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+					Return(&ec2.DescribeInternetGatewaysOutput{
+						InternetGateways: []*ec2.InternetGateway{
+							{
+								InternetGatewayId: aws.String("igw-0"),
+								Attachments: []*ec2.InternetGatewayAttachment{
+									{
+										State: aws.String(ec2.AttachmentStatusAttached),
+										VpcId: aws.String(subnetsVPCID),
+									},
 								},
 							},
 						},
@@ -181,6 +220,39 @@ func TestReconcileSubnets(t *testing.T) {
 					},
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
+
+				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{}, nil)
+
+				m.DescribeNatGatewaysPages(
+					gomock.Eq(&ec2.DescribeNatGatewaysInput{
+						Filter: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
+						},
+					}),
+					gomock.Any()).Return(nil)
+
+				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+					Return(&ec2.DescribeInternetGatewaysOutput{
+						InternetGateways: []*ec2.InternetGateway{
+							{
+								InternetGatewayId: aws.String("igw-0"),
+								Attachments: []*ec2.InternetGatewayAttachment{
+									{
+										State: aws.String(ec2.AttachmentStatusAttached),
+										VpcId: aws.String(subnetsVPCID),
+									},
+								},
+							},
+						},
+					}, nil)
 
 				firstSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
@@ -271,6 +343,39 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
+				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{}, nil)
+
+				m.DescribeNatGatewaysPages(
+					gomock.Eq(&ec2.DescribeNatGatewaysInput{
+						Filter: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
+						},
+					}),
+					gomock.Any()).Return(nil)
+
+				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+					Return(&ec2.DescribeInternetGatewaysOutput{
+						InternetGateways: []*ec2.InternetGateway{
+							{
+								InternetGatewayId: aws.String("igw-0"),
+								Attachments: []*ec2.InternetGatewayAttachment{
+									{
+										State: aws.String(ec2.AttachmentStatusAttached),
+										VpcId: aws.String(subnetsVPCID),
+									},
+								},
+							},
+						},
+					}, nil)
+
 				firstSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String(defaultPrivateSubnetCidr),
@@ -325,6 +430,133 @@ func TestReconcileSubnets(t *testing.T) {
 
 			},
 		},
+		{
+			name: "managed VPC respects public tag",
+			input: &v1alpha1.NetworkSpec{
+				VPC: v1alpha1.VPCSpec{
+					ID: subnetsVPCID,
+					Tags: tags.Map{
+						tags.NameAWSProviderManaged: "true",
+					},
+				},
+				Subnets: []*v1alpha1.SubnetSpec{
+					{
+						ID:               "subnet-1",
+						AvailabilityZone: "us-east-1a",
+						CidrBlock:        "10.0.10.0/24",
+						IsPublic:         true,
+					},
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				m.DescribeAvailabilityZones(gomock.AssignableToTypeOf(&ec2.DescribeAvailabilityZonesInput{})).
+					Return(&ec2.DescribeAvailabilityZonesOutput{
+						AvailabilityZones: []*ec2.AvailabilityZone{
+							{
+								RegionName: aws.String("us-east-1"),
+								ZoneName:   aws.String("us-east-1a"),
+							},
+						},
+					}, nil)
+
+				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name:   aws.String("state"),
+							Values: []*string{aws.String("pending"), aws.String("available")},
+						},
+						{
+							Name:   aws.String("vpc-id"),
+							Values: []*string{aws.String(subnetsVPCID)},
+						},
+					},
+				})).
+					Return(&ec2.DescribeSubnetsOutput{
+						Subnets: []*ec2.Subnet{
+							{
+								VpcId:            aws.String(subnetsVPCID),
+								SubnetId:         aws.String("subnet-1"),
+								AvailabilityZone: aws.String("us-east-1a"),
+								CidrBlock:        aws.String("10.0.10.0/24"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/managed"),
+										Value: aws.String("true"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("common"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("test-cluster-subnet-public"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/routable"),
+										Value: aws.String("public"),
+									},
+								},
+							},
+						},
+					}, nil)
+
+				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{}, nil)
+
+				m.DescribeNatGatewaysPages(
+					gomock.Eq(&ec2.DescribeNatGatewaysInput{
+						Filter: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
+						},
+					}),
+					gomock.Any()).Return(nil)
+
+				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+					Return(&ec2.DescribeInternetGatewaysOutput{
+						InternetGateways: []*ec2.InternetGateway{
+							{
+								InternetGatewayId: aws.String("igw-0"),
+								Attachments: []*ec2.InternetGatewayAttachment{
+									{
+										State: aws.String(ec2.AttachmentStatusAttached),
+										VpcId: aws.String(subnetsVPCID),
+									},
+								},
+							},
+						},
+					}, nil)
+
+				m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+					VpcId:            aws.String(subnetsVPCID),
+					CidrBlock:        aws.String(defaultPrivateSubnetCidr),
+					AvailabilityZone: aws.String("us-east-1a"),
+				})).
+					Return(&ec2.CreateSubnetOutput{
+						Subnet: &ec2.Subnet{
+							VpcId:            aws.String(subnetsVPCID),
+							SubnetId:         aws.String("subnet-2"),
+							CidrBlock:        aws.String("10.0.0.0/24"),
+							AvailabilityZone: aws.String("us-east-1a"),
+						},
+					}, nil)
+
+				m.WaitUntilSubnetAvailable(gomock.Any())
+
+				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+					Return(nil, nil)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -355,6 +587,214 @@ func TestReconcileSubnets(t *testing.T) {
 			s := NewService(scope)
 			if err := s.reconcileSubnets(); err != nil {
 				t.Fatalf("got an unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDiscoverSubnets(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testCases := []struct {
+		name   string
+		input  *v1alpha1.NetworkSpec
+		mocks  func(m *mock_ec2iface.MockEC2APIMockRecorder)
+		expect []*v1alpha1.SubnetSpec
+	}{
+		{
+			name: "provided VPC finds internet routes",
+			input: &v1alpha1.NetworkSpec{
+				VPC: v1alpha1.VPCSpec{
+					ID: subnetsVPCID,
+				},
+			},
+			mocks: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name:   aws.String("state"),
+							Values: []*string{aws.String("pending"), aws.String("available")},
+						},
+						{
+							Name:   aws.String("vpc-id"),
+							Values: []*string{aws.String(subnetsVPCID)},
+						},
+					},
+				})).
+					Return(&ec2.DescribeSubnetsOutput{
+						Subnets: []*ec2.Subnet{
+							{
+								VpcId:            aws.String(subnetsVPCID),
+								SubnetId:         aws.String("subnet-1"),
+								AvailabilityZone: aws.String("us-east-1a"),
+								CidrBlock:        aws.String("10.0.10.0/24"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("provided-subnet-public"),
+									},
+								},
+							},
+							{
+								VpcId:            aws.String(subnetsVPCID),
+								SubnetId:         aws.String("subnet-2"),
+								AvailabilityZone: aws.String("us-east-1a"),
+								CidrBlock:        aws.String("10.0.11.0/24"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("provided-subnet-private"),
+									},
+								},
+							},
+						},
+					}, nil)
+
+				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{
+						RouteTables: []*ec2.RouteTable{
+							{
+								Associations: []*ec2.RouteTableAssociation{
+									{
+										SubnetId: aws.String("subnet-1"),
+									},
+								},
+								Routes: []*ec2.Route{
+									{
+										DestinationCidrBlock: aws.String("10.0.10.0/24"),
+										GatewayId:            aws.String("local"),
+									},
+									{
+										DestinationCidrBlock: aws.String("0.0.0.0/0"),
+										GatewayId:            aws.String("igw-0"),
+									},
+								},
+								RouteTableId: aws.String("rtb-1"),
+							},
+							{
+								Associations: []*ec2.RouteTableAssociation{
+									{
+										SubnetId: aws.String("subnet-2"),
+									},
+								},
+								Routes: []*ec2.Route{
+									{
+										DestinationCidrBlock: aws.String("10.0.11.0/24"),
+										GatewayId:            aws.String("local"),
+									},
+								},
+								RouteTableId: aws.String("rtb-2"),
+							},
+						},
+					}, nil)
+
+				m.DescribeNatGatewaysPages(
+					gomock.Eq(&ec2.DescribeNatGatewaysInput{
+						Filter: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
+						},
+					}),
+					gomock.Any()).Return(nil)
+
+				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+					Return(&ec2.DescribeInternetGatewaysOutput{
+						InternetGateways: []*ec2.InternetGateway{
+							{
+								InternetGatewayId: aws.String("igw-0"),
+								Attachments: []*ec2.InternetGatewayAttachment{
+									{
+										State: aws.String(ec2.AttachmentStatusAttached),
+										VpcId: aws.String(subnetsVPCID),
+									},
+								},
+							},
+						},
+					}, nil)
+
+			},
+			expect: []*v1alpha1.SubnetSpec{
+				{
+					ID:               "subnet-1",
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         true,
+					RouteTableID:     aws.String("rtb-1"),
+					Tags: tags.Map{
+						"Name": "provided-subnet-public",
+					},
+				},
+				{
+					ID:               "subnet-2",
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.11.0/24",
+					IsPublic:         false,
+					RouteTableID:     aws.String("rtb-2"),
+					Tags: tags.Map{
+						"Name": "provided-subnet-private",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ec2Mock := mock_ec2iface.NewMockEC2API(mockCtrl)
+			elbMock := mock_elbiface.NewMockELBAPI(mockCtrl)
+
+			scope, err := actuators.NewScope(actuators.ScopeParams{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				},
+				AWSClients: actuators.AWSClients{
+					EC2: ec2Mock,
+					ELB: elbMock,
+				},
+			})
+
+			scope.ClusterConfig = &v1alpha1.AWSClusterProviderSpec{
+				NetworkSpec: *tc.input,
+			}
+
+			if err != nil {
+				t.Fatalf("Failed to create test context: %v", err)
+			}
+
+			tc.mocks(ec2Mock.EXPECT())
+
+			s := NewService(scope)
+			if err := s.reconcileSubnets(); err != nil {
+				t.Fatalf("got an unexpected error: %v", err)
+			}
+
+			subnets := s.scope.ClusterConfig.NetworkSpec.Subnets
+			out := make(map[string]*v1alpha1.SubnetSpec)
+			for _, sn := range subnets {
+				out[sn.ID] = sn
+			}
+			for _, exp := range tc.expect {
+				sn, ok := out[exp.ID]
+				if !ok {
+					t.Errorf("Expected to find subnet %s in %+v", exp.ID, subnets)
+					continue
+				}
+
+				if !reflect.DeepEqual(sn, exp) {
+					expected, _ := json.MarshalIndent(exp, "", "\t")
+					actual, _ := json.MarshalIndent(sn, "", "\t")
+					t.Errorf("Expected %s, got %s", string(expected), string(actual))
+				}
+				delete(out, exp.ID)
+			}
+			if len(out) > 0 {
+				t.Errorf("Got unexpected subnets: %+v", out)
 			}
 		})
 	}

--- a/pkg/cloud/aws/services/ec2/subnets_test.go
+++ b/pkg/cloud/aws/services/ec2/subnets_test.go
@@ -106,15 +106,11 @@ func TestReconcileSubnets(t *testing.T) {
 									},
 									{
 										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
-										Value: aws.String("common"),
+										Value: aws.String("private"),
 									},
 									{
 										Key:   aws.String("Name"),
 										Value: aws.String("test-cluster-subnet-private"),
-									},
-									{
-										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/routable"),
-										Value: aws.String("private"),
 									},
 								},
 							},
@@ -444,15 +440,11 @@ func TestReconcileSubnets(t *testing.T) {
 									},
 									{
 										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
-										Value: aws.String("common"),
+										Value: aws.String("public"),
 									},
 									{
 										Key:   aws.String("Name"),
 										Value: aws.String("test-cluster-subnet-public"),
-									},
-									{
-										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/routable"),
-										Value: aws.String("public"),
 									},
 								},
 							},

--- a/pkg/cloud/aws/tags/types.go
+++ b/pkg/cloud/aws/tags/types.go
@@ -76,14 +76,19 @@ const (
 	// The tag value is an ownership value
 	NameKubernetesClusterPrefix = "kubernetes.io/cluster/"
 
+	// NameAWSProviderPrefix is the tag prefix we use to differentiate
+	// cluster-api-provider-aws owned components from other tooling that
+	// uses NameKubernetesClusterPrefix
+	NameAWSProviderPrefix = "sigs.k8s.io/cluster-api-provider-aws/"
+
 	// NameAWSProviderManaged is the tag name we use to differentiate
 	// cluster-api-provider-aws owned components from other tooling that
 	// uses NameKubernetesClusterPrefix
-	NameAWSProviderManaged = "sigs.k8s.io/cluster-api-provider-aws/managed"
+	NameAWSProviderManaged = NameAWSProviderPrefix + "managed"
 
 	// NameAWSClusterAPIRole is the tag name we use to mark roles for resources
 	// dedicated to this cluster api provider implementation.
-	NameAWSClusterAPIRole = "sigs.k8s.io/cluster-api-provider-aws/role"
+	NameAWSClusterAPIRole = NameAWSProviderPrefix + "role"
 
 	// ValueAPIServerRole describes the value for the apiserver role
 	ValueAPIServerRole = "apiserver"

--- a/pkg/cloud/aws/tags/types.go
+++ b/pkg/cloud/aws/tags/types.go
@@ -46,7 +46,6 @@ func (m Map) GetRole() string {
 	return m[NameAWSClusterAPIRole]
 }
 
-
 // Difference returns the difference between this map and the other map.
 // Items are considered equals if key and value are equals.
 func (m Map) Difference(other Map) Map {

--- a/pkg/cloud/aws/tags/types.go
+++ b/pkg/cloud/aws/tags/types.go
@@ -41,6 +41,12 @@ func (m Map) HasManaged() bool {
 	return ok && value == "true"
 }
 
+// GetRole returns the Cluster API role for the tagged resource
+func (m Map) GetRole() string {
+	return m[NameAWSClusterAPIRole]
+}
+
+
 // Difference returns the difference between this map and the other map.
 // Items are considered equals if key and value are equals.
 func (m Map) Difference(other Map) Map {
@@ -98,4 +104,10 @@ const (
 
 	// ValueCommonRole describes the value for the common role
 	ValueCommonRole = "common"
+
+	// ValuePublicRole describes the value for the public role
+	ValuePublicRole = "public"
+
+	// ValuePrivateRole describes the value for the private role
+	ValuePrivateRole = "private"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The subnet tracking code did not recognize our public subnets, because we've defaulted IP assignment off everywhere. Reading the docs seems to indicate that "public" or "private" subnets in AWS are an emergent property from how the traffic flows:

https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Scenario2.html

> The instances in the public subnet can send outbound traffic directly to the Internet, whereas the instances in the private subnet can't. Instead, the instances in the private subnet can access the Internet by using a network address translation (NAT) gateway that resides in the public subnet.

Which concurs with Stack Overflow:

https://stackoverflow.com/a/38691109

> A subnet is deemed to be a Public Subnet if it has a Route Table that directs traffic to the Internet Gateway.

So this PR modifies the existing logic to instead look for an internet-facing route in the subnet's route to determine whether this subnet is public or private.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The tests are still failing, but I wanted to get the PR up early for any feedback you have, especially around workflow. Currently, I'm running `make docker-push-dev MANAGER_IMAGE_TAG=0.0.3-2` and re-launching the pod in my local kind cluster. That's working ok, but it's a little slow and seems like it might be missing some things (is the CRD yaml generated?). Any tips would be appreciated!

Also, on an unrelated note, I was hoping to pull in the latest `cluster-api` upstream to make use of the `get-kubeconfig` phase: would it make more sense to add that to this PR, or open a second one?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
find public subnets by inspecting routes
```