### PR TITLE
e2e testing improvement

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,7 +104,7 @@ go_repository(
 go_repository(
     name = "io_k8s_sigs_kind",
     importpath = "sigs.k8s.io/kind",
-    tag = "0.1.0",
+    tag = "0.2.1",
 )
 
 go_repository(


### PR DESCRIPTION
* Bump kind version
* Remove docker load in favor of kind load for e2e cluster

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
We don't strictly need this PR but it's nice to have. This bumps the version of kind to 0.2.1 which will bump the bootstrap cluster to version 1.13.4.

```release-note
NONE
```