### PR TITLE
feat: support customizing root device size

### DIFF
--- a/config/crds/awsprovider_v1alpha1_awsclusterproviderstatus.yaml
+++ b/config/crds/awsprovider_v1alpha1_awsclusterproviderstatus.yaml
@@ -49,6 +49,10 @@ spec:
             publicIp:
               description: The public IPv4 address assigned to the instance, if applicable.
               type: string
+            rootDeviceSize:
+              description: Specifies size (in Gi) of the root storage device
+              format: int64
+              type: integer
             securityGroupIds:
               description: SecurityGroupIDs are one or more security group IDs this
                 instance belongs to.

--- a/config/crds/awsprovider_v1alpha1_awsmachineproviderspec.yaml
+++ b/config/crds/awsprovider_v1alpha1_awsmachineproviderspec.yaml
@@ -392,6 +392,10 @@ spec:
             IP. Precedence for this setting is as follows: 1. This field if set 2.
             Cluster/flavor setting 3. Subnet default'
           type: boolean
+        rootDeviceSize:
+          description: RootDeviceSize is the size of the root volume.
+          format: int64
+          type: integer
         subnet:
           description: Subnet is a reference to the subnet to use for this instance.
             If not specified, the cluster subnet will be used.

--- a/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
@@ -74,6 +74,10 @@ type AWSMachineProviderSpec struct {
 	// +optional
 	KeyName string `json:"keyName,omitempty"`
 
+	// RootDeviceSize is the size of the root volume.
+	// +optional
+	RootDeviceSize int64 `json:"rootDeviceSize,omitempty"`
+
 	// KubeadmConfiguration holds the kubeadm configuration options
 	// +optional
 	KubeadmConfiguration KubeadmConfiguration `json:"kubeadmConfiguration,omitempty"`

--- a/pkg/apis/awsprovider/v1alpha1/types.go
+++ b/pkg/apis/awsprovider/v1alpha1/types.go
@@ -423,6 +423,9 @@ type Instance struct {
 	// Indicates whether the instance is optimized for Amazon EBS I/O.
 	EBSOptimized *bool `json:"ebsOptimized,omitempty"`
 
+	// Specifies size (in Gi) of the root storage device
+	RootDeviceSize int64 `json:"rootDeviceSize,omitempty"`
+
 	// The tags associated with the instance.
 	Tags map[string]string `json:"tags,omitempty"`
 }

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -305,6 +305,11 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 		errs = append(errs, errors.Errorf("SSH key name cannot be mutated from %q to %q", aws.StringValue(instance.KeyName), machineSpec.KeyName))
 	}
 
+	// Root Device Size
+	if machineSpec.RootDeviceSize != instance.RootDeviceSize {
+		errs = append(errs, errors.Errorf("Root volume size cannot be mutated from %v to %v", instance.RootDeviceSize, machineSpec.RootDeviceSize))
+	}
+
 	// Subnet ID
 	// machineSpec.Subnet is a *AWSResourceReference and could technically be
 	// a *string, ARN or Filter. However, elsewhere in the code it is only used

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -444,6 +444,26 @@ func TestImmutableStateChange(t *testing.T) {
 			expected: 1,
 		},
 		{
+			name: "root device size is unchanged",
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
+				RootDeviceSize: 12,
+			},
+			instance: v1alpha1.Instance{
+				RootDeviceSize: 12,
+			},
+			expected: 0,
+		},
+		{
+			name: "root device size is changed",
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
+				RootDeviceSize: 12,
+			},
+			instance: v1alpha1.Instance{
+				RootDeviceSize: 16,
+			},
+			expected: 1,
+		},
+		{
 			name: "multiple immutable changes",
 			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				IAMInstanceProfile: "test-profile-updated",

--- a/pkg/cloud/aws/converters/instance.go
+++ b/pkg/cloud/aws/converters/instance.go
@@ -24,6 +24,10 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
 )
 
+// SDKToInstance converts an EC2 instance type to the CAPA
+// instance type.
+// Note: This does not return a complete instance, as rootVolumeSize
+// can not be determined via the output of EC2.DescribeInstances.
 func SDKToInstance(v *ec2.Instance) *v1alpha1.Instance {
 	i := &v1alpha1.Instance{
 		ID:           aws.StringValue(v.InstanceId),

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -403,7 +403,7 @@ func (s *Service) runInstance(role string, i *v1alpha1.Instance) (*v1alpha1.Inst
 		}
 
 		input.BlockDeviceMappings = []*ec2.BlockDeviceMapping{
-			&ec2.BlockDeviceMapping{
+			{
 				DeviceName: rootDeviceName,
 				Ebs: &ec2.EbsBlockDevice{
 					DeleteOnTermination: aws.Bool(true),

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -576,6 +576,10 @@ func (s *Service) getInstanceRootDeviceSize(instance *ec2.Instance) (*int64, err
 	return nil, nil
 }
 
+// sdkToInstance converts an AWS EC2 SDK instance to the CAPA instance type.
+// converters.SDKToInstance populates all instance fields except for rootVolumeSize,
+// because EC2.DescribeInstances does not return the size of storage devices. An
+// additional call to EC2 is required to get this value.
 func (s *Service) sdkToInstance(v *ec2.Instance) (*v1alpha1.Instance, error) {
 	instance := converters.SDKToInstance(v)
 

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -62,7 +62,7 @@ func (s *Service) InstanceByTags(machine *actuators.MachineScope) (*v1alpha1.Ins
 	// match
 	for _, res := range out.Reservations {
 		for _, inst := range res.Instances {
-			return converters.SDKToInstance(inst), nil
+			return s.sdkToInstance(inst)
 		}
 	}
 
@@ -95,7 +95,7 @@ func (s *Service) InstanceIfExists(id *string) (*v1alpha1.Instance, error) {
 	}
 
 	if len(out.Reservations) > 0 && len(out.Reservations[0].Instances) > 0 {
-		return converters.SDKToInstance(out.Reservations[0].Instances[0]), nil
+		return s.sdkToInstance(out.Reservations[0].Instances[0])
 	}
 
 	return nil, nil
@@ -106,8 +106,9 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 	s.scope.V(2).Info("Creating an instance for a machine")
 
 	input := &v1alpha1.Instance{
-		Type:       machine.MachineConfig.InstanceType,
-		IAMProfile: machine.MachineConfig.IAMInstanceProfile,
+		Type:           machine.MachineConfig.InstanceType,
+		IAMProfile:     machine.MachineConfig.IAMInstanceProfile,
+		RootDeviceSize: machine.MachineConfig.RootDeviceSize,
 	}
 
 	input.Tags = tags.Build(tags.BuildParams{
@@ -395,6 +396,23 @@ func (s *Service) runInstance(role string, i *v1alpha1.Instance) (*v1alpha1.Inst
 		}
 	}
 
+	if i.RootDeviceSize != 0 {
+		rootDeviceName, err := s.getImageRootDevice(i.ImageID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get root volume from image %q", i.ImageID)
+		}
+
+		input.BlockDeviceMappings = []*ec2.BlockDeviceMapping{
+			&ec2.BlockDeviceMapping{
+				DeviceName: rootDeviceName,
+				Ebs: &ec2.EbsBlockDevice{
+					DeleteOnTermination: aws.Bool(true),
+					VolumeSize:          aws.Int64(i.RootDeviceSize),
+				},
+			},
+		}
+	}
+
 	if len(i.Tags) > 0 {
 		spec := &ec2.TagSpecification{ResourceType: aws.String(ec2.ResourceTypeInstance)}
 		for key, value := range i.Tags {
@@ -416,8 +434,14 @@ func (s *Service) runInstance(role string, i *v1alpha1.Instance) (*v1alpha1.Inst
 		return nil, errors.Errorf("no instance returned for reservation %v", out.GoString())
 	}
 
+<<<<<<< HEAD
 	err = s.scope.EC2.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{InstanceIds: []*string{out.Instances[0].InstanceId}})
 	return converters.SDKToInstance(out.Instances[0]), err
+=======
+	s.scope.EC2.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{InstanceIds: []*string{out.Instances[0].InstanceId}})
+
+	return s.sdkToInstance(out.Instances[0])
+>>>>>>> feat: support customizing root device size
 }
 
 // UpdateInstanceSecurityGroups modifies the security groups of the given
@@ -510,4 +534,56 @@ func (s *Service) getInstanceENIs(instanceID string) ([]*ec2.NetworkInterface, e
 	}
 
 	return output.NetworkInterfaces, nil
+}
+
+func (s *Service) getImageRootDevice(imageID string) (*string, error) {
+	input := &ec2.DescribeImagesInput{
+		ImageIds: []*string{aws.String(imageID)},
+	}
+
+	output, err := s.scope.EC2.DescribeImages(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.Images) == 0 {
+		return nil, errors.Errorf("no images returned when looking up ID %q", imageID)
+	}
+
+	return output.Images[0].RootDeviceName, nil
+}
+
+func (s *Service) getInstanceRootDeviceSize(instance *ec2.Instance) (*int64, error) {
+
+	for _, bdm := range instance.BlockDeviceMappings {
+		if aws.StringValue(bdm.DeviceName) == aws.StringValue(instance.RootDeviceName) {
+			input := &ec2.DescribeVolumesInput{
+				VolumeIds: []*string{bdm.Ebs.VolumeId},
+			}
+
+			out, err := s.scope.EC2.DescribeVolumes(input)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(out.Volumes) == 0 {
+				return nil, errors.Errorf("no volumes found for id %q", aws.StringValue(bdm.Ebs.VolumeId))
+			}
+
+			return out.Volumes[0].Size, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *Service) sdkToInstance(v *ec2.Instance) (*v1alpha1.Instance, error) {
+	instance := converters.SDKToInstance(v)
+
+	rootSize, err := s.getInstanceRootDeviceSize(v)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get root volume size for instance: %q", aws.StringValue(v.InstanceId))
+	}
+
+	instance.RootDeviceSize = aws.Int64Value(rootSize)
+	return instance, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR adds `rootDeviceSize` into the AWSMachineProviderSpec, allowing customization of the provisioned EC2 instance's root volume size.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for customizing instance root device size
```