### PR TITLE
Update the releasing docs

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,7 +3,7 @@
 ## Semi-automatic
 
 1. Make sure your repo is clean by git's standards
-2. If the controller has changed, it would be good to bump the version of the controller image. Look in `cmd/release/main.go`.
+2. If this is a new minor release, create a new release branch and push to github, for example `release-0.2`
 3. run `go run cmd/release/main.go -version v0.1.2` but replace the version with the version you'd like.
 4. push the docker images that were generated with this release tool
 5. Edit the release notes and make sure the binaries uploaded return the correct version
@@ -12,19 +12,21 @@
 
 ## Manual
 
-1. Tag the repository and push the tag `git tag -s $VERSION`
-1. Create a draft release in github and associate it with the tag that was just created
-2. Checkout the tag you've just created and make sure git is in a clean state
-3. Run `make release-artifacts`
-4. Attach the tarball to the drafted release
-5. Attach `clusterawsadm` and `clusterctl` to the drafted release (for darwin
+1. Make sure your repo is clean by git's standards
+2. If this is a new minor release, create a new release branch and push to github, for example `release-0.2`
+3. Tag the repository and push the tag `git tag -s $VERSION`
+4. Create a draft release in github and associate it with the tag that was just created
+5. Checkout the tag you've just created and make sure git is in a clean state
+6. Run `make release-artifacts`
+7. Attach the tarball to the drafted release
+8. Attach `clusterawsadm` and `clusterctl` to the drafted release (for darwin
    and linux architectures)
-6. Write the release notes (see note below on release notes)
-7. Get someone with permission (any ex heptio) to copy the container image from your own
+9. Write the release notes (see note below on release notes)
+10. Get someone with permission (any ex heptio) to copy the container image from your own
    personal gcr registry to the production one, or have them build and push the
    container image themselves.
-8. Publish release
-9. Email `kubernetes-dev@googlegroups.com` to announce the release
+11. Publish release
+12. Email `kubernetes-dev@googlegroups.com` to announce the release
 
 ## Expected artifacts
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the docs for releasing cluster-api-provider-aws

**Release note**:
```release-note
NONE
```