### PR TITLE
:bug: Clean up some of the security group events and logs

### DIFF
--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -216,10 +216,10 @@ func (s *Service) createSecurityGroup(role v1alpha2.SecurityGroupRole, input *ec
 
 	if err != nil {
 		record.Warnf(s.scope.Cluster, "FailedCreateSecurityGroup", "Failed to create managed SecurityGroup for Role %q: %v", role, err)
-		return errors.Wrapf(err, "failed to create security group %q in vpc %q", *input.GroupName, *input.VpcId)
+		return errors.Wrapf(err, "failed to create security group %q in vpc %q", *out.GroupId, *input.VpcId)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateSecurityGroup", "Created managed SecurityGroup %q for Role %q", s.scope.SecurityGroups()[role].Name, role)
+	record.Eventf(s.scope.Cluster, "SuccessfulCreateSecurityGroup", "Created managed SecurityGroup %q for Role %q", out.GroupId, role)
 
 	// Set the group id.
 	input.GroupId = out.GroupId
@@ -235,7 +235,7 @@ func (s *Service) createSecurityGroup(role v1alpha2.SecurityGroupRole, input *ec
 		return true, nil
 	}, awserrors.GroupNotFound); err != nil {
 		record.Warnf(s.scope.Cluster, "FailedTagSecurityGroup", "Failed to tag managed SecurityGroup %q: %v", *out.GroupId, err)
-		return errors.Wrapf(err, "failed to tag security group %q in vpc %q", *input.GroupName, *input.VpcId)
+		return errors.Wrapf(err, "failed to tag security group %q in vpc %q", *out.GroupId, *input.VpcId)
 	}
 
 	record.Eventf(s.scope.Cluster, "SuccessfulTagSecurityGroup", "Tagged managed SecurityGroup %q", *out.GroupId)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up some of the events generated related to security groups

**Release note**:
```release-note
NONE
```
