### PR TITLE
Do not update LB attachments or providerID in Exists

### DIFF
--- a/pkg/cloud/aws/actuators/machine_scope.go
+++ b/pkg/cloud/aws/actuators/machine_scope.go
@@ -127,6 +127,11 @@ func (m *MachineScope) Close() {
 		return
 	}
 
+	if m.Machine.Spec.ProviderID == nil || *m.Machine.Spec.ProviderID == "" {
+		providerID := fmt.Sprintf("aws:////%s", *m.MachineStatus.InstanceID)
+		m.Machine.Spec.ProviderID = &providerID
+	}
+
 	ext, err := v1alpha1.EncodeMachineSpec(m.MachineConfig)
 	if err != nil {
 		m.Error(err, "failed to encode machine spec")


### PR DESCRIPTION
**What this PR does / why we need it**:

- Moves the update of LB attachments and providerID from Exists to Update
- Always set providerID if unset.

**Release note**:
```release-note
- Moves the update of LB attachments and providerID from Exists to Update
- Always set providerID if unset.
```