### PR TITLE
Add ability to override Organization ID for image lookups

### DIFF
--- a/config/crds/awsprovider_v1alpha1_awsmachineproviderspec.yaml
+++ b/config/crds/awsprovider_v1alpha1_awsmachineproviderspec.yaml
@@ -95,6 +95,10 @@ spec:
           description: IAMInstanceProfile is a name of an IAM instance profile to
             assign to the instance
           type: string
+        imageLookupOrg:
+          description: ImageLookupOrg is the AWS Organization ID to use for image
+            lookup if AMI is not set.
+          type: string
         instanceType:
           description: 'InstanceType is the type of instance to create. Example: m4.xlarge'
           type: string

--- a/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
@@ -37,6 +37,9 @@ type AWSMachineProviderSpec struct {
 	// AMI is the reference to the AMI from which to create the machine instance.
 	AMI AWSResourceReference `json:"ami,omitempty"`
 
+	// ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.
+	ImageLookupOrg string `json:"imageLookupOrg,omitempty"`
+
 	// InstanceType is the type of instance to create. Example: m4.xlarge
 	InstanceType string `json:"instanceType,omitempty"`
 

--- a/pkg/cloud/aws/services/ec2/ami.go
+++ b/pkg/cloud/aws/services/ec2/ami.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	// machineAMIOwnerID is a heptio/VMware owned account. Please see:
+	// defaultMachineAMIOwnerID is a heptio/VMware owned account. Please see:
 	// https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/487
 	defaultMachineAMIOwnerID = "258751437250"
 

--- a/pkg/cloud/aws/services/ec2/ami.go
+++ b/pkg/cloud/aws/services/ec2/ami.go
@@ -30,7 +30,7 @@ import (
 const (
 	// machineAMIOwnerID is a heptio/VMware owned account. Please see:
 	// https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/487
-	machineAMIOwnerID = "258751437250"
+	defaultMachineAMIOwnerID = "258751437250"
 
 	// amiNameFormat is defined in the build/ directory of this project.
 	// The pattern is:
@@ -50,12 +50,15 @@ func amiName(baseOS, baseOSVersion, kubernetesVersion string) string {
 }
 
 // defaultAMILookup returns the default AMI based on region
-func (s *Service) defaultAMILookup(baseOS, baseOSVersion, kubernetesVersion string) (string, error) {
+func (s *Service) defaultAMILookup(ownerID, baseOS, baseOSVersion, kubernetesVersion string) (string, error) {
+	if ownerID == "" {
+		ownerID = defaultMachineAMIOwnerID
+	}
 	describeImageInput := &ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("owner-id"),
-				Values: []*string{aws.String(machineAMIOwnerID)},
+				Values: []*string{aws.String(ownerID)},
 			},
 			{
 				Name:   aws.String("name"),

--- a/pkg/cloud/aws/services/ec2/ami_test.go
+++ b/pkg/cloud/aws/services/ec2/ami_test.go
@@ -76,7 +76,7 @@ func TestAMIs(t *testing.T) {
 			tc.expect(ec2Mock.EXPECT())
 
 			s := NewService(scope)
-			id, err := s.defaultAMILookup("base os", "baseos version", "1.11.1")
+			id, err := s.defaultAMILookup("", "base os", "baseos version", "1.11.1")
 			if err != nil {
 				t.Fatalf("did not expect error calling a mock: %v", err)
 			}

--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -122,7 +122,7 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 	if machine.MachineConfig.AMI.ID != nil {
 		input.ImageID = *machine.MachineConfig.AMI.ID
 	} else {
-		input.ImageID, err = s.defaultAMILookup("ubuntu", "18.04", machine.Machine.Spec.Versions.Kubelet)
+		input.ImageID, err = s.defaultAMILookup(machine.MachineConfig.ImageLookupOrg, "ubuntu", "18.04", machine.Machine.Spec.Versions.Kubelet)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to override the default Organization ID used for image lookups.

**Release note**:
```release-note
- Users can now set machine.spec.providerSpec.imageLookupOrg to override the default Organization ID used for image lookups.
```