### PR TITLE
Fixes a bug and adds tests for kubeadm defaults

### DIFF
--- a/pkg/cloud/aws/actuators/machine_scope.go
+++ b/pkg/cloud/aws/actuators/machine_scope.go
@@ -97,6 +97,16 @@ func (m *MachineScope) Region() string {
 	return m.Scope.Region()
 }
 
+// GetMachine returns the machine wrapped in the scope.
+func (m *MachineScope) GetMachine() *clusterv1.Machine {
+	return m.Machine
+}
+
+// GetScope() returns the scope that is wrapping the machine.
+func (m *MachineScope) GetScope() *Scope {
+	return m.Scope
+}
+
 func (m *MachineScope) storeMachineSpec(machine *clusterv1.Machine) (*clusterv1.Machine, error) {
 	ext, err := v1alpha1.EncodeMachineSpec(m.MachineConfig)
 	if err != nil {

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -171,7 +171,7 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 		if bootstrapToken != "" {
 			klog.V(2).Infof("Allowing machine %q to join control plane for cluster %q", machine.Name(), s.scope.Name())
 
-			kubeadm.SetJoinNodeConfigurationOverrides(caCertHash, bootstrapToken, machine, &machine.MachineConfig.KubeadmConfiguration.Join)
+			machine.MachineConfig.KubeadmConfiguration.Join = kubeadm.SetJoinNodeConfigurationOverrides(caCertHash, bootstrapToken, machine, &machine.MachineConfig.KubeadmConfiguration.Join)
 			kubeadm.SetControlPlaneJoinConfigurationOverrides(&machine.MachineConfig.KubeadmConfiguration.Join)
 			joinConfigurationYAML, err := kubeadm.ConfigurationToYAML(&machine.MachineConfig.KubeadmConfiguration.Join)
 			if err != nil {

--- a/pkg/cloud/aws/services/kubeadm/BUILD.bazel
+++ b/pkg/cloud/aws/services/kubeadm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -16,7 +16,20 @@ go_library(
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
         "//vendor/k8s.io/kubernetes/cmd/kubeadm/app/util:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/util:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/runtime/scheme:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["aws_defaults_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/awsprovider/v1alpha1:go_default_library",
+        "//pkg/cloud/aws/actuators:go_default_library",
+        "//vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
     ],
 )

--- a/pkg/cloud/aws/services/kubeadm/aws_defaults_test.go
+++ b/pkg/cloud/aws/services/kubeadm/aws_defaults_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm_test
+
+import (
+	"fmt"
+	"testing"
+
+	kubeadmv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services/kubeadm"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+type jm struct {
+	*actuators.Scope
+	*clusterv1.Machine
+}
+
+func (j *jm) GetScope() *actuators.Scope {
+	return j.Scope
+}
+func (j *jm) GetMachine() *clusterv1.Machine {
+	return j.Machine
+}
+
+func TestSetJoinNodeConfigurationBootstrapSettings(t *testing.T) {
+	testcases := []struct {
+		name              string
+		caCertHash        string
+		bootstrapToken    string
+		joinMachine       *jm
+		joinConfiguration *kubeadmv1beta1.JoinConfiguration
+	}{
+		{
+			name: "test default values",
+			joinMachine: &jm{
+				Scope: &actuators.Scope{
+					ClusterStatus: &v1alpha1.AWSClusterProviderStatus{
+						Network: v1alpha1.Network{
+							APIServerELB: v1alpha1.ClassicELB{
+								DNSName: "test.test",
+							},
+						},
+					},
+				},
+				Machine: &clusterv1.Machine{},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := kubeadm.SetJoinNodeConfigurationOverrides(tc.caCertHash, tc.bootstrapToken, tc.joinMachine, tc.joinConfiguration)
+
+			// The apiserver endpoint should always match the incoming machine's network
+			expected := fmt.Sprintf("%v:%v", tc.joinMachine.GetScope().Network().APIServerELB.DNSName, kubeadm.APIServerBindPort)
+			if out.Discovery.BootstrapToken.APIServerEndpoint != expected {
+				t.Fatalf("join configuration apiserver endpoint: %q but expected %q", out.Discovery.BootstrapToken.APIServerEndpoint, expected)
+			}
+
+			// The bootstrap token on the new join node configuration should be
+			// the same that is passed in
+			if out.Discovery.BootstrapToken.Token != tc.bootstrapToken {
+				t.Fatalf("bootstrap tokens did  not match: got %q but expected %q", out.Discovery.BootstrapToken.Token, tc.bootstrapToken)
+			}
+
+			// The passed in caCertHash should be appended to the existing hashes
+			if !contains(out.Discovery.BootstrapToken.CACertHashes, tc.caCertHash) {
+				t.Fatalf("did not find %q in %v", tc.caCertHash, out.Discovery.BootstrapToken.CACertHashes)
+			}
+		})
+	}
+}
+
+func TestSetJoinNodeConfigurationOverrides(t *testing.T) {
+	testcases := []struct {
+		name              string
+		caCertHash        string
+		bootstrapToken    string
+		joinMachine       *jm
+		joinConfiguration *kubeadmv1beta1.JoinConfiguration
+	}{
+		{
+			name: "test node registration override values",
+			joinMachine: &jm{
+				Scope: &actuators.Scope{
+					ClusterStatus: &v1alpha1.AWSClusterProviderStatus{
+						Network: v1alpha1.Network{
+							APIServerELB: v1alpha1.ClassicELB{
+								DNSName: "test.test",
+							},
+						},
+					},
+				},
+				Machine: &clusterv1.Machine{},
+			},
+			joinConfiguration: &kubeadmv1beta1.JoinConfiguration{
+				NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
+					Name:      "cat",
+					CRISocket: "unix:///var/run/docker/docker.sock",
+					KubeletExtraArgs: map[string]string{
+						"cloud-provider": "gcp",
+					},
+				},
+			},
+		},
+		{
+			name: "should set the cloud-provider extra args even if args are nil",
+			joinMachine: &jm{
+				Scope: &actuators.Scope{
+					ClusterStatus: &v1alpha1.AWSClusterProviderStatus{},
+				},
+				Machine: &clusterv1.Machine{},
+			},
+			joinConfiguration: &kubeadmv1beta1.JoinConfiguration{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := kubeadm.SetJoinNodeConfigurationOverrides(tc.caCertHash, tc.bootstrapToken, tc.joinMachine, tc.joinConfiguration)
+
+			if tc.joinConfiguration.NodeRegistration.Name != kubeadm.HostnameLookup &&
+				tc.joinConfiguration.NodeRegistration.Name == out.NodeRegistration.Name {
+				t.Fatal("did not properly override the NodeRegistration.Name")
+			}
+
+			if tc.joinConfiguration.NodeRegistration.CRISocket != kubeadm.ContainerdSocket &&
+				tc.joinConfiguration.NodeRegistration.CRISocket == out.NodeRegistration.CRISocket {
+				t.Fatal("did not properly override the CRISocket")
+			}
+
+			if out.NodeRegistration.KubeletExtraArgs["cloud-provider"] != kubeadm.CloudProvider {
+				t.Fatal("did not properly set the cloud-provider on the kubelet extra args")
+			}
+		})
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, hay := range haystack {
+		if needle == hay {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The pointers were not working as expected so the API is changing
to be more functional and leverage kubernetes' DeepCopy function.

**What this PR does / why we need it**:
This PR fixes a bug (bad pointer work) with regards to kubeadm defaults being set properly on the JoinConfiguration option.

This bug still exists in the neighboring functions but will be addressed in following PRs.

This adds tests to that function and makes the function more functional and easier to use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #685 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```