### PR TITLE
Restructure Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,17 @@
 
 .DEFAULT_GOAL:=help
 
-FASTBUILD ?= n ## Set FASTBUILD=y (case-sensitive) to skip some slow tasks
-
 ## Image URL to use all building/pushing image targets
 REGISTRY_DEV ?= gcr.io/$(shell gcloud config get-value project)
 DEPCACHEAGE ?= 24h # Enables caching for Dep
 BAZEL_ARGS ?=
 BAZEL_DOCKER_ARGS := --define=REGISTRY_DEV=$(REGISTRY_DEV) $(BAZEL_ARGS)
 
-DEPCACHEAGE ?= 24h # Enables caching for Dep
-BAZEL_ARGS ?=
-
 # Bazel variables
 BAZEL_VERSION := $(shell command -v bazel 2> /dev/null)
 DEP ?= bazel run dep
 
-# determine the OS
+# Determine the OS
 HOSTOS := $(shell go env GOHOSTOS)
 HOSTARCH := $(shell go env GOARCH)
 BINARYPATHPATTERN :=${HOSTOS}_${HOSTARCH}_*
@@ -44,67 +39,23 @@ ifndef BAZEL_VERSION
 endif
 
 .PHONY: all
-all: check-install test manager clusterctl clusterawsadm
+all: check-install test binaries
 
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: dep-ensure
-dep-ensure: check-install ## Ensure dependencies are up to date
-	@echo Checking status of dependencies
-	@${DEP} status 2>&1 > /dev/null || make dep-install
-	@echo Finished verifying dependencies
 
-.PHONY: dep-install
-dep-install: ## Force install go dependencies
-	${DEP} ensure
-	bazel run //:gazelle $(BAZEL_ARGS)
+## --------------------------------------
+## Testing
+## --------------------------------------
 
-.PHONY: gazelle
-gazelle: ## Run Bazel Gazelle
-	bazel run //:gazelle $(BAZEL_ARGS)
-
-.PHONY: check-install
-check-install: ## Checks that you've installed this repository correctly
-	@./scripts/check-install.sh
-
-.PHONY: manager
-manager: generate  ## Build manager binary.
-	bazel build //cmd/manager $(BAZEL_ARGS)
-	install bazel-bin/cmd/manager/${BINARYPATHPATTERN}/manager $(shell go env GOPATH)/bin/aws-manager
-
-.PHONY: clusterctl
-clusterctl: generate ## Build clusterctl binary.
-	bazel build --workspace_status_command=./hack/print-workspace-status.sh //cmd/clusterctl $(BAZEL_ARGS)
-	install bazel-bin/cmd/clusterctl/${BINARYPATHPATTERN}/clusterctl $(shell go env GOPATH)/bin/clusterctl
-
-.PHONY: clusterawsadm
-clusterawsadm: dep-ensure ## Build clusterawsadm binary.
-	bazel build --workspace_status_command=./hack/print-workspace-status.sh //cmd/clusterawsadm $(BAZEL_ARGS)
-	install bazel-bin/cmd/clusterawsadm/${BINARYPATHPATTERN}/clusterawsadm $(shell go env GOPATH)/bin/clusterawsadm
-
-.PHONY: release-artifacts
-release-artifacts: ## Build release artifacts
-	bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/clusterctl //cmd/clusterawsadm
-	bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //cmd/clusterctl //cmd/clusterawsadm
-	bazel build //cmd/clusterctl/examples/aws
-	mkdir -p out
-	install bazel-bin/cmd/clusterawsadm/darwin_amd64_pure_stripped/clusterawsadm out/clusterawsadm-darwin-amd64
-	install bazel-bin/cmd/clusterawsadm/linux_amd64_pure_stripped/clusterawsadm out/clusterawsadm-linux-amd64
-	install bazel-bin/cmd/clusterctl/darwin_amd64_pure_stripped/clusterctl out/clusterctl-darwin-amd64
-	install bazel-bin/cmd/clusterctl/linux_amd64_pure_stripped/clusterctl out/clusterctl-linux-amd64
-	install bazel-bin/cmd/clusterctl/examples/aws/aws.tar out/cluster-api-provider-aws-examples.tar
-
-.PHONY: test verify
+.PHONY: test
 test: generate verify ## Run tests
 	bazel test --nosandbox_debug //pkg/... //cmd/... $(BAZEL_ARGS)
 
-verify:
-	./hack/verify_boilerplate.py
-
-.PHONY: copy-genmocks
-copy-genmocks: ## Copies generated mocks into the repository
-	cp -Rf bazel-genfiles/pkg/* pkg/
+## --------------------------------------
+## Docker
+## --------------------------------------
 
 .PHONY: docker-build
 docker-build: generate ## Build the production docker image
@@ -112,15 +63,19 @@ docker-build: generate ## Build the production docker image
 
 .PHONY: docker-build-dev
 docker-build-dev: generate ## Build the development docker image
-	bazel run //cmd/manager:manager-image-dev  $(BAZEL_DOCKER_ARGS)
+	bazel run //cmd/manager:manager-image-dev $(BAZEL_DOCKER_ARGS)
 
 .PHONY: docker-push
-docker-push: generate ## Push production docker image
+docker-push: ## Push production docker image
 	bazel run //cmd/manager:manager-push $(BAZEL_DOCKER_ARGS)
 
 .PHONY: docker-push-dev
-docker-push-dev: generate ## Push development image
+docker-push-dev: ## Push development image
 	bazel run //cmd/manager:manager-push-dev  $(BAZEL_DOCKER_ARGS)
+
+## --------------------------------------
+## Cleanup / Verification
+## --------------------------------------
 
 .PHONY: clean
 clean: ## Remove all generated files
@@ -131,9 +86,17 @@ clean: ## Remove all generated files
 	rm -rf out/
 	rm -f cmd/clusterctl/examples/aws/provider-components-base-dev.yaml
 
-.PHONY: reset-bazel
-reset-bazel: ## Deep cleaning for bazel
-	bazel clean --expunge
+.PHONY: check-install
+check-install: ## Checks that you've installed this repository correctly
+	@./scripts/check-install.sh
+
+.PHONY: verify
+verify: ## Runs verification scripts to ensure correct execution
+	./hack/verify_boilerplate.py
+
+## --------------------------------------
+## Manifests
+## --------------------------------------
 
 .PHONY: manifests
 manifests: cmd/clusterctl/examples/aws/provider-components-base.yaml
@@ -153,23 +116,95 @@ cmd/clusterctl/examples/aws/provider-components-base-dev.yaml:
 	bazel build //cmd/clusterctl/examples/aws:provider-components-base-dev $(BAZEL_DOCKER_ARGS)
 	install bazel-genfiles/cmd/clusterctl/examples/aws/provider-components-base-dev.yaml cmd/clusterctl/examples/aws
 
-.PHONY: crds
-crds:
+## --------------------------------------
+## Generate
+## --------------------------------------
+
+.PHONY: dep-ensure
+dep-ensure: check-install ## Ensure dependencies are up to date
+	@${DEP} ensure
+	$(MAKE) gazelle
+
+.PHONY: gazelle
+gazelle: ## Run Bazel Gazelle
+	bazel run //:gazelle $(BAZEL_ARGS)
+
+.PHONY: generate
+generate: ## Generate mocks, CRDs and runs `go generate` through Bazel
+	GOPATH=$(shell go env GOPATH) bazel run //:generate $(BAZEL_ARGS)
+	$(MAKE) dep-ensure
+	bazel build $(BAZEL_ARGS) //pkg/cloud/aws/services/mocks:go_mock_interfaces \
+		//pkg/cloud/aws/services/ec2/mock_ec2iface:go_default_library \
+		//pkg/cloud/aws/services/elb/mock_elbiface:go_default_library
+	cp -Rf bazel-genfiles/pkg/* pkg/
+	$(MAKE) generate-crds
+
+.PHONY: generate-crds
+generate-crds:
 	bazel build //config
 	cp -R bazel-genfiles/config/crds/* config/crds/
 	cp -R bazel-genfiles/config/rbac/* config/rbac/
 
+## --------------------------------------
+## Linting
+## --------------------------------------
+
+.PHONY: lint
+lint: dep-ensure ## Lint codebase
+	bazel run //:lint $(BAZEL_ARGS)
+
 lint-full: dep-ensure ## Run slower linters to detect possible issues
 	bazel run //:lint-full $(BAZEL_ARGS)
 
-## Define local development targets here
+## --------------------------------------
+## Binaries
+## --------------------------------------
 
 .PHONY: binaries
-binaries: manager clusterawsadm clusterctl ## Builds and installs all binaries
+binaries: generate manager clusterawsadm clusterctl ## Builds and installs all binaries
+
+.PHONY: manager
+manager: ## Build manager binary.
+	bazel build //cmd/manager $(BAZEL_ARGS)
+	install bazel-bin/cmd/manager/${BINARYPATHPATTERN}/manager $(shell go env GOPATH)/bin/aws-manager
+
+.PHONY: clusterctl
+clusterctl: ## Build clusterctl binary.
+	bazel build --workspace_status_command=./hack/print-workspace-status.sh //cmd/clusterctl $(BAZEL_ARGS)
+	install bazel-bin/cmd/clusterctl/${BINARYPATHPATTERN}/clusterctl $(shell go env GOPATH)/bin/clusterctl
+
+.PHONY: clusterawsadm
+clusterawsadm: ## Build clusterawsadm binary.
+	bazel build --workspace_status_command=./hack/print-workspace-status.sh //cmd/clusterawsadm $(BAZEL_ARGS)
+	install bazel-bin/cmd/clusterawsadm/${BINARYPATHPATTERN}/clusterawsadm $(shell go env GOPATH)/bin/clusterawsadm
+
+## --------------------------------------
+## Release
+## --------------------------------------
+
+.PHONY: release-artifacts
+release-artifacts: ## Build release artifacts
+	bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/clusterctl //cmd/clusterawsadm
+	bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //cmd/clusterctl //cmd/clusterawsadm
+	bazel build //cmd/clusterctl/examples/aws
+	mkdir -p out
+	install bazel-bin/cmd/clusterawsadm/darwin_amd64_pure_stripped/clusterawsadm out/clusterawsadm-darwin-amd64
+	install bazel-bin/cmd/clusterawsadm/linux_amd64_pure_stripped/clusterawsadm out/clusterawsadm-linux-amd64
+	install bazel-bin/cmd/clusterctl/darwin_amd64_pure_stripped/clusterctl out/clusterctl-darwin-amd64
+	install bazel-bin/cmd/clusterctl/linux_amd64_pure_stripped/clusterctl out/clusterctl-linux-amd64
+	install bazel-bin/cmd/clusterctl/examples/aws/aws.tar out/cluster-api-provider-aws-examples.tar
+
+## --------------------------------------
+## Define local development targets here
+## --------------------------------------
+
+.PHONY: binaries-dev
+binaries-dev: ## Builds and installs all development binaries using go get
+	go get -v ./...
 
 .PHONY: create-cluster
-create-cluster: binaries ## Create a Kubernetes cluster on AWS using examples
-	clusterctl create cluster -v 3 \
+create-cluster: binaries-dev ## Create a development Kubernetes cluster on AWS using examples
+	clusterctl create cluster -v 4 \
 	--provider aws \
 	--bootstrap-type kind \
 	-m ./cmd/clusterctl/examples/aws/out/machines.yaml \
@@ -177,38 +212,17 @@ create-cluster: binaries ## Create a Kubernetes cluster on AWS using examples
 	-p ./cmd/clusterctl/examples/aws/out/provider-components-dev.yaml \
 	-a ./cmd/clusterctl/examples/aws/out/addons.yaml
 
+.PHONY: delete-cluster
+delete-cluster: binaries-dev ## Deletes the development Kubernetes Cluster "test1"
+	clusterctl delete cluster -v 4 \
+	--bootstrap-type kind \
+	--cluster test1 \
+	--kubeconfig ./kubeconfig \
+	-p ./cmd/clusterctl/examples/aws/out/provider-components-dev.yaml \
+
 kind-reset: ## Destroys the "clusterapi" kind cluster.
 	kind delete cluster --name=clusterapi || true
 
-ifneq ($(FASTBUILD),y)
-
-## Define slow dependency targets here
-
-.PHONY: generate
-generate: gazelle dep-ensure ## Run go generate
-	GOPATH=$(shell go env GOPATH) bazel run //:generate $(BAZEL_ARGS)
-	$(MAKE) dep-ensure
-	bazel build $(BAZEL_ARGS) //pkg/cloud/aws/services/mocks:go_mock_interfaces \
-		//pkg/cloud/aws/services/ec2/mock_ec2iface:go_default_library \
-		//pkg/cloud/aws/services/elb/mock_elbiface:go_default_library
-	cp -Rf bazel-genfiles/pkg/* pkg/
-	$(MAKE) crds
-
-.PHONY: lint
-lint: dep-ensure ## Lint codebase
-	@echo If you have genereated new mocks, run make copy-genmocks before linting
-	bazel run //:lint $(BAZEL_ARGS)
-
-else
-
-## Add skips for slow depedency targets here
-
-.PHONY: generate
-generate:
-	@echo FASTBUILD is set: Skipping generate
-
-.PHONY: lint
-lint:
-	@echo FASTBUILD is set: Skipping lint
-
-endif
+.PHONY: reset-bazel
+reset-bazel: ## Deep cleaning for bazel
+	bazel clean --expunge


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR is an effort to restructure the current Makefile in to provide better runtime for common targets, remove unused options and simplify cross-target dependencies.

- Remove FASTBUILD option in an effort to make most of the target fast instead of relying on on/off flags.
- Removes `dep status` and `dep-install` target which takes more time than just `dep ensure` in latest version of `dep`.
- Removes `generate` prereq from docker-push which isn't required or necessary.
- Reduces the amount of calls to `generate` and `gazelle` throughout the Makefile which increased the total time running a development build by several seconds.
- Adds `delete-cluster` development target.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```