### PR TITLE
Set attributes for managed VPCs

### DIFF
--- a/pkg/cloud/aws/services/ec2/vpc.go
+++ b/pkg/cloud/aws/services/ec2/vpc.go
@@ -89,6 +89,16 @@ func (s *Service) createVPC() (*v1alpha1.VPCSpec, error) {
 		return nil, errors.Wrap(err, "failed to create vpc")
 	}
 
+	attrInput := &ec2.ModifyVpcAttributeInput{
+		VpcId:              out.Vpc.VpcId,
+		EnableDnsHostnames: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
+		EnableDnsSupport:   &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
+	}
+
+	if _, err = s.scope.EC2.ModifyVpcAttribute(attrInput); err != nil {
+		return nil, errors.Wrap(err, "failed to set vpc attributes")
+	}
+
 	wReq := &ec2.DescribeVpcsInput{VpcIds: []*string{out.Vpc.VpcId}}
 	if err := s.scope.EC2.WaitUntilVpcAvailable(wReq); err != nil {
 		return nil, errors.Wrapf(err, "failed to wait for vpc %q", *out.Vpc.VpcId)

--- a/pkg/cloud/aws/services/ec2/vpc_test.go
+++ b/pkg/cloud/aws/services/ec2/vpc_test.go
@@ -112,6 +112,8 @@ func TestReconcileVPC(t *testing.T) {
 						},
 					}, nil)
 
+				m.ModifyVpcAttribute(gomock.AssignableToTypeOf(&ec2.ModifyVpcAttributeInput{})).Return(&ec2.ModifyVpcAttributeOutput{}, nil)
+
 				m.WaitUntilVpcAvailable(gomock.Eq(&ec2.DescribeVpcsInput{
 					VpcIds: []*string{aws.String("vpc-new")},
 				})).


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR sets `EnableDnsHostnames` and `EnableDnsSupport` to `true` for managed VPCs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #780 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```