### PR TITLE
OWNERS_ALIASES: Remove randomvariable

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,7 +23,6 @@ aliases:
     - detiber
     - enxebre
     - ingvagabund
-    - randomvariable
     - vincepri
   cluster-api-aws-reviewers:
     - ashish-amarnath


### PR DESCRIPTION
Not working on CAPA much at the moment, so am removing myself from the loop for now.