### PR TITLE
Update AMIs and Calico

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ This provider's versions are compatible with the following versions of Cluster A
 
 This provider's versions are able to install and manage the following versions of Kubernetes:
 
-||Kubernetes 1.13|Kubernetes 1.14 (unreleased)|
+||Kubernetes 1.13|Kubernetes 1.14|
 |-|-|-|
-|AWS Provider v1alpha1 (v0.2)|✓|? (Currently untested)|
+|AWS Provider v1alpha1 (v0.2)|✓|✓|
 
 Each version of Cluster API for AWS will attempt to support two Kubernetes versions; e.g., Cluster API for AWS `v0.2`
 may support Kubernetes 1.13 and Kubernetes 1.14.
@@ -58,7 +58,7 @@ may support Kubernetes 1.13 and Kubernetes 1.14.
 **NOTE:** As the versioning for this project is tied to the versioning of Cluster API, future modifications to this
 policy may be made to more closely align with other providers in the Cluster API ecosystem.
 
------
+------
 
 ## Documentation
 
@@ -126,7 +126,6 @@ We also use the issue tracker to track features. If you have an idea for a featu
 - After the new feature is well understood, and the design agreed upon we can
   start coding the feature. We would love for you to code it. So please open
   up a **WIP** *(work in progress)* pull request, and happy coding.
-
 
 >“Amazon Web Services, AWS, and the “Powered by AWS” logo materials are
 trademarks of Amazon.com, Inc. or its affiliates in the United States

--- a/build/amis/README.md
+++ b/build/amis/README.md
@@ -32,13 +32,13 @@ The following variables can be overriden when building images using the `-var` o
 
 | Variable               | Default   | Description                   |
 |------------------------|-----------|-------------------------------|
-| kubernetes_version     | 1.13.3-00 | Kubernetes Version to install |
-| kubernetes_cni_version | 0.6.0-00  | CNI Version to install        |
+| kubernetes_version     | 1.13.5-00 | Kubernetes Version to install |
+| kubernetes_cni_version | 0.7.5-00  | CNI Version to install        |
 
-For example, to build all images for use with Kubernetes 1.11.3 for build version 1:
+For example, to build all images for use with Kubernetes 1.14.0 for build version 1:
 
 ```sh
-packer build -var kubernetes_version=1.11.3-00
+packer build -var kubernetes_version=1.14.0-00
 ```
 
 There are additional variables that may be set that affect the behavior of specific builds or packer post-processors. `packer inspect packer.json` will list all available variables and their default values.
@@ -116,7 +116,7 @@ packer build -var-file base-images-us-east-1.json packer.json
 The output of this command is a list of created AMIs. To format them you can
 copy the output and pipe it through this to get a desired table:
 
-```
+```sh
 echo 'us-fake-1: ami-123
 us-fake-2: ami-234' | column -t | sed 's/^/| /g' | sed 's/: //g' | sed 's/ami/| ami/g' | sed 's/$/ |/g'
 ```

--- a/build/amis/ansible/roles/containerd/defaults/main.yml
+++ b/build/amis/ansible/roles/containerd/defaults/main.yml
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-containerd_version: "1.2.4"
-containerd_sha256: "3391758c62d17a56807ddac98b05487d9e78e5beb614a0602caab747b0eda9e0"
+containerd_version: "1.2.5"
+containerd_sha256: "40300c61ab44bd39a2440c5eedb8ac573d8b8d848acbad5efa0bc214cffb422b"

--- a/build/amis/packer/base-images-us-east-1.json
+++ b/build/amis/packer/base-images-us-east-1.json
@@ -1,5 +1,6 @@
 {
-  "ubuntu_18_04_ami": "ami-0ac019f4fcb7cb7e6",
+  "aws_region": "us-east-1",
+  "ubuntu_18_04_ami": "ami-0a313d6098716f372",
   "centos_7_ami": "ami-77ec9308",
-  "amazon_2_ami": "ami-009d6802948d06e52"
+  "amazon_2_ami": "ami-0de53d8956e8dcf80"
 }

--- a/build/amis/packer/packer.json
+++ b/build/amis/packer/packer.json
@@ -3,8 +3,8 @@
     "aws_access_key": "",
     "aws_secret_key": "",
     "build_timestamp": "{{timestamp}}",
-    "kubernetes_version": "1.13.3-00",
-    "kubernetes_cni_version": "0.6.0-00",
+    "kubernetes_version": "1.13.5-00",
+    "kubernetes_cni_version": "0.7.5-00",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "ami_groups": "all",
     "ami_regions": "ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2"
@@ -18,6 +18,7 @@
       "ami_groups": "{{user `ami_groups`}}",
       "ami_regions": "{{user `ami_regions`}}",
       "access_key": "{{user `aws_access_key`}}",
+      "region": "{{ user `aws_region` }}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "ubuntu",
       "tags": {
@@ -41,6 +42,7 @@
       "ami_product_codes": "",
       "ami_regions": "{{user `ami_regions`}}",
       "access_key": "{{user `aws_access_key`}}",
+      "region": "{{ user `aws_region` }}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "centos",
       "tags": {
@@ -63,6 +65,7 @@
       "ami_groups": "{{user `ami_groups`}}",
       "ami_regions": "{{user `ami_regions`}}",
       "access_key": "{{user `aws_access_key`}}",
+      "region": "{{ user `aws_region` }}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "ec2-user",
       "tags": {

--- a/cmd/clusterctl/examples/aws/addons.yaml
+++ b/cmd/clusterctl/examples/aws/addons.yaml
@@ -1,97 +1,7 @@
-# Calico Version v3.2.3
-# https://docs.projectcalico.org/v3.2/releases#v3.2.3
+# Calico Version v3.6
+# https://docs.projectcalico.org/v3.6/release-notes/
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: calico-node
-rules:
-  - apiGroups: [""]
-    resources:
-      - namespaces
-      - serviceaccounts
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: [""]
-    resources:
-      - pods/status
-    verbs:
-      - update
-  - apiGroups: [""]
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-      - patch
-  - apiGroups: [""]
-    resources:
-      - services
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - endpoints
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - update
-      - watch
-  - apiGroups: ["extensions"]
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["networking.k8s.io"]
-    resources:
-      - networkpolicies
-    verbs:
-      - watch
-      - list
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - globalfelixconfigs
-      - felixconfigurations
-      - bgppeers
-      - globalbgpconfigs
-      - bgpconfigurations
-      - ippools
-      - globalnetworkpolicies
-      - globalnetworksets
-      - networkpolicies
-      - clusterinformations
-      - hostendpoints
-    verbs:
-      - create
-      - get
-      - list
-      - update
-      - watch
-
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: calico-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-node
-subjects:
-  - kind: ServiceAccount
-    name: calico-node
-    namespace: kube-system
----
+# Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
 apiVersion: v1
@@ -99,9 +9,7 @@ metadata:
   name: calico-config
   namespace: kube-system
 data:
-  # To enable Typha, set this to "calico-typha" *and* set a non-zero value for Typha replicas
-  # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
-  # essential.
+  # Typha is disabled.
   typha_service_name: "none"
   # Configure the Calico backend to use.
   calico_backend: "bird"
@@ -123,8 +31,7 @@ data:
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,
           "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
+              "type": "calico-ipam"
           },
           "policy": {
               "type": "k8s"
@@ -142,112 +49,412 @@ data:
     }
 
 ---
-# This manifest creates a Service, which will be backed by Calico's Typha daemon.
-# Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+# Source: calico/templates/kdd-crds.yaml
+# Create all the CustomResourceDefinitions needed for
+# Calico policy and networking mode.
 
-apiVersion: v1
-kind: Service
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: calico-typha
-  namespace: kube-system
-  labels:
-    k8s-app: calico-typha
+   name: felixconfigurations.crd.projectcalico.org
 spec:
-  ports:
-    - port: 5473
-      protocol: TCP
-      targetPort: calico-typha
-      name: calico-typha
-  selector:
-    k8s-app: calico-typha
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock
 
 ---
-# This manifest creates a Deployment of Typha to back the above service.
 
-apiVersion: apps/v1beta1
-kind: Deployment
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: calico-typha
-  namespace: kube-system
-  labels:
-    k8s-app: calico-typha
+  name: blockaffinities.crd.projectcalico.org
 spec:
-  # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
-  # typha_service_name variable in the calico-config ConfigMap above.
-  #
-  # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
-  # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
-  # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
-  replicas: 0
-  revisionHistoryLimit: 2
-  template:
-    metadata:
-      labels:
-        k8s-app: calico-typha
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
-        # add-on, ensuring it gets priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ""
-    spec:
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-      hostNetwork: true
-      tolerations:
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
-      # as a host-networked pod.
-      serviceAccountName: calico-node
-      containers:
-        - image: quay.io/calico/typha:v3.2.3
-          name: calico-typha
-          ports:
-            - containerPort: 5473
-              name: calico-typha
-              protocol: TCP
-          env:
-            # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
-            - name: TYPHA_LOGSEVERITYSCREEN
-              value: "info"
-            # Disable logging to file and syslog since those don't make sense in Kubernetes.
-            - name: TYPHA_LOGFILEPATH
-              value: "none"
-            - name: TYPHA_LOGSEVERITYSYS
-              value: "none"
-            # Monitor the Kubernetes API to find the number of running instances and rebalance
-            # connections.
-            - name: TYPHA_CONNECTIONREBALANCINGMODE
-              value: "kubernetes"
-            - name: TYPHA_DATASTORETYPE
-              value: "kubernetes"
-            - name: TYPHA_HEALTHENABLED
-              value: "true"
-            # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
-            # this opens a port on the host, which may need to be secured.
-            #- name: TYPHA_PROMETHEUSMETRICSENABLED
-            #  value: "true"
-            #- name: TYPHA_PROMETHEUSMETRICSPORT
-            #  value: "9093"
-          livenessProbe:
-            exec:
-              command:
-                - calico-typha
-                - check
-                - liveness
-            periodSeconds: 30
-            initialDelaySeconds: 30
-          readinessProbe:
-            exec:
-              command:
-                - calico-typha
-                - check
-                - readiness
-            periodSeconds: 10
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity
 
 ---
-# This manifest installs the calico/node container, as well
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMHandle
+    plural: ipamhandles
+    singular: ipamhandle
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMConfig
+    plural: ipamconfigs
+    singular: ipamconfig
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
+---
+# Source: calico/templates/rbac.yaml
+
+# Include a clusterrole for the kube-controllers component,
+# and bind it to the calico-kube-controllers serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+rules:
+  # Nodes are watched to monitor for deletions.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - watch
+      - list
+      - get
+  # Pods are queried to check for existence.
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+  # IPAM resources are manipulated when nodes are deleted.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  # Needs access to update clusterinformations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - clusterinformations
+    verbs:
+      - get
+      - create
+      - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+rules:
+  # The CNI plugin needs to get pods, nodes, and namespaces.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      # Used to discover service IPs for advertisement.
+      - watch
+      - list
+      # Used to discover Typhas.
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  # Used by Calico for policy information.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  # The CNI plugin patches pods/status.
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  # Calico monitors various CRDs for config.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - clusterinformations
+      - hostendpoints
+    verbs:
+      - get
+      - list
+      - watch
+  # Calico must create and update some CRDs on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+    verbs:
+      - create
+      - update
+  # Calico stores some configuration information on the node.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  # These permissions are only requried for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
+  # These permissions are required for Calico CNI to perform IPAM allocations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipamconfigs
+    verbs:
+      - get
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+---
+
+---
+# Source: calico/templates/calico-node.yaml
+# This manifest installs the node container, as well
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
@@ -274,7 +481,7 @@ spec:
         # marks the pod as a critical add-on, ensuring it gets
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -292,22 +499,72 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      initContainers:
+        # This container performs upgrade from host-local IPAM to calico-ipam.
+        # It can be deleted if this is a fresh installation, or if you have already
+        # upgraded to use calico-ipam.
+        - name: upgrade-ipam
+          image: calico/cni:v3.6.0
+          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+          volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: calico/cni:v3.6.0
+          command: ["/install-cni.sh"]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
       containers:
-        # Runs calico/node container on each Kubernetes node.  This
+        # Runs node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.2.3
+          image: calico/node:v3.6.0
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
-            # Typha support: controlled by the ConfigMap.
-            - name: FELIX_TYPHAK8SSERVICENAME
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: typha_service_name
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
@@ -331,9 +588,6 @@ spec:
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "Always"
-            # Enable IP-in-IP within Felix.
-            - name: FELIX_IPINIPENABLED
-              value: "true"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:
@@ -375,53 +629,25 @@ spec:
           readinessProbe:
             exec:
               command:
-                - /bin/calico-node
-                - -bird-ready
-                - -felix-ready
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
-        # This container installs the Calico CNI binaries
-        # and CNI network config file on each node.
-        - name: install-cni
-          image: quay.io/calico/cni:v3.2.3
-          command: ["/install-cni.sh"]
-          env:
-            # Name of the CNI config file to create.
-            - name: CNI_CONF_NAME
-              value: "10-calico.conflist"
-            # Set the hostname based on the k8s node name.
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: cni_network_config
-            # CNI MTU Config variable
-            - name: CNI_MTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
       volumes:
-        # Used by calico/node.
+        # Used by node.
         - name: lib-modules
           hostPath:
             path: /lib/modules
@@ -431,6 +657,10 @@ spec:
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -438,7 +668,14 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        # Mount in the directory for host-local IPAM allocations. This is
+        # used when upgrading from host-local to calico-ipam, and can be removed
+        # if not using the upgrade-ipam init container.
+        - name: host-local-net-dir
+          hostPath:
+            path: /var/lib/cni/networks
 ---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -446,129 +683,68 @@ metadata:
   namespace: kube-system
 
 ---
-# Create all the CustomResourceDefinitions needed for
-# Calico policy and networking mode.
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+# Source: calico/templates/calico-kube-controllers.yaml
+# This manifest deploys the Calico node controller.
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
-  name: felixconfigurations.crd.projectcalico.org
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: bgppeers.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: BGPPeer
-    plural: bgppeers
-    singular: bgppeer
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: bgpconfigurations.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: BGPConfiguration
-    plural: bgpconfigurations
-    singular: bgpconfiguration
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ippools.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPPool
-    plural: ippools
-    singular: ippool
+  # The controller can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      containers:
+        - name: calico-kube-controllers
+          image: calico/kube-controllers:v3.6.0
+          env:
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: hostendpoints.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: HostEndpoint
-    plural: hostendpoints
-    singular: hostendpoint
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Source: calico/templates/calico-etcd-secrets.yaml
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: clusterinformations.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: ClusterInformation
-    plural: clusterinformations
-    singular: clusterinformation
+# Source: calico/templates/calico-typha.yaml
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: globalnetworkpolicies.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: GlobalNetworkPolicy
-    plural: globalnetworkpolicies
-    singular: globalnetworkpolicy
+# Source: calico/templates/configure-canal.yaml
 
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: globalnetworksets.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: GlobalNetworkSet
-    plural: globalnetworksets
-    singular: globalnetworkset
 
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: networkpolicies.crd.projectcalico.org
-spec:
-  scope: Namespaced
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: NetworkPolicy
-    plural: networkpolicies
-    singular: networkpolicy

--- a/cmd/clusterctl/examples/aws/machines.yaml.template
+++ b/cmd/clusterctl/examples/aws/machines.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.3
-        controlPlane: v1.13.3
+        kubelet: v1.13.5
+        controlPlane: v1.13.5
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1
@@ -28,7 +28,7 @@ items:
         set: node
     spec:
       versions:
-        kubelet: v1.13.3
+        kubelet: v1.13.5
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/docs/amis.md
+++ b/docs/amis.md
@@ -4,71 +4,137 @@
 
 <!-- TOC -->
 
-- [Kubernetes Version v1.13.3](#kubernetes-version-v1133)
+- [Kubernetes Version v1.13.5](#kubernetes-version-v1135)
   - [Amazon Linux 2](#amazon-linux-2)
   - [CentOS 7](#centos-7)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic)
+- [Kubernetes Version v1.14.0](#kubernetes-version-v1140)
+  - [Amazon Linux 2](#amazon-linux-2-1)
+  - [CentOS 7](#centos-7-1)
+  - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-1)
 
 <!-- TOC -->
 
-## Kubernetes Version v1.13.3
+## Kubernetes Version v1.13.5
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0c78b208a283c16b9 |
-| ap-northeast-2 | ami-0c702d099c07d4849 |
-| ap-south-1     | ami-00a357fdf0e37d384 |
-| ap-southeast-1 | ami-0a363d6cc3f41d01f |
-| ap-southeast-2 | ami-08d65863a44c758b0 |
-| ca-central-1   | ami-04105172a0f4fa0a0 |
-| eu-central-1   | ami-0caba3baafb7ac0a6 |
-| eu-west-1      | ami-07bd8e4f509cba829 |
-| eu-west-2      | ami-0c940a804c8fcf4d4 |
-| eu-west-3      | ami-0cab805a139c13b6e |
-| sa-east-1      | ami-00c82c548937d840b |
-| us-east-1      | ami-06669682afff39909 |
-| us-east-2      | ami-0cb9cbc6442247605 |
-| us-west-1      | ami-0f8ddd7fdcd56634f |
-| us-west-2      | ami-0d3790859b605ecdd |
+| ap-northeast-1 | ami-0688d72891d3583d6 |
+| ap-northeast-2 | ami-02a033d516840cfc2 |
+| ap-south-1     | ami-00c67e4e6fbff461c |
+| ap-southeast-1 | ami-0fae2278696ff3d4e |
+| ap-southeast-2 | ami-082da781aaafed6e8 |
+| ca-central-1   | ami-010ab60975789413b |
+| eu-central-1   | ami-0761487dce48232b2 |
+| eu-west-1      | ami-0dfa4442aadf01c62 |
+| eu-west-2      | ami-0a67bbbd89e7987cd |
+| eu-west-3      | ami-0cb2da8c37b515aa4 |
+| sa-east-1      | ami-0ddfc1dd24c014267 |
+| us-east-1      | ami-0fa499d8135116e9d |
+| us-east-2      | ami-0a8392b2e9de560e1 |
+| us-west-1      | ami-08e0337e58fbd5faf |
+| us-west-2      | ami-08a788942678765f6 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-05887ec1d37b0b977 |
-| ap-northeast-2 | ami-023e63610ace66f8f |
-| ap-south-1     | ami-0120813397c39356e |
-| ap-southeast-1 | ami-0f63ba701025980a4 |
-| ap-southeast-2 | ami-0f3f3460ee7cda28e |
-| ca-central-1   | ami-0ac8611aa49a7c375 |
-| eu-central-1   | ami-04de15d41c706134b |
-| eu-west-1      | ami-092e02b4bf4549695 |
-| eu-west-2      | ami-03d891a3b13d5e452 |
-| eu-west-3      | ami-083dee099e03e7ca0 |
-| sa-east-1      | ami-0ce0082532885ad57 |
-| us-east-1      | ami-0d9115e0a324d2379 |
-| us-east-2      | ami-00c70d5b4d52f7edc |
-| us-west-1      | ami-0dc611a28513bf9a4 |
-| us-west-2      | ami-009f6d2495429961e |
+| ap-northeast-1 | ami-02324463edcbb8c1a |
+| ap-northeast-2 | ami-0770f7f4d461d129a |
+| ap-south-1     | ami-0d3121e5ddf1fd60c |
+| ap-southeast-1 | ami-06851fd67009a6b8f |
+| ap-southeast-2 | ami-0d6af4d9c35af5728 |
+| ca-central-1   | ami-0f079b3f9da5fce72 |
+| eu-central-1   | ami-0eb1da7e029e40718 |
+| eu-west-1      | ami-0f97257ed35776888 |
+| eu-west-2      | ami-0531f56e114bf5b41 |
+| eu-west-3      | ami-09b10f260dbb61cad |
+| sa-east-1      | ami-060afbcebe8b61927 |
+| us-east-1      | ami-0b46755a70c6a6217 |
+| us-east-2      | ami-07da6996c051c2d30 |
+| us-west-1      | ami-03cf4e98f43e75e61 |
+| us-west-2      | ami-04bdfddfa9db00e72 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0e02585d6eb07dc7d |
-| ap-northeast-2 | ami-009fb5539f21fd359 |
-| ap-south-1     | ami-03cadb5241a21366d |
-| ap-southeast-1 | ami-00e0be9a40ccfb8b3 |
-| ap-southeast-2 | ami-013f6df61471ffc1d |
-| ca-central-1   | ami-0b0543f31d4a02bf7 |
-| eu-central-1   | ami-09dfeca48919eadd7 |
-| eu-west-1      | ami-00730ecf8796291a5 |
-| eu-west-2      | ami-078007d754269d160 |
-| eu-west-3      | ami-027968d67a8771a22 |
-| sa-east-1      | ami-004fa3e89cb288114 |
-| us-east-1      | ami-02b8a5477f3faca0c |
-| us-east-2      | ami-0e94cd42e10a8863a |
-| us-west-1      | ami-0ea4397a7ca0f6cf1 |
-| us-west-2      | ami-030cbaf4db0da6036 |
+| ap-northeast-1 | ami-04bb5d5bc99913301 |
+| ap-northeast-2 | ami-09ff3da4bb9aed616 |
+| ap-south-1     | ami-00ec192fdd55893de |
+| ap-southeast-1 | ami-09c14c3ce5478def0 |
+| ap-southeast-2 | ami-079993d9d3cddc690 |
+| ca-central-1   | ami-0a9620450ebe48c7f |
+| eu-central-1   | ami-0e941cbc45d8c84e2 |
+| eu-west-1      | ami-0fd10f5363abe78f9 |
+| eu-west-2      | ami-0afbd4e1afc73a30d |
+| eu-west-3      | ami-08c0295bf0f7ddfaa |
+| sa-east-1      | ami-0db5c28f2664dcbb5 |
+| us-east-1      | ami-0506cbd2c148a21d3 |
+| us-east-2      | ami-097e20b9b0a873930 |
+| us-west-1      | ami-08966c37e0140c3d1 |
+| us-west-2      | ami-00a33ed2a8fc8c3e8 |
+
+## Kubernetes Version v1.14.0
+
+### Amazon Linux 2
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-0f45a5bd2bfb04741 |
+| ap-northeast-2 | ami-049834ba9566e62bc |
+| ap-south-1     | ami-0a9d15d50a0d1051f |
+| ap-southeast-1 | ami-0fb4b55e75eec74ac |
+| ap-southeast-2 | ami-0330f679d365cea8c |
+| ca-central-1   | ami-057948ce6362cf5d0 |
+| eu-central-1   | ami-0d39727798a8d990f |
+| eu-west-1      | ami-077e900c1d635539a |
+| eu-west-2      | ami-027742c4ff63fa8bf |
+| eu-west-3      | ami-09d7337bf48531d16 |
+| sa-east-1      | ami-05e76d1313b041bd2 |
+| us-east-1      | ami-06e9efa49080a34f3 |
+| us-east-2      | ami-072175305658a8cc1 |
+| us-west-1      | ami-03a927b71dd62900c |
+| us-west-2      | ami-0f7f3df9b085ad831 |
+
+### CentOS 7
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-0c301d38a6585e2b8 |
+| ap-northeast-2 | ami-06f2c6503e566d38f |
+| ap-south-1     | ami-000ec39b83793a663 |
+| ap-southeast-1 | ami-02efaa3cd4ec9acb7 |
+| ap-southeast-2 | ami-0e718f9b87eb47ea6 |
+| ca-central-1   | ami-00b2eb5934cf51417 |
+| eu-central-1   | ami-0d4a90494fcbba30e |
+| eu-west-1      | ami-0b23330aa5c2cc2c4 |
+| eu-west-2      | ami-06d24b1c07007f3db |
+| eu-west-3      | ami-0ed31ac0422d7d975 |
+| sa-east-1      | ami-05bdd15b132a4b9e9 |
+| us-east-1      | ami-04aa2bcdba99af0ab |
+| us-east-2      | ami-078b14e31784da13f |
+| us-west-1      | ami-0bc32fe0cc52f2d22 |
+| us-west-2      | ami-054de5bbf5c94b85d |
+
+### Ubuntu 18.04 (Bionic)
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-0c8b2fc237d06dda1 |
+| ap-northeast-2 | ami-0fd9f77c799a71e97 |
+| ap1-south-1    | ami-0d28e86e536520feb |
+| ap-southeast-1 | ami-0df231612a45f0125 |
+| ap-southeast-2 | ami-0ff1378435ce11f47 |
+| ca-central-1   | ami-0c316257d2335aa39 |
+| eu-central-1   | ami-0841bc13831462a00 |
+| eu-west-1      | ami-019ea6e9e776a90a5 |
+| eu-west-2      | ami-06c3d9ec4466cdbe5 |
+| eu-west-3      | ami-0ddf3bda070c56daf |
+| sa-east-1      | ami-0dafc3fe84b493382 |
+| us-east-1      | ami-08020bd3fb04c17b1 |
+| us-east-2      | ami-0db12114992cdf710 |
+| us-west-1      | ami-0fcf44efb977f9fe8 |
+| us-west-2      | ami-021f138cd7f314398 |


### PR DESCRIPTION
- Update containerd to v1.2.5
- Update kubernetes-cni to v0.7.5
- Publish AMIs for Kubernetes v1.13.5 and v1.14.0
- Update machines template to use v1.13.5 by default
- Update Calico to v3.6.0
