### PR TITLE
:bug: Fix reconciliation issue when not specifying an ssh key

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -231,6 +231,7 @@ func (r *AWSMachineReconciler) findInstance(scope *scope.MachineScope, ec2svc *e
 }
 
 func (r *AWSMachineReconciler) reconcileNormal(ctx context.Context, machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
+	machineScope.Info("Reconciling AWSMachine")
 	// If the AWSMachine is in an error state, return early.
 	if machineScope.AWSMachine.Status.ErrorReason != nil || machineScope.AWSMachine.Status.ErrorMessage != nil {
 		machineScope.Info("Error state detected, skipping reconciliation")
@@ -361,8 +362,8 @@ func (r *AWSMachineReconciler) validateUpdate(spec *infrav1.AWSMachineSpec, i *i
 		errs = append(errs, errors.Errorf("instance IAM profile cannot be mutated from %q to %q", i.IAMProfile, spec.IAMInstanceProfile))
 	}
 
-	// SSH Key Name
-	if spec.KeyName != aws.StringValue(i.KeyName) {
+	// SSH Key Name (also account for default)
+	if spec.KeyName != aws.StringValue(i.KeyName) && spec.KeyName != "" {
 		errs = append(errs, errors.Errorf("SSH key name cannot be mutated from %q to %q", aws.StringValue(i.KeyName), spec.KeyName))
 	}
 

--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -219,7 +219,7 @@ func (s *Service) createSecurityGroup(role v1alpha2.SecurityGroupRole, input *ec
 		return errors.Wrapf(err, "failed to create security group %q in vpc %q", *input.GroupName, *input.VpcId)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateSecurityGroup", "Created managed SecurityGroup %v for Role %q", s.scope.SecurityGroups()[role], role)
+	record.Eventf(s.scope.Cluster, "SuccessfulCreateSecurityGroup", "Created managed SecurityGroup %q for Role %q", s.scope.SecurityGroups()[role].Name, role)
 
 	// Set the group id.
 	input.GroupId = out.GroupId
@@ -290,7 +290,7 @@ func (s *Service) revokeAllSecurityGroupIngressRules(id string) error {
 				record.Warnf(s.scope.Cluster, "FailedRevokeSecurityGroupIngressRules", "Failed to revoke all security group ingress rules for SecurityGroup %q: %v", *sg.GroupId, err)
 				return errors.Wrapf(err, "failed to revoke security group %q ingress rules", id)
 			}
-			record.Eventf(s.scope.Cluster, "SuccessfulRevokeSecurityGroupIngressRules", "Revoked all security group ingress rules for SecurityGroup %q: %v", *sg.GroupId, err)
+			record.Eventf(s.scope.Cluster, "SuccessfulRevokeSecurityGroupIngressRules", "Revoked all security group ingress rules for SecurityGroup %q", *sg.GroupId)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- fixes reconciliation when ssh key is not specified
- clean up some events
- add initial reconciliation logging for AWSMachine

**Release note**:
```release-note
NONE
```
