### PR TITLE
Add cli flag to supply namespace for capa controller to watch for capi objects

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -44,13 +44,13 @@ func main() {
 	cfg := config.GetConfigOrDie()
 
 	// Setup a Manager
-	var mgrOps manager.Options
+	var opts manager.Options
 	if *watchNamespace != "" {
-		mgrOps.Namespace = *watchNamespace
-		klog.Infof("Reconciling cluster-api objects in namespace %q", mgrOps.Namespace)
+		opts.Namespace = *watchNamespace
+		klog.Infof("Watching cluster-api objects in only in namespace %q for reconciliation.", opts.Namespace)
 	}
 
-	mgr, err := manager.New(cfg, mgrOps)
+	mgr, err := manager.New(cfg, opts)
 	if err != nil {
 		klog.Fatalf("Failed to set up overall controller manager: %v", err)
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,12 +37,20 @@ import (
 func main() {
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
+	watchNamespace := flag.String("namespace", "",
+		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 	flag.Parse()
 
 	cfg := config.GetConfigOrDie()
 
 	// Setup a Manager
-	mgr, err := manager.New(cfg, manager.Options{})
+	var mgrOps manager.Options
+	if *watchNamespace != "" {
+		mgrOps.Namespace = *watchNamespace
+		klog.Infof("Reconciling cluster-api objects in namespace %q", mgrOps.Namespace)
+	}
+
+	mgr, err := manager.New(cfg, mgrOps)
 	if err != nil {
 		klog.Fatalf("Failed to set up overall controller manager: %v", err)
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -47,7 +47,7 @@ func main() {
 	var opts manager.Options
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
-		klog.Infof("Watching cluster-api objects in only in namespace %q for reconciliation.", opts.Namespace)
+		klog.Infof("Watching cluster-api objects only in namespace %q for reconciliation.", opts.Namespace)
 	}
 
 	mgr, err := manager.New(cfg, opts)


### PR DESCRIPTION
Add cli flag to supply namespace for capa controller to watch for capi objects

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds a CLI flag to restrict the namespace that capa controllers watch for capi objects to reconcile

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #581

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```