### PR TITLE
[0.3] Update clusterawsadm bootstrap policy

### DIFF
--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -178,6 +178,7 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 					"ec2:DescribeSecurityGroups",
 					"ec2:DescribeSubnets",
 					"ec2:DescribeVpcs",
+					"ec2:DescribeVpcAttribute",
 					"ec2:DescribeVolumes",
 					"ec2:DetachInternetGateway",
 					"ec2:DisassociateRouteTable",


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a missing IAM policy action for the CAPA controllers.

**Release note**:
```release-note
- clusterawsadm now deploys the proper policy with permission for describing vpc attributes
```