### PR TITLE
Set the ProviderID if unset

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -414,6 +414,14 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return true, err
 	}
 
+	if machine.Spec.ProviderID == nil || *machine.Spec.ProviderID == "" {
+		// TODO: This should be unified with the logic for getting the nodeRef, and
+		// should potentially leverage the code that already exists in
+		// kubernetes/cloud-provider-aws
+		providerID := fmt.Sprintf("aws:////%s", *scope.MachineStatus.InstanceID)
+		scope.Machine.Spec.ProviderID = &providerID
+	}
+
 	// Set the Machine NodeRef.
 	if machine.Status.NodeRef == nil {
 		nodeRef, err := a.getNodeReference(scope)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we do not set Machine.Spec.ProviderID on machines that we create, this resolves that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #610

**Release note**:
```release-note
The Machine Actuator now sets Machine.Spec.ProviderID
```