### PR TITLE
Update to cluster-api v0.1.4

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1149,7 +1149,7 @@
 
 [[projects]]
   branch = "release-0.1"
-  digest = "1:3452e35031ae03db7181c47bc2c364e067d5e2a4078c2580fd4d9985e1f32140"
+  digest = "1:f8d62976bc1f504c2ce6d7fbe2f72a39fe9cf4aa78d7dff5a0654ccdb362acf2"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "cmd/clusterctl/clientcmd",
@@ -1178,7 +1178,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "d1b07f40847c37e8933056c3eb99be08f87b9a81"
+  revision = "bf950adfea7c117e58ca30770d02067d8e43d3c7"
 
 [[projects]]
   digest = "1:407e7e9e1b2bfc90b6ea79840fd1e6f88f6917e0f9f24fee7e00e1e1aeae241e"

--- a/vendor/sigs.k8s.io/cluster-api/Makefile
+++ b/vendor/sigs.k8s.io/cluster-api/Makefile
@@ -22,7 +22,7 @@ export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
 
 # Image URL to use all building/pushing image targets
-export CONTROLLER_IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:0.1.3
+export CONTROLLER_IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4
 export EXAMPLE_PROVIDER_IMG ?= gcr.io/k8s-cluster-api/example-provider-controller:latest
 
 all: test manager clusterctl

--- a/vendor/sigs.k8s.io/cluster-api/config/default/manager_image_patch.yaml
+++ b/vendor/sigs.k8s.io/cluster-api/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/k8s-cluster-api/cluster-api-controller:0.1.3
+      - image: gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4
         name: manager

--- a/vendor/sigs.k8s.io/cluster-api/docs/developer/releasing.md
+++ b/vendor/sigs.k8s.io/cluster-api/docs/developer/releasing.md
@@ -11,30 +11,35 @@
 
 1. The container image is found in the registry `gcr.io/k8s-cluster-api` with an
    image name of `cluster-api-controller` and a tag that matches the release
-   version. For example, in the `0.0.0-alpha.4` release, the container image
-   location is `gcr.io/k8s-cluster-api/cluster-api-controller:0.0.0-alpha.4`
+   version. For example, in the `v0.1.4` release, the container image
+   location is `gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4`
+
+1. Prior to the `v0.1.4` release, the container image is found in the
+   registry `gcr.io/k8s-cluster-api` with an image name of `cluster-api-controller`
+   and a tag that matches the release version. For example, in the `0.1.3` release,
+   the container image location is `gcr.io/k8s-cluster-api/cluster-api-controller:0.1.3`
 
 ## Process
 
-For version 0.x.y:
+For version v0.x.y:
 
-1. We will target a branch called `release-0.x`.  If this is `0.x.0` then we'll
+1. We will target a branch called `release-0.x`.  If this is `v0.x.0` then we'll
    create a branch from master using `git push origin master:release-0.x`, otherwise
    simply checkout the existing branch `git checkout release-0.x`
 2. Make two changes:
    1. Change [the cluster api controller manager image
    tag][managerimg] from `:latest` to whatever version is being released
-   2. Change the `CONTROLLER_IMG` variable in the [Makefile][makefile] to the
+   1. Change the `CONTROLLER_IMG` variable in the [Makefile][makefile] to the
       version being released
    (Note that we do not release the example-provider image, so we don't tag that)
-3. Commit it using `git commit -m "Release 0.x.y"`
+3. Commit it using `git commit -m "Release v0.x.y"`
 4. Submit a PR to the `release-0.x` branch, e.g. `git push $USER; hub pull-request -b release-0.x`
 5. Get the pull request merged
 6. Switch to the release branch and update to pick up the commit.  (e.g. `git
    checkout release 0.x && git pull`).  From there build and push the container
-   images and fat manifest with `make all-push` (on the 0.1 release branch, we
+   images and fat manifest with `REGISTRY="gcr.io/k8s-cluster-api" make all-push` (on the 0.1 release branch, we
    do `make docker-push`)
-7. Create a tag from this same commit `git tag 0.x.y` and push the tag to the github repository `git push origin 0.x.y`
+7. Create an annotated tag from this same commit `git tag -a v0.x.y -m v0.x.y` and push the tag to the github repository `git push origin v0.x.y`
 8. Create a release in github based on the tag created above
 9. Manually create the release notes by going through the merged PRs since the
    last release


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of #858 to release-0.3

**Release note**:
```release-note
NONE
```