### PR TITLE
Fix repeated error messages for clusterawsadm

### DIFF
--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -122,18 +122,7 @@ func createStackCmd() *cobra.Command {
 		Use:   "create-stack",
 		Short: "Create a new AWS CloudFormation stack using the bootstrap template",
 		Long:  "Create a new AWS CloudFormation stack using the bootstrap template",
-
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) >= 1 {
-				fmt.Printf("Error: No arguments are required for create-stack. \n")
-				if err := cmd.Help(); err != nil {
-					return err
-				}
-				os.Exit(400)
-			}
-
-			return nil
-		},
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			stackName := "cluster-api-provider-aws-sigs-k8s-io"
 			fmt.Printf("Attempting to create CloudFormation stack %s\n", stackName)
@@ -141,21 +130,22 @@ func createStackCmd() *cobra.Command {
 				SharedConfigState: session.SharedConfigEnable,
 			})
 			if err != nil {
-				return err
+				fmt.Printf("Error: %v", err)
+				return nil
 			}
 
 			stsSvc := sts.NewService(awssts.New(sess))
 			accountID, stsErr := stsSvc.AccountID()
 			if stsErr != nil {
 				fmt.Printf("Error: %v", stsErr)
-				os.Exit(401)
+				return nil
 			}
 
 			cfnSvc := cloudformation.NewService(cfn.New(sess))
 			err = cfnSvc.ReconcileBootstrapStack(stackName, accountID)
 			if err != nil {
 				fmt.Printf("Error: %v", err)
-				os.Exit(402)
+				return nil
 			}
 
 			return cfnSvc.ShowStackResources(stackName)

--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -122,6 +122,18 @@ func createStackCmd() *cobra.Command {
 		Use:   "create-stack",
 		Short: "Create a new AWS CloudFormation stack using the bootstrap template",
 		Long:  "Create a new AWS CloudFormation stack using the bootstrap template",
+
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) >= 1 {
+				fmt.Printf("Error: No arguments are required for create-stack. \n")
+				if err := cmd.Help(); err != nil {
+					return err
+				}
+				os.Exit(400)
+			}
+
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			stackName := "cluster-api-provider-aws-sigs-k8s-io"
 			fmt.Printf("Attempting to create CloudFormation stack %s\n", stackName)
@@ -135,13 +147,15 @@ func createStackCmd() *cobra.Command {
 			stsSvc := sts.NewService(awssts.New(sess))
 			accountID, stsErr := stsSvc.AccountID()
 			if stsErr != nil {
-				return stsErr
+				fmt.Printf("Error: %v", stsErr)
+				os.Exit(401)
 			}
 
 			cfnSvc := cloudformation.NewService(cfn.New(sess))
 			err = cfnSvc.ReconcileBootstrapStack(stackName, accountID)
 			if err != nil {
-				return err
+				fmt.Printf("Error: %v", err)
+				os.Exit(402)
 			}
 
 			return cfnSvc.ShowStackResources(stackName)


### PR DESCRIPTION
Signed-off-by: ishantanu <shantanud106@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
1. Fixes repeated error messages for clusterawsadm CLI.
2. Adds a validation for arguments passed to `clusterawsadm`'s `create-stack` command.
3. Skips printing `Usage:` when a genuine error occurs for `create-stack`. Only prints `Usage` details when invalid arguments are passed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #550 