### PR TITLE
Configurable region

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -19,6 +19,7 @@ package e2e_test
 import (
 	"flag"
 	"io/ioutil"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -57,16 +58,24 @@ const (
 	clusterName      = "capa-test-cluster"
 	controlPlaneName = "capa-test-control-plane"
 
-	awsRegion   = "us-east-1"
 	stackName   = "cluster-api-provider-aws-sigs-k8s-io"
 	keyPairName = "cluster-api-provider-aws-sigs-k8s-io"
 )
 
 var (
+	region      string
 	credFile    = flag.String("credFile", "", "path to an AWS credentials file")
 	clusterYAML = flag.String("clusterYAML", "", "path to the YAML for the cluster we're creating")
 	machineYAML = flag.String("machineYAML", "", "path to the YAML describing the control plane we're creating")
 )
+
+func init() {
+	if region = os.Getenv("AWS_DEFAULT_REGION"); region == "" {
+		if region = os.Getenv("AWS_REGION"); region == "" {
+			region = "us-east-1"
+		}
+	}
+}
 
 var _ = Describe("AWS", func() {
 	var (
@@ -144,7 +153,7 @@ func makeCluster() *capi.Cluster {
 	awsSpec, err := capa.ClusterConfigFromProviderSpec(cluster.Spec.ProviderSpec)
 	Expect(err).To(BeNil())
 	awsSpec.SSHKeyName = keyPairName
-	awsSpec.Region = awsRegion
+	awsSpec.Region = region
 	cluster.Spec.ProviderSpec.Value, err = capa.EncodeClusterSpec(awsSpec)
 	Expect(err).To(BeNil())
 
@@ -219,7 +228,7 @@ func getSession() client.ConfigProvider {
 	creds := credentials.NewCredentials(&credentials.SharedCredentialsProvider{
 		Filename: *credFile,
 	})
-	sess, err := session.NewSession(aws.NewConfig().WithCredentials(creds).WithRegion(awsRegion))
+	sess, err := session.NewSession(aws.NewConfig().WithCredentials(creds).WithRegion(region))
 	Expect(err).To(BeNil())
 	return sess
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch makes the AWS region used for e2e configurable via the environment variable `AWS_DEFAULT_REGION`, falling back to `AWS_REGION` if the former is not specified. If not specified, the region defaults to `us-east-1`.

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:
You're special, and gosh darnit, people like you.

**Release note**:
```release-note
The AWS region used for e2e may now be configured with the environment variable AWS_DEFAULT_REGION, falling back to AWS_REGION if the former is not specified. The region defaults to "us-east-1".
```