### PR TITLE
Change APIServer healthcheck to SSL protocol

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -148,7 +148,7 @@ func (s *Service) getAPIServerClassicELBSpec() *v1alpha2.ClassicELB {
 			},
 		},
 		HealthCheck: &v1alpha2.ClassicELBHealthCheck{
-			Target:             fmt.Sprintf("%v:%d", v1alpha2.ClassicELBProtocolTCP, 6443),
+			Target:             fmt.Sprintf("%v:%d", v1alpha2.ClassicELBProtocolSSL, 6443),
 			Interval:           10 * time.Second,
 			Timeout:            5 * time.Second,
 			HealthyThreshold:   5,


### PR DESCRIPTION

Signed-off-by: John Harris <joharris@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
When the healthcheck protocol is TCP the APIServer logs are
constantly spammed with Handshake EOF errors. This alters the
healthcheck target from `TCP:6443` to `SSL:6443`.

```
...
I0811 22:52:53.992577       1 log.go:172] http: TLS handshake error from 10.0.1.129:4224: EOF
I0811 22:52:54.630065       1 log.go:172] http: TLS handshake error from 10.0.1.203:16836: EOF
I0811 22:53:03.992780       1 log.go:172] http: TLS handshake error from 10.0.1.129:4240: EOF
...
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1000 

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```