### PR TITLE
bazel: Expand make variables in stateful_set_patch

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,6 @@
 build --define=MANAGER_IMAGE_NAME=cluster-api-aws-controller
 build --define=MANAGER_IMAGE_TAG=0.1.0
 build --define=REGISTRY_STABLE=gcr.io/cluster-api-provider-aws
-build --define=REGISTRY_TEST_SHIM=bazel/cmd
 
 build --workspace_status_command=./hack/print-workspace-status.sh
 build --verbose_failures

--- a/build/stateful_set_patch.bzl
+++ b/build/stateful_set_patch.bzl
@@ -24,10 +24,10 @@ def _stateful_set_patch_impl(ctx):
         template = ctx.file._template,
         output = ctx.outputs.source_file,
         substitutions = {
-            "<registry>": ctx.attr.registry,
-            "<image_name>": ctx.attr.image_name,
-            "<tag>": ctx.attr.tag,
-            "<pull_policy>": ctx.attr.pull_policy,
+            "<registry>": ctx.expand_make_variables("registry", ctx.attr.registry, {}),
+            "<image_name>": ctx.expand_make_variables("image_name",ctx.attr.image_name, {}),
+            "<tag>": ctx.expand_make_variables("tag", ctx.attr.tag, {}),
+            "<pull_policy>": ctx.expand_make_variables("pull_policy",ctx.attr.pull_policy, {}),
         },
     )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -18,7 +18,7 @@ stateful_set_patch(
     name = "manager-version-patch",
     image_name = "manager",
     pull_policy = "Never",
-    registry = "$(REGISTRY_TEST_SHIM)",
+    registry = "bazel/cmd",
     tag = "manager-amd64",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Small fix to #580 to expand make variables in stateful_set_patch.bzl

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```