### PR TITLE
Update OWNERS_ALIASES and SECURITY_CONTACTS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,39 +2,28 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
-    - lukemarsden
+    - justinsb
     - luxas
-    - roberthbailey
     - timothysc
   cluster-api-admins:
-    - justinsb
-    - krousey
-    - luxas
-    - roberthbailey
-    - kris-nova
-  cluster-api-maintainers:
-    - jessicaochen
-    - k4leung4
-    - karan
-    - kris-nova
-    - krousey
-    - medinatiger
-    - mkjelland
-    - roberthbailey
-    - rsdcastro
-    - spew
-  sig-aws-leads:
-    - justinsb
-    - kris-nova
-    - countspongebob
-  cluster-api-aws-maintainers:
+    - davidewatson
     - detiber
+    - justinsb
+  cluster-api-maintainers:
+    - detiber
+    - justinsb
+    - vincepri
+  sig-aws-leads:
+    - d-nishi
+    - justinsb
+    - kris-nova
+  cluster-api-aws-maintainers:
     - chuckha
     - davidewatson
-    - d-nishi
+    - detiber
     - enxebre
     - ingvagabund
-    - vincepri
     - randomvariable
+    - vincepri
   cluster-api-aws-reviewers:
     - ashish-amarnath

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,7 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-luxas
-roberthbailey
-timothysc
 detiber
+justinsb
+luxas
+timothysc


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the OWNERS_ALIASES and SECURITY_CONTACTS for the repo to reflect current leadership and participation

~~Blocked on: https://github.com/kubernetes-sigs/cluster-api/pull/884~~
/hold


**Release note**:
```release-note
NONE
```