### PR TITLE
fix: Don't try to update root size when it's unset

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -306,7 +306,7 @@ func (a *Actuator) isMachineOutdated(machineSpec *v1alpha1.AWSMachineProviderSpe
 	}
 
 	// Root Device Size
-	if machineSpec.RootDeviceSize != instance.RootDeviceSize {
+	if machineSpec.RootDeviceSize > 0 && machineSpec.RootDeviceSize != instance.RootDeviceSize {
 		errs = append(errs, errors.Errorf("Root volume size cannot be mutated from %v to %v", instance.RootDeviceSize, machineSpec.RootDeviceSize))
 	}
 

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -444,6 +444,16 @@ func TestImmutableStateChange(t *testing.T) {
 			expected: 1,
 		},
 		{
+			name: "root device size is omitted",
+			machineSpec: v1alpha1.AWSMachineProviderSpec{
+			},
+			instance: v1alpha1.Instance{
+				// All instances have a root device size, even when we don't set one
+				RootDeviceSize: 12,
+			},
+			expected: 0,
+		},
+		{
 			name: "root device size is unchanged",
 			machineSpec: v1alpha1.AWSMachineProviderSpec{
 				RootDeviceSize: 12,

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -444,9 +444,8 @@ func TestImmutableStateChange(t *testing.T) {
 			expected: 1,
 		},
 		{
-			name: "root device size is omitted",
-			machineSpec: v1alpha1.AWSMachineProviderSpec{
-			},
+			name:        "root device size is omitted",
+			machineSpec: v1alpha1.AWSMachineProviderSpec{},
 			instance: v1alpha1.Instance{
 				// All instances have a root device size, even when we don't set one
 				RootDeviceSize: 12,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This commit looks for empty RootDeviceSize in the spec and ignores it.
Otherwise, none of our control plane machines were updating with this
error:

```
E0418 23:07:48.250925       1 controller.go:214] Error updating machine "ns/controlplane-2": found attempt to change immutable state for machine "controlplane-2": ["Root volume size cannot be mutated from 8 to 0"]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes issue updating machines with an unspecified root device size
```