### PR TITLE
Ensure `make manifests` generates machines file for HA control plane too.

### DIFF
--- a/cmd/clusterctl/examples/aws/generate-yaml.sh
+++ b/cmd/clusterctl/examples/aws/generate-yaml.sh
@@ -38,6 +38,8 @@ CLUSTER_NETWORKSPEC_TEMPLATE_FILE=${DIR}/cluster-network-spec.yaml.template
 CLUSTER_GENERATED_FILE=${OUTPUT_DIR}/cluster.yaml
 MACHINES_TEMPLATE_FILE=${DIR}/machines.yaml.template
 MACHINES_GENERATED_FILE=${OUTPUT_DIR}/machines.yaml
+HA_MACHINES_TEMPLATE_FILE=${DIR}/machines-ha.yaml.template
+HA_MACHINES_GENERATED_FILE=${OUTPUT_DIR}/machines-ha.yaml
 ADDONS_FILE=${OUTPUT_DIR}/addons.yaml
 PROVIDER_COMPONENTS_SRC=${DIR}/provider-components-base.yaml
 PROVIDER_COMPONENTS_FILE=${OUTPUT_DIR}/provider-components.yaml
@@ -78,6 +80,11 @@ if [ $OVERWRITE -ne 1 ] && [ -f $MACHINES_GENERATED_FILE ]; then
   exit 1
 fi
 
+if [ $OVERWRITE -ne 1 ] && [ -f $HA_MACHINES_GENERATED_FILE ]; then
+  echo File $HA_MACHINES_GENERATED_FILE already exists. Delete it manually before running this script.
+  exit 1
+fi
+
 if [ $OVERWRITE -ne 1 ] && [ -f $CLUSTER_GENERATED_FILE ]; then
   echo File $CLUSTER_GENERATED_FILE already exists. Delete it manually before running this script.
   exit 1
@@ -95,6 +102,9 @@ fi
 
 $ENVSUBST < $MACHINES_TEMPLATE_FILE > "${MACHINES_GENERATED_FILE}"
 echo "Done generating ${MACHINES_GENERATED_FILE}"
+
+$ENVSUBST < $HA_MACHINES_TEMPLATE_FILE > "${HA_MACHINES_GENERATED_FILE}"
+echo "Done generating ${HA_MACHINES_GENERATED_FILE}"
 
 cp  ${DIR}/addons.yaml ${ADDONS_FILE}
 echo "Done copying ${ADDONS_FILE}"

--- a/cmd/clusterctl/examples/aws/machines-ha.yaml.template
+++ b/cmd/clusterctl/examples/aws/machines-ha.yaml.template
@@ -1,0 +1,74 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineList
+items:
+  - apiVersion: "cluster.k8s.io/v1alpha1"
+    kind: Machine
+    metadata:
+      name: controlplane-0
+      labels:
+        cluster.k8s.io/cluster-name: ${CLUSTER_NAME}
+        set: controlplane
+    spec:
+      versions:
+        kubelet: v1.13.5
+        controlPlane: v1.13.5
+      providerSpec:
+        value:
+          apiVersion: awsprovider/v1alpha1
+          kind: AWSMachineProviderSpec
+          instanceType: "${CONTROL_PLANE_MACHINE_TYPE}"
+          iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+          keyName: "${SSH_KEY_NAME}"
+  - apiVersion: "cluster.k8s.io/v1alpha1"
+    kind: Machine
+    metadata:
+      name: controlplane-1
+      labels:
+        cluster.k8s.io/cluster-name: ${CLUSTER_NAME}
+        set: controlplane
+    spec:
+      versions:
+        kubelet: v1.13.5
+        controlPlane: v1.13.5
+      providerSpec:
+        value:
+          apiVersion: awsprovider/v1alpha1
+          kind: AWSMachineProviderSpec
+          instanceType: "${CONTROL_PLANE_MACHINE_TYPE}"
+          iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+          keyName: "${SSH_KEY_NAME}"
+  - apiVersion: "cluster.k8s.io/v1alpha1"
+    kind: Machine
+    metadata:
+      name: controlplane-2
+      labels:
+        cluster.k8s.io/cluster-name: ${CLUSTER_NAME}
+        set: controlplane
+    spec:
+      versions:
+        kubelet: v1.13.5
+        controlPlane: v1.13.5
+      providerSpec:
+        value:
+          apiVersion: awsprovider/v1alpha1
+          kind: AWSMachineProviderSpec
+          instanceType: "${CONTROL_PLANE_MACHINE_TYPE}"
+          iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+          keyName: "${SSH_KEY_NAME}"
+  - apiVersion: "cluster.k8s.io/v1alpha1"
+    kind: Machine
+    metadata:
+      generateName: node-
+      labels:
+        cluster.k8s.io/cluster-name: ${CLUSTER_NAME}
+        set: node
+    spec:
+      versions:
+        kubelet: v1.13.5
+      providerSpec:
+        value:
+          apiVersion: awsprovider/v1alpha1
+          kind: AWSMachineProviderSpec
+          instanceType: "${NODE_MACHINE_TYPE}"
+          iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
+          keyName: "${SSH_KEY_NAME}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

We want to have an easy way to create highly available clusters. This PR introduces `machines-ha.yaml` file that is generated by `make manifests` command. It can be passed into `clusterctl` while new cluster is created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #415 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```