### PR TITLE
chore: set status.ready when machine is running

### DIFF
--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -139,6 +139,11 @@ func (m *MachineScope) SetInstanceState(v infrav1.InstanceState) {
 	m.AWSMachine.Status.InstanceState = &v
 }
 
+// SetReady sets the AWSMachine Ready Status
+func (m *MachineScope) SetReady() {
+	m.AWSMachine.Status.Ready = true
+}
+
 // SetErrorMessage sets the AWSMachine status error message.
 func (m *MachineScope) SetErrorMessage(v error) {
 	m.AWSMachine.Status.ErrorMessage = pointer.StringPtr(v.Error())

--- a/pkg/controller/awsmachine/awsmachine_controller.go
+++ b/pkg/controller/awsmachine/awsmachine_controller.go
@@ -258,6 +258,7 @@ func (r *ReconcileAWSMachine) reconcileNormal(ctx context.Context, machineScope 
 	switch instance.State {
 	case infrav1.InstanceStateRunning:
 		machineScope.Info("Machine instance is running", "instance-id", *machineScope.GetInstanceID())
+		machineScope.SetReady()
 	case infrav1.InstanceStatePending:
 		machineScope.Info("Machine instance is pending", "instance-id", *machineScope.GetInstanceID())
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Sets `.Status.Ready` to true when instance is running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1032 

**Special notes for your reviewer**:
Is there anywhere in here we need to set it to false or is that too spicy?

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```