### PR TITLE
fix: update rbac for working with Cluster objects, enable status endpoint

### DIFF
--- a/config/crds/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crds/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -11,6 +11,8 @@ spec:
     kind: AWSCluster
     plural: awsclusters
   scope: ""
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: AWSCluster is the Schema for the awsclusters API
@@ -335,11 +337,9 @@ spec:
                               format: int64
                               type: integer
                           required:
-                          - cidrBlocks
                           - description
                           - fromPort
                           - protocol
-                          - sourceSecurityGroupIds
                           - toPort
                           type: object
                         type: array
@@ -354,7 +354,6 @@ spec:
                         type: object
                     required:
                     - id
-                    - ingressRule
                     - name
                     type: object
                   description: SecurityGroups is a map from the role/kind of the security

--- a/config/crds/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crds/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -11,6 +11,8 @@ spec:
     kind: AWSMachine
     plural: awsmachines
   scope: ""
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: AWSMachine is the Schema for the awsmachines API

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,8 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - awsclusters
+  - awsclusters/status
   - awsmachines
   - awsmachines/status
   verbs:

--- a/pkg/apis/infrastructure/v1alpha2/awscluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/awscluster_types.go
@@ -134,6 +134,7 @@ type APIEndpoint struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:subresource:status
 
 // AWSCluster is the Schema for the awsclusters API
 // +k8s:openapi-gen=true

--- a/pkg/apis/infrastructure/v1alpha2/awsmachine_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/awsmachine_types.go
@@ -140,6 +140,7 @@ type AWSMachineStatus struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:subresource:status
 
 // AWSMachine is the Schema for the awsmachines API
 // +k8s:openapi-gen=true

--- a/pkg/apis/infrastructure/v1alpha2/types.go
+++ b/pkg/apis/infrastructure/v1alpha2/types.go
@@ -244,6 +244,7 @@ type SecurityGroup struct {
 	Name string `json:"name"`
 
 	// IngressRules is the inbound rules associated with the security group.
+	// +optional
 	IngressRules IngressRules `json:"ingressRule"`
 
 	// Tags is a map of tags associated with the security group.
@@ -286,9 +287,11 @@ type IngressRule struct {
 	ToPort      int64                 `json:"toPort"`
 
 	// List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
+	// +optional
 	CidrBlocks []string `json:"cidrBlocks"`
 
 	// The security group id to allow access from. Cannot be specified with CidrBlocks.
+	// +optional
 	SourceSecurityGroupIDs []string `json:"sourceSecurityGroupIds"`
 }
 

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -138,10 +138,17 @@ func (s *ClusterScope) ListOptionsLabelSelector() client.ListOptionFunc {
 func (s *ClusterScope) Close() error {
 	ctx := context.TODO()
 
+	// TODO: remove when patch bug is fixed. Currently patches
+	// result in GVK info being removed from the object
+	gvk := s.AWSCluster.GroupVersionKind()
+
 	// Patch Cluster object.
 	if err := s.client.Patch(ctx, s.AWSCluster, s.awsClusterPatch); err != nil {
 		return errors.Wrapf(err, "error patching AWSCluster %s/%s", s.Cluster.Namespace, s.Cluster.Name)
 	}
+
+	// TODO: remove when patch bug is fixed
+	s.AWSCluster.SetGroupVersionKind(gvk)
 
 	// Patch Cluster status.
 	if err := s.client.Status().Patch(ctx, s.AWSCluster, s.awsClusterPatch); err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -25,7 +25,7 @@ import (
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=awsprovider.k8s.io,resources=awsclusterproviderconfigs;awsclusterproviderstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status;clusters;clusters/status,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachines;awsmachines/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachines;awsmachines/status;awsclusters;awsclusters/status,verbs=get;list;watch;create;update;patch;delete
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
1. Update RBAC to allow working with AWSCluster objects
2. Enable the status endpoint
3. Some fields in the network status needed to be made optional based on their behaviors in AWS. There may be more out there but these are the ones that blocked me.
4. Another edition of everyone's favorite GVK patch hack

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
RBAC/CRD manifest updates
```