### PR TITLE
fix: pass cluster into machinescope return

### DIFF
--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -63,6 +63,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 	return &MachineScope{
 		client:     params.Client,
 		patch:      client.MergeFrom(params.AWSMachine.DeepCopy()),
+		Cluster:    params.Cluster,
 		Machine:    params.Machine,
 		AWSMachine: params.AWSMachine,
 		Logger:     params.Logger,

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -52,6 +52,9 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 	if params.Machine == nil {
 		return nil, errors.New("machine is required when creating a MachineScope")
 	}
+	if params.Cluster == nil {
+		return nil, errors.New("cluster is required when creating a MachineScope")
+	}
 	if params.AWSMachine == nil {
 		return nil, errors.New("aws machine is required when creating a MachineScope")
 	}


### PR DESCRIPTION
Signed-off-by: Andrew Rudoi <arudoi@newrelic.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cluster wasn't being passed through NewMachineScope, causing an NPE later down the line. I was on the fence about adding the nil check here because I thought we didn't need a cluster to make Machines even in v1a2, but most of the other helpers return hard errors when there's no cluster object so I followed that pattern. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```