### PR TITLE
Rev the version of golangci-lint used

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,7 +88,7 @@ go_repository(
     name = "com_github_golangci_golangci-lint",
     build_file_generation = "on",
     importpath = "github.com/golangci/golangci-lint",
-    tag = "v1.13",
+    tag = "v1.15.0",
 )
 
 go_repository(


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates golangci-lint to the latest version, followup to https://github.com/kubernetes-sigs/cluster-api/pull/806

**Release note**:
```release-note
NONE
```