### PR TITLE
Avoid infinite APIEndpoints

### DIFF
--- a/pkg/cloud/aws/actuators/scope.go
+++ b/pkg/cloud/aws/actuators/scope.go
@@ -204,12 +204,14 @@ func (s *Scope) Close() {
 		s.Cluster.ResourceVersion = result.ResourceVersion
 	}
 
-	// Check if API endpoints is not set or has changed.
-	if s.Cluster.Status.APIEndpoints == nil || s.Cluster.Status.APIEndpoints[0].Host != s.ClusterStatus.Network.APIServerELB.DNSName {
-		s.Cluster.Status.APIEndpoints = append(s.Cluster.Status.APIEndpoints, clusterv1.APIEndpoint{
-			Host: s.ClusterStatus.Network.APIServerELB.DNSName,
-			Port: apiEndpointPort,
-		})
+	// Set the APIEndpoint.
+	if s.ClusterStatus.Network.APIServerELB.DNSName != "" {
+		s.Cluster.Status.APIEndpoints = []clusterv1.APIEndpoint{
+			{
+				Host: s.ClusterStatus.Network.APIServerELB.DNSName,
+				Port: apiEndpointPort,
+			},
+		}
 	}
 	s.Cluster.Status.ProviderStatus = newStatus
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes an issue where the first reconciliation loop assigns APIEndpoints.Host to an empty string because the ELB might not be ready, and it'll start appending after that. The logic here changes to always have a single APIEndpoint and update if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #880

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```