### PR TITLE
feature: support set metric address

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -48,6 +48,8 @@ func main() {
 
 	profilerAddress := flag.String("profiler-address", "", "Bind address to expose the pprof profiler (e.g. localhost:6060)")
 
+	metricsAddress := flag.String("metrics-address", "", "Bind address to expose the metrics (e.g. localhost:8080)")
+
 	flag.Parse()
 	if *watchNamespace != "" {
 		klog.Infof("Watching cluster-api objects only in namespace %q for reconciliation", *watchNamespace)
@@ -71,6 +73,7 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		SyncPeriod: &syncPeriod,
 		Namespace:  *watchNamespace,
+		MetricsBindAddress: *metricsAddress,
 	})
 	if err != nil {
 		klog.Fatalf("Failed to set up overall controller manager: %v", err)


### PR DESCRIPTION
Fixes #906 

`./manager -metrics-address="localhost:1233"`

I0717 09:23:53.474902   14910 listener.go:40] controller-runtime/metrics "level"=0 "msg"="metrics server is starting to listen"  "addr"="localhost:1233"

`./manager`

main.go:79] Failed to set up overall controller manager: error listening on :8080: listen tcp :8080: bind: address already in use

as before log, the output of CIL is expected.

Signed-off-by: guohaowang <wangguohao.2009@gmail.com>