### PR TITLE
fix for AMI build to detect Amazon Linux

### DIFF
--- a/build/amis/ansible/roles/common/tasks/redhat.yml
+++ b/build/amis/ansible/roles/common/tasks/redhat.yml
@@ -55,4 +55,4 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
+  when: ansible_distribution == "Amazon"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The AMI build process doesn't recognize Amazon Linux properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #978 

**Special notes for your reviewer**:
`ansible_distribution_major_version` is `2`. I think you may have wanted `ansible_distribution_release` which is `NA` but I didn't see any reason why that was necessary. Can add it if there is.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```