### PR TITLE
Rev minimum version of Bazel to match requirements

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,7 +60,7 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(
-    minimum_bazel_version = "0.23.0",
+    minimum_bazel_version = "0.25.0",
     maximum_bazel_version = "1.0.0",
 )  # fails if not within range
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the docker-push target requires Bazel 0.25.0+, but the bazel minimum version check is set to 0.23.0+.

**Release note**:
```release-note
NONE
```