### PR TITLE
Allow user to use arbitraty userdata

### DIFF
--- a/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 )
@@ -77,6 +78,11 @@ type AWSMachineProviderSpec struct {
 	// KubeadmConfiguration holds the kubeadm configuration options
 	// +optional
 	KubeadmConfiguration KubeadmConfiguration `json:"kubeadmConfiguration,omitempty"`
+
+	// UserDataSecret contains a local reference to a secret that contains the
+	// UserData to apply to the instance
+	// + optional
+	UserDataSecret *corev1.LocalObjectReference `json:"userDataSecret,omitempty"`
 }
 
 // KubeadmConfiguration holds the various configurations that kubeadm uses

--- a/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	tags "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/tags"
 )
@@ -134,6 +135,11 @@ func (in *AWSMachineProviderSpec) DeepCopyInto(out *AWSMachineProviderSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.KubeadmConfiguration.DeepCopyInto(&out.KubeadmConfiguration)
+	if in.UserDataSecret != nil {
+		in, out := &in.UserDataSecret, &out.UserDataSecret
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cloud/aws/actuators/BUILD.bazel
+++ b/pkg/cloud/aws/actuators/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -164,7 +164,7 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 			errors.Errorf("failed to get userData for machine %q", machine.Name()),
 		)
 	}
-	input.UserData = userData
+	input.UserData = &userData
 
 	securityGroupID, err := s.getSecurityGroupID(machine)
 	if err != nil {
@@ -209,6 +209,15 @@ func (s *Service) getSecurityGroupID(machine *actuators.MachineScope) (string, e
 
 func (s *Service) getUserData(machine *actuators.MachineScope, bootstrapToken, caCertHash string, kubeConfig string) (string, error) {
 	var userData string
+
+	userData, err := userdata.GetUserDataFromSecret(machine)
+	if err != nil {
+		return "", errors.Errorf("failed getting userData from secret %v", err)
+	}
+	if userData != "" {
+		return userData, nil
+	}
+
 	switch machine.Role() {
 	case "controlplane":
 		if s.scope.SecurityGroups()[v1alpha1.SecurityGroupControlPlane] == nil {

--- a/pkg/cloud/aws/services/userdata/BUILD.bazel
+++ b/pkg/cloud/aws/services/userdata/BUILD.bazel
@@ -10,7 +10,11 @@ go_library(
     ],
     importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/userdata",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/pkg/errors:go_default_library"],
+    deps = [
+        "//pkg/cloud/aws/actuators:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )
 
 go_test(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR removes tight coupling between machine resource and kubeadm while keeping the current behaviour pristine.
This allows flexibility for the API consumers to support broader use cases by injecting arbitrary userdata into a secret optionally referenced by the spec.
While being a fairly scoped change this would favour adoption of the project extremely.

Related:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/135
https://github.com/kubernetes-sigs/cluster-api/issues/721 and https://docs.google.com/document/d/1pzXtwYWRsOzq5Ftu03O5FcFAlQE26nD3bjYBPenbhjg/edit#heading=h.etxqa0k5waej

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```