### PR TITLE
fix: add AWS ExtraArgs for ControllerManager

### DIFF
--- a/pkg/cloud/aws/services/kubeadm/aws_defaults.go
+++ b/pkg/cloud/aws/services/kubeadm/aws_defaults.go
@@ -76,6 +76,14 @@ func SetClusterConfigurationOverrides(machine *actuators.MachineScope, base *kub
 	}
 	base.APIServer.ControlPlaneComponent.ExtraArgs["cloud-provider"] = cloudProvider
 
+	if base.ControllerManager.ExtraArgs == nil {
+		base.ControllerManager.ExtraArgs = map[string]string{}
+	}
+	if cp, ok := base.ControllerManager.ExtraArgs["cloud-provider"]; ok && cp != cloudProvider {
+		klog.Infof("Overriding cloud provider %q with required value %q", cp, cloudProvider)
+	}
+	base.ControllerManager.ExtraArgs["cloud-provider"] = cloudProvider
+
 	// The kubeadm config clustername must match the provided name of the cluster.
 	if base.ClusterName != "" && base.ClusterName != s.Name() {
 		klog.Infof("Overriding provided cluster name %q with %q. The kubeadm cluster name and cluster-api name must match.", base.ClusterName, s.Name())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Adds a missing `--cloud-provider=aws` parameter for the controllermanager pod

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds an ExtraArg for the controllermanager pod for AWS cloud provider.
```