### PR TITLE
Adds retry-on-conflict during updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1300,6 +1300,7 @@
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
     "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/util/retry",
     "k8s.io/cluster-bootstrap/token/api",
     "k8s.io/cluster-bootstrap/token/util",
     "k8s.io/code-generator/cmd/deepcopy-gen",

--- a/pkg/cloud/aws/actuators/BUILD.bazel
+++ b/pkg/cloud/aws/actuators/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog/klogr:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -452,13 +452,13 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 	if machine.Status.NodeRef == nil {
 		nodeRef, err := a.getNodeReference(scope)
 		if err != nil {
-			// non critical error
 			a.log.Info("Failed to set nodeRef", "error", err)
+			// non critical error
 			return true, nil
 		}
 
 		scope.Machine.Status.NodeRef = nodeRef
-		a.log.Info("Setting machine's nodeRef", "machine-name", scope.Name(), "machine-namespace", scope.Namespace(), "nodeRef", nodeRef.Name)
+		a.log.V(2).Info("Setting machine's nodeRef", "machine-name", scope.Name(), "machine-namespace", scope.Namespace(), "nodeRef", nodeRef.Name)
 	}
 
 	return true, nil

--- a/pkg/cloud/aws/actuators/machine_scope.go
+++ b/pkg/cloud/aws/actuators/machine_scope.go
@@ -147,13 +147,13 @@ func (m *MachineScope) Close() {
 		m.V(6).Info("Machine status before update", "machine-status", m.Machine.Status)
 		latest, err := m.MachineClient.Update(m.Machine)
 		if err != nil {
-			m.Error(err, "error updating machine")
+			m.V(3).Info("Machine resource version is out of date")
+			// Fetch and update the latest resource version
 			newestMachine, err2 := m.MachineClient.Get(m.Machine.Name, metav1.GetOptions{})
 			if err2 != nil {
 				m.Error(err2, "failed to fetch latest Machine")
 				return err2
 			}
-			// Error if anything but the machine resource version changes
 			m.Machine.ResourceVersion = newestMachine.ResourceVersion
 			return err
 		}

--- a/pkg/cloud/aws/actuators/machine_scope.go
+++ b/pkg/cloud/aws/actuators/machine_scope.go
@@ -158,7 +158,8 @@ func (m *MachineScope) Close() {
 			return err
 		}
 		m.V(5).Info("Latest machine", "machine", latest)
-		// The machine may have status (nodeRef) that the latest doesn't yet have.
+		// The machine may have status (nodeRef) that the latest doesn't yet
+		// have, however some timestamps may be rolled back a bit with this copy.
 		m.Machine.Status.DeepCopyInto(&latest.Status)
 		latest.Status.ProviderStatus = status
 		_, err = m.MachineClient.UpdateStatus(latest)

--- a/pkg/cloud/aws/actuators/machine_scope.go
+++ b/pkg/cloud/aws/actuators/machine_scope.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
@@ -109,30 +110,9 @@ func (m *MachineScope) GetMachine() *clusterv1.Machine {
 	return m.Machine
 }
 
-// GetScope() returns the scope that is wrapping the machine.
+// GetScope returns the scope that is wrapping the machine.
 func (m *MachineScope) GetScope() *Scope {
 	return m.Scope
-}
-
-func (m *MachineScope) storeMachineSpec(machine *clusterv1.Machine) (*clusterv1.Machine, error) {
-	ext, err := v1alpha1.EncodeMachineSpec(m.MachineConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	machine.Spec.ProviderSpec.Value = ext
-	return m.MachineClient.Update(machine)
-}
-
-func (m *MachineScope) storeMachineStatus(machine *clusterv1.Machine) (*clusterv1.Machine, error) {
-	ext, err := v1alpha1.EncodeMachineStatus(m.MachineStatus)
-	if err != nil {
-		return nil, err
-	}
-
-	m.Machine.Status.DeepCopyInto(&machine.Status)
-	machine.Status.ProviderStatus = ext
-	return m.MachineClient.UpdateStatus(machine)
 }
 
 // Close the MachineScope by updating the machine spec, machine status.
@@ -140,17 +120,53 @@ func (m *MachineScope) Close() {
 	if m.MachineClient == nil {
 		return
 	}
-
-	latestMachine, err := m.storeMachineSpec(m.Machine)
+	ext, err := v1alpha1.EncodeMachineSpec(m.MachineConfig)
 	if err != nil {
-		m.Error(err, "failed to update machine")
+		m.Error(err, "failed to encode machine spec")
+		return
+	}
+	status, err := v1alpha1.EncodeMachineStatus(m.MachineStatus)
+	if err != nil {
+		m.Error(err, "failed to encode machine status")
 		return
 	}
 
-	_, err = m.storeMachineStatus(latestMachine)
-	if err != nil {
-		m.Error(err, "failed to store machine provider status")
+	// Sometimes when an object gets updated the local copy is out of date with
+	// the copy stored on the server. In the case of cluster-api this will
+	// always be because the local copy will have an out-of-date resource
+	// version. This is because something else has updated the resource version
+	// on the server and thus the local copy is behind.
+	// This retry function will update the resource version if the local copy is
+	// behind and try again.
+	// This retry function will *only* update the resource version. If some
+	// other data has changed then there is a problem. Nothing else should be
+	// updating the object and this function will (correctly) fail.
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		m.V(2).Info("Updating machine", "machine-resource-version", m.Machine.ResourceVersion, "node-ref", m.Machine.Status.NodeRef)
+		m.Machine.Spec.ProviderSpec.Value = ext
+		m.V(6).Info("Machine status before update", "machine-status", m.Machine.Status)
+		latest, err := m.MachineClient.Update(m.Machine)
+		if err != nil {
+			m.Error(err, "error updating machine")
+			newestMachine, err2 := m.MachineClient.Get(m.Machine.Name, metav1.GetOptions{})
+			if err2 != nil {
+				m.Error(err2, "failed to fetch latest Machine")
+				return err2
+			}
+			// Error if anything but the machine resource version changes
+			m.Machine.ResourceVersion = newestMachine.ResourceVersion
+			return err
+		}
+		m.V(5).Info("Latest machine", "machine", latest)
+		// The machine may have status (nodeRef) that the latest doesn't yet have.
+		m.Machine.Status.DeepCopyInto(&latest.Status)
+		latest.Status.ProviderStatus = status
+		_, err = m.MachineClient.UpdateStatus(latest)
+		return err
+	}); err != nil {
+		m.Error(err, "error retrying on conflict")
 	}
+	m.V(2).Info("Successfully updated machine")
 }
 
 // MachineConfigFromProviderSpec tries to decode the JSON-encoded spec, falling back on getting a MachineClass if the value is absent.

--- a/pkg/cloud/aws/actuators/scope.go
+++ b/pkg/cloud/aws/actuators/scope.go
@@ -23,6 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/klogr"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -131,40 +133,46 @@ func (s *Scope) Region() string {
 	return s.ClusterConfig.Region
 }
 
-func (s *Scope) storeClusterConfig(cluster *clusterv1.Cluster) (*clusterv1.Cluster, error) {
-	ext, err := v1alpha1.EncodeClusterSpec(s.ClusterConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	cluster.Spec.ProviderSpec.Value = ext
-	return s.ClusterClient.Update(cluster)
-}
-
-func (s *Scope) storeClusterStatus(cluster *clusterv1.Cluster) (*clusterv1.Cluster, error) {
-	ext, err := v1alpha1.EncodeClusterStatus(s.ClusterStatus)
-	if err != nil {
-		return nil, err
-	}
-
-	cluster.Status.ProviderStatus = ext
-	return s.ClusterClient.UpdateStatus(cluster)
-}
-
 // Close closes the current scope persisting the cluster configuration and status.
 func (s *Scope) Close() {
 	if s.ClusterClient == nil {
 		return
 	}
-
-	latestCluster, err := s.storeClusterConfig(s.Cluster)
+	ext, err := v1alpha1.EncodeClusterSpec(s.ClusterConfig)
 	if err != nil {
-		s.Error(err, "failed to store provider config")
+		s.Error(err, "failed encoding cluster spec")
+		return
+	}
+	status, err := v1alpha1.EncodeClusterStatus(s.ClusterStatus)
+	if err != nil {
+		s.Error(err, "failed encoding cluster status")
 		return
 	}
 
-	_, err = s.storeClusterStatus(latestCluster)
-	if err != nil {
-		s.Error(err, "failed to store provider status")
+	// Update the resource version and try again if there is a conflict saving the object.
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		s.V(2).Info("Updating cluster", "cluster-resource-version", s.Cluster.ResourceVersion)
+		s.Cluster.Spec.ProviderSpec.Value = ext
+		s.V(6).Info("Cluster status before update", "cluster-status", s.Cluster.Status)
+		latest, err := s.ClusterClient.Update(s.Cluster)
+		if err != nil {
+			s.Error(err, "error updating cluster")
+			newestCluster, err2 := s.ClusterClient.Get(s.Cluster.Name, metav1.GetOptions{})
+			if err2 != nil {
+				s.Error(err2, "failed to fetch latest cluster")
+				return err2
+			}
+			// Error if anything but the cluster resource version changes
+			s.Cluster.ResourceVersion = newestCluster.ResourceVersion
+			return err
+		}
+		s.V(5).Info("Latest cluster status", "cluster-status", latest.Status)
+		s.Cluster.Status.DeepCopyInto(&latest.Status)
+		latest.Status.ProviderStatus = status
+		_, err = s.ClusterClient.UpdateStatus(latest)
+		return err
+	}); err != nil {
+		s.Error(err, "failed to retry on conflict")
 	}
+	s.V(2).Info("Successfully updated cluster")
 }

--- a/pkg/cloud/aws/actuators/scope.go
+++ b/pkg/cloud/aws/actuators/scope.go
@@ -156,13 +156,13 @@ func (s *Scope) Close() {
 		s.V(6).Info("Cluster status before update", "cluster-status", s.Cluster.Status)
 		latest, err := s.ClusterClient.Update(s.Cluster)
 		if err != nil {
-			s.Error(err, "error updating cluster")
+			s.V(3).Info("Cluster resource version is out of date")
+			// Fetch and update the latest resource version
 			newestCluster, err2 := s.ClusterClient.Get(s.Cluster.Name, metav1.GetOptions{})
 			if err2 != nil {
 				s.Error(err2, "failed to fetch latest cluster")
 				return err2
 			}
-			// Error if anything but the cluster resource version changes
 			s.Cluster.ResourceVersion = newestCluster.ResourceVersion
 			return err
 		}

--- a/pkg/cloud/aws/services/ec2/BUILD.bazel
+++ b/pkg/cloud/aws/services/ec2/BUILD.bazel
@@ -33,7 +33,9 @@ go_library(
         "//pkg/cloud/aws/tags:go_default_library",
         "//pkg/record:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/request:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
     ],
 )

--- a/pkg/cloud/aws/services/ec2/instances_test.go
+++ b/pkg/cloud/aws/services/ec2/instances_test.go
@@ -381,7 +381,7 @@ vuO9LYxDXLVY9F7W4ccyCqe27Cj1xyAvdZxwhITrib8Wg5CMqoRpqTw5V3+TpA==
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunning(gomock.Any()).
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 			},
 			check: func(instance *v1alpha1.Instance, err error) {


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This fixes the errors we were seeing with Update conflicts.

The new logic will try to update; fetch a new version, set the most recent resource version and then try updating again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #717

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```