### PR TITLE
--partition flag for clusterawsadm

### DIFF
--- a/pkg/cloud/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/services/cloudformation/bootstrap.go
@@ -41,13 +41,13 @@ var ManagedIAMPolicyNames = [...]string{ControllersPolicy, ControlPlanePolicy, N
 
 // BootstrapTemplate is an AWS CloudFormation template to bootstrap
 // IAM policies, users and roles for use by Cluster API Provider AWS
-func BootstrapTemplate(accountID string) *cloudformation.Template {
+func BootstrapTemplate(accountID, partition string) *cloudformation.Template {
 	template := cloudformation.NewTemplate()
 
 	template.Resources[ControllersPolicy] = &resources.AWSIAMManagedPolicy{
 		ManagedPolicyName: iam.NewManagedName("controllers"),
 		Description:       `For the Kubernetes Cluster API Provider AWS Controllers`,
-		PolicyDocument:    controllersPolicy(accountID),
+		PolicyDocument:    controllersPolicy(accountID, partition),
 		Groups: []string{
 			cloudformation.Ref("AWSIAMGroupBootstrapper"),
 		},
@@ -139,7 +139,7 @@ func ec2AssumeRolePolicy() *iam.PolicyDocument {
 	}
 }
 
-func controllersPolicy(accountID string) *iam.PolicyDocument {
+func controllersPolicy(accountID, partition string) *iam.PolicyDocument {
 	return &iam.PolicyDocument{
 		Version: iam.CurrentVersion,
 		Statement: []iam.StatementEntry{
@@ -202,9 +202,10 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 			{
 				Effect: iam.EffectAllow,
 				Resource: iam.Resources{fmt.Sprintf(
-					"arn:aws:iam::%s:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing",
-					accountID),
-				},
+					"arn:%s:iam::%s:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing",
+					partition,
+					accountID,
+				)},
 				Action: iam.Actions{
 					"iam:CreateServiceLinkedRole",
 				},
@@ -215,7 +216,8 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 			{
 				Effect: iam.EffectAllow,
 				Resource: iam.Resources{fmt.Sprintf(
-					"arn:aws:iam::%s:role/%s",
+					"arn:%s:iam::%s:role/%s",
+					partition,
 					accountID,
 					iam.NewManagedName("*"),
 				)},
@@ -321,10 +323,10 @@ func cloudProviderNodeAwsPolicy() *iam.PolicyDocument {
 	}
 }
 
-func getPolicyDocFromPolicyName(policyName, accountID string) (*iam.PolicyDocument, error) {
+func getPolicyDocFromPolicyName(policyName, accountID, partition string) (*iam.PolicyDocument, error) {
 	switch policyName {
 	case ControllersPolicy:
-		return controllersPolicy(accountID), nil
+		return controllersPolicy(accountID, partition), nil
 	case ControlPlanePolicy:
 		return cloudProviderControlPlaneAwsPolicy(), nil
 	case NodePolicy:
@@ -334,9 +336,9 @@ func getPolicyDocFromPolicyName(policyName, accountID string) (*iam.PolicyDocume
 }
 
 // GenerateManagedIAMPolicyDocuments generates JSON representation of policy documents for all ManagedIAMPolicy
-func (s *Service) GenerateManagedIAMPolicyDocuments(policyDocDir, accountID string) error {
+func (s *Service) GenerateManagedIAMPolicyDocuments(policyDocDir, accountID, partition string) error {
 	for _, pn := range ManagedIAMPolicyNames {
-		pd, err := getPolicyDocFromPolicyName(pn, accountID)
+		pd, err := getPolicyDocFromPolicyName(pn, accountID, partition)
 		if err != nil {
 			return fmt.Errorf("Error: failed to get PolicyDocument for ManagedIAMPolicy %q, %v", pn, err)
 		}
@@ -356,9 +358,9 @@ func (s *Service) GenerateManagedIAMPolicyDocuments(policyDocDir, accountID stri
 }
 
 // ReconcileBootstrapStack creates or updates bootstrap CloudFormation
-func (s *Service) ReconcileBootstrapStack(stackName string, accountID string) error {
+func (s *Service) ReconcileBootstrapStack(stackName, accountID, partition string) error {
 
-	template := BootstrapTemplate(accountID)
+	template := BootstrapTemplate(accountID, partition)
 	yaml, err := template.YAML()
 	processedYaml := iam.ProcessPolicyDocument(string(yaml))
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Currently, `clusterawsadm` can create IAM policies for the stardard AWS regions. For AWS GovCloud and AWS China, the ARN needs to updated with a specific partition name. From the AWS documentation: 

```
AWS accounts are scoped to a single partition. You can get a partition by name. Valid partition names include:

"aws" - Public AWS partition
"aws-cn" - AWS China
"aws-us-gov" - AWS GovCloud
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #959 

**Special notes for your reviewer**:
I'm not super familiar with Cobra, so let me know if there is a different convention I should use for setting the flag and retrieving it's value.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
clusterawsadm: Support for different AWS partitions, including AWS GovCloud, using the --partition flag
```