### PR TITLE
Fix integration test error

### DIFF
--- a/scripts/ci-bazel-integration.sh
+++ b/scripts/ci-bazel-integration.sh
@@ -21,7 +21,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}/hack/ensure-go.sh"
 cd "${REPO_ROOT}" || exit 1
 
-bazel test --define='gotags=integration' --test_output all //test/integration/...
+bazel test --define='gotags=integration' --test_output all --host_force_python=PY2 //test/integration/...
 bazel_status="${?}"
 python hack/coalesce.py
 exit "${bazel_status}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bazel error when running the integration tests from prow

**Release note**:
```release-note
NONE
```