### PR TITLE
Remove generation from v1alpha1 types

### DIFF
--- a/cmd/clusterawsadm/client/BUILD.bazel
+++ b/cmd/clusterawsadm/client/BUILD.bazel
@@ -6,8 +6,6 @@ go_library(
     importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/client",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/awsprovider/v1alpha1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset:go_default_library",
     ],

--- a/cmd/clusterawsadm/client/client.go
+++ b/cmd/clusterawsadm/client/client.go
@@ -23,9 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	providerv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
@@ -58,21 +56,4 @@ func homeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
-}
-
-// MachineInstanceID gets an instance ID for a Cluster API machine
-func MachineInstanceID(name string) (string, error) {
-	c := NewClient()
-
-	m, err := c.ClusterDeprecatedV1alpha1().Machines("default").Get(name, v1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	status, err := providerv1.MachineStatusFromProviderStatus(m.Status.ProviderStatus)
-	if err != nil {
-		return "", err
-	}
-
-	return *status.InstanceID, nil
 }

--- a/cmd/clusterawsadm/cmd/alpha/migrate/BUILD
+++ b/cmd/clusterawsadm/cmd/alpha/migrate/BUILD
@@ -6,7 +6,7 @@ go_library(
     importpath = "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/alpha/migrate",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/awsprovider/v1alpha1:go_default_library",
+        "//pkg/apis/infrastructure/v1alpha2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi:go_default_library",

--- a/cmd/clusterawsadm/cmd/alpha/migrate/migrate.go
+++ b/cmd/clusterawsadm/cmd/alpha/migrate/migrate.go
@@ -25,7 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	awstags "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/infrastructure/v1alpha2"
 )
 
 var (
@@ -133,7 +133,7 @@ func applyNewTags(svc *awstags.ResourceGroupsTaggingAPI, arns []*string, name st
 		input := &awstags.TagResourcesInput{
 			ResourceARNList: arns[i*maxARNs : end],
 			Tags: map[string]*string{
-				v1alpha1.ClusterTagKey(name): aws.String("owned"),
+				v1alpha2.ClusterTagKey(name): aws.String("owned"),
 			},
 		}
 

--- a/pkg/apis/awsprovider/v1alpha1/doc.go
+++ b/pkg/apis/awsprovider/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=awsprovider.k8s.io
+// If regeneration is necessary use this tag: // +groupName=awsprovider.k8s.io
 package v1alpha1

--- a/pkg/apis/awsprovider/v1alpha1/register.go
+++ b/pkg/apis/awsprovider/v1alpha1/register.go
@@ -21,7 +21,6 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=awsprovider.k8s.io
 package v1alpha1
 
 import (

--- a/pkg/cloud/filter/BUILD.bazel
+++ b/pkg/cloud/filter/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     importpath = "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/filter",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/awsprovider/v1alpha1:go_default_library",
+        "//pkg/apis/infrastructure/v1alpha2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
     ],

--- a/pkg/cloud/filter/ec2.go
+++ b/pkg/cloud/filter/ec2.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/infrastructure/v1alpha2"
 )
 
 const (
@@ -42,7 +42,7 @@ type ec2Filters struct{}
 func (ec2Filters) Cluster(clusterName string) *ec2.Filter {
 	return &ec2.Filter{
 		Name:   aws.String(filterNameTagKey),
-		Values: aws.StringSlice([]string{v1alpha1.ClusterTagKey(clusterName)}),
+		Values: aws.StringSlice([]string{v1alpha2.ClusterTagKey(clusterName)}),
 	}
 }
 
@@ -58,8 +58,8 @@ func (ec2Filters) Name(name string) *ec2.Filter {
 // the resource is owned
 func (ec2Filters) ClusterOwned(clusterName string) *ec2.Filter {
 	return &ec2.Filter{
-		Name:   aws.String(fmt.Sprintf("tag:%s", v1alpha1.ClusterTagKey(clusterName))),
-		Values: aws.StringSlice([]string{string(v1alpha1.ResourceLifecycleOwned)}),
+		Name:   aws.String(fmt.Sprintf("tag:%s", v1alpha2.ClusterTagKey(clusterName))),
+		Values: aws.StringSlice([]string{string(v1alpha2.ResourceLifecycleOwned)}),
 	}
 }
 
@@ -67,15 +67,15 @@ func (ec2Filters) ClusterOwned(clusterName string) *ec2.Filter {
 // the resource is shared.
 func (ec2Filters) ClusterShared(clusterName string) *ec2.Filter {
 	return &ec2.Filter{
-		Name:   aws.String(fmt.Sprintf("tag:%s", v1alpha1.ClusterTagKey(clusterName))),
-		Values: aws.StringSlice([]string{string(v1alpha1.ResourceLifecycleShared)}),
+		Name:   aws.String(fmt.Sprintf("tag:%s", v1alpha2.ClusterTagKey(clusterName))),
+		Values: aws.StringSlice([]string{string(v1alpha2.ResourceLifecycleShared)}),
 	}
 }
 
 // ProviderRole returns a filter using cluster-api-provider-aws role tag.
 func (ec2Filters) ProviderRole(role string) *ec2.Filter {
 	return &ec2.Filter{
-		Name:   aws.String(fmt.Sprintf("tag:%s", v1alpha1.NameAWSClusterAPIRole)),
+		Name:   aws.String(fmt.Sprintf("tag:%s", v1alpha2.NameAWSClusterAPIRole)),
 		Values: aws.StringSlice([]string{role}),
 	}
 }


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:

This PR removes CRD generation from v1alpha1 types. We no longer need to generate CRDs from the v1alpha1 types but we will need to generate deep copy and other code. We keep the types around for the upgrade tool that will be built here.

This unblocks us from keeping this repo up-to-date with a controller-gen style config directory and a single `kustomize.yaml` file to generate all necessary CRDs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #968 

**Special notes for your reviewer**:
The deleted code in `clusterawsadm` is unused.

**Release note**:
```release-note
NONE
```

/assign @ncdc @detiber 