### PR TITLE
Scope nodeRef to workload cluster

### DIFF
--- a/cmd/manager/BUILD.bazel
+++ b/cmd/manager/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/cloud/aws/actuators/cluster:go_default_library",
         "//pkg/cloud/aws/actuators/machine:go_default_library",
         "//pkg/record:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common:go_default_library",

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"time"
 
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/cluster"
@@ -65,6 +66,11 @@ func main() {
 		klog.Fatalf("Failed to create client from configuration: %v", err)
 	}
 
+	coreClient, err := corev1.NewForConfig(cfg)
+	if err != nil {
+		klog.Fatalf("Failed to create corev1 client from configuration: %v", err)
+	}
+
 	// Initialize event recorder.
 	record.InitFromRecorder(mgr.GetRecorder("aws-controller"))
 
@@ -76,7 +82,8 @@ func main() {
 
 	// Initialize machine actuator.
 	machineActuator := machine.NewActuator(machine.ActuatorParams{
-		Client:         cs.ClusterV1alpha1(),
+		CoreClient:     coreClient,
+		ClusterClient:  cs.ClusterV1alpha1(),
 		LoggingContext: "[machine-actuator]",
 	})
 

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -58,22 +58,25 @@ const (
 type Actuator struct {
 	*deployer.Deployer
 
-	client client.ClusterV1alpha1Interface
-	log    logr.Logger
+	coreClient    corev1.CoreV1Interface
+	clusterClient client.ClusterV1alpha1Interface
+	log           logr.Logger
 }
 
 // ActuatorParams holds parameter information for Actuator.
 type ActuatorParams struct {
-	Client         client.ClusterV1alpha1Interface
+	CoreClient     corev1.CoreV1Interface
+	ClusterClient  client.ClusterV1alpha1Interface
 	LoggingContext string
 }
 
 // NewActuator returns an actuator.
 func NewActuator(params ActuatorParams) *Actuator {
 	return &Actuator{
-		Deployer: deployer.New(deployer.Params{ScopeGetter: actuators.DefaultScopeGetter}),
-		client:   params.Client,
-		log:      klogr.New().WithName(params.LoggingContext),
+		Deployer:      deployer.New(deployer.Params{ScopeGetter: actuators.DefaultScopeGetter}),
+		coreClient:    params.CoreClient,
+		clusterClient: params.ClusterClient,
+		log:           klogr.New().WithName(params.LoggingContext),
 	}
 }
 
@@ -102,7 +105,7 @@ func (a *Actuator) isNodeJoin(scope *actuators.MachineScope, controlPlaneMachine
 			m, err := actuators.NewMachineScope(actuators.MachineScopeParams{
 				Machine: cm,
 				Cluster: scope.Cluster,
-				Client:  a.client,
+				Client:  a.clusterClient,
 				Logger:  a.log,
 			})
 
@@ -134,7 +137,7 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 	}
 	a.log.Info("Creating machine in cluster", "machine-name", machine.Name, "machine-namespace", machine.Namespace, "cluster-name", cluster.Name)
 
-	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.client, Logger: a.log})
+	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.clusterClient, Logger: a.log})
 	if err != nil {
 		return errors.Errorf("failed to create scope: %+v", err)
 	}
@@ -243,7 +246,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 	}
 	a.log.Info("Deleting machine in cluster", "machine-name", machine.Name, "machine-namespace", machine.Namespace, "cluster-name", cluster.Name)
 
-	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.client, Logger: a.log})
+	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.clusterClient, Logger: a.log})
 	if err != nil {
 		return errors.Errorf("failed to create scope: %+v", err)
 	}
@@ -349,7 +352,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 	a.log.Info("Updating machine in cluster", "machine-name", machine.Name, "machine-namespace", machine.Namespace, "cluster-name", cluster.Name)
 
-	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.client, Logger: a.log})
+	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.clusterClient, Logger: a.log})
 	if err != nil {
 		return errors.Errorf("failed to create scope: %+v", err)
 	}
@@ -400,7 +403,7 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 	a.log.Info("Checking if machine exists in cluster", "machine-name", machine.Name, "machine-namespace", machine.Namespace, "cluster-name", cluster.Name)
 
-	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.client, Logger: a.log})
+	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{Machine: machine, Cluster: cluster, Client: a.clusterClient, Logger: a.log})
 	if err != nil {
 		return false, errors.Errorf("failed to create scope: %+v", err)
 	}
@@ -451,14 +454,12 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 	// Set the Machine NodeRef.
 	if machine.Status.NodeRef == nil {
 		nodeRef, err := a.getNodeReference(scope)
-		if err != nil {
-			a.log.Info("Failed to set nodeRef", "error", err)
-			// non critical error
-			return true, nil
+		if err == nil {
+			scope.Machine.Status.NodeRef = nodeRef
+			a.log.V(2).Info("Setting machine's nodeRef", "machine-name", scope.Name(), "machine-namespace", scope.Namespace(), "nodeRef", nodeRef.Name)
+		} else {
+			a.log.Info("Cannot set nodeRef", "error", err)
 		}
-
-		scope.Machine.Status.NodeRef = nodeRef
-		a.log.V(2).Info("Setting machine's nodeRef", "machine-name", scope.Name(), "machine-namespace", scope.Namespace(), "nodeRef", nodeRef.Name)
 	}
 
 	return true, nil
@@ -467,15 +468,10 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 func (a *Actuator) getNodeReference(scope *actuators.MachineScope) (*apicorev1.ObjectReference, error) {
 	instanceID := *scope.MachineStatus.InstanceID
 
-	coreClient, err := a.coreV1Client(scope.Cluster)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve corev1 client for cluster %q", scope.Cluster.Name)
-	}
-
 	listOpt := metav1.ListOptions{}
 
 	for {
-		nodeList, err := coreClient.Nodes().List(listOpt)
+		nodeList, err := a.coreClient.Nodes().List(listOpt)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to query cluster nodes")
 		}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR makes sure that NodeRef is set only in case the manager is running on the workload cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```