### PR TITLE
increase size of bazel e2e test

### DIFF
--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -25,7 +25,7 @@ alias(
 
 go_test(
     name = "go_default_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "aws_test.go",
         "e2e_suite_test.go",


### PR DESCRIPTION
**What this PR does / why we need it**:

Increases the "size" of the e2e test in bazel, to avoid timeouts that we've been hitting in the periodics.

**Release note**:
```release-note
NONE
```