### PR TITLE
Allow Nodes to talk to Kubelet API Port

### DIFF
--- a/pkg/cloud/aws/services/ec2/securitygroups.go
+++ b/pkg/cloud/aws/services/ec2/securitygroups.go
@@ -316,11 +316,15 @@ func (s *Service) getSecurityGroupIngressRules(role v1alpha1.SecurityGroupRole) 
 				CidrBlocks:  []string{anyIPv4CidrBlock},
 			},
 			{
-				Description:            "Kubelet API",
-				Protocol:               v1alpha1.SecurityGroupProtocolTCP,
-				FromPort:               10250,
-				ToPort:                 10250,
-				SourceSecurityGroupIDs: []string{s.scope.SecurityGroups()[v1alpha1.SecurityGroupControlPlane].ID},
+				Description: "Kubelet API",
+				Protocol:    v1alpha1.SecurityGroupProtocolTCP,
+				FromPort:    10250,
+				ToPort:      10250,
+				SourceSecurityGroupIDs: []string{
+					s.scope.SecurityGroups()[v1alpha1.SecurityGroupControlPlane].ID,
+					// This is needed to support metrics-server deployments
+					s.scope.SecurityGroups()[v1alpha1.SecurityGroupNode].ID,
+				},
 			},
 			{
 				Description: "bgp (calico)",


### PR DESCRIPTION
**What this PR does / why we need it**:

- Allows metrics-server to function

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #825 

**Release note**:
```release-note
NONE
```

I verified this with a 3 node (1 control plane, 2 workers) cluster with the metrics-server deployed on one of the worker nodes, and metrics appear to be fully functional afterwards:

```
> kubectl top node
NAME                         CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
ip-10-0-0-187.ec2.internal   52m          2%     779Mi           20%       
ip-10-0-0-206.ec2.internal   48m          2%     709Mi           18%       
ip-10-0-0-42.ec2.internal    193m         9%     1374Mi          35%     
```