### PR TITLE
use cluster api patch helper to do the scope close

### DIFF
--- a/pkg/cloud/scope/BUILD.bazel
+++ b/pkg/cloud/scope/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/sigs.k8s.io/cluster-api/controllers/noderefutil:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/errors:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/util:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/util/patch:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -465,6 +465,7 @@ sigs.k8s.io/cluster-api/errors
 sigs.k8s.io/cluster-api/controllers/noderefutil
 sigs.k8s.io/cluster-api/util
 sigs.k8s.io/cluster-api/pkg/apis/deprecated/v1alpha1
+sigs.k8s.io/cluster-api/util/patch
 # sigs.k8s.io/controller-runtime v0.2.0-rc.0
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/scheme


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
fix issue: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1019
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```