### PR TITLE
Attach node security group to control plane nodes, so control plane n…

### DIFF
--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -231,7 +231,7 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 		}
 
 		input.UserData = aws.String(userData)
-		input.SecurityGroupIDs = append(input.SecurityGroupIDs, s.scope.SecurityGroups()[v1alpha1.SecurityGroupControlPlane].ID)
+		input.SecurityGroupIDs = append(input.SecurityGroupIDs, s.scope.SecurityGroups()[v1alpha1.SecurityGroupControlPlane].ID, s.scope.SecurityGroups()[v1alpha1.SecurityGroupNode].ID)
 	case "node":
 		input.SecurityGroupIDs = append(input.SecurityGroupIDs, s.scope.SecurityGroups()[v1alpha1.SecurityGroupNode].ID)
 


### PR DESCRIPTION
…odes can talk to each other in HA setup. (#694)

**What this PR does / why we need it**:
Attaches node security group to control plane instances, so they can talk to each other in HA setup.

**Release note**:
```release-note
Control Plane instances are now correctly created with the node security group as well as the control plane security group.
```