### PR TITLE
Add AMIs for Kubernetes v1.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Note: These AMIs are not updated for security fixes and it is recommended to alw
 |                          | v1.14.3                 |
 |                          | v1.14.4                 |
 | v1.15                    | v1.15.0                 |
+|                          | v1.15.1                 |
 
 ------
 

--- a/docs/amis.md
+++ b/docs/amis.md
@@ -12,7 +12,7 @@
   - [Amazon Linux 2](#Amazon-Linux-2-1)
   - [CentOS 7](#CentOS-7-1)
   - [Ubuntu 18.04 (Bionic)](#Ubuntu-1804-Bionic-1)
-- [Kubernetes Version v1.15.0](#Kubernetes-Version-v1150)
+- [Kubernetes Version v1.15.1](#Kubernetes-Version-v1151)
   - [Amazon Linux 2](#Amazon-Linux-2-2)
   - [CentOS 7](#CentOS-7-2)
   - [Ubuntu 18.04 (Bionic)](#Ubuntu-1804-Bionic-2)
@@ -143,64 +143,64 @@
 | us-west-1      | ami-0c9a716b87d0767db |
 | us-west-2      | ami-0b7f66ff29f86637f |
 
-## Kubernetes Version v1.15.0
+## Kubernetes Version v1.15.1
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-01de6bf0428c64095 |
-| ap-northeast-2 | ami-0d6591b92248f77d2 |
-| ap-south-1     | ami-06dbfdfea6717c575 |
-| ap-southeast-1 | ami-0be50f14bc06d8eb7 |
-| ap-southeast-2 | ami-00843a266441a88c4 |
-| ca-central-1   | ami-03a8b1dd7a0276f1c |
-| eu-central-1   | ami-02d9e4602e8b3672d |
-| eu-west-1      | ami-0cb5be8c87224018f |
-| eu-west-2      | ami-097db7d2b34299402 |
-| eu-west-3      | ami-0dc8c4e3d1de37279 |
-| sa-east-1      | ami-072e34fa40995e394 |
-| us-east-1      | ami-0a01f809ba34d218c |
-| us-east-2      | ami-0a2715c747c837a6d |
-| us-west-1      | ami-0c59a8040e2534132 |
-| us-west-2      | ami-0b2f29b69bd62ba8c |
+| ap-northeast-1 | ami-0e58e3f4bb60ade9d |
+| ap-northeast-2 | ami-0383e2e510287a262 |
+| ap-south-1     | ami-0f8f54399198751e7 |
+| ap-southeast-1 | ami-0f434538a7bc58ece |
+| ap-southeast-2 | ami-00a90ef2edb1fdf09 |
+| ca-central-1   | ami-0245853872087b5b4 |
+| eu-central-1   | ami-0503824d4a8df4fba |
+| eu-west-1      | ami-06ada6bbe0976df66 |
+| eu-west-2      | ami-09a6ef88af3bae2a1 |
+| eu-west-3      | ami-02bd8b08deb79445a |
+| sa-east-1      | ami-054a930b61abda32b |
+| us-east-1      | ami-0f3f36c1160bc2dcc |
+| us-east-2      | ami-0441897b9c3ce00b1 |
+| us-west-1      | ami-0076f90a1f8076f8c |
+| us-west-2      | ami-06c17c8025e895751 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0a540601792641fc1 |
-| ap-northeast-2 | ami-007e41ddf07e6122e |
-| ap-south-1     | ami-0f004fc38a4a81ff3 |
-| ap-southeast-1 | ami-08504967a03fd9cc2 |
-| ap-southeast-2 | ami-0a502fccbb99c15ff |
-| ca-central-1   | ami-03e1567253e871535 |
-| eu-central-1   | ami-06eea567f8e1ea269 |
-| eu-west-1      | ami-0f525b01bbf0673b7 |
-| eu-west-2      | ami-0c21de4fc375c4494 |
-| eu-west-3      | ami-060855cf31f3cc41f |
-| sa-east-1      | ami-05ad74046e5f4587a |
-| us-east-1      | ami-00925e03285fc1b5a |
-| us-east-2      | ami-023901ce16cdadb42 |
-| us-west-1      | ami-0f75df4011be7efd9 |
-| us-west-2      | ami-087208dacd7912911 |
+| ap-northeast-1 | ami-0b57709c1fed2c874 |
+| ap-northeast-2 | ami-09d582c1595e74788 |
+| ap-south-1     | ami-0112ad62eab87e8eb |
+| ap-southeast-1 | ami-05af1b3d8adfefef1 |
+| ap-southeast-2 | ami-00a198f5726250d81 |
+| ca-central-1   | ami-03c49fe2ac326295c |
+| eu-central-1   | ami-0c6e06d5cd18f82d4 |
+| eu-west-1      | ami-066ba806c7a163319 |
+| eu-west-2      | ami-067c7a4ad74a28f12 |
+| eu-west-3      | ami-0f1cc942b7bf57415 |
+| sa-east-1      | ami-0048a2a842bc04a63 |
+| us-east-1      | ami-0a419267496471c82 |
+| us-east-2      | ami-0d15d44471b6ce025 |
+| us-west-1      | ami-0c2b67fd6e9f61d0e |
+| us-west-2      | ami-0af5561c212ca17a2 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0689854f9b7612e60 |
-| ap-northeast-2 | ami-0faa7708dabe2b827 |
-| ap-south-1     | ami-032e345b1cb956785 |
-| ap-southeast-1 | ami-05f7e5b51211f8b82 |
-| ap-southeast-2 | ami-0a1a0dfb36656bca6 |
-| ca-central-1   | ami-0f4ec97080e5bcabd |
-| eu-central-1   | ami-07bfeedb5a7297db5 |
-| eu-west-1      | ami-0a31ed56fb49f9a9a |
-| eu-west-2      | ami-0e23a4c089fa6e02f |
-| eu-west-3      | ami-010f046b75799a561 |
-| sa-east-1      | ami-067cc4a8f1b683b3b |
-| us-east-1      | ami-030b08b03d05b947a |
-| us-east-2      | ami-0874f87c24a78dc20 |
-| us-west-1      | ami-0b86440572bb776d3 |
-| us-west-2      | ami-0e0f8310ee88200b7 |
+| ap-northeast-1 | ami-07955fd72a6e50be2 |
+| ap-northeast-2 | ami-05fbe6201fc8eacbd |
+| ap-south-1     | ami-006b4054e077061ca |
+| ap-southeast-1 | ami-067b9ee05354c3980 |
+| ap-southeast-2 | ami-065dca0c511d9f4c8 |
+| ca-central-1   | ami-0fd69802297e6c2f4 |
+| eu-central-1   | ami-048bc8041f2cffeca |
+| eu-west-1      | ami-0431e73ee64723785 |
+| eu-west-2      | ami-053c4ea1fe6ee9b1e |
+| eu-west-3      | ami-01ca487850d19500f |
+| sa-east-1      | ami-02dbe923215930789 |
+| us-east-1      | ami-0b5f3581ddf3aa573 |
+| us-east-2      | ami-0c6d91ea2ac6ec341 |
+| us-west-1      | ami-0b15ede7ae6b9e539 |
+| us-west-2      | ami-0ed01a97c9f036c18 |


### PR DESCRIPTION
**What this PR does / why we need it**:
Add AMIs for Kubernetes v1.15.1

**Release note**:
```release-note
NONE
```