### PR TITLE
fix: avoid duplicate nodeRole label in spec

### DIFF
--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -324,8 +324,10 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 	case "node":
 		s.scope.V(2).Info("Joining a worker node to the cluster")
 
+		kubeadmConfig := machine.MachineConfig.KubeadmConfiguration.Join.DeepCopy()
+
 		kubeadm.SetJoinConfigurationOptions(
-			&machine.MachineConfig.KubeadmConfiguration.Join,
+			kubeadmConfig,
 			kubeadm.WithBootstrapTokenDiscovery(
 				kubeadm.NewBootstrapTokenDiscovery(
 					kubeadm.WithAPIServerEndpoint(fmt.Sprintf("%s:%d", machine.Network().APIServerELB.DNSName, apiServerBindPort)),
@@ -335,7 +337,7 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 			),
 			kubeadm.WithJoinNodeRegistrationOptions(
 				kubeadm.SetNodeRegistrationOptions(
-					&machine.MachineConfig.KubeadmConfiguration.Join.NodeRegistration,
+					&kubeadmConfig.NodeRegistration,
 					kubeadm.WithNodeRegistrationName(hostnameLookup),
 					kubeadm.WithCRISocket(containerdSocket),
 					kubeadm.WithKubeletExtraArgs(map[string]string{"cloud-provider": cloudProvider}),
@@ -344,7 +346,7 @@ func (s *Service) createInstance(machine *actuators.MachineScope, bootstrapToken
 				),
 			),
 		)
-		joinConfigurationYAML, err := kubeadm.ConfigurationToYAML(&machine.MachineConfig.KubeadmConfiguration.Join)
+		joinConfigurationYAML, err := kubeadm.ConfigurationToYAML(kubeadmConfig)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Previously, we observed a machine that was repeatedly failing to create
(we wanted an m5.large, but we were already at our quota for m5.larges)
would get a new copy of the node role appended to its labels every time
it tried.

I don't think it would've hurt anything and so this is a low-priority
(v1alpha1-only) item to be sure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes issue where node-labels would grow unbounded if a machine could not be created
```