### PR TITLE
Do not include input object in the error message

### DIFF
--- a/pkg/cloud/aws/services/ec2/instances.go
+++ b/pkg/cloud/aws/services/ec2/instances.go
@@ -585,7 +585,7 @@ func (s *Service) runInstance(role string, i *v1alpha1.Instance, idempotencyToke
 
 	out, err := s.scope.EC2.RunInstances(input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to run instance: %v", i)
+		return nil, errors.Wrap(err, "failed to run instance")
 	}
 
 	if len(out.Instances) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

It was pointed out in #1022 that the returned error message also includes the input instance in the error message, while this provides additional information about what the inputs going in were, it makes the returned error message more difficult to parse.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1022

**Special notes for your reviewer**:
If we would like to still provide the given inputs as debug information, I would be happy to look at adding separate debug logging that contains that information.

Also, if this is deemed to be a good approach for handling this, I'm happy to open up a similar patch against master.

```release-note

```