### PR TITLE
Remove more bazel defaults

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,3 @@
-build --define=MANAGER_IMAGE_NAME=cluster-api-aws-controller
-build --define=MANAGER_IMAGE_TAG=0.0.4
-
 build --workspace_status_command=./hack/print-workspace-status.sh
 build --verbose_failures
 

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,25 @@
 
 # A release should define this with gcr.io/cluster-api-provider-aws
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+
 # A release should define this with IfNotPresent
 PULL_POLICY ?= Always
+
+# A release does not need to define this
+MANAGER_IMAGE_NAME ?= cluster-api-aws-controller
+
+# A release should define this with the next version after 0.0.4
+MANAGER_IMAGE_TAG ?= dev
 
 ## Image URL to use all building/pushing image targets
 DEPCACHEAGE ?= 24h # Enables caching for Dep
 BAZEL_ARGS ?=
-BAZEL_BUILD_ARGS := --define=REGISTRY=$(REGISTRY) --define=PULL_POLICY=$(PULL_POLICY) $(BAZEL_ARGS)
+
+BAZEL_BUILD_ARGS := --define=REGISTRY=$(REGISTRY)\
+ --define=PULL_POLICY=$(PULL_POLICY)\
+ --define=MANAGER_IMAGE_NAME=$(MANAGER_IMAGE_NAME)\
+ --define=MANAGER_IMAGE_TAG=$(MANAGER_IMAGE_TAG)\
+$(BAZEL_ARGS)
 
 # Bazel variables
 BAZEL_VERSION := $(shell command -v bazel 2> /dev/null)


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This moves all the build variables into the make file so a release can happen entirely through make without having to modify bazel definitions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Aids in the next release

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```