### PR TITLE
fix: base64 decode bootstrap data

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -204,7 +204,7 @@ func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, er
 	switch scope.Role() {
 	case "node":
 		// Just the common security groups above
-	case "controlplane":
+	case "control-plane":
 		sgRoles = append(sgRoles, v1alpha2.SecurityGroupControlPlane)
 	default:
 		return nil, errors.Errorf("Unknown node role %q", scope.Role())
@@ -272,8 +272,13 @@ func (s *Service) runInstance(role string, i *v1alpha2.Instance) (*v1alpha2.Inst
 	if i.UserData != nil {
 		var buf bytes.Buffer
 
+		decoded, err := base64.StdEncoding.DecodeString(*i.UserData)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode bootstrapData")
+		}
+
 		gz := gzip.NewWriter(&buf)
-		if _, err := gz.Write([]byte(*i.UserData)); err != nil {
+		if _, err := gz.Write(decoded); err != nil {
 			return nil, errors.Wrap(err, "failed to gzip userdata")
 		}
 

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -245,7 +245,8 @@ func TestCreateInstance(t *testing.T) {
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						Data: pointer.StringPtr("user-data"),
+						// echo "user-data" | base64
+						Data: pointer.StringPtr("dXNlci1kYXRhCg=="),
 					},
 				},
 			},
@@ -333,7 +334,8 @@ func TestCreateInstance(t *testing.T) {
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						Data: pointer.StringPtr("user-data"),
+						// echo "user-data" | base64
+						Data: pointer.StringPtr("dXNlci1kYXRhCg=="),
 					},
 				},
 			},
@@ -469,7 +471,8 @@ func TestCreateInstance(t *testing.T) {
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						Data: pointer.StringPtr("user-data"),
+						// echo "user-data" | base64
+						Data: pointer.StringPtr("dXNlci1kYXRhCg=="),
 					},
 				},
 			}


### PR DESCRIPTION
Signed-off-by: Andrew Rudoi <arudoi@newrelic.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Decodes bootstrap data. The bootstrap provider sets the bootstrap data as a base64-encoded string, so we must decode it.

Also snuck in a small typo fix. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```