### PR TITLE
fix: repair node joins

### DIFF
--- a/pkg/cloud/aws/services/kubeadm/aws_defaults.go
+++ b/pkg/cloud/aws/services/kubeadm/aws_defaults.go
@@ -132,7 +132,7 @@ func SetJoinNodeConfigurationOverrides(caCertHash, bootstrapToken string, machin
 		base.Discovery.BootstrapToken = &kubeadmv1beta1.BootstrapTokenDiscovery{}
 	}
 	// TODO: should this actually be the cluster's ContolPlaneEndpoint?
-	base.Discovery.BootstrapToken.APIServerEndpoint = s.Network().APIServerELB.DNSName
+	base.Discovery.BootstrapToken.APIServerEndpoint = fmt.Sprintf("%s:%d", s.Network().APIServerELB.DNSName, apiServerBindPort)
 	base.Discovery.BootstrapToken.Token = bootstrapToken
 	base.Discovery.BootstrapToken.CACertHashes = append(base.Discovery.BootstrapToken.CACertHashes, caCertHash)
 

--- a/pkg/cloud/aws/services/userdata/node.go
+++ b/pkg/cloud/aws/services/userdata/node.go
@@ -24,7 +24,7 @@ write_files:
     permissions: '0640'
     content: |
       ---
-      {{.JoinConfiguration | Indent 6}}
+{{.JoinConfiguration | Indent 6}}
 kubeadm:
   operation: join
   config: /tmp/kubeadm-node.yaml


### PR DESCRIPTION
We observed that the user-data being created for nodes had illegal
indentation, and omitted the port from the api server address.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Previously, we observed user-data being generated that looks like:

```
    permissions: '0640'
    content: |
      ---
            apiVersion: kubeadm.k8s.io/v1beta1
      caCertPath: ""
      discovery:
        bootstrapToken:
```

Removing the leading spaces produced a cloud-config that seem 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```