### PR TITLE
apply tags to all subnets, not just private, to fix #1008

### DIFF
--- a/pkg/cloud/aws/services/ec2/subnets.go
+++ b/pkg/cloud/aws/services/ec2/subnets.go
@@ -313,14 +313,15 @@ func (s *Service) getSubnetTagParams(id string, public bool) v1alpha1.BuildParam
 	var role string
 	var additionalTags v1alpha1.Tags
 
+	// Add tag needed for Service type=LoadBalancer
+	additionalTags = v1alpha1.Tags{
+		v1alpha1.NameKubernetesAWSCloudProviderPrefix + s.scope.Name(): string(v1alpha1.ResourceLifecycleShared),
+	}
+
 	if public {
 		role = v1alpha1.PublicRoleTagValue
 	} else {
 		role = v1alpha1.PrivateRoleTagValue
-		// Add tag needed for Service type=LoadBalancer
-		additionalTags = v1alpha1.Tags{
-			v1alpha1.NameKubernetesAWSCloudProviderPrefix + s.scope.Name(): string(v1alpha1.ResourceLifecycleShared),
-		}
 	}
 
 	var name strings.Builder

--- a/pkg/cloud/aws/services/ec2/subnets_test.go
+++ b/pkg/cloud/aws/services/ec2/subnets_test.go
@@ -441,6 +441,10 @@ func TestReconcileSubnets(t *testing.T) {
 										Key:   aws.String("Name"),
 										Value: aws.String("test-cluster-subnet-public"),
 									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("shared"),
+									},
 								},
 							},
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
when creating a service of type LoadBalancer, the controller manager searches for subnets tagged with `kubernetes.io/cluster/<name>`. If only the private subnet is tagged, only services with the annotation `service.beta.kubernetes.io/aws-load-balancer-internal: "true"` will work. The default service of type LoadBalancer provisions an internet-facing ELB that requires a public subnet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1008 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```