### PR TITLE
Remove go get install instructions for binaries

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,8 @@
   - [Creating a cluster](#creating-a-cluster)
 - [Using the cluster](#using-the-cluster)
 - [Troubleshooting](#troubleshooting)
-- [Bootstrap running, but resources aren't being created](#bootstrap-running-but-resources-arent-being-created)
+  - [Bootstrap running, but resources aren't being created](#bootstrap-running-but-resources-arent-being-created)
+  - [Target cluster's control plane machine is up but target cluster's apiserver not working as expected](#target-clusters-control-plane-machine-is-up-but-target-clusters-apiserver-not-working-as-expected)
 
 <!-- /TOC -->
 
@@ -50,10 +51,6 @@
 Get the latest [release of `clusterctl` and
 `clusterawsadm`](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases)
 and place them in your path.
-
-If you prefer to build the latest version from master you can use `go get
-sigs.k8s.io/cluster-api-provider-aws/...` – the trailing `...` will ask for both
-`clusterctl` and `clusterawsadm` to be built.
 
 ### Setting up AWS
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Installing `clusterctl` and/or `clusterawsadm` using `go get` causes the resulting binaries to not contain any version information, we should avoid telling users to install using this method as part of the getting started instructions. The development instructions already tell users how to build the binaries from master (correctly using bazel).

**Release note**:
```release-note
NONE
```