### PR TITLE
Fix: all traffic ingress rule triggers fatal nil dereference

### DIFF
--- a/pkg/apis/awsprovider/v1alpha1/types.go
+++ b/pkg/apis/awsprovider/v1alpha1/types.go
@@ -274,6 +274,9 @@ var (
 
 	// SecurityGroupProtocolICMP represents the ICMP protocol in ingress rules
 	SecurityGroupProtocolICMP = SecurityGroupProtocol("icmp")
+
+	// SecurityGroupProtocolICMPv6 represents the ICMPv6 protocol in ingress rules
+	SecurityGroupProtocolICMPv6 = SecurityGroupProtocol("58")
 )
 
 // IngressRule defines an AWS ingress rule for security groups.

--- a/pkg/cloud/aws/services/ec2/securitygroups.go
+++ b/pkg/cloud/aws/services/ec2/securitygroups.go
@@ -348,6 +348,9 @@ func (s *Service) getSecurityGroupTagParams(name string, role v1alpha1.SecurityG
 }
 
 func ingressRuleToSDKType(i *v1alpha1.IngressRule) (res *ec2.IpPermission) {
+	// AWS seems to ignore the From/To port when set on protocols where it doesn't apply, but
+	// we avoid serializing it out for clarity's sake.
+	// See: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html
 	switch i.Protocol {
 	case v1alpha1.SecurityGroupProtocolTCP,
 		v1alpha1.SecurityGroupProtocolUDP,

--- a/pkg/cloud/aws/services/ec2/securitygroups.go
+++ b/pkg/cloud/aws/services/ec2/securitygroups.go
@@ -397,10 +397,10 @@ func ingressRuleFromSDKType(v *ec2.IpPermission) (res *v1alpha1.IngressRule) {
 	// including the custom "-1" All Traffic protcol, FromPort and ToPort are omitted from the response.
 	// See: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html
 	switch *v.IpProtocol {
-	case IpProtocolTCP,
-		IpProtocolUDP,
-		IpProtocolICMP,
-		IpProtocolICMPv6:
+	case IPProtocolTCP,
+		IPProtocolUDP,
+		IPProtocolICMP,
+		IPProtocolICMPv6:
 		res = &v1alpha1.IngressRule{
 			Protocol: v1alpha1.SecurityGroupProtocol(*v.IpProtocol),
 			FromPort: *v.FromPort,

--- a/pkg/cloud/aws/services/ec2/securitygroups.go
+++ b/pkg/cloud/aws/services/ec2/securitygroups.go
@@ -352,17 +352,27 @@ func ingressRuleToSDKType(i *v1alpha1.IngressRule) *ec2.IpPermission {
 	}
 
 	for _, cidr := range i.CidrBlocks {
-		res.IpRanges = append(res.IpRanges, &ec2.IpRange{
-			Description: aws.String(i.Description),
-			CidrIp:      aws.String(cidr),
-		})
+		ipRange := &ec2.IpRange{
+			CidrIp: aws.String(cidr),
+		}
+
+		if i.Description != "" {
+			ipRange.Description = aws.String(i.Description)
+		}
+
+		res.IpRanges = append(res.IpRanges, ipRange)
 	}
 
 	for _, groupID := range i.SourceSecurityGroupIDs {
-		res.UserIdGroupPairs = append(res.UserIdGroupPairs, &ec2.UserIdGroupPair{
-			Description: aws.String(i.Description),
-			GroupId:     aws.String(groupID),
-		})
+		userIDGroupPair := &ec2.UserIdGroupPair{
+			GroupId: aws.String(groupID),
+		}
+
+		if i.Description != "" {
+			userIDGroupPair.Description = aws.String(i.Description)
+		}
+
+		res.UserIdGroupPairs = append(res.UserIdGroupPairs, userIDGroupPair)
 	}
 
 	return res
@@ -371,7 +381,7 @@ func ingressRuleToSDKType(i *v1alpha1.IngressRule) *ec2.IpPermission {
 func ingressRuleFromSDKType(v *ec2.IpPermission) *v1alpha1.IngressRule {
 	var res *v1alpha1.IngressRule
 	switch *v.IpProtocol {
-	case "tcp", "udp", "icmp", "58" /* ICMPv6 */:
+	case "tcp", "udp", "icmp", "58" /* ICMPv6 */ :
 		res = &v1alpha1.IngressRule{
 			Protocol: v1alpha1.SecurityGroupProtocol(*v.IpProtocol),
 			FromPort: *v.FromPort,

--- a/pkg/cloud/aws/services/ec2/securitygroups.go
+++ b/pkg/cloud/aws/services/ec2/securitygroups.go
@@ -32,17 +32,17 @@ import (
 )
 
 const (
-	// IpProtocolTCP is how EC2 represents the TCP protocol in ingress rules
-	IpProtocolTCP = "tcp"
+	// IPProtocolTCP is how EC2 represents the TCP protocol in ingress rules
+	IPProtocolTCP = "tcp"
 
-	// IpProtocolUDP is how EC2 represents the UDP protocol in ingress rules
-	IpProtocolUDP = "udp"
+	// IPProtocolUDP is how EC2 represents the UDP protocol in ingress rules
+	IPProtocolUDP = "udp"
 
-	// IpProtocolICMP is how EC2 represents the ICMP protocol in ingress rules
-	IpProtocolICMP = "icmp"
+	// IPProtocolICMP is how EC2 represents the ICMP protocol in ingress rules
+	IPProtocolICMP = "icmp"
 
-	// IpProtocolICMPv6 is how EC2 represents the ICMPv6 protocol in ingress rules
-	IpProtocolICMPv6 = "58"
+	// IPProtocolICMPv6 is how EC2 represents the ICMPv6 protocol in ingress rules
+	IPProtocolICMPv6 = "58"
 )
 
 func (s *Service) reconcileSecurityGroups() error {
@@ -388,7 +388,7 @@ func ingressRuleToSDKType(i *v1alpha1.IngressRule) (res *ec2.IpPermission) {
 		res.UserIdGroupPairs = append(res.UserIdGroupPairs, userIDGroupPair)
 	}
 
-	return
+	return res
 }
 
 func ingressRuleFromSDKType(v *ec2.IpPermission) (res *v1alpha1.IngressRule) {
@@ -432,5 +432,5 @@ func ingressRuleFromSDKType(v *ec2.IpPermission) (res *v1alpha1.IngressRule) {
 		res.SourceSecurityGroupIDs = append(res.SourceSecurityGroupIDs, *pair.GroupId)
 	}
 
-	return
+	return res
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This change does two things:

1. Handles ingress rules that don't have a "port" notion. Counterintuitively, ICMP and ICMPv6 traffic _does_ have a "port" notion in AWS-land.
2. Fix a bug related to deleting ingress rules without a description, which AWS considers distinct from those with an empty description

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

These patches fix the crasher, but the story isn't yet fully told. We found ourselves in this situation after spinning up a Service of `Type: LoadBalancer`, which caused the cloud provider to helpfully add a rule to the nodes' security group for "all traffic" coming from the ELB.

This change will enable the management tooling to handle that new rule, decide it's not spec'd, and clean it up properly. At which point, I expect, the cloud provider will put it back. We're still investigating what to do about that tug of war, but I wanted to open the PR for collaboration.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
prevent fatal crash when handling "all traffic" rules
```