### PR TITLE
Update manager image references

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,7 +46,7 @@ gazelle(
 filegroup(
     name = "all-images",
     srcs = [
-        "//cmd/manager:manager-image",
+        "//:manager-image",
     ],
 )
 

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -31,14 +31,14 @@ go_test(
         "e2e_suite_test.go",
     ],
     args = [
-        "-managerImageTar=$(location //cmd/manager:manager-amd64.tar)",
+        "-managerImageTar=$(location //:manager-amd64.tar)",
         "-credFile=$(location manifests/provider-credentials.profile)",
         "-regionFile=$(location region.txt)",
     ],
     data = [
         "manifests/provider-credentials.profile",
         "region.txt",
-        "//cmd/manager:manager-amd64.tar",
+        "//:manager-amd64.tar",
     ],
     rundir = ".",
     tags = ["external"],


### PR DESCRIPTION
**What this PR does / why we need it**:

In the [latest e2e test failure](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cluster-api-provider-aws-bazel-e2e/1163552170134474752) I noticed that bazel was referencing a location that no longer exists, so this updates the references to point to the correct location.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```