### PR TITLE
Add support for MachineClass

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -52,6 +52,7 @@ rules:
   - machinedeployments/status
   - machinesets
   - machinesets/status
+  - machineclasses
   verbs:
   - get
   - list

--- a/pkg/apis/awsprovider/v1alpha1/register.go
+++ b/pkg/apis/awsprovider/v1alpha1/register.go
@@ -68,19 +68,6 @@ func ClusterStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSClust
 	return status, nil
 }
 
-// MachineConfigFromProviderSpec unmarshals a provider config into an AWS machine type
-func MachineConfigFromProviderSpec(providerConfig clusterv1.ProviderSpec) (*AWSMachineProviderSpec, error) {
-	var config AWSMachineProviderSpec
-	if providerConfig.Value == nil {
-		return &config, nil
-	}
-
-	if err := yaml.Unmarshal(providerConfig.Value.Raw, &config); err != nil {
-		return nil, err
-	}
-	return &config, nil
-}
-
 // MachineStatusFromProviderStatus unmarshals a raw extension into an AWS machine type
 func MachineStatusFromProviderStatus(extension *runtime.RawExtension) (*AWSMachineProviderStatus, error) {
 	if extension == nil {

--- a/pkg/cloud/aws/actuators/BUILD.bazel
+++ b/pkg/cloud/aws/actuators/BUILD.bazel
@@ -19,8 +19,11 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/elb/elbiface:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -42,7 +42,7 @@ import (
 )
 
 //+kubebuilder:rbac:groups=awsprovider.k8s.io,resources=awsmachineproviderconfigs;awsmachineproviderstatuses,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machines;machines/status;machinedeployments;machinedeployments/status;machinesets;machinesets/status,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machines;machines/status;machinedeployments;machinedeployments/status;machinesets;machinesets/status;machineclasses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=nodes;events,verbs=get;list;watch;create;update;patch;delete
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for retrieving the ProviderSpec from a MachineClass

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #513

**Release note**:
<!--  Write your release note:
```release-note
- cluster-api-provider-aws now supports using MachineClass
```