### PR TITLE
:sparkles: Remove unnecessary requeues

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -75,8 +75,8 @@ func (r *AWSClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 		return reconcile.Result{}, err
 	}
 	if cluster == nil {
-		log.Info("Waiting for Cluster Controller to set OwnerRef on AWSCluster")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		log.Info("Cluster Controller has not yet set OwnerRef")
+		return reconcile.Result{}, nil
 	}
 
 	log = log.WithName(fmt.Sprintf("cluster=%s", cluster.Name))

--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -32,7 +32,7 @@ var _ = Describe("AWSClusterReconciler", func() {
 	AfterEach(func() {})
 
 	Context("Reconcile an AWSCluster", func() {
-		It("should not error and requeue the request with insufficient set up", func() {
+		It("should not error and not requeue the request with insufficient set up", func() {
 
 			ctx := context.Background()
 
@@ -53,7 +53,7 @@ var _ = Describe("AWSClusterReconciler", func() {
 				},
 			})
 			Expect(err).To(BeNil())
-			Expect(result.RequeueAfter).ToNot(BeZero())
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

- Removes requeues for resources that we are watching
- Adds a watch for AWSClusters in the AWSMachine controller

Fixes #1037 

**Release note**:
```release-note
NONE
```
