### PR TITLE
more verbose immutable machine state errors

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -280,12 +280,12 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 
 	// Instance Type
 	if machineSpec.InstanceType != instance.Type {
-		errs = append(errs, errors.Errorf("(instance type cannot be mutated from  %q to %q")",  instance.Type, machineSpec.InstanceType))
+		errs = append(errs, errors.Errorf("(instance type cannot be mutated from %q to %q)", instance.Type, machineSpec.InstanceType))
 	}
 
 	// IAM Profile
 	if machineSpec.IAMInstanceProfile != instance.IAMProfile {
-		errs = append(errs, errors.Errorf("(instance IAM profile cannot be mutated from %q to %q)",  instance.IAMProfile, machineSpec.IAMInstanceProfile))
+		errs = append(errs, errors.Errorf("(instance IAM profile cannot be mutated from %q to %q)", instance.IAMProfile, machineSpec.IAMInstanceProfile))
 	}
 
 	// SSH Key Name

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -272,9 +272,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 // isMachineOudated checks that no immutable fields have been updated in an
 // Update request.
-// Returns a bool indicating if an attempt to change immutable state occurred.
-//  - true:  An attempt to change immutable state occurred.
-//  - false: Immutable state was untouched.
+// Returns a slice of errors representing attempts to change immutable state
 func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpec, instance *v1alpha1.Instance) (errs []error) {
 	// Instance Type
 	if machineSpec.InstanceType != instance.Type {

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -345,7 +345,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	// We will check immutable state first, in order to fail quickly before
 	// moving on to state that we can mutate.
 	if errs := a.isMachineOutdated(scope.MachineConfig, instanceDescription); len(errs) > 0 {
-		return errors.Errorf("found attempt to change immutable state for machine %s: %v", machine.Name, errs)
+		return errors.Errorf("found attempt to change immutable state for machine %q: %v", machine.Name, errs)
 	}
 
 	// Ensure that the security groups are correct.

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -278,17 +278,17 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpec, instance *v1alpha1.Instance) (errs []error) {
 	// Instance Type
 	if machineSpec.InstanceType != instance.Type {
-		errs = append(errs, errors.Errorf("(instance type cannot be mutated from %q to %q)", instance.Type, machineSpec.InstanceType))
+		errs = append(errs, errors.Errorf("instance type cannot be mutated from %q to %q", instance.Type, machineSpec.InstanceType))
 	}
 
 	// IAM Profile
 	if machineSpec.IAMInstanceProfile != instance.IAMProfile {
-		errs = append(errs, errors.Errorf("(instance IAM profile cannot be mutated from %q to %q)", instance.IAMProfile, machineSpec.IAMInstanceProfile))
+		errs = append(errs, errors.Errorf("instance IAM profile cannot be mutated from %q to %q", instance.IAMProfile, machineSpec.IAMInstanceProfile))
 	}
 
 	// SSH Key Name
 	if machineSpec.KeyName != aws.StringValue(instance.KeyName) {
-		errs = append(errs, errors.Errorf("(SSH key name cannot be mutated from %q to %q)", aws.StringValue(instance.KeyName), machineSpec.KeyName))
+		errs = append(errs, errors.Errorf("SSH key name cannot be mutated from %q to %q", aws.StringValue(instance.KeyName), machineSpec.KeyName))
 	}
 
 	// Subnet ID
@@ -297,7 +297,7 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 	// as a *string, so do the same here.
 	if machineSpec.Subnet != nil {
 		if aws.StringValue(machineSpec.Subnet.ID) != instance.SubnetID {
-			errs = append(errs, errors.Errorf("(machine subnet ID cannot be mutated from %q to %q)", instance.SubnetID, aws.StringValue(machineSpec.Subnet.ID)))
+			errs = append(errs, errors.Errorf("machine subnet ID cannot be mutated from %q to %q", instance.SubnetID, aws.StringValue(machineSpec.Subnet.ID)))
 		}
 	}
 
@@ -314,7 +314,7 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 	}
 
 	if aws.BoolValue(machineSpec.PublicIP) != instanceHasPublicIP {
-		errs = append(errs, errors.Errorf("(public IP setting cannot be mutated from \"%v\" to \"%v\")", instanceHasPublicIP, aws.BoolValue(machineSpec.PublicIP)))
+		errs = append(errs, errors.Errorf(`public IP setting cannot be mutated from "%v" to "%v"`, instanceHasPublicIP, aws.BoolValue(machineSpec.PublicIP)))
 	}
 
 	return errs
@@ -345,7 +345,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	// We will check immutable state first, in order to fail quickly before
 	// moving on to state that we can mutate.
 	if errs := a.isMachineOutdated(scope.MachineConfig, instanceDescription); len(errs) > 0 {
-		return errors.Errorf("found attempt to change immutable state for machine %q: %v", machine.Name, errs)
+		return errors.Errorf("found attempt to change immutable state for machine %q: %+q", machine.Name, errs)
 	}
 
 	// Ensure that the security groups are correct.

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -280,17 +280,17 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 
 	// Instance Type
 	if machineSpec.InstanceType != instance.Type {
-		errs = append(errs, errors.Errorf("(input instance type \"%s\" != existing \"%s\")", machineSpec.InstanceType, instance.Type))
+		errs = append(errs, errors.Errorf("(instance type cannot be mutated from  %q to %q")",  instance.Type, machineSpec.InstanceType))
 	}
 
 	// IAM Profile
 	if machineSpec.IAMInstanceProfile != instance.IAMProfile {
-		errs = append(errs, errors.Errorf("(input instance profile \"%s\" != existing \"%s\")", machineSpec.IAMInstanceProfile, instance.IAMProfile))
+		errs = append(errs, errors.Errorf("(instance IAM profile cannot be mutated from %q to %q)",  instance.IAMProfile, machineSpec.IAMInstanceProfile))
 	}
 
 	// SSH Key Name
 	if machineSpec.KeyName != aws.StringValue(instance.KeyName) {
-		errs = append(errs, errors.Errorf("(input SSH key name \"%s\" != existing \"%s\")", machineSpec.KeyName, aws.StringValue(instance.KeyName)))
+		errs = append(errs, errors.Errorf("(SSH key name cannot be mutated from %q to %q)", aws.StringValue(instance.KeyName), machineSpec.KeyName))
 	}
 
 	// Subnet ID
@@ -299,7 +299,7 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 	// as a *string, so do the same here.
 	if machineSpec.Subnet != nil {
 		if aws.StringValue(machineSpec.Subnet.ID) != instance.SubnetID {
-			errs = append(errs, errors.Errorf("(input subnet ID \"%s\" != existing \"%s\")", aws.StringValue(machineSpec.Subnet.ID), instance.SubnetID))
+			errs = append(errs, errors.Errorf("(machine subnet ID cannot be mutated from %q to %q)", instance.SubnetID, aws.StringValue(machineSpec.Subnet.ID)))
 		}
 	}
 
@@ -316,7 +316,7 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 	}
 
 	if aws.BoolValue(machineSpec.PublicIP) != instanceHasPublicIP {
-		errs = append(errs, errors.Errorf("(input public IP setting \"%v\" != existing \"%v\")", aws.BoolValue(machineSpec.PublicIP), instanceHasPublicIP))
+		errs = append(errs, errors.Errorf("(public IP setting cannot be mutated from \"%v\" to \"%v\")", instanceHasPublicIP, aws.BoolValue(machineSpec.PublicIP)))
 	}
 
 	return errs

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -275,9 +275,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 // Returns a bool indicating if an attempt to change immutable state occurred.
 //  - true:  An attempt to change immutable state occurred.
 //  - false: Immutable state was untouched.
-func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpec, instance *v1alpha1.Instance) []error {
-	var errs []error
-
+func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpec, instance *v1alpha1.Instance) (errs []error) {
 	// Instance Type
 	if machineSpec.InstanceType != instance.Type {
 		errs = append(errs, errors.Errorf("(instance type cannot be mutated from %q to %q)", instance.Type, machineSpec.InstanceType))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR adds slightly more error logging when Machine reconciliation fails, with additional details when the failure is due to an attempt to change immutable fields such as SSH key name or IAM instance profile.

Issue discovered while troubleshooting for https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/635.

**Special notes for your reviewer**:

Sample log output:
```
E0312 15:24:59.803917       1 controller.go:214] Error updating machine rudeboy-machine-name: found attempt to change immutable state for machine rudeboy-machine-name: [(input instance profile "new" != existing "old") (input subnet ID "subnet-123" != existing "subnet-456")]
```

Edit: the above log output relies on https://github.com/kubernetes-sigs/cluster-api/pull/819

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve machine reconciliation error logging
```