### PR TITLE
Separate e2e and integration scripts

### DIFF
--- a/scripts/ci-bazel-integration.sh
+++ b/scripts/ci-bazel-integration.sh
@@ -18,6 +18,9 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-cd "${REPO_ROOT}" || exit 1
 
-exec scripts/ci-bazel-integration.sh
+cd "${REPO_ROOT}" || exit 1
+bazel test --define='gotags=integration' --test_output all //test/integration/...
+bazel_status="${?}"
+python hack/coalesce.py
+exit "${bazel_status}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch creates separate scripts for running the e2e and integration tests. For now the e2e script simply execs the integration script in order to provide backward-compatibility with the [existing e2e Prow jobs](https://github.com/kubernetes/test-infra/pull/9974/files). Once those are updated, the e2e script will invoke the e2e tests instead.

Related to https://github.com/kubernetes/test-infra/pull/11459

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:
NA

**Release note**:
NA