### PR TITLE
Update tags for managed subnets for Service type=LoadBalancer

### DIFF
--- a/pkg/cloud/services/ec2/subnets.go
+++ b/pkg/cloud/services/ec2/subnets.go
@@ -316,10 +316,16 @@ func (s *Service) deleteSubnet(id string) error {
 
 func (s *Service) getSubnetTagParams(id string, public bool) v1alpha2.BuildParams {
 	var role string
+	var additionalTags v1alpha2.Tags
+
 	if public {
 		role = v1alpha2.PublicRoleTagValue
 	} else {
 		role = v1alpha2.PrivateRoleTagValue
+		// Add tag needed for Service type=LoadBalancer
+		additionalTags = v1alpha2.Tags{
+			v1alpha2.NameKubernetesAWSCloudProviderPrefix + s.scope.Name(): string(v1alpha2.ResourceLifecycleShared),
+		}
 	}
 
 	var name strings.Builder
@@ -333,5 +339,6 @@ func (s *Service) getSubnetTagParams(id string, public bool) v1alpha2.BuildParam
 		Lifecycle:   v1alpha2.ResourceLifecycleOwned,
 		Name:        aws.String(name.String()),
 		Role:        aws.String(role),
+		Additional:  additionalTags,
 	}
 }

--- a/pkg/cloud/services/ec2/subnets_test.go
+++ b/pkg/cloud/services/ec2/subnets_test.go
@@ -115,6 +115,10 @@ func TestReconcileSubnets(t *testing.T) {
 										Key:   aws.String("Name"),
 										Value: aws.String("test-cluster-subnet-private"),
 									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("shared"),
+									},
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Forward port of #1010 

**Release note**:
```release-note
Fixed bug where Service with type=LoadBalancer would fail on workload clusters.
```