### PR TITLE
Update cluster-api for v0.1.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1149,7 +1149,7 @@
 
 [[projects]]
   branch = "release-0.1"
-  digest = "1:3ce00f966bc22129f46fc480f89701a423776ae10d9f21ddbf737b98c4169e61"
+  digest = "1:1aff817d3537e74f08cc2cb278c953fff9d103bbd259e3e257920ec5fab7a7da"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "cmd/clusterctl/clientcmd",
@@ -1177,7 +1177,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "0535e73ca0911cdf3b8abade41bef8adb0fe09b5"
+  revision = "95a2a8cf2c586592538f823bbb02c00cbcce8a9c"
 
 [[projects]]
   digest = "1:57a9c2ddb4a72fcb01da494ff7edb109a052bf98f5f91af75977055717f18742"

--- a/vendor/sigs.k8s.io/cluster-api/Makefile
+++ b/vendor/sigs.k8s.io/cluster-api/Makefile
@@ -22,7 +22,7 @@ export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
 
 # Image URL to use all building/pushing image targets
-export CONTROLLER_IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:0.1.1
+export CONTROLLER_IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:0.1.2
 export EXAMPLE_PROVIDER_IMG ?= gcr.io/k8s-cluster-api/example-provider-controller:latest
 
 all: test manager clusterctl

--- a/vendor/sigs.k8s.io/cluster-api/config/default/manager_image_patch.yaml
+++ b/vendor/sigs.k8s.io/cluster-api/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/k8s-cluster-api/cluster-api-controller:0.1.1
+      - image: gcr.io/k8s-cluster-api/cluster-api-controller:0.1.2
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates cluster-api to v0.1.2

**Release note**:
```release-note
Updates common cluster-api components to v0.1.2
```