### PR TITLE
[WIP] Tighter IAM policies

### DIFF
--- a/pkg/cloud/aws/services/cloudformation/BUILD
+++ b/pkg/cloud/aws/services/cloudformation/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/cloud/aws/services/awserrors:go_default_library",
         "//pkg/cloud/aws/services/iam:go_default_library",
+        "//pkg/cloud/aws/tags:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/cloudformation:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface:go_default_library",

--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -235,6 +235,16 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 				},
 			},
 			{
+				Effect: iam.EffectDeny,
+				Resource: iam.Resources{
+					"arn:aws:ec2:::instance/*",
+					"arn:aws:elasicloadbalancing:::loadbalancer/*",
+				},
+				Action: iam.Actions{
+					"ec2:CreateTags",
+				},
+			},
+			{
 				Effect:   iam.EffectAllow,
 				Resource: iam.Resources{"*"},
 				Action: iam.Actions{

--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/iam"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/tags"
 )
 
 const (
@@ -180,10 +181,8 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 					"ec2:ReleaseAddress",
 					"ec2:RevokeSecurityGroupIngress",
 					"ec2:RunInstances",
-					"ec2:TerminateInstances",
 					"elasticloadbalancing:CreateLoadBalancer",
 					"elasticloadbalancing:ConfigureHealthCheck",
-					"elasticloadbalancing:DeleteLoadBalancer",
 					"elasticloadbalancing:DescribeLoadBalancers",
 					"elasticloadbalancing:DescribeLoadBalancerAttributes",
 					"elasticloadbalancing:ModifyLoadBalancerAttributes",
@@ -201,6 +200,26 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 				},
 				Condition: iam.Conditions{
 					"StringLike": map[string]string{"iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"},
+				},
+			},
+			{
+				Effect:   iam.EffectAllow,
+				Resource: iam.Resources{"*"},
+				Action: iam.Actions{
+					"ec2:TerminateInstances",
+				},
+				Condition: iam.Conditions{
+					"StringEquals": map[string]string{fmt.Sprintf("ec2:ResourceTag/%s", tags.NameAWSProviderManaged): "true"},
+				},
+			},
+			{
+				Effect:   iam.EffectAllow,
+				Resource: iam.Resources{"*"},
+				Action: iam.Actions{
+					"elasticloadbalancing:DeleteLoadBalancer",
+				},
+				Condition: iam.Conditions{
+					"StringEquals": map[string]string{fmt.Sprintf("elasticloadbalancing:ResourceTag/%s", tags.NameAWSProviderManaged): "true"},
 				},
 			},
 			{

--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -157,7 +157,6 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 					"ec2:CreateRouteTable",
 					"ec2:CreateSecurityGroup",
 					"ec2:CreateSubnet",
-					"ec2:CreateTags",
 					"ec2:CreateVpc",
 					"ec2:DeleteInternetGateway",
 					"ec2:DeleteNatGateway",
@@ -200,6 +199,39 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 				},
 				Condition: iam.Conditions{
 					"StringLike": map[string]string{"iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"},
+				},
+			},
+			{
+				Effect:   iam.EffectAllow,
+				Resource: iam.Resources{"*"},
+				Action: iam.Actions{
+					"ec2:CreateTags",
+				},
+				Condition: iam.Conditions{
+					"StringEquals": map[string][]string{
+						fmt.Sprintf("aws:RequestTag/%s", tags.NameAWSProviderManaged): {"true"},
+						fmt.Sprintf("aws:RequestTag/%s", tags.NameAWSClusterAPIRole): {
+							tags.ValueAPIServerRole,
+							tags.ValueBastionRole,
+							tags.ValueCommonRole,
+							tags.ValuePrivateRole,
+							tags.ValuePublicRole,
+						},
+					},
+					"ForAllValues:StringEquals": map[string][]string{
+						"aws:TagKeys": {
+							tags.NameAWSProviderManaged,
+							tags.NameAWSClusterAPIRole,
+						},
+					},
+					"ForAllValues:StringLike": map[string][]string{
+						"aws:TagKeys": {
+							fmt.Sprintf("%s*", tags.NameKubernetesClusterPrefix),
+							tags.NameAWSClusterAPIRole,
+							tags.NameAWSProviderManaged,
+							"Name",
+						},
+					},
 				},
 			},
 			{

--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -166,7 +166,6 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 					"ec2:DeleteVpc",
 					"ec2:DescribeAddresses",
 					"ec2:DescribeAvailabilityZones",
-					"ec2:DescribeInstances",
 					"ec2:DescribeInternetGateways",
 					"ec2:DescribeImages",
 					"ec2:DescribeNatGateways",
@@ -179,13 +178,6 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 					"ec2:ModifySubnetAttribute",
 					"ec2:ReleaseAddress",
 					"ec2:RevokeSecurityGroupIngress",
-					"ec2:RunInstances",
-					"elasticloadbalancing:CreateLoadBalancer",
-					"elasticloadbalancing:ConfigureHealthCheck",
-					"elasticloadbalancing:DescribeLoadBalancers",
-					"elasticloadbalancing:DescribeLoadBalancerAttributes",
-					"elasticloadbalancing:ModifyLoadBalancerAttributes",
-					"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
 				},
 			},
 			{
@@ -206,6 +198,8 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 				Resource: iam.Resources{"*"},
 				Action: iam.Actions{
 					"ec2:CreateTags",
+					"ec2:RunInstances",
+					"elasticloadbalancing:CreateLoadBalancer",
 				},
 				Condition: iam.Conditions{
 					"StringEquals": map[string][]string{
@@ -249,6 +243,7 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 				Resource: iam.Resources{"*"},
 				Action: iam.Actions{
 					"ec2:TerminateInstances",
+					"ec2:DescribeInstances",
 				},
 				Condition: iam.Conditions{
 					"StringEquals": map[string]string{fmt.Sprintf("ec2:ResourceTag/%s", tags.NameAWSProviderManaged): "true"},
@@ -259,6 +254,11 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 				Resource: iam.Resources{"*"},
 				Action: iam.Actions{
 					"elasticloadbalancing:DeleteLoadBalancer",
+					"elasticloadbalancing:ConfigureHealthCheck",
+					"elasticloadbalancing:DescribeLoadBalancers",
+					"elasticloadbalancing:DescribeLoadBalancerAttributes",
+					"elasticloadbalancing:ModifyLoadBalancerAttributes",
+					"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
 				},
 				Condition: iam.Conditions{
 					"StringEquals": map[string]string{fmt.Sprintf("elasticloadbalancing:ResourceTag/%s", tags.NameAWSProviderManaged): "true"},

--- a/pkg/cloud/aws/services/iam/types.go
+++ b/pkg/cloud/aws/services/iam/types.go
@@ -110,5 +110,5 @@ func NewManagedName(prefix string) string {
 // objects with Condition as per the AWS IAM policy schema as a work-around for
 // https://github.com/awslabs/goformation/issues/157
 func ProcessPolicyDocument(p string) string {
-	return strings.Replace(p, "IAMConditions", "Condition", 1)
+	return strings.Replace(p, "IAMConditions", "Condition", -1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

EC2 and ELB instances are tagged upon creation. Therefore, ensuring that only EC2/ELB instances are deleted when they match the Cluster API Provider AWS tag minimises privileges.

This approach cannot be used for other resources as they are tagged after creation - backing out of a failed tagging may prevent deletion, and controller can tag a resource appropriately to delete it.

Also additionally constrain which tags are allowed to be used by the controller.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #608 

**Special notes for your reviewer**:

In order to restrict privilege escalation via instance profile, all resources are now put under a `sigs.k8s.io/cluster-api-provider-aws` path so this can be referenced in a policy condition. Unfortunately, this breaks CloudFormation being able to do an in-place update. There doesn't seem to be a way around this, so have also taken the opportunity to rename two incorrectly named resources. These are in the release notes below.

Recommend this is not merged prior to e2e tests making use of CloudFormation with a delete process.

Current example policy:
``` json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Condition": {
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                }
            },
            "Action": [
                "ec2:AllocateAddress",
                "ec2:AssociateRouteTable",
                "ec2:AttachInternetGateway",
                "ec2:AuthorizeSecurityGroupIngress",
                "ec2:CreateInternetGateway",
                "ec2:CreateNatGateway",
                "ec2:CreateRoute",
                "ec2:CreateRouteTable",
                "ec2:CreateSecurityGroup",
                "ec2:CreateSubnet",
                "ec2:CreateVpc",
                "ec2:DeleteInternetGateway",
                "ec2:DeleteNatGateway",
                "ec2:DeleteRouteTable",
                "ec2:DeleteSecurityGroup",
                "ec2:DeleteSubnet",
                "ec2:DeleteVpc",
                "ec2:DescribeAddresses",
                "ec2:DescribeAvailabilityZones",
                "ec2:DescribeInternetGateways",
                "ec2:DescribeImages",
                "ec2:DescribeNatGateways",
                "ec2:DescribeRouteTables",
                "ec2:DescribeSecurityGroups",
                "ec2:DescribeSubnets",
                "ec2:DescribeVpcs",
                "ec2:DetachInternetGateway",
                "ec2:DisassociateRouteTable",
                "ec2:ModifySubnetAttribute",
                "ec2:ReleaseAddress",
                "ec2:RevokeSecurityGroupIngress"
            ],
            "Resource": [
                "*"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
                },
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                }
            },
            "Action": [
                "iam:CreateServiceLinkedRole"
            ],
            "Resource": [
                "arn:aws:iam::xxxxxxxx:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringEquals": {
                    "aws:RequestTag/sigs.k8s.io/cluster-api-provider-aws/managed": [
                        "true"
                    ],
                    "aws:RequestTag/sigs.k8s.io/cluster-api-provider-aws/role": [
                        "apiserver",
                        "bastion",
                        "common",
                        "private",
                        "public"
                    ]
                },
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                },
                "ForAnyValue:StringLike": {
                    "aws:TagKeys": [
                        "kubernetes.io/cluster/*",
                        "sigs.k8s.io/cluster-api-provider-aws/managed",
                        "sigs.k8s.io/cluster-api-provider-aws/role",
                        "Name"
                    ]
                }
            },
            "Action": [
                "ec2:CreateTags",
                "ec2:RunInstances",
                "elasticloadbalancing:CreateLoadBalancer"
            ],
            "Resource": [
                "*"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringEquals": {
                    "aws:RequestTag/sigs.k8s.io/cluster-api-provider-aws/managed": [
                        "true"
                    ],
                    "aws:RequestTag/sigs.k8s.io/cluster-api-provider-aws/role": [
                        "apiserver",
                        "bastion",
                        "common",
                        "private",
                        "public"
                    ]
                },
                "StringLike": {
                    "ec2:InstanceProfile": "arn:aws:iam::xxxxxxxx:instance-profile/sigs.k8s.io/cluster-api-provider-aws/*"
                },
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                },
                "ForAnyValue:StringLike": {
                    "aws:TagKeys": [
                        "kubernetes.io/cluster/*",
                        "sigs.k8s.io/cluster-api-provider-aws/managed",
                        "sigs.k8s.io/cluster-api-provider-aws/role",
                        "Name"
                    ]
                }
            },
            "Action": [
                "ec2:RunInstances"
            ],
            "Resource": [
                "*"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringEquals": {
                    "aws:RequestTag/sigs.k8s.io/cluster-api-provider-aws/managed": [
                        "true"
                    ],
                    "aws:RequestTag/sigs.k8s.io/cluster-api-provider-aws/role": [
                        "apiserver",
                        "bastion",
                        "common",
                        "private",
                        "public"
                    ],
                    "ec2:ResourceTag/sigs.k8s.io/cluster-api-provider-aws/managed": [
                        "true"
                    ]
                },
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                },
                "ForAnyValue:StringLike": {
                    "aws:TagKeys": [
                        "kubernetes.io/cluster/*",
                        "sigs.k8s.io/cluster-api-provider-aws/managed",
                        "sigs.k8s.io/cluster-api-provider-aws/role",
                        "Name"
                    ]
                }
            },
            "Action": [
                "ec2:CreateTags"
            ],
            "Resource": [
                "arn:aws:ec2:::instance/*"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringEquals": {
                    "ec2:ResourceTag/sigs.k8s.io/cluster-api-provider-aws/managed": [
                        "true"
                    ]
                },
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                }
            },
            "Action": [
                "ec2:TerminateInstances",
                "ec2:DescribeInstances"
            ],
            "Resource": [
                "*"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringEquals": {
                    "elasticloadbalancing:ResourceTag/sigs.k8s.io/cluster-api-provider-aws/managed": [
                        "true"
                    ]
                },
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                }
            },
            "Action": [
                "elasticloadbalancing:DeleteLoadBalancer",
                "elasticloadbalancing:ConfigureHealthCheck",
                "elasticloadbalancing:DescribeLoadBalancers",
                "elasticloadbalancing:DescribeLoadBalancerAttributes",
                "elasticloadbalancing:ModifyLoadBalancerAttributes",
                "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
            ],
            "Resource": [
                "*"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "Bool": {
                    "aws:SecureTransport": [
                        "true"
                    ]
                }
            },
            "Action": [
                "iam:PassRole"
            ],
            "Resource": [
                 "arn:aws:iam::xxxxxxxx:role/sigs.k8s.io/cluster-api-provider-aws/*"
            ],
            "Effect": "Allow"
        }
    ]
}
```



/hold

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Reduced privileges required by the controllers to delete EC2 and ELB instances.
* The `nodes.cluster-api-provider-aws.sigs.k8s.io` policy has been renamed `nodes.cloud-provider-aws.k8s.io` to better represent its purpose.
* The `control-plane.cluster-api-provider-aws.sigs.k8s.io` policy has been renamed `control-plane.cloud-provider-aws.k8s.io` to better represent its purpose.

Breaking changes:
 * clusterawsadm now places all IAM resources under a `/sigs.k8s.io/cluster-api-provider-aws` path, which AWS CloudFormation cannot do an in-place update for. Please delete the `cluster-api-provider-aws-sigs-k8s-io`  stack and replace it.
```