### PR TITLE
Fixes the infinite reconcile loop

### DIFF
--- a/pkg/cloud/aws/actuators/BUILD.bazel
+++ b/pkg/cloud/aws/actuators/BUILD.bazel
@@ -22,10 +22,11 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/client-go/util/retry:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/klog/klogr:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/patch:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/cloud/aws/actuators/scope.go
+++ b/pkg/cloud/aws/actuators/scope.go
@@ -17,18 +17,20 @@ limitations under the License.
 package actuators
 
 import (
+	"encoding/json"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/klogr"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/patch"
 )
 
 // ScopeParams defines the input parameters used to create a new Scope.
@@ -81,6 +83,7 @@ func NewScope(params ScopeParams) (*Scope, error) {
 	return &Scope{
 		AWSClients:    params.AWSClients,
 		Cluster:       params.Cluster,
+		ClusterCopy:   params.Cluster.DeepCopy(),
 		ClusterClient: clusterClient,
 		ClusterConfig: clusterConfig,
 		ClusterStatus: clusterStatus,
@@ -91,7 +94,9 @@ func NewScope(params ScopeParams) (*Scope, error) {
 // Scope defines the basic context for an actuator to operate upon.
 type Scope struct {
 	AWSClients
-	Cluster       *clusterv1.Cluster
+	Cluster *clusterv1.Cluster
+	// ClusterCopy is used for patch generation at the end of the scope's lifecycle.
+	ClusterCopy   *clusterv1.Cluster
 	ClusterClient client.ClusterInterface
 	ClusterConfig *v1alpha1.AWSClusterProviderSpec
 	ClusterStatus *v1alpha1.AWSClusterProviderStatus
@@ -138,6 +143,7 @@ func (s *Scope) Close() {
 	if s.ClusterClient == nil {
 		return
 	}
+
 	ext, err := v1alpha1.EncodeClusterSpec(s.ClusterConfig)
 	if err != nil {
 		s.Error(err, "failed encoding cluster spec")
@@ -149,30 +155,31 @@ func (s *Scope) Close() {
 		return
 	}
 
-	// Update the resource version and try again if there is a conflict saving the object.
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		s.V(2).Info("Updating cluster", "cluster-resource-version", s.Cluster.ResourceVersion)
-		s.Cluster.Spec.ProviderSpec.Value = ext
-		s.V(6).Info("Cluster status before update", "cluster-status", s.Cluster.Status)
-		latest, err := s.ClusterClient.Update(s.Cluster)
-		if err != nil {
-			s.V(3).Info("Cluster resource version is out of date")
-			// Fetch and update the latest resource version
-			newestCluster, err2 := s.ClusterClient.Get(s.Cluster.Name, metav1.GetOptions{})
-			if err2 != nil {
-				s.Error(err2, "failed to fetch latest cluster")
-				return err2
-			}
-			s.Cluster.ResourceVersion = newestCluster.ResourceVersion
-			return err
-		}
-		s.V(5).Info("Latest cluster status", "cluster-status", latest.Status)
-		s.Cluster.Status.DeepCopyInto(&latest.Status)
-		latest.Status.ProviderStatus = status
-		_, err = s.ClusterClient.UpdateStatus(latest)
-		return err
-	}); err != nil {
-		s.Error(err, "failed to retry on conflict")
+	s.Cluster.Spec.ProviderSpec.Value = ext
+
+	// Build a patch and marshal that patch to something the client will understand.
+	p, err := patch.NewJSONPatch(s.ClusterCopy, s.Cluster)
+	if err != nil {
+		s.Error(err, "failed to create new JSONPatch")
+		return
 	}
-	s.V(2).Info("Successfully updated cluster")
+
+	pb, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		s.Error(err, "failed to json marshal patch")
+		return
+	}
+
+	updated, err := s.ClusterClient.Patch(s.Cluster.Name, types.JSONPatchType, pb)
+	if err != nil {
+		s.Error(err, "failed to patch cluster")
+		return
+	}
+
+	updated.Status.ProviderStatus = status
+	if _, err := s.ClusterClient.UpdateStatus(updated); err != nil {
+		s.Error(err, "failed to update cluster status")
+		return
+	}
+	s.V(1).Info("Updated cluster")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Uses patch for updating the cluster and machine specs
  - patch does not cause a re-reconcile in the capi controller
* Uses update for updating the cluster and machine status
  - update for status is ok since it does not update any of the metadata
    no re-reconcile is necessary for the capi controller

Signed-off-by: Chuck Ha <chuckh@vmware.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
apparently there is no issue, but creating a cluster was weird.

**Special notes for your reviewer**:
I believe this will be the first step to fixing the long-create times we were seeing.

**Release note**:
```release-note
None
```