### PR TITLE
Fix tag for cluster-api-aws-controller

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 build --define=MANAGER_IMAGE_NAME=cluster-api-aws-controller
-build --define=MANAGER_IMAGE_TAG=0.1.0
+build --define=MANAGER_IMAGE_TAG=0.0.4
 build --define=REGISTRY_STABLE=gcr.io/cluster-api-provider-aws
 
 build --workspace_status_command=./hack/print-workspace-status.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
The current release tag for cluster-api-aws-controller is 0.0.4, not 0.1.0


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
NONE
```