### PR TITLE
Add availaibilityZone to Machine Spec

### DIFF
--- a/config/crds/awsprovider_v1alpha1_awsmachineproviderspec.yaml
+++ b/config/crds/awsprovider_v1alpha1_awsmachineproviderspec.yaml
@@ -91,6 +91,11 @@ spec:
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
+        availabilityZone:
+          description: AvailabilityZone is references the AWS availability zone to
+            use for this instance. If multiple subnets are matched for the availability
+            zone, the first one return is picked.
+          type: string
         iamInstanceProfile:
           description: IAMInstanceProfile is a name of an IAM instance profile to
             assign to the instance

--- a/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1alpha1/awsmachineproviderconfig_types.go
@@ -68,6 +68,11 @@ type AWSMachineProviderSpec struct {
 	// +optional
 	AdditionalSecurityGroups []AWSResourceReference `json:"additionalSecurityGroups,omitempty"`
 
+	// AvailabilityZone is references the AWS availability zone to use for this instance.
+	// If multiple subnets are matched for the availability zone, the first one return is picked.
+	// +optional
+	AvailabilityZone *string `json:"availabilityZone,omitempty"`
+
 	// Subnet is a reference to the subnet to use for this instance. If not specified,
 	// the cluster subnet will be used.
 	// +optional

--- a/pkg/apis/awsprovider/v1alpha1/types.go
+++ b/pkg/apis/awsprovider/v1alpha1/types.go
@@ -221,6 +221,16 @@ func (s Subnets) FilterPublic() (res Subnets) {
 	return
 }
 
+// FilterByZone returns a slice containing all subnets that live in the availability zone specified.
+func (s Subnets) FilterByZone(zone string) (res Subnets) {
+	for _, x := range s {
+		if x.AvailabilityZone == zone {
+			res = append(res, x)
+		}
+	}
+	return
+}
+
 // RouteTable defines an AWS routing table.
 type RouteTable struct {
 	ID string `json:"id"`

--- a/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/awsprovider/v1alpha1/zz_generated.deepcopy.go
@@ -128,6 +128,11 @@ func (in *AWSMachineProviderSpec) DeepCopyInto(out *AWSMachineProviderSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AvailabilityZone != nil {
+		in, out := &in.AvailabilityZone, &out.AvailabilityZone
+		*out = new(string)
+		**out = **in
+	}
 	if in.Subnet != nil {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds a new field to the Machine Spec called "availabilityZone". As expressed in the linked issue, users might prefer to specify an AZ to a SubnetID for simplicity. This PR is a simple implementation for that request which picks the first available private subnet within the AZ specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #799 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```