### PR TITLE
Fix cross compilation issue with bazel 0.26+

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,14 +13,21 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-http_archive(
+# Use the git repository for bazel rules until a released version contains https://github.com/bazelbuild/rules_go/pull/2090
+# http_archive(
+#     name = "io_bazel_rules_go",
+#     urls = [
+#         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+#         "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+#     ],
+#     sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
+# )
+git_repository(
     name = "io_bazel_rules_go",
-    urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-    ],
-    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    commit = "f2373c9fbd09586d8e591dda3c43d66445b2d7ca",
 )
 
 http_archive(
@@ -53,7 +60,7 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(
-    minimum_bazel_version = "0.21.0",
+    minimum_bazel_version = "0.23.0",
     maximum_bazel_version = "1.0.0",
 )  # fails if not within range
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport rules_go update for release-0.3 branch

**Release note**:
```release-note
NONE
```