### PR TITLE
chore: append nodeRole label if additional labels provided

### DIFF
--- a/pkg/cloud/aws/services/kubeadm/aws_defaults.go
+++ b/pkg/cloud/aws/services/kubeadm/aws_defaults.go
@@ -193,7 +193,11 @@ func SetJoinNodeConfigurationOverrides(caCertHash, bootstrapToken string, machin
 	}
 	out.NodeRegistration.KubeletExtraArgs["cloud-provider"] = CloudProvider
 	if !util.IsControlPlaneMachine(machine.GetMachine()) {
-		out.NodeRegistration.KubeletExtraArgs["node-labels"] = nodeRole
+		if labels, ok := out.NodeRegistration.KubeletExtraArgs["node-labels"]; ok {
+			out.NodeRegistration.KubeletExtraArgs["node-labels"] = fmt.Sprintf("%s,%s", labels, nodeRole)
+		} else {
+			out.NodeRegistration.KubeletExtraArgs["node-labels"] = nodeRole
+		}
 	}
 	return out
 }

--- a/pkg/cloud/aws/services/kubeadm/aws_defaults.go
+++ b/pkg/cloud/aws/services/kubeadm/aws_defaults.go
@@ -18,6 +18,7 @@ package kubeadm
 
 import (
 	"fmt"
+	"strings"
 
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/util"
@@ -193,8 +194,9 @@ func SetJoinNodeConfigurationOverrides(caCertHash, bootstrapToken string, machin
 	}
 	out.NodeRegistration.KubeletExtraArgs["cloud-provider"] = CloudProvider
 	if !util.IsControlPlaneMachine(machine.GetMachine()) {
-		if labels, ok := out.NodeRegistration.KubeletExtraArgs["node-labels"]; ok {
-			out.NodeRegistration.KubeletExtraArgs["node-labels"] = fmt.Sprintf("%s,%s", labels, nodeRole)
+		if val, ok := out.NodeRegistration.KubeletExtraArgs["node-labels"]; ok {
+			labels := append(strings.Split(val, ","), nodeRole)
+			out.NodeRegistration.KubeletExtraArgs["node-labels"] = strings.Join(labels, ",")
 		} else {
 			out.NodeRegistration.KubeletExtraArgs["node-labels"] = nodeRole
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR appends the `nodeRole` Node label when the `node-labels` Kubelet argument is supplied, rather than overriding it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #789 

**Special notes for your reviewer**:

Tested with worker node MachineDeployments.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```