### PR TITLE
fixes bug in generated manifests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1097,6 +1097,7 @@
     "github.com/emicklei/go-restful",
     "github.com/golang/mock/gomock",
     "github.com/onsi/ginkgo",
+    "github.com/onsi/ginkgo/config",
     "github.com/onsi/gomega",
     "github.com/onsi/gomega/gstruct",
     "github.com/onsi/gomega/types",

--- a/cmd/clusterctl/examples/aws/generate-yaml.sh
+++ b/cmd/clusterctl/examples/aws/generate-yaml.sh
@@ -43,7 +43,6 @@ PROVIDER_COMPONENTS_SRC=${DIR}/provider-components-base.yaml
 PROVIDER_COMPONENTS_SRC_DEV=${DIR}/provider-components-base-dev.yaml
 PROVIDER_COMPONENTS_FILE=${OUTPUT_DIR}/provider-components.yaml
 PROVIDER_COMPONENTS_FILE_DEV=${OUTPUT_DIR}/provider-components-dev.yaml
-CREDENTIALS_FILE=${OUTPUT_DIR}/aws-credentials.yaml
 
 # Overwrite flag.
 OVERWRITE=0
@@ -106,14 +105,14 @@ echo "Generated credentials"
 
 PROVIDER_COMPONENTS="$(cat ${PROVIDER_COMPONENTS_SRC})"
 
-echo -e "${PROVIDER_COMPONENTS}\n${CREDENTIALS}" > "${PROVIDER_COMPONENTS_FILE}"
+echo -e "${PROVIDER_COMPONENTS}\n---\n${CREDENTIALS}" > "${PROVIDER_COMPONENTS_FILE}"
 echo "Done writing ${PROVIDER_COMPONENTS_FILE}"
 echo "WARNING: ${PROVIDER_COMPONENTS_FILE} includes credentials"
 
 if [ -f $PROVIDER_COMPONENTS_SRC_DEV ]; then
   PROVIDER_COMPONENTS_DEV=$(cat ${PROVIDER_COMPONENTS_SRC_DEV})
 
-  echo -e "${PROVIDER_COMPONENTS_DEV}\n${CREDENTIALS}" > "${PROVIDER_COMPONENTS_FILE_DEV}"
+  echo -e "${PROVIDER_COMPONENTS_DEV}\n---\n${CREDENTIALS}" > "${PROVIDER_COMPONENTS_FILE_DEV}"
   echo "Done writing ${PROVIDER_COMPONENTS_FILE_DEV}"
   echo "WARNING: ${PROVIDER_COMPONENTS_FILE_DEV} includes credentials"
 fi


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>


**What this PR does / why we need it**:
Generated manifests, both dev and non-dev missing a yaml document break `---`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #588 

**Special notes for your reviewer**:
The Gopkg.lock file seemed to be missing online. This got generated after running a make command.

**Release note**:
```release-note

```