### PR TITLE
Copy taints to new machines

### DIFF
--- a/pkg/cloud/aws/services/kubeadm/BUILD.bazel
+++ b/pkg/cloud/aws/services/kubeadm/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//pkg/apis/awsprovider/v1alpha1:go_default_library",
         "//pkg/cloud/aws/actuators:go_default_library",
         "//pkg/cloudtest:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",

--- a/pkg/cloud/aws/services/kubeadm/aws_defaults.go
+++ b/pkg/cloud/aws/services/kubeadm/aws_defaults.go
@@ -150,6 +150,9 @@ func SetInitConfigurationOverrides(machine joinMachine, base *kubeadmv1beta1.Ini
 		machine.GetScope().Info("Overriding node's cloud-provider", "provided-cloud-provider", cp, "required-cloud-provider", CloudProvider)
 	}
 	out.NodeRegistration.KubeletExtraArgs["cloud-provider"] = CloudProvider
+	if machine != nil && machine.GetMachine() != nil {
+		out.NodeRegistration.Taints = machine.GetMachine().Spec.Taints
+	}
 	return out
 }
 
@@ -200,6 +203,9 @@ func SetJoinNodeConfigurationOverrides(caCertHash, bootstrapToken string, machin
 		} else {
 			out.NodeRegistration.KubeletExtraArgs["node-labels"] = nodeRole
 		}
+	}
+	if machine != nil && machine.GetMachine() != nil {
+		out.NodeRegistration.Taints = machine.GetMachine().Spec.Taints
 	}
 	return out
 }


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR allows taints from the machine object (from machine set, from machine deployment) to make their way into the kubeadm config so the nodes have the correct taints applied.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #793 

**Special notes for your reviewer**:
Tested by creating a cluster, deleting the default machine, applying this machine deployment:

```
apiVersion: "cluster.k8s.io/v1alpha1"
kind: MachineDeployment
metadata:
  name: sample-machinedeployment
  labels:
    cluster.k8s.io/cluster-name: test1
spec:
  replicas: 2
  selector:
    matchLabels:
      cluster.k8s.io/cluster-name: test1
      set: node
  template:
    metadata:
      labels:
        cluster.k8s.io/cluster-name: test1
        set: node
    spec:
      taints:
      - effect: NoSchedule
        key: taintKey
        value: taintValue
      versions:
        kubelet: v1.13.6
      providerSpec:
        value:
          apiVersion: awsprovider/v1alpha1
          kind: AWSMachineProviderSpec
          instanceType: "t2.medium"
          iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
          keyName: "laptop"
```

and seeing this value:

```
 chuckh-a01:cluster-api-provider-aws cha$ k describe node ip-10-0-0-203.us-west-2.compute.internal  --kubeconfig kubeconfig 
Name:               ip-10-0-0-203.us-west-2.compute.internal
Roles:              node
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=t2.medium
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=us-west-2
                    failure-domain.beta.kubernetes.io/zone=us-west-2a
                    kubernetes.io/hostname=ip-10-0-0-203.us-west-2.compute.internal
                    node-role.kubernetes.io/node=
Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /var/run/containerd/containerd.sock
                    node.alpha.kubernetes.io/ttl: 0
                    projectcalico.org/IPv4Address: 10.0.0.203/24
                    projectcalico.org/IPv4IPIPTunnelAddr: 192.168.9.192
                    volumes.kubernetes.io/controller-managed-attach-detach: true
CreationTimestamp:  Fri, 24 May 2019 12:49:36 -0400
Taints:             taintKey=taintValue:NoSchedule
Unschedulable:      false
*snip*
```

**Release note**:
```release-note
improved MachineDeployments support by passing taints through
```