### PR TITLE
Cluster actuator: Remove the control plane ready annotation if no control plane machine is ready

### DIFF
--- a/pkg/cloud/aws/actuators/cluster/actuator.go
+++ b/pkg/cloud/aws/actuators/cluster/actuator.go
@@ -165,7 +165,7 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 		return nil
 	}
 
-	log.Info("Cluster does not have ready annotation - checking for ready control plane machines")
+	log.Info("Cluster does not have the control plane ready annotation - checking for ready control plane machines")
 
 	machines, err := a.client.Machines(cluster.Namespace).List(actuators.ListOptionsForCluster(cluster.Name))
 	if err != nil {
@@ -187,7 +187,7 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 		return &controllerError.RequeueAfterError{RequeueAfter: waitForControlPlaneMachineDuration}
 	}
 
-	log.Info("Setting cluster ready annotation")
+	log.Info("Setting control plane ready annotation")
 	cluster.Annotations[v1alpha1.AnnotationControlPlaneReady] = v1alpha1.ValueReady
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The control plane ready annotation should be removed when no control plane machines are ready, as is the case when all such machines are deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #936

**Special notes for your reviewer**:
The cluster actuator is responsible for changing the annotation. It does that whenever the cluster controller reconciles the cluster. In theory, the annotation can be removed as soon as there are no ready control plane machines. But that may not immediately trigger a cluster reconciliation.

For now, the annotation is _eventually_ removed, namely when the cluster controller reconciles the cluster for the first time after no control plane machines are ready.

Until the cluster is reconciled, creating a new control plane machine will fail, since the machine actuator will try to join the machine, though it has to init instead. Here's what this looks like:

Control plane machine is deleted:
```
I0730 00:16:34.307557       1 machine_controller.go:115] Reconciling Machine "remove-annotation-controlplane-0"                                                                                                                        
I0730 00:16:34.307603       1 machine_controller.go:157] Reconciling machine "remove-annotation-controlplane-0" triggers delete                                                                                                        
I0730 00:16:34.307628       1 actuator.go:248] [machine-actuator] "level"=0 "msg"="Deleting machine in cluster"  "cluster-name"="remove-annotation" "machine-name"="remove-annotation-controlplane-0" "machine-namespace"="default"    
I0730 00:16:34.310423       1 instances.go:105] [machine-actuator]/cluster.k8s.io/v1alpha1/default/remove-annotation/remove-annotation-controlplane-0 "level"=2 "msg"="Looking for instance by id"  "instance-id"="i-03c963ec8712d9447"
I0730 00:16:34.534507       1 actuator.go:284] [machine-actuator] "level"=0 "msg"="Terminating machine"                                                                                                                                
I0730 00:16:34.534582       1 instances.go:423] [machine-actuator]/cluster.k8s.io/v1alpha1/default/remove-annotation/remove-annotation-controlplane-0 "level"=2 "msg"="Attempting to terminate instance"  "instance-id"="i-03c963ec8712
d9447"                                                                                                                                                                                                                                 
I0730 00:16:34.707048       1 instances.go:433] [machine-actuator]/cluster.k8s.io/v1alpha1/default/remove-annotation/remove-annotation-controlplane-0 "level"=2 "msg"="Terminated instance"  "instance-id"="i-03c963ec8712d9447"       
I0730 00:16:34.708749       1 machine_controller.go:173] Deleting node "ip-10-0-0-110.us-west-2.compute.internal" is not allowed for machine "remove-annotation-controlplane-0": last control plane member                             
I0730 00:16:34.908308       1 machine_controller.go:193] Machine "remove-annotation-controlplane-0" deletion successful   
```

Control plane machine is created. Note that the machine actuator decides the machine needs to join, because the annotation exists.
```
I0730 00:18:49.347687       1 machine_controller.go:115] Reconciling Machine "remove-annotation-controlplane-0"                                                                                                                        
I0730 00:18:49.347895       1 actuator.go:418] [machine-actuator] "level"=0 "msg"="Checking if machine exists in cluster"  "cluster-name"="remove-annotation" "machine-name"="remove-annotation-controlplane-0" "machine-namespace"="de
fault"
I0730 00:18:49.411309       1 machine_controller.go:219] Reconciling machine object remove-annotation-controlplane-0 triggers idempotent create.
I0730 00:18:49.411431       1 actuator.go:116] [machine-actuator] "level"=0 "msg"="Processing machine creation" "cluster-name"="remove-annotation" "machine-name"="remove-annotation-controlplane-0" "namespace"="default" 
I0730 00:18:49.607091       1 actuator.go:132] [machine-actuator] "level"=0 "msg"="Retrieving machines for cluster" "cluster-name"="remove-annotation" "machine-name"="remove-annotation-controlplane-0" "namespace"="default" 
I0730 00:19:21.906492       1 actuator.go:156] [machine-actuator] "level"=0 "msg"="Machine will join the cluster" "cluster-name"="remove-annotation" "machine-name"="remove-annotation-controlplane-0" "namespace"="default" 
W0730 00:19:22.017182       1 machine_controller.go:226] Failed to create machine "remove-annotation-controlplane-0": failed to create new bootstrap token: Post https://remove-annotation-apiserver-1981756551.us-west-2.elb.amazonaws
.com:6443/api/v1/namespaces/kube-system/secrets: EOF
```

The machine actuator continue to try to join the machine. At some point, the cluster actuator reconciles the cluster, sees that no control plane machines are ready, and removes the annotation:
```
I0730 00:26:09.913063       1 cluster_controller.go:92] Running reconcile Cluster for "remove-annotation"                                                                                                                              
I0730 00:26:09.913120       1 machine_controller.go:115] Reconciling Machine "remove-annotation-controlplane-0"                                                                                                                        
I0730 00:26:09.913159       1 cluster_controller.go:160] reconciling cluster object remove-annotation triggers idempotent reconcile. 
...
I0730 00:26:14.476411       1 actuator.go:163] [cluster-actuator] "level"=0 "msg"="Cluster has the control plane ready annotation" "cluster-name"="remove-annotation" "cluster-namespace"="default"                                    
I0730 00:26:14.476496       1 actuator.go:167] [cluster-actuator] "level"=0 "msg"="No control plane machines are ready - removing the control plane ready annotation" "cluster-name"="remove-annotation" "cluster-namespace"="default" 
```

If this behavior is a bug, or it is correct, but you can suggest a better approach. please leave a comment. Thanks!