### PR TITLE
Fix panic when IAM profile isn't available

### DIFF
--- a/pkg/cloud/aws/converters/instance.go
+++ b/pkg/cloud/aws/converters/instance.go
@@ -41,12 +41,10 @@ func SDKToInstance(v *ec2.Instance) *v1alpha1.Instance {
 	// Extract IAM Instance Profile name from ARN
 	// TODO: Handle this comparison more safely, perhaps by querying IAM for the
 	// instance profile ARN and comparing to the ARN returned by EC2
-	if v.IamInstanceProfile.Arn != nil {
+	if v.IamInstanceProfile != nil && v.IamInstanceProfile.Arn != nil {
 		split := strings.Split(aws.StringValue(v.IamInstanceProfile.Arn), "instance-profile/")
-		if len(split) > 1 {
-			if split[1] != "" {
-				i.IAMProfile = split[1]
-			}
+		if len(split) > 1 && split[1] != "" {
+			i.IAMProfile = split[1]
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes a panic that occurs on a new cluster creation for instances that don't have an associated instance profile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #642

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```