### PR TITLE
Backport #897 to release-0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ This provider's versions are compatible with the following versions of Cluster A
 
 This provider's versions are able to install and manage the following versions of Kubernetes:
 
-||Kubernetes 1.13|Kubernetes 1.14|
-|-|-|-|
-|AWS Provider v1alpha1 (v0.2)|✓|✓|
-|AWS Provider v1alpha1 (v0.3)|✓|✓|
+||Kubernetes 1.13|Kubernetes 1.14|Kubernetes 1.15|
+|-|-|-|-|
+|AWS Provider v1alpha1 (v0.2)|✓|✓|✓|
+|AWS Provider v1alpha1 (v0.3)|✓|✓|✓|
 
 Each version of Cluster API for AWS will attempt to support two Kubernetes versions; e.g., Cluster API for AWS `v0.2`
 may support Kubernetes 1.13 and Kubernetes 1.14.
@@ -72,10 +72,13 @@ Note: These AMIs are not updated for security fixes and it is recommended to alw
 |                          | v1.13.5                 |
 |                          | v1.13.6                 |
 |                          | v1.13.7                 |
+|                          | v1.13.8                 |
 | v1.14                    | v1.14.0                 |
 |                          | v1.14.1                 |
 |                          | v1.14.2                 |
 |                          | v1.14.3                 |
+|                          | v1.14.4                 |
+| v1.15                    | v1.15.0                 |
 
 ------
 

--- a/build/amis/packer/packer.json
+++ b/build/amis/packer/packer.json
@@ -3,7 +3,7 @@
     "aws_access_key": "",
     "aws_secret_key": "",
     "build_timestamp": "{{timestamp}}",
-    "kubernetes_version": "1.13.7-00",
+    "kubernetes_version": "1.14.4-00",
     "kubernetes_cni_version": "0.7.5-00",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "ami_groups": "all",

--- a/cmd/clusterctl/examples/aws/controlplane-machine.yaml.template
+++ b/cmd/clusterctl/examples/aws/controlplane-machine.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.7
-        controlPlane: v1.13.7
+        kubelet: v1.14.4
+        controlPlane: v1.14.4
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/cmd/clusterctl/examples/aws/controlplane-machines-ha.yaml.template
+++ b/cmd/clusterctl/examples/aws/controlplane-machines-ha.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.7
-        controlPlane: v1.13.7
+        kubelet: v1.14.4
+        controlPlane: v1.14.4
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1
@@ -28,8 +28,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.7
-        controlPlane: v1.13.7
+        kubelet: v1.14.4
+        controlPlane: v1.14.4
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1
@@ -46,8 +46,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.7
-        controlPlane: v1.13.7
+        kubelet: v1.14.4
+        controlPlane: v1.14.4
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/cmd/clusterctl/examples/aws/machine-deployment.yaml.template
+++ b/cmd/clusterctl/examples/aws/machine-deployment.yaml.template
@@ -17,7 +17,7 @@ spec:
         set: node
     spec:
       versions:
-        kubelet: v1.13.7
+        kubelet: v1.14.4
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/cmd/clusterctl/examples/aws/machines.yaml.template
+++ b/cmd/clusterctl/examples/aws/machines.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: v1.13.7
-        controlPlane: v1.13.7
+        kubelet: v1.14.4
+        controlPlane: v1.14.4
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1
@@ -28,7 +28,7 @@ items:
         set: node
     spec:
       versions:
-        kubelet: v1.13.7
+        kubelet: v1.14.4
       providerSpec:
         value:
           apiVersion: awsprovider/v1alpha1

--- a/docs/amis.md
+++ b/docs/amis.md
@@ -4,137 +4,203 @@
 
 <!-- TOC -->
 
-- [Kubernetes Version v1.13.7](#kubernetes-version-v1137)
-  - [Amazon Linux 2](#amazon-linux-2)
-  - [CentOS 7](#centos-7)
-  - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic)
-- [Kubernetes Version v1.14.3](#kubernetes-version-v1143)
-  - [Amazon Linux 2](#amazon-linux-2-1)
-  - [CentOS 7](#centos-7-1)
-  - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-1)
+- [Kubernetes Version v1.13.8](#Kubernetes-Version-v1138)
+  - [Amazon Linux 2](#Amazon-Linux-2)
+  - [CentOS 7](#CentOS-7)
+  - [Ubuntu 18.04 (Bionic)](#Ubuntu-1804-Bionic)
+- [Kubernetes Version v1.14.4](#Kubernetes-Version-v1144)
+  - [Amazon Linux 2](#Amazon-Linux-2-1)
+  - [CentOS 7](#CentOS-7-1)
+  - [Ubuntu 18.04 (Bionic)](#Ubuntu-1804-Bionic-1)
+- [Kubernetes Version v1.15.0](#Kubernetes-Version-v1150)
+  - [Amazon Linux 2](#Amazon-Linux-2-2)
+  - [CentOS 7](#CentOS-7-2)
+  - [Ubuntu 18.04 (Bionic)](#Ubuntu-1804-Bionic-2)
 
 <!-- TOC -->
 
-## Kubernetes Version v1.13.7
+## Kubernetes Version v1.13.8
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-01e2e045751272ce0 |
-| ap-northeast-2 | ami-01a071ac0dda886d9 |
-| ap-south-1     | ami-075ab7d27e9e17c5b |
-| ap-southeast-1 | ami-0e01e4e7ec297b23e |
-| ap-southeast-2 | ami-0318915a2bd6bb44f |
-| ca-central-1   | ami-036859a99b810afdf |
-| eu-central-1   | ami-060004c0b99d4daf0 |
-| eu-west-1      | ami-049ba95df77580c67 |
-| eu-west-2      | ami-0ff0825fe10714055 |
-| eu-west-3      | ami-04e67cf18e48013b6 |
-| sa-east-1      | ami-0a2a0fb10bcf6da49 |
-| us-east-1      | ami-0070654c62029c10b |
-| us-east-2      | ami-033c3335e493cd59d |
-| us-west-1      | ami-0d667463f774297ac |
-| us-west-2      | ami-0227359d78292a806 |
+| ap-northeast-1 | ami-00732f0f27000e049 |
+| ap-northeast-2 | ami-09111674a09891cf3 |
+| ap-south-1     | ami-039295d7ea5a67d5d |
+| ap-southeast-1 | ami-0cc186981c545fe36 |
+| ap-southeast-2 | ami-0b6fa82633de9c226 |
+| ca-central-1   | ami-0c4262603d70c1d6e |
+| eu-central-1   | ami-0d362c7b94f98d5d1 |
+| eu-west-1      | ami-0fa37b5df35ecbe94 |
+| eu-west-2      | ami-00ffc923004e1f527 |
+| eu-west-3      | ami-0f80ae55a19d5a316 |
+| sa-east-1      | ami-07f99e31efc308def |
+| us-east-1      | ami-0673ed675883231de |
+| us-east-2      | ami-04e46fb39b0766e03 |
+| us-west-1      | ami-01da3856fb1d1fd68 |
+| us-west-2      | ami-0eab50fde90167b08 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0b07e44e2f2cc1036 |
-| ap-northeast-2 | ami-0725a83db8e9f720a |
-| ap-south-1     | ami-0a96b9c542581efab |
-| ap-southeast-1 | ami-01dcbc5851d1020b8 |
-| ap-southeast-2 | ami-0e2518baa903c9364 |
-| ca-central-1   | ami-01f149b3047701d13 |
-| eu-central-1   | ami-04deb8a0752771def |
-| eu-west-1      | ami-016e35ee4a8c3582b |
-| eu-west-2      | ami-05dbd8a05acfee60e |
-| eu-west-3      | ami-014c36de1d71f586d |
-| sa-east-1      | ami-059bb17aea125dd58 |
-| us-east-1      | ami-0f8ffd533f9769fcd |
-| us-east-2      | ami-0876ccee5f0f3b9e5 |
-| us-west-1      | ami-03fa5682e71b47467 |
-| us-west-2      | ami-0436aba3a0365431f |
+| ap-northeast-1 | ami-05fbe6b21fcbb1b52 |
+| ap-northeast-2 | ami-0f3d3cf3fe9f0199c |
+| ap-south-1     | ami-04f1c6f1955d5c114 |
+| ap-southeast-1 | ami-0f27b2cff380e0406 |
+| ap-southeast-2 | ami-02aba81308b5d05fc |
+| ca-central-1   | ami-04845b738e5e77177 |
+| eu-central-1   | ami-0af6a9af060acc703 |
+| eu-west-1      | ami-04dcb954d7e44aaeb |
+| eu-west-2      | ami-0c1371ff42fa89e9f |
+| eu-west-3      | ami-09c9b25e3633a181f |
+| sa-east-1      | ami-0904d8434af05e537 |
+| us-east-1      | ami-09c403a6346e8def5 |
+| us-east-2      | ami-0d4b927581a37d403 |
+| us-west-1      | ami-00485972f66eca827 |
+| us-west-2      | ami-0975a798bac31eb8f |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-069b275e5f9a02211 |
-| ap-northeast-2 | ami-0e8e27098a2f64cf7 |
-| ap-south-1     | ami-06ba30d00985fe275 |
-| ap-southeast-1 | ami-04acd5ce4c66321e4 |
-| ap-southeast-2 | ami-01ed8512b5adcc384 |
-| ca-central-1   | ami-0195af1fe8445b99c |
-| eu-central-1   | ami-064d96ba02543e415 |
-| eu-west-1      | ami-0b004abc64943b838 |
-| eu-west-2      | ami-03a010f668cdcec6a |
-| eu-west-3      | ami-0aa0836984f5061c1 |
-| sa-east-1      | ami-03434718d30fb96ca |
-| us-east-1      | ami-0d0090b1c292f4777 |
-| us-east-2      | ami-08a798b6238ded07b |
-| us-west-1      | ami-061613a533cbf9813 |
-| us-west-2      | ami-07b651eb834fb95f0 |
+| ap-northeast-1 | ami-0a7f4102cf87f58e9 |
+| ap-northeast-2 | ami-0572c0c6d721d6b62 |
+| ap-south-1     | ami-06cc8349b51f9121b |
+| ap-southeast-1 | ami-06cab2e551e2293c7 |
+| ap-southeast-2 | ami-0082e037dce9c53a4 |
+| ca-central-1   | ami-08603d910808cc213 |
+| eu-central-1   | ami-0ad8201f04a19e793 |
+| eu-west-1      | ami-041fd27b7d9badf08 |
+| eu-west-2      | ami-0155075f79ab12a77 |
+| eu-west-3      | ami-0068456e48925c629 |
+| sa-east-1      | ami-0e69de9ee4bfbbc67 |
+| us-east-1      | ami-0673637b08f918c45 |
+| us-east-2      | ami-09428229c8d4a21a4 |
+| us-west-1      | ami-0094a2ee1ee2f115f |
+| us-west-2      | ami-0edc13980e9f24efa |
 
-## Kubernetes Version v1.14.3
+## Kubernetes Version v1.14.4
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-024785f752f237247 |
-| ap-northeast-2 | ami-0be165aeb15b841ca |
-| ap-south-1     | ami-06fa8c0a5fba85134 |
-| ap-southeast-1 | ami-0e9b1021997e60a3a |
-| ap-southeast-2 | ami-03ee73a57dd600f64 |
-| ca-central-1   | ami-0e4e906c5d6152344 |
-| eu-central-1   | ami-062f7f988211f726e |
-| eu-west-1      | ami-0ce754ab137e593b2 |
-| eu-west-2      | ami-04473e776956e5193 |
-| eu-west-3      | ami-0063a4ea56373b1c8 |
-| sa-east-1      | ami-05208b2f92f1ed77f |
-| us-east-1      | ami-039e523f964eef9e7 |
-| us-east-2      | ami-0acf32832568654fe |
-| us-west-1      | ami-00aa3e254263b7ce9 |
-| us-west-2      | ami-045528490d52d3799 |
+| ap-northeast-1 | ami-09faee6f49ae3b0cb |
+| ap-northeast-2 | ami-0280c42a0a42c4047 |
+| ap-south-1     | ami-0f2a5e4c737923cd5 |
+| ap-southeast-1 | ami-0ae24924d9c7d7774 |
+| ap-southeast-2 | ami-0c4af52e138762c75 |
+| ca-central-1   | ami-0c867762156dd09d9 |
+| eu-central-1   | ami-03c90b13903764bda |
+| eu-west-1      | ami-0ec14cdd4d468c2c1 |
+| eu-west-2      | ami-05554269c8b63da6d |
+| eu-west-3      | ami-0b5ee95db30104b61 |
+| sa-east-1      | ami-0263d92a034e0c162 |
+| us-east-1      | ami-00295ce418da7c227 |
+| us-east-2      | ami-092d9d6a36468257d |
+| us-west-1      | ami-0ca199cb4a97545ce |
+| us-west-2      | ami-01ebf5bb7eb9585ba |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0e34e9f16f68f3972 |
-| ap-northeast-2 | ami-05154bcda50c819d7 |
-| ap-south-1     | ami-07acdcaeaeb6473ce |
-| ap-southeast-1 | ami-0922256840fc0998b |
-| ap-southeast-2 | ami-0f16fb0643114e205 |
-| ca-central-1   | ami-04c463b88d62733e8 |
-| eu-central-1   | ami-0dceedaa37f1b46d1 |
-| eu-west-1      | ami-03a9efabf59bec704 |
-| eu-west-2      | ami-0b5f6ce174343a061 |
-| eu-west-3      | ami-05139da88e4f192d3 |
-| sa-east-1      | ami-08a1eed5b71ba1da1 |
-| us-east-1      | ami-097e99c007d70e9bc |
-| us-east-2      | ami-01ba1ef7ddda5f6ee |
-| us-west-1      | ami-087a63cb44f810fa2 |
-| us-west-2      | ami-0a8f182b86e6ad21f |
+| ap-northeast-1 | ami-00977d8ac6c50749b |
+| ap-northeast-2 | ami-0cd86a92035ef5175 |
+| ap-south-1     | ami-04582f101f0d80109 |
+| ap-southeast-1 | ami-01f46a7f42305a150 |
+| ap-southeast-2 | ami-0e6abf8710224441a |
+| ca-central-1   | ami-085d5a79d8516d9c0 |
+| eu-central-1   | ami-01ad2520903a2bf22 |
+| eu-west-1      | ami-07e4e16274bd41b75 |
+| eu-west-2      | ami-06dfa319d465d85e7 |
+| eu-west-3      | ami-019842007c3bff5f3 |
+| sa-east-1      | ami-07b67d0ffbf042911 |
+| us-east-1      | ami-033dcda62494cf82b |
+| us-east-2      | ami-0cf28ce2e4d1c46bf |
+| us-west-1      | ami-0bb5b4340fdcbb541 |
+| us-west-2      | ami-0abfd3dd7e978234e |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-01a40b0f437d526ae |
-| ap-northeast-2 | ami-062eabeb8982d2b07 |
-| ap-south-1     | ami-0716a3178c4ae8184 |
-| ap-southeast-1 | ami-057b8b67ca2636126 |
-| ap-southeast-2 | ami-0294f4ac18d26bb89 |
-| ca-central-1   | ami-091c6c59d734ba269 |
-| eu-central-1   | ami-00783ad1ae427f479 |
-| eu-west-1      | ami-0ce14f5dd835c0200 |
-| eu-west-2      | ami-0ce0e3229cbdeef72 |
-| eu-west-3      | ami-01b2c754b0396712b |
-| sa-east-1      | ami-0d067bab5fedb8f4a |
-| us-east-1      | ami-0bb94fdf6ce0d918c |
-| us-east-2      | ami-0cb7f202ebf82e0b5 |
-| us-west-1      | ami-043d894549993cef9 |
-| us-west-2      | ami-0becb1da3d9b18b49 |
+| ap-northeast-1 | ami-0fd94c8619ac56132 |
+| ap-northeast-2 | ami-09ed991499cb91539 |
+| ap-south-1     | ami-01b6cc5f00269f1e1 |
+| ap-southeast-1 | ami-0a052edcd2cbcee0f |
+| ap-southeast-2 | ami-0d7347b0a357a356e |
+| ca-central-1   | ami-04de6b048853cdcfa |
+| eu-central-1   | ami-0e2253baf26e2cc54 |
+| eu-west-1      | ami-064a6d45a3f8efb32 |
+| eu-west-2      | ami-0b13260b01d85f138 |
+| eu-west-3      | ami-0d613f7789acfb675 |
+| sa-east-1      | ami-0e4fdab8693c46e8d |
+| us-east-1      | ami-0117ebc3cd07994fc |
+| us-east-2      | ami-01ebb99e197ce1189 |
+| us-west-1      | ami-0c9a716b87d0767db |
+| us-west-2      | ami-0b7f66ff29f86637f |
+
+## Kubernetes Version v1.15.0
+
+### Amazon Linux 2
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-01de6bf0428c64095 |
+| ap-northeast-2 | ami-0d6591b92248f77d2 |
+| ap-south-1     | ami-06dbfdfea6717c575 |
+| ap-southeast-1 | ami-0be50f14bc06d8eb7 |
+| ap-southeast-2 | ami-00843a266441a88c4 |
+| ca-central-1   | ami-03a8b1dd7a0276f1c |
+| eu-central-1   | ami-02d9e4602e8b3672d |
+| eu-west-1      | ami-0cb5be8c87224018f |
+| eu-west-2      | ami-097db7d2b34299402 |
+| eu-west-3      | ami-0dc8c4e3d1de37279 |
+| sa-east-1      | ami-072e34fa40995e394 |
+| us-east-1      | ami-0a01f809ba34d218c |
+| us-east-2      | ami-0a2715c747c837a6d |
+| us-west-1      | ami-0c59a8040e2534132 |
+| us-west-2      | ami-0b2f29b69bd62ba8c |
+
+### CentOS 7
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-0a540601792641fc1 |
+| ap-northeast-2 | ami-007e41ddf07e6122e |
+| ap-south-1     | ami-0f004fc38a4a81ff3 |
+| ap-southeast-1 | ami-08504967a03fd9cc2 |
+| ap-southeast-2 | ami-0a502fccbb99c15ff |
+| ca-central-1   | ami-03e1567253e871535 |
+| eu-central-1   | ami-06eea567f8e1ea269 |
+| eu-west-1      | ami-0f525b01bbf0673b7 |
+| eu-west-2      | ami-0c21de4fc375c4494 |
+| eu-west-3      | ami-060855cf31f3cc41f |
+| sa-east-1      | ami-05ad74046e5f4587a |
+| us-east-1      | ami-00925e03285fc1b5a |
+| us-east-2      | ami-023901ce16cdadb42 |
+| us-west-1      | ami-0f75df4011be7efd9 |
+| us-west-2      | ami-087208dacd7912911 |
+
+### Ubuntu 18.04 (Bionic)
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-0689854f9b7612e60 |
+| ap-northeast-2 | ami-0faa7708dabe2b827 |
+| ap-south-1     | ami-032e345b1cb956785 |
+| ap-southeast-1 | ami-05f7e5b51211f8b82 |
+| ap-southeast-2 | ami-0a1a0dfb36656bca6 |
+| ca-central-1   | ami-0f4ec97080e5bcabd |
+| eu-central-1   | ami-07bfeedb5a7297db5 |
+| eu-west-1      | ami-0a31ed56fb49f9a9a |
+| eu-west-2      | ami-0e23a4c089fa6e02f |
+| eu-west-3      | ami-010f046b75799a561 |
+| sa-east-1      | ami-067cc4a8f1b683b3b |
+| us-east-1      | ami-030b08b03d05b947a |
+| us-east-2      | ami-0874f87c24a78dc20 |
+| us-west-1      | ami-0b86440572bb776d3 |
+| us-west-2      | ami-0e0f8310ee88200b7 |


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add AMIs for Kubernetes v1.13.8 and v1.14.4
- Update manifests to default to Kubernetes v1.14.4

**Release note**:
```release-note
- Update manifests to default to Kubernetes v1.14.4
```