### PR TITLE
Automate release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,45 @@
+# Consider this for container image release.
+# before:
+#   hooks:
+#     - make docker-push
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/noop/main.go
+    binary: clusterctl
+    goarch:
+      - amd64
+    hooks:
+      post: make release-artifacts
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+  files:
+    - cmd/clusterctl/examples/aws/addons.yaml
+    - cmd/clusterctl/examples/aws/cluster-network-spec.yaml.template
+    - cmd/clusterctl/examples/aws/cluster.yaml.template
+    - cmd/clusterctl/examples/aws/generate-yaml.sh
+    - cmd/clusterctl/examples/aws/machines.yaml.template
+    - cmd/clusterctl/examples/aws/provider-components-base.yaml
+    - docs/getting-started.md
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+release:
+  github:
+    owner: kubernetes-sigs
+    name: cluster-api-provider-aws
+  draft: true
+  # consider turning this off if we use complex versioning e.g. (v0.1.0-capi-v0.2.0)
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -87,13 +87,13 @@ clusterawsadm: dep-ensure ## Build clusterawsadm binary.
 release-artifacts: ## Build release artifacts
 	bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/clusterctl //cmd/clusterawsadm
 	bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //cmd/clusterctl //cmd/clusterawsadm
-	bazel build //cmd/clusterctl/examples/aws
-	mkdir -p out
-	install bazel-bin/cmd/clusterawsadm/darwin_amd64_pure_stripped/clusterawsadm out/clusterawsadm-darwin-amd64
-	install bazel-bin/cmd/clusterawsadm/linux_amd64_pure_stripped/clusterawsadm out/clusterawsadm-linux-amd64
-	install bazel-bin/cmd/clusterctl/darwin_amd64_pure_stripped/clusterctl out/clusterctl-darwin-amd64
-	install bazel-bin/cmd/clusterctl/linux_amd64_pure_stripped/clusterctl out/clusterctl-linux-amd64
-	install bazel-bin/cmd/clusterctl/examples/aws/aws.tar out/cluster-api-provider-aws-examples.tar
+	bazel build //cmd/clusterctl/examples/aws:provider-components-base
+	mkdir -p dist/darwin_amd64
+	install bazel-bin/cmd/clusterawsadm/darwin_amd64_pure_stripped/clusterawsadm dist/darwin_amd64/clusterawsadm-darwin-amd64
+	install bazel-bin/cmd/clusterctl/darwin_amd64_pure_stripped/clusterctl dist/darwin_amd64/clusterctl-darwin-amd64
+	mkdir -p dist/linux_amd64
+	install bazel-bin/cmd/clusterawsadm/linux_amd64_pure_stripped/clusterawsadm dist/linux_amd64/clusterawsadm-linux-amd64
+	install bazel-bin/cmd/clusterctl/linux_amd64_pure_stripped/clusterctl dist/linux_amd64/clusterctl-linux-amd64
 
 .PHONY: test verify
 test: generate verify ## Run tests

--- a/cmd/noop/main.go
+++ b/cmd/noop/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
Using goreleaser this will automatically build binaries,
collect resources, package them into appropriate tarballs
and upload them to github. There is commented out code
for also pushing container images to gcr.io that we could
consider using.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR automates the release process. It may not be the way we want to go but it could be a nice first option.

This uses goreleaser to automate the release process. It however does have some ups and downs.

The pros of this are:
* Automatic GitHub release drafts with notes
* Can also push container images to gcr.io (with correct permissions)
* Wraps up binaries and files together

The cons of this:
* It's awkward to use this in conjunction with bazel as our build tool because bazel wants to do things its own way.
* There is no way to specify where files end up in the release tar. See: https://github.com/goreleaser/goreleaser/issues/679
* Building a hack binary only to overwrite it with Bazel
* cannot use docker feature of goreleaser because we use bazel to build docker images

```release-note

```