### PR TITLE
Guard against missing instanceID on delete

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -261,7 +261,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return errors.Errorf("failed to get instance: %+v", err)
 	}
 
-	if instance == nil {
+	if instance == nil || instance.ID == "" {
 		instance, err = ec2svc.InstanceByTags(scope)
 		if err != nil {
 			return errors.Errorf("failed to query instance by tags: %+v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Guard against missing instanceID on delete

**Release note**:
```release-note
Guard against missing instanceID when deleting Machines
```