### PR TITLE
[0.3]Update tags for managed subnets for Service type=LoadBalancer

### DIFF
--- a/pkg/cloud/aws/services/ec2/subnets.go
+++ b/pkg/cloud/aws/services/ec2/subnets.go
@@ -311,10 +311,16 @@ func (s *Service) deleteSubnet(id string) error {
 
 func (s *Service) getSubnetTagParams(id string, public bool) v1alpha1.BuildParams {
 	var role string
+	var additionalTags v1alpha1.Tags
+
 	if public {
 		role = v1alpha1.PublicRoleTagValue
 	} else {
 		role = v1alpha1.PrivateRoleTagValue
+		// Add tag needed for Service type=LoadBalancer
+		additionalTags = v1alpha1.Tags{
+			v1alpha1.NameKubernetesAWSCloudProviderPrefix + s.scope.Name(): string(v1alpha1.ResourceLifecycleShared),
+		}
 	}
 
 	var name strings.Builder
@@ -328,5 +334,6 @@ func (s *Service) getSubnetTagParams(id string, public bool) v1alpha1.BuildParam
 		Lifecycle:   v1alpha1.ResourceLifecycleOwned,
 		Name:        aws.String(name.String()),
 		Role:        aws.String(role),
+		Additional:  additionalTags,
 	}
 }

--- a/pkg/cloud/aws/services/ec2/subnets_test.go
+++ b/pkg/cloud/aws/services/ec2/subnets_test.go
@@ -107,6 +107,10 @@ func TestReconcileSubnets(t *testing.T) {
 										Key:   aws.String("Name"),
 										Value: aws.String("test-cluster-subnet-private"),
 									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("shared"),
+									},
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently creating a Service with type=LoadBalancer will fail with the existing managed private subnets, this change will let the subnet be returned by the cloud provider integration query and allow the LoadBalancer to be created

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1008 

**Release note**:
```release-note
Fixed bug where Service with type=LoadBalancer would fail on workload clusters.
```