### PR TITLE
e2e: Fix-up for changes to release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ integration: generate verify ## Run integraion tests
 JANITOR_ENABLED ?= 0
 .PHONY: e2e
 e2e: generate verify ## Run e2e tests
-	JANITOR_ENABLED=$(JANITOR_ENABLED) ./hack/e2e.sh
+	JANITOR_ENABLED=$(JANITOR_ENABLED) ./hack/e2e.sh  $(BAZEL_BUILD_ARGS)
 
 .PHONY: e2e-janitor
 e2e-janitor:

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -60,7 +60,7 @@ if grep -iqF "$(echo "${AWS_ACCESS_KEY_ID-}" | \
   exit 1
 fi
 
-bazel test --define='gotags=e2e' --test_output all //test/e2e/...
+bazel test --define='gotags=e2e' --test_output all //test/e2e/... $@
 bazel_status="${?}"
 
 # If the artifacts environment variable is set then coalesce the test results.
@@ -70,7 +70,7 @@ bazel_status="${?}"
 [ -z "${BOSKOS_HOST:-}" ] || hack/checkin_account.py
 
 # The janitor is typically not run as part of the e2e process, but rather
-# in a parallel process via a service on the same cluster that runs Prow and 
+# in a parallel process via a service on the same cluster that runs Prow and
 # Boskos.
 #
 # However, setting JANITOR_ENABLED=1 tells this program to run the janitor


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Allows `make e2e` to work again