### PR TITLE
Fix error with `make clean-bazel-mocks` when bazel-bin/pkg does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ clean-bazel: ## Remove all generated bazel symlinks
 
 .PHONY: clean-bazel-mocks
 clean-bazel-mocks: ## Remove all generated bazel mocks files
-	find bazel-bin/pkg -name '*_mock.go' -type f -delete
+	if [[ -d "bazel-bin/pkg" ]]; then find bazel-bin/pkg -name '*_mock.go' -type f -delete; fi
 
 .PHONY: clean-bin
 clean-bin: ## Remove all generated binaries


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix error with `make clean-bazel-mocks` when bazel-bin/pkg does not exist


**Release note**:
```release-note
NONE
```