### PR TITLE
Update for k8s v1.13.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Note: These AMIs are not updated for security fixes and it is recommended to alw
 | v1.13                    | v1.13.3                 |
 |                          | v1.13.5                 |
 |                          | v1.13.6                 |
+|                          | v1.13.7                 |
 | v1.14                    | v1.14.0                 |
 |                          | v1.14.1                 |
 |                          | v1.14.2                 |

--- a/build/amis/packer/packer.json
+++ b/build/amis/packer/packer.json
@@ -3,7 +3,7 @@
     "aws_access_key": "",
     "aws_secret_key": "",
     "build_timestamp": "{{timestamp}}",
-    "kubernetes_version": "1.13.6-00",
+    "kubernetes_version": "1.13.7-00",
     "kubernetes_cni_version": "0.7.5-00",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "ami_groups": "all",

--- a/cmd/clusterctl/examples/aws/machine-deployment.yaml.template
+++ b/cmd/clusterctl/examples/aws/machine-deployment.yaml.template
@@ -17,7 +17,7 @@ spec:
         set: node
     spec:
       versions:
-        kubelet: v1.13.6
+        kubelet: v1.13.7
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/cmd/clusterctl/examples/aws/machines-ha.yaml.template
+++ b/cmd/clusterctl/examples/aws/machines-ha.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.6
-        controlPlane: v1.13.6
+        kubelet: v1.13.7
+        controlPlane: v1.13.7
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1
@@ -28,8 +28,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.6
-        controlPlane: v1.13.6
+        kubelet: v1.13.7
+        controlPlane: v1.13.7
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1
@@ -46,8 +46,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.6
-        controlPlane: v1.13.6
+        kubelet: v1.13.7
+        controlPlane: v1.13.7
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/cmd/clusterctl/examples/aws/machines.yaml.template
+++ b/cmd/clusterctl/examples/aws/machines.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.6
-        controlPlane: v1.13.6
+        kubelet: v1.13.7
+        controlPlane: v1.13.7
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1
@@ -28,7 +28,7 @@ items:
         set: node
     spec:
       versions:
-        kubelet: v1.13.6
+        kubelet: v1.13.7
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/docs/amis.md
+++ b/docs/amis.md
@@ -4,7 +4,7 @@
 
 <!-- TOC -->
 
-- [Kubernetes Version v1.13.6](#kubernetes-version-v1136)
+- [Kubernetes Version v1.13.7](#kubernetes-version-v1137)
   - [Amazon Linux 2](#amazon-linux-2)
   - [CentOS 7](#centos-7)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic)
@@ -15,67 +15,67 @@
 
 <!-- TOC -->
 
-## Kubernetes Version v1.13.6
+## Kubernetes Version v1.13.7
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0ef69992f31955161 |
-| ap-northeast-2 | ami-05c81fca30725328a |
-| ap-south-1     | ami-079021ba5157e98a5 |
-| ap-southeast-1 | ami-0e41f9902b6985b7b |
-| ap-southeast-2 | ami-07eeef698ef1af2ae |
-| ca-central-1   | ami-06215fcc8b7e1aea6 |
-| eu-central-1   | ami-033aab11000459c0a |
-| eu-west-1      | ami-050c03774b01c316c |
-| eu-west-2      | ami-080a7159611255eb4 |
-| eu-west-3      | ami-0c1d54eb7d3e2ff94 |
-| sa-east-1      | ami-0958e5f6dec1e9c27 |
-| us-east-1      | ami-0d7308a6db4f183ba |
-| us-east-2      | ami-036e59c6dc6bae5a4 |
-| us-west-1      | ami-05e446e36b30caeff |
-| us-west-2      | ami-02c930bdf996776ad |
+| ap-northeast-1 | ami-01e2e045751272ce0 |
+| ap-northeast-2 | ami-01a071ac0dda886d9 |
+| ap-south-1     | ami-075ab7d27e9e17c5b |
+| ap-southeast-1 | ami-0e01e4e7ec297b23e |
+| ap-southeast-2 | ami-0318915a2bd6bb44f |
+| ca-central-1   | ami-036859a99b810afdf |
+| eu-central-1   | ami-060004c0b99d4daf0 |
+| eu-west-1      | ami-049ba95df77580c67 |
+| eu-west-2      | ami-0ff0825fe10714055 |
+| eu-west-3      | ami-04e67cf18e48013b6 |
+| sa-east-1      | ami-0a2a0fb10bcf6da49 |
+| us-east-1      | ami-0070654c62029c10b |
+| us-east-2      | ami-033c3335e493cd59d |
+| us-west-1      | ami-0d667463f774297ac |
+| us-west-2      | ami-0227359d78292a806 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0ce71130e4154ef4a |
-| ap-northeast-2 | ami-03ceecc3879855b13 |
-| ap-south-1     | ami-091f7443b43575090 |
-| ap-southeast-1 | ami-0a143671a7fff9f72 |
-| ap-southeast-2 | ami-0372d9d6cc2fa6d5c |
-| ca-central-1   | ami-013c423f4d22a2853 |
-| eu-central-1   | ami-0b4b3c747b9043abc |
-| eu-west-1      | ami-07aaf2ad83a0e32bd |
-| eu-west-2      | ami-0c14be94277fdca7a |
-| eu-west-3      | ami-06c1072e6dc34dcfa |
-| sa-east-1      | ami-09958500c528fb12a |
-| us-east-1      | ami-0d73dd36462965ff3 |
-| us-east-2      | ami-010f1a4cdd566eb3c |
-| us-west-1      | ami-0145caef50175878f |
-| us-west-2      | ami-0303a3cf0482b933d |
+| ap-northeast-1 | ami-0b07e44e2f2cc1036 |
+| ap-northeast-2 | ami-0725a83db8e9f720a |
+| ap-south-1     | ami-0a96b9c542581efab |
+| ap-southeast-1 | ami-01dcbc5851d1020b8 |
+| ap-southeast-2 | ami-0e2518baa903c9364 |
+| ca-central-1   | ami-01f149b3047701d13 |
+| eu-central-1   | ami-04deb8a0752771def |
+| eu-west-1      | ami-016e35ee4a8c3582b |
+| eu-west-2      | ami-05dbd8a05acfee60e |
+| eu-west-3      | ami-014c36de1d71f586d |
+| sa-east-1      | ami-059bb17aea125dd58 |
+| us-east-1      | ami-0f8ffd533f9769fcd |
+| us-east-2      | ami-0876ccee5f0f3b9e5 |
+| us-west-1      | ami-03fa5682e71b47467 |
+| us-west-2      | ami-0436aba3a0365431f |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0e0207bcf34a79db4 |
-| ap-northeast-2 | ami-0c308749dbd1f6ddb |
-| ap-south-1     | ami-01f7676d64719a17c |
-| ap-southeast-1 | ami-0206d935e0b74d563 |
-| ap-southeast-2 | ami-040e47674436cd4f7 |
-| ca-central-1   | ami-01f7800c2c62e93b0 |
-| eu-central-1   | ami-06b594e685daadb91 |
-| eu-west-1      | ami-02e8defa9d8fabb48 |
-| eu-west-2      | ami-061577a0bac1a7919 |
-| eu-west-3      | ami-0ad7c614ad60f0781 |
-| sa-east-1      | ami-077982ef97be47203 |
-| us-east-1      | ami-0145e724f98032517 |
-| us-east-2      | ami-041d62325e55c67c6 |
-| us-west-1      | ami-0ed33c1ac38d85afa |
-| us-west-2      | ami-0dd81c4758561f929 |
+| ap-northeast-1 | ami-069b275e5f9a02211 |
+| ap-northeast-2 | ami-0e8e27098a2f64cf7 |
+| ap-south-1     | ami-06ba30d00985fe275 |
+| ap-southeast-1 | ami-04acd5ce4c66321e4 |
+| ap-southeast-2 | ami-01ed8512b5adcc384 |
+| ca-central-1   | ami-0195af1fe8445b99c |
+| eu-central-1   | ami-064d96ba02543e415 |
+| eu-west-1      | ami-0b004abc64943b838 |
+| eu-west-2      | ami-03a010f668cdcec6a |
+| eu-west-3      | ami-0aa0836984f5061c1 |
+| sa-east-1      | ami-03434718d30fb96ca |
+| us-east-1      | ami-0d0090b1c292f4777 |
+| us-east-2      | ami-08a798b6238ded07b |
+| us-west-1      | ami-061613a533cbf9813 |
+| us-west-2      | ami-07b651eb834fb95f0 |
 
 ## Kubernetes Version v1.14.3
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Build/Publish AMIs for k8s v1.13.7
- Set k8s v1.13.7 as default for templates

**Release note**:
```release-note
NONE
```