### PR TITLE
Add logic to handle implicit route table associations to main route table

### DIFF
--- a/pkg/cloud/aws/services/ec2/routetables.go
+++ b/pkg/cloud/aws/services/ec2/routetables.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	anyIPv4CidrBlock = "0.0.0.0/0"
+	mainRouteTableInVPCKey = "main"
 )
 
 func (s *Service) reconcileRouteTables() error {
@@ -109,6 +110,9 @@ func (s *Service) describeVpcRouteTablesBySubnet() (map[string]*ec2.RouteTable, 
 	res := make(map[string]*ec2.RouteTable)
 	for _, rt := range rts {
 		for _, as := range rt.Associations {
+			if *as.Main {
+				res[mainRouteTableInVPCKey] = rt
+			}
 			if as.SubnetId == nil {
 				continue
 			}

--- a/pkg/cloud/aws/services/ec2/routetables.go
+++ b/pkg/cloud/aws/services/ec2/routetables.go
@@ -110,7 +110,7 @@ func (s *Service) describeVpcRouteTablesBySubnet() (map[string]*ec2.RouteTable, 
 	res := make(map[string]*ec2.RouteTable)
 	for _, rt := range rts {
 		for _, as := range rt.Associations {
-			if *as.Main {
+			if as.Main != nil && *as.Main {
 				res[mainRouteTableInVPCKey] = rt
 			}
 			if as.SubnetId == nil {

--- a/pkg/cloud/aws/services/ec2/routetables.go
+++ b/pkg/cloud/aws/services/ec2/routetables.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	anyIPv4CidrBlock = "0.0.0.0/0"
+	anyIPv4CidrBlock       = "0.0.0.0/0"
 	mainRouteTableInVPCKey = "main"
 )
 

--- a/pkg/cloud/aws/services/ec2/subnets.go
+++ b/pkg/cloud/aws/services/ec2/subnets.go
@@ -202,6 +202,12 @@ func (s *Service) describeVpcSubnets() (v1alpha1.Subnets, error) {
 
 		// ... or if it has an internet route
 		rt := routeTables[*ec2sn.SubnetId]
+		if rt == nil {
+			// If there is no explicit association, subnet defaults to main route table as implicit association
+			if mainRt, ok := routeTables[mainRouteTableInVPCKey]; ok {
+				rt = mainRt
+			}
+		}
 		if rt != nil {
 			spec.RouteTableID = rt.RouteTableId
 			for _, route := range rt.Routes {

--- a/pkg/cloud/aws/services/ec2/subnets.go
+++ b/pkg/cloud/aws/services/ec2/subnets.go
@@ -204,9 +204,7 @@ func (s *Service) describeVpcSubnets() (v1alpha1.Subnets, error) {
 		rt := routeTables[*ec2sn.SubnetId]
 		if rt == nil {
 			// If there is no explicit association, subnet defaults to main route table as implicit association
-			if mainRt, ok := routeTables[mainRouteTableInVPCKey]; ok {
-				rt = mainRt
-			}
+			rt = routeTables[mainRouteTableInVPCKey]
 		}
 		if rt != nil {
 			spec.RouteTableID = rt.RouteTableId

--- a/pkg/cloud/aws/services/mocks/services_mock.go
+++ b/pkg/cloud/aws/services/mocks/services_mock.go
@@ -51,18 +51,18 @@ func (m *MockEC2Interface) EXPECT() *MockEC2InterfaceMockRecorder {
 }
 
 // CreateOrGetMachine mocks base method
-func (m *MockEC2Interface) CreateOrGetMachine(arg0 *actuators.MachineScope, arg1, arg2 string) (*v1alpha1.Instance, error) {
+func (m *MockEC2Interface) CreateOrGetMachine(arg0 *actuators.MachineScope, arg1 string) (*v1alpha1.Instance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrGetMachine", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateOrGetMachine", arg0, arg1)
 	ret0, _ := ret[0].(*v1alpha1.Instance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateOrGetMachine indicates an expected call of CreateOrGetMachine
-func (mr *MockEC2InterfaceMockRecorder) CreateOrGetMachine(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEC2InterfaceMockRecorder) CreateOrGetMachine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrGetMachine", reflect.TypeOf((*MockEC2Interface)(nil).CreateOrGetMachine), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrGetMachine", reflect.TypeOf((*MockEC2Interface)(nil).CreateOrGetMachine), arg0, arg1)
 }
 
 // DeleteBastion mocks base method


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->


**What this PR does / why we need it**:
Currently, when specifying a pre-provisioned VPC in the cluster provider spec, the provider controller scans each subnet in the VPC and labels it as `public` if it has a tag `sigs.k8s.io/cluster-api-provider-aws/role = public`, or if it's _explicitly_ associated with a route table that has an internet gateway route. 

The problem is that a subnet may be _implicitly_ associated with a "main" route table in the VPC, which can include an internet gateway route. The current logic ignores such implicit associations, which can leave users wondering why their subnet is not marked as public. 

This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add logic to handle implicit route tables associations
```