### PR TITLE
Use InstanceState instead of String in Machine Status

### DIFF
--- a/pkg/apis/awsprovider/v1alpha1/awsmachineproviderstatus_types.go
+++ b/pkg/apis/awsprovider/v1alpha1/awsmachineproviderstatus_types.go
@@ -35,7 +35,7 @@ type AWSMachineProviderStatus struct {
 
 	// InstanceState is the state of the AWS instance for this machine
 	// +optional
-	InstanceState *string `json:"instanceState,omitempty"`
+	InstanceState *InstanceState `json:"instanceState,omitempty"`
 
 	// Conditions is a set of conditions associated with the Machine to indicate
 	// errors or other status

--- a/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
@@ -165,7 +165,7 @@ func (in *AWSMachineProviderStatus) DeepCopyInto(out *AWSMachineProviderStatus) 
 	}
 	if in.InstanceState != nil {
 		in, out := &in.InstanceState, &out.InstanceState
-		*out = new(string)
+		*out = new(InstanceState)
 		**out = **in
 	}
 	if in.Conditions != nil {

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -166,7 +166,7 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 	}
 
 	scope.MachineStatus.InstanceID = &i.ID
-	scope.MachineStatus.InstanceState = aws.String(string(i.State))
+	scope.MachineStatus.InstanceState = &i.State
 
 	if machine.Annotations == nil {
 		machine.Annotations = map[string]string{}
@@ -405,6 +405,8 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 	default:
 		return false, nil
 	}
+
+	scope.MachineStatus.InstanceState = &instance.State
 
 	if err := a.reconcileLBAttachment(scope, machine, instance); err != nil {
 		return true, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

InstanceState is presently just a string. It ought to be the proper, previously created type

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
InstanceState in Machine Status is now properly an InstanceState type
```