### PR TITLE
Do not exit immediately if gazelle fix finds something; address shellcheck nit

### DIFF
--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -18,9 +18,11 @@ set -o nounset
 set -o pipefail
 set -o verbose
 
-if ! which bazel &>/dev/null; then echo "Bazel not available, skipping validation"; exit; fi
+if ! command -v bazel &>/dev/null; then echo "Bazel not available, skipping validation"; exit; fi
 
+set +o errexit
 diff=$(bazel run //:gazelle -- update -mode diff -external vendored -build_tags=integration)
+set -o errexit
 
 if [[ -n "${diff}" ]]; then
   echo "${diff}" >&2


### PR DESCRIPTION
**What this PR does / why we need it**:

When looking at the one of the test failure outputs from #1042, I noticed that [`make verify` failure](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/1042/pull-cluster-api-provider-aws-verify/1163595080984956930#0:build-log.txt%3A58) wasn't returning much in the way of helpful output as to what caused it to fail.

Replicating this locally, I noticed that [`bazel run //:gazelle ...`](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/f1ae6d0021e95b6b2fab56da7210b1f3035e2fd8/hack/verify-bazel.sh#L23) would return with code 1 if it found anything, which in combination with `set -o errexit` would simply cause an early exit without the intended output.

These changes make it possible to capture the diff output without exiting and provide it back to in the output from running the script, thus making debugging slightly easier.

I also took the liberty of addressing a shellcheck nit that I came across while checking the file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```