### PR TITLE
fix: no longer panic when instance id is nil

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -241,6 +241,11 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 	ec2svc := ec2.NewService(scope.Scope)
 
+	if scope.MachineStatus.InstanceID == nil {
+		klog.Error("Instance does not have an instance id")
+		return nil
+	}
+
 	instance, err := ec2svc.InstanceIfExists(*scope.MachineStatus.InstanceID)
 	if err != nil {
 		return errors.Errorf("failed to get instance: %+v", err)

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -241,12 +241,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 	ec2svc := ec2.NewService(scope.Scope)
 
-	if scope.MachineStatus.InstanceID == nil {
-		klog.Error("Instance does not have an instance id")
-		return nil
-	}
-
-	instance, err := ec2svc.InstanceIfExists(*scope.MachineStatus.InstanceID)
+	instance, err := ec2svc.InstanceIfExists(scope.MachineStatus.InstanceID)
 	if err != nil {
 		return errors.Errorf("failed to get instance: %+v", err)
 	}
@@ -342,7 +337,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	ec2svc := ec2.NewService(scope.Scope)
 
 	// Get the current instance description from AWS.
-	instanceDescription, err := ec2svc.InstanceIfExists(*scope.MachineStatus.InstanceID)
+	instanceDescription, err := ec2svc.InstanceIfExists(scope.MachineStatus.InstanceID)
 	if err != nil {
 		return errors.Errorf("failed to get instance: %+v", err)
 	}
@@ -393,7 +388,7 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return false, nil
 	}
 
-	instance, err := ec2svc.InstanceIfExists(*scope.MachineStatus.InstanceID)
+	instance, err := ec2svc.InstanceIfExists(scope.MachineStatus.InstanceID)
 	if err != nil {
 		return false, errors.Errorf("failed to retrieve instance: %+v", err)
 	}

--- a/pkg/cloud/aws/services/ec2/instances_test.go
+++ b/pkg/cloud/aws/services/ec2/instances_test.go
@@ -180,7 +180,7 @@ func TestInstanceIfExists(t *testing.T) {
 			tc.expect(ec2Mock.EXPECT())
 
 			s := NewService(scope)
-			instance, err := s.InstanceIfExists(tc.instanceID)
+			instance, err := s.InstanceIfExists(&tc.instanceID)
 			tc.check(instance, err)
 		})
 	}

--- a/pkg/cloud/aws/services/interfaces.go
+++ b/pkg/cloud/aws/services/interfaces.go
@@ -62,7 +62,7 @@ type EC2ClusterInterface interface {
 // EC2MachineInterface encapsulates the methods exposed to the machine
 // actuator
 type EC2MachineInterface interface {
-	InstanceIfExists(id string) (*providerv1.Instance, error)
+	InstanceIfExists(id *string) (*providerv1.Instance, error)
 	TerminateInstance(id string) error
 	CreateOrGetMachine(machine *actuators.MachineScope, token, kubeConfig string) (*providerv1.Instance, error)
 	UpdateInstanceSecurityGroups(id string, securityGroups []string) error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes a bug where if the machine resource was deleted before the ec2 instance is created, the provider panics. The alternative to this is removing the finalizer by hand and then deleting them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Provider no longer panics when instance id is nil
```