### PR TITLE
fix: use provided NodeRegistrationOptions as base

### DIFF
--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -221,7 +221,8 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 					),
 				),
 				kubeadm.WithJoinNodeRegistrationOptions(
-					kubeadm.NewNodeRegistration(
+					kubeadm.SetNodeRegistrationOptions(
+						&machine.MachineConfig.KubeadmConfiguration.Join.NodeRegistration,
 						kubeadm.WithTaints(machine.GetMachine().Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
 						kubeadm.WithCRISocket(containerdSocket),
@@ -275,7 +276,8 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 			kubeadm.SetInitConfigurationOptions(
 				&machine.MachineConfig.KubeadmConfiguration.Init,
 				kubeadm.WithNodeRegistrationOptions(
-					kubeadm.NewNodeRegistration(
+					kubeadm.SetNodeRegistrationOptions(
+						&machine.MachineConfig.KubeadmConfiguration.Init.NodeRegistration,
 						kubeadm.WithTaints(machine.GetMachine().Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
 						kubeadm.WithCRISocket(containerdSocket),
@@ -283,6 +285,7 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 					),
 				),
 			)
+
 			initConfigYAML, err := kubeadm.ConfigurationToYAML(&machine.MachineConfig.KubeadmConfiguration.Init)
 			if err != nil {
 				return nil, err
@@ -320,7 +323,8 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 				),
 			),
 			kubeadm.WithJoinNodeRegistrationOptions(
-				kubeadm.NewNodeRegistration(
+				kubeadm.SetNodeRegistrationOptions(
+					&machine.MachineConfig.KubeadmConfiguration.Join.NodeRegistration,
 					kubeadm.WithNodeRegistrationName(hostnameLookup),
 					kubeadm.WithCRISocket(containerdSocket),
 					kubeadm.WithKubeletExtraArgs(map[string]string{"cloud-provider": cloudProvider}),

--- a/pkg/cloud/aws/services/kubeadm/configs_test.go
+++ b/pkg/cloud/aws/services/kubeadm/configs_test.go
@@ -39,7 +39,7 @@ func TestInitConfiguration(t *testing.T) {
 			},
 			options: []kubeadm.InitConfigurationOption{
 				kubeadm.WithNodeRegistrationOptions(
-					kubeadm.NewNodeRegistration(),
+					kubeadm.SetNodeRegistrationOptions(&kubeadmv1beta1.NodeRegistrationOptions{}),
 				),
 			},
 		},

--- a/pkg/cloud/aws/services/kubeadm/noderegistration.go
+++ b/pkg/cloud/aws/services/kubeadm/noderegistration.go
@@ -26,13 +26,12 @@ import (
 // NodeRegistrationOption is a function that sets a value on a Kubeadm NodeRegistrationOptions.
 type NodeRegistrationOption func(*kubeadmv1beta1.NodeRegistrationOptions)
 
-// NewNodeRegistration will create a kubeadmNodeRegistrationOptions with some defaults and the ability to provide customizations.
-func NewNodeRegistration(opts ...NodeRegistrationOption) kubeadmv1beta1.NodeRegistrationOptions {
-	nro := &kubeadmv1beta1.NodeRegistrationOptions{}
+// SetNodeRegistrationOptions will take a kubeadmNodeRegistrationOptions and apply customizations.
+func SetNodeRegistrationOptions(base *kubeadmv1beta1.NodeRegistrationOptions, opts ...NodeRegistrationOption) kubeadmv1beta1.NodeRegistrationOptions {
 	for _, opt := range opts {
-		opt(nro)
+		opt(base)
 	}
-	return *nro
+	return *base
 }
 
 // WithTaints will set the taints on the NodeRegistration.

--- a/pkg/cloud/aws/services/kubeadm/noderegistration_test.go
+++ b/pkg/cloud/aws/services/kubeadm/noderegistration_test.go
@@ -48,7 +48,8 @@ func TestNewNodeRegistration(t *testing.T) {
 					},
 				},
 			},
-			actual: kubeadm.NewNodeRegistration(
+			actual: kubeadm.SetNodeRegistrationOptions(
+				&kubeadmv1beta1.NodeRegistrationOptions{},
 				kubeadm.WithNodeRegistrationName("test name"),
 				kubeadm.WithCRISocket("/test/path/to/socket.sock"),
 				kubeadm.WithTaints([]corev1.Taint{
@@ -68,7 +69,8 @@ func TestNewNodeRegistration(t *testing.T) {
 					"node-labels": "test value one,test value two",
 				},
 			},
-			actual: kubeadm.NewNodeRegistration(
+			actual: kubeadm.SetNodeRegistrationOptions(
+				&kubeadmv1beta1.NodeRegistrationOptions{},
 				kubeadm.WithKubeletExtraArgs(map[string]string{"node-labels": "test value one"}),
 				kubeadm.WithKubeletExtraArgs(map[string]string{"node-labels": "test value two"}),
 			),

--- a/pkg/cloud/aws/services/kubeadm/noderegistration_test.go
+++ b/pkg/cloud/aws/services/kubeadm/noderegistration_test.go
@@ -75,6 +75,25 @@ func TestNewNodeRegistration(t *testing.T) {
 				kubeadm.WithKubeletExtraArgs(map[string]string{"node-labels": "test value two"}),
 			),
 		},
+		{
+			name: "test starting with non-empty base",
+			expected: kubeadmv1beta1.NodeRegistrationOptions{
+				CRISocket: "/test/path/to/socket.sock",
+				KubeletExtraArgs: map[string]string{
+					"cni-bin-dir":  "/opt/cni/bin",
+					"cni-conf-dir": "/etc/cni/net.d",
+				},
+			},
+			actual: kubeadm.SetNodeRegistrationOptions(
+				&kubeadmv1beta1.NodeRegistrationOptions{
+					KubeletExtraArgs: map[string]string{
+						"cni-bin-dir":  "/opt/cni/bin",
+						"cni-conf-dir": "/etc/cni/net.d",
+					},
+				},
+				kubeadm.WithCRISocket("/test/path/to/socket.sock"),
+			),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This uses the provided Init/Join configurations' NodeRegistration as a base. If there is no provided NodeRegistration, this effectively functions the same as before, starting with a blank NodeRegistrationOptions and executing the funcOpts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #822 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes bug where provided NodeRegistration is not honored
```