### PR TITLE
Fix AWS credentials mountpoint with distroless image

### DIFF
--- a/cmd/clusterctl/examples/aws/provider-components-base.yaml
+++ b/cmd/clusterctl/examples/aws/provider-components-base.yaml
@@ -2337,7 +2337,7 @@ spec:
             cpu: 100m
             memory: 20Mi
         volumeMounts:
-        - mountPath: /root/.aws
+        - mountPath: /home/.aws
           name: credentials
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/cmd/clusterctl/examples/aws/provider-components-base/stateful-set-credentials-patch.yaml
+++ b/cmd/clusterctl/examples/aws/provider-components-base/stateful-set-credentials-patch.yaml
@@ -16,7 +16,7 @@
   path: "/spec/template/spec/containers/0/volumeMounts"
   value:
     - name: credentials
-      mountPath: /root/.aws
+      mountPath: /home/.aws
 
 - op: add
   path: "/spec/template/spec/volumes"

--- a/docs/reconcile-in-custom-namespace.md
+++ b/docs/reconcile-in-custom-namespace.md
@@ -15,7 +15,7 @@ reconciliation to a single namespace and this document tells you how.
   managing clusters across multiple AWS accounts. This will require each
   `cluster-api-provider-aws` controller to have credentials to their respective
   AWS accounts. These credentials can be created as kubernetes secret and be
-  mounted in the pod at `/root/.aws` or as environment variables.
+  mounted in the pod at `/home/.aws` or as environment variables.
 - Grouping clusters into a namespace based on their environment, (test,
   qualification, canary, production) will allow a phased rolling out of
   `cluster-api-provider-aws` releases.


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fixes an issue where the credentials couldn't be found after updating cluster-api to distroless.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```