### PR TITLE
[0.3] Add ownerRef to kubeconfig secret, fix NPE in MachineScope

### DIFF
--- a/pkg/cloud/aws/actuators/cluster/actuator.go
+++ b/pkg/cloud/aws/actuators/cluster/actuator.go
@@ -123,6 +123,14 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 		kubeConfigSecret := &apiv1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: kubeConfigSecretName,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: cluster.APIVersion,
+						Kind:       cluster.Kind,
+						Name:       cluster.Name,
+						UID:        cluster.UID,
+					},
+				},
 			},
 			StringData: map[string]string{
 				"value": kubeConfig,

--- a/pkg/cloud/aws/actuators/machine_scope.go
+++ b/pkg/cloud/aws/actuators/machine_scope.go
@@ -127,7 +127,7 @@ func (m *MachineScope) Close() {
 		return
 	}
 
-	if m.Machine.Spec.ProviderID == nil || *m.Machine.Spec.ProviderID == "" {
+	if m.MachineStatus.InstanceID != nil && (m.Machine.Spec.ProviderID == nil || *m.Machine.Spec.ProviderID == "") {
 		providerID := fmt.Sprintf("aws:////%s", *m.MachineStatus.InstanceID)
 		m.Machine.Spec.ProviderID = &providerID
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #925 
Fixes #928

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```