### PR TITLE
userdata: Fix cloud-init header

### DIFF
--- a/pkg/cloud/services/userdata/userdata.go
+++ b/pkg/cloud/services/userdata/userdata.go
@@ -24,10 +24,8 @@ import (
 )
 
 const (
-	cloudConfigHeader = `## template: jinja
-#cloud-config
-`
-	defaultHeader = `#!/usr/bin/env bash
+	cloudConfigHeader = "#cloud-config"
+	defaultHeader     = `#!/usr/bin/env bash
 
 # Copyright 2018 by the contributors
 #


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Amazon Linux 2 has strict validation of the cloud-init
header and rejects `##template`.


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Set correct header for cloud-init userdata
```