### PR TITLE
Update the resync interval to 10m instead of 10h

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"time"
 
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis"
@@ -44,7 +45,11 @@ func main() {
 	cfg := config.GetConfigOrDie()
 
 	// Setup a Manager
-	var opts manager.Options
+	syncPeriod := 10 * time.Minute
+	opts := manager.Options{
+		SyncPeriod: &syncPeriod,
+	}
+
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
 		klog.Infof("Watching cluster-api objects only in namespace %q for reconciliation.", opts.Namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
Overrides the default resync interval (10h) to 10m

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to: https://github.com/kubernetes-sigs/cluster-api/issues/748

**Release note**:
```release-note
The resync interval for reconciling Machines and Clusters is now 10m instead of the Kubebuilder default of 10h
```