### PR TITLE
:bug: Cleanup events

### DIFF
--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -59,11 +59,11 @@ func (s *Service) ReconcileBastion() error {
 	if awserrors.IsNotFound(err) {
 		instance, err = s.runInstance("bastion", spec)
 		if err != nil {
-			record.Warnf(s.scope.Cluster, "FailedCreateBastion", "Failed to create bastion instance: %v", err)
+			record.Warnf(s.scope.AWSCluster, "FailedCreateBastion", "Failed to create bastion instance: %v", err)
 			return err
 		}
 
-		record.Eventf(s.scope.Cluster, "SuccessfulCreateBastion", "Created bastion instance %q", instance.ID)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulCreateBastion", "Created bastion instance %q", instance.ID)
 		s.scope.V(2).Info("Created new bastion host", "instance", instance)
 
 	} else if err != nil {
@@ -94,10 +94,10 @@ func (s *Service) DeleteBastion() error {
 	}
 
 	if err := s.TerminateInstanceAndWait(instance.ID); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTerminateBastion", "Failed to terminate bastion instance %q: %v", instance.ID, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTerminateBastion", "Failed to terminate bastion instance %q: %v", instance.ID, err)
 		return errors.Wrap(err, "unable to delete bastion instance")
 	}
-	record.Eventf(s.scope.Cluster, "SuccessfulTerminateBastion", "Terminated bastion instance %q", instance.ID)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulTerminateBastion", "Terminated bastion instance %q", instance.ID)
 
 	return nil
 }

--- a/pkg/cloud/services/ec2/gateways.go
+++ b/pkg/cloud/services/ec2/gateways.go
@@ -67,7 +67,7 @@ func (s *Service) reconcileInternetGateways() error {
 		}
 		return true, nil
 	}, awserrors.InternetGatewayNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", gateway.InternetGatewayId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", gateway.InternetGatewayId, err)
 		return errors.Wrapf(err, "failed to tag internet gateway %q", *gateway.InternetGatewayId)
 	}
 
@@ -94,11 +94,11 @@ func (s *Service) deleteInternetGateways() error {
 		}
 
 		if _, err := s.scope.EC2.DetachInternetGateway(detachReq); err != nil {
-			record.Warnf(s.scope.Cluster, "FailedDetachInternetGateway", "Failed to detach Internet Gateway %q from VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
+			record.Warnf(s.scope.AWSCluster, "FailedDetachInternetGateway", "Failed to detach Internet Gateway %q from VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
 			return errors.Wrapf(err, "failed to detach internet gateway %q", *ig.InternetGatewayId)
 		}
 
-		record.Eventf(s.scope.Cluster, "SuccessfulDetachInternetGateway", "Detached Internet Gateway %q from VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulDetachInternetGateway", "Detached Internet Gateway %q from VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
 		s.scope.Info("Detached internet gateway from VPC", "internet-gateway-id", *ig.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 
 		deleteReq := &ec2.DeleteInternetGatewayInput{
@@ -106,11 +106,11 @@ func (s *Service) deleteInternetGateways() error {
 		}
 
 		if _, err = s.scope.EC2.DeleteInternetGateway(deleteReq); err != nil {
-			record.Warnf(s.scope.Cluster, "FailedDeleteInternetGateway", "Failed to delete Internet Gateway %q previously attached to VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
+			record.Warnf(s.scope.AWSCluster, "FailedDeleteInternetGateway", "Failed to delete Internet Gateway %q previously attached to VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
 			return errors.Wrapf(err, "failed to delete internet gateway %q", *ig.InternetGatewayId)
 		}
 
-		record.Eventf(s.scope.Cluster, "SuccessfulDeleteInternetGateway", "Deleted Internet Gateway %q previously attached to VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteInternetGateway", "Deleted Internet Gateway %q previously attached to VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
 		s.scope.Info("Deleted internet gateway in VPC", "internet-gateway-id", *ig.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 	}
 
@@ -120,10 +120,10 @@ func (s *Service) deleteInternetGateways() error {
 func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 	ig, err := s.scope.EC2.CreateInternetGateway(&ec2.CreateInternetGatewayInput{})
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedCreateInternetGateway", "Failed to create new managed Internet Gateway: %v", err)
+		record.Warnf(s.scope.AWSCluster, "FailedCreateInternetGateway", "Failed to create new managed Internet Gateway: %v", err)
 		return nil, errors.Wrap(err, "failed to create internet gateway")
 	}
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateInternetGateway", "Created new managed Internet Gateway %q", *ig.InternetGateway.InternetGatewayId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateInternetGateway", "Created new managed Internet Gateway %q", *ig.InternetGateway.InternetGatewayId)
 	s.scope.Info("Created internet gateway for VPC", "vpc-id", s.scope.VPC().ID)
 
 	tagParams := s.getGatewayTagParams(*ig.InternetGateway.InternetGatewayId)
@@ -136,7 +136,7 @@ func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 		}
 		return true, nil
 	}, awserrors.InternetGatewayNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", *ig.InternetGateway.InternetGatewayId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", *ig.InternetGateway.InternetGatewayId, err)
 		return nil, errors.Wrapf(err, "failed to tag internet gateway %q", *ig.InternetGateway.InternetGatewayId)
 	}
 
@@ -152,10 +152,10 @@ func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 		}
 		return true, nil
 	}, awserrors.InternetGatewayNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedAttachInternetGateway", "Failed to attach managed Internet Gateway %q to vpc %q: %v", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID, err)
+		record.Warnf(s.scope.AWSCluster, "FailedAttachInternetGateway", "Failed to attach managed Internet Gateway %q to vpc %q: %v", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID, err)
 		return nil, errors.Wrapf(err, "failed to attach internet gateway %q to vpc %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
 	}
-	record.Eventf(s.scope.Cluster, "SuccessfulAttachInternetGateway", "Internet Gateway %q attached to VPC %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulAttachInternetGateway", "Internet Gateway %q attached to VPC %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
 	s.scope.Info("attached internet gateway to VPC", "internet-gateway-id", *ig.InternetGateway.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 
 	return ig.InternetGateway, nil

--- a/pkg/cloud/services/ec2/natgateways.go
+++ b/pkg/cloud/services/ec2/natgateways.go
@@ -68,7 +68,7 @@ func (s *Service) reconcileNatGateways() error {
 				}
 				return true, nil
 			}, awserrors.ResourceNotFound); err != nil {
-				record.Warnf(s.scope.Cluster, "FailedTagNATGateway", "Failed to tag managed NAT Gateway %q: %v", *ngw.NatGatewayId, err)
+				record.Warnf(s.scope.AWSCluster, "FailedTagNATGateway", "Failed to tag managed NAT Gateway %q: %v", *ngw.NatGatewayId, err)
 				return errors.Wrapf(err, "failed to tag nat gateway %q", *ngw.NatGatewayId)
 			}
 
@@ -174,10 +174,10 @@ func (s *Service) createNatGateway(subnetID string) (*ec2.NatGateway, error) {
 		}
 		return true, nil
 	}, awserrors.InvalidSubnet); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedCreateNATGateway", "Failed to create new NAT Gateway %q: %v", *out.NatGateway.NatGatewayId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedCreateNATGateway", "Failed to create new NAT Gateway %q: %v", *out.NatGateway.NatGatewayId, err)
 		return nil, errors.Wrapf(err, "failed to create NAT gateway for subnet ID %q", subnetID)
 	}
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateNATGateway", "Created new NAT Gateway %q", *out.NatGateway.NatGatewayId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateNATGateway", "Created new NAT Gateway %q", *out.NatGateway.NatGatewayId)
 
 	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
@@ -188,11 +188,11 @@ func (s *Service) createNatGateway(subnetID string) (*ec2.NatGateway, error) {
 		}
 		return true, nil
 	}, awserrors.ResourceNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagNATGateway", "Failed to tag NAT Gateway %q: %v", *out.NatGateway.NatGatewayId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagNATGateway", "Failed to tag NAT Gateway %q: %v", *out.NatGateway.NatGatewayId, err)
 		return nil, errors.Wrapf(err, "failed to tag nat gateway %q", *out.NatGateway.NatGatewayId)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulTagNATGateway", "Tagged NAT Gateway %q", *out.NatGateway.NatGatewayId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulTagNATGateway", "Tagged NAT Gateway %q", *out.NatGateway.NatGatewayId)
 	s.scope.Info("Created NAT gateway for subnet, waiting for it to become available...", "nat-gateway-id", *out.NatGateway.NatGatewayId, "subnet-id", subnetID)
 
 	wReq := &ec2.DescribeNatGatewaysInput{NatGatewayIds: []*string{out.NatGateway.NatGatewayId}}
@@ -209,10 +209,10 @@ func (s *Service) deleteNatGateway(id string) error {
 		NatGatewayId: aws.String(id),
 	})
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedDeleteNATGateway", "Failed to delete NAT Gateway %q previously attached to VPC %q: %v", id, s.scope.VPC().ID, err)
+		record.Warnf(s.scope.AWSCluster, "FailedDeleteNATGateway", "Failed to delete NAT Gateway %q previously attached to VPC %q: %v", id, s.scope.VPC().ID, err)
 		return errors.Wrapf(err, "failed to delete nat gateway %q", id)
 	}
-	record.Eventf(s.scope.Cluster, "SuccessfulDeleteNATGateway", "Deleted NAT Gateway %q previously attached to VPC %q", id, s.scope.VPC().ID)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteNATGateway", "Deleted NAT Gateway %q previously attached to VPC %q", id, s.scope.VPC().ID)
 	s.scope.Info("Deleted NAT gateway in VPC", "nat-gateway-id", id, "vpc-id", s.scope.VPC().ID)
 
 	describeInput := &ec2.DescribeNatGatewaysInput{

--- a/pkg/cloud/services/ec2/routetables.go
+++ b/pkg/cloud/services/ec2/routetables.go
@@ -66,7 +66,7 @@ func (s *Service) reconcileRouteTables() error {
 				}
 				return true, nil
 			}, awserrors.RouteTableNotFound); err != nil {
-				record.Warnf(s.scope.Cluster, "FailedTagRouteTable", "Failed to tag managed RouteTable %q: %v", *rt.RouteTableId, err)
+				record.Warnf(s.scope.AWSCluster, "FailedTagRouteTable", "Failed to tag managed RouteTable %q: %v", *rt.RouteTableId, err)
 				return errors.Wrapf(err, "failed to ensure tags on route table %q", *rt.RouteTableId)
 			}
 
@@ -157,20 +157,20 @@ func (s *Service) deleteRouteTables() error {
 			}
 
 			if _, err := s.scope.EC2.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{AssociationId: as.RouteTableAssociationId}); err != nil {
-				record.Warnf(s.scope.Cluster, "FailedDisassociateRouteTable", "Failed to disassociate managed RouteTable %q from Subnet %q: %v", *rt.RouteTableId, *as.SubnetId, err)
+				record.Warnf(s.scope.AWSCluster, "FailedDisassociateRouteTable", "Failed to disassociate managed RouteTable %q from Subnet %q: %v", *rt.RouteTableId, *as.SubnetId, err)
 				return errors.Wrapf(err, "failed to disassociate route table %q from subnet %q", *rt.RouteTableId, *as.SubnetId)
 			}
 
-			record.Eventf(s.scope.Cluster, "SuccessfulDisassociateRouteTable", "Disassociated managed RouteTable %q from subnet %q", *rt.RouteTableId, *as.SubnetId)
+			record.Eventf(s.scope.AWSCluster, "SuccessfulDisassociateRouteTable", "Disassociated managed RouteTable %q from subnet %q", *rt.RouteTableId, *as.SubnetId)
 			s.scope.Info("Deleted association between route table and subnet", "route-table-id", *rt.RouteTableId, "subnet-id", *as.SubnetId)
 		}
 
 		if _, err := s.scope.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{RouteTableId: rt.RouteTableId}); err != nil {
-			record.Warnf(s.scope.Cluster, "FailedDeleteRouteTable", "Failed to delete managed RouteTable %q: %v", *rt.RouteTableId, err)
+			record.Warnf(s.scope.AWSCluster, "FailedDeleteRouteTable", "Failed to delete managed RouteTable %q: %v", *rt.RouteTableId, err)
 			return errors.Wrapf(err, "failed to delete route table %q", *rt.RouteTableId)
 		}
 
-		record.Eventf(s.scope.Cluster, "SuccessfulDeleteRouteTable", "Deleted managed RouteTable %q", *rt.RouteTableId)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteRouteTable", "Deleted managed RouteTable %q", *rt.RouteTableId)
 		s.scope.Info("Deleted route table", "route-table-id", *rt.RouteTableId)
 	}
 	return nil
@@ -201,10 +201,10 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool)
 		VpcId: aws.String(s.scope.VPC().ID),
 	})
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedCreateRouteTable", "Failed to create managed RouteTable: %v", err)
+		record.Warnf(s.scope.AWSCluster, "FailedCreateRouteTable", "Failed to create managed RouteTable: %v", err)
 		return nil, errors.Wrapf(err, "failed to create route table in vpc %q", s.scope.VPC().ID)
 	}
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateRouteTable", "Created managed RouteTable %q", *out.RouteTable.RouteTableId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateRouteTable", "Created managed RouteTable %q", *out.RouteTable.RouteTableId)
 
 	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
@@ -215,10 +215,10 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool)
 		}
 		return true, nil
 	}, awserrors.RouteTableNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagRouteTable", "Failed to tag managed RouteTable %q: %v", *out.RouteTable.RouteTableId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagRouteTable", "Failed to tag managed RouteTable %q: %v", *out.RouteTable.RouteTableId, err)
 		return nil, errors.Wrapf(err, "failed to tag route table %q", *out.RouteTable.RouteTableId)
 	}
-	record.Eventf(s.scope.Cluster, "SuccessfulTagRouteTable", "Tagged managed RouteTable %q", *out.RouteTable.RouteTableId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulTagRouteTable", "Tagged managed RouteTable %q", *out.RouteTable.RouteTableId)
 
 	for _, route := range routes {
 		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
@@ -238,10 +238,10 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool)
 			return true, nil
 		}, awserrors.RouteTableNotFound, awserrors.NATGatewayNotFound, awserrors.GatewayNotFound); err != nil {
 			// TODO(vincepri): cleanup the route table if this fails.
-			record.Warnf(s.scope.Cluster, "FailedCreateRoute", "Failed to create route %s for RouteTable %q: %v", route.GoString(), *out.RouteTable.RouteTableId, err)
+			record.Warnf(s.scope.AWSCluster, "FailedCreateRoute", "Failed to create route %s for RouteTable %q: %v", route.GoString(), *out.RouteTable.RouteTableId, err)
 			return nil, errors.Wrapf(err, "failed to create route in route table %q: %s", *out.RouteTable.RouteTableId, route.GoString())
 		}
-		record.Eventf(s.scope.Cluster, "SuccessfulCreateRoute", "Created route %s for RouteTable %q", route.GoString(), *out.RouteTable.RouteTableId)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulCreateRoute", "Created route %s for RouteTable %q", route.GoString(), *out.RouteTable.RouteTableId)
 	}
 
 	return &v1alpha2.RouteTable{
@@ -255,11 +255,11 @@ func (s *Service) associateRouteTable(rt *v1alpha2.RouteTable, subnetID string) 
 		SubnetId:     aws.String(subnetID),
 	})
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedAssociateRouteTable", "Failed to associate managed RouteTable %q with Subnet %q: %v", rt.ID, subnetID, err)
+		record.Warnf(s.scope.AWSCluster, "FailedAssociateRouteTable", "Failed to associate managed RouteTable %q with Subnet %q: %v", rt.ID, subnetID, err)
 		return errors.Wrapf(err, "failed to associate route table %q to subnet %q", rt.ID, subnetID)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulAssociateRouteTable", "Associated managed RouteTable %q with subnet %q", rt.ID, subnetID)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulAssociateRouteTable", "Associated managed RouteTable %q with subnet %q", rt.ID, subnetID)
 
 	return nil
 }

--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -165,11 +165,11 @@ func (s *Service) deleteSecurityGroups() error {
 		}
 
 		if _, err := s.scope.EC2.DeleteSecurityGroup(input); awserrors.IsIgnorableSecurityGroupError(err) != nil {
-			record.Warnf(s.scope.Cluster, "FailedDeleteSecurityGroup", "Failed to delete managed SecurityGroup %q: %v", sg.ID, err)
+			record.Warnf(s.scope.AWSCluster, "FailedDeleteSecurityGroup", "Failed to delete managed SecurityGroup %q: %v", sg.ID, err)
 			return errors.Wrapf(err, "failed to delete security group %q", sg.ID)
 		}
 
-		record.Eventf(s.scope.Cluster, "SuccessfulDeleteSecurityGroup", "Deleted managed SecurityGroup %q", sg.ID)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteSecurityGroup", "Deleted managed SecurityGroup %q", sg.ID)
 		s.scope.V(2).Info("Deleted security group security group", "security-group-id", sg.ID)
 	}
 
@@ -215,11 +215,11 @@ func (s *Service) createSecurityGroup(role v1alpha2.SecurityGroupRole, input *ec
 	})
 
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedCreateSecurityGroup", "Failed to create managed SecurityGroup for Role %q: %v", role, err)
+		record.Warnf(s.scope.AWSCluster, "FailedCreateSecurityGroup", "Failed to create managed SecurityGroup for Role %q: %v", role, err)
 		return errors.Wrapf(err, "failed to create security group %q in vpc %q", *out.GroupId, *input.VpcId)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateSecurityGroup", "Created managed SecurityGroup %q for Role %q", out.GroupId, role)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateSecurityGroup", "Created managed SecurityGroup %q for Role %q", *out.GroupId, role)
 
 	// Set the group id.
 	input.GroupId = out.GroupId
@@ -234,11 +234,11 @@ func (s *Service) createSecurityGroup(role v1alpha2.SecurityGroupRole, input *ec
 		}
 		return true, nil
 	}, awserrors.GroupNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagSecurityGroup", "Failed to tag managed SecurityGroup %q: %v", *out.GroupId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagSecurityGroup", "Failed to tag managed SecurityGroup %q: %v", *out.GroupId, err)
 		return errors.Wrapf(err, "failed to tag security group %q in vpc %q", *out.GroupId, *input.VpcId)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulTagSecurityGroup", "Tagged managed SecurityGroup %q", *out.GroupId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulTagSecurityGroup", "Tagged managed SecurityGroup %q", *out.GroupId)
 	return nil
 }
 
@@ -249,11 +249,11 @@ func (s *Service) authorizeSecurityGroupIngressRules(id string, rules v1alpha2.I
 	}
 
 	if _, err := s.scope.EC2.AuthorizeSecurityGroupIngress(input); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedAuthorizeSecurityGroupIngressRules", "Failed to authorize security group ingress rules %v for SecurityGroup %q: %v", rules, id, err)
+		record.Warnf(s.scope.AWSCluster, "FailedAuthorizeSecurityGroupIngressRules", "Failed to authorize security group ingress rules %v for SecurityGroup %q: %v", rules, id, err)
 		return errors.Wrapf(err, "failed to authorize security group %q ingress rules: %v", id, rules)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulAuthorizeSecurityGroupIngressRules", "Authorized security group ingress rules %v for SecurityGroup %q", rules, id)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulAuthorizeSecurityGroupIngressRules", "Authorized security group ingress rules %v for SecurityGroup %q", rules, id)
 	return nil
 }
 
@@ -264,11 +264,11 @@ func (s *Service) revokeSecurityGroupIngressRules(id string, rules v1alpha2.Ingr
 	}
 
 	if _, err := s.scope.EC2.RevokeSecurityGroupIngress(input); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedRevokeSecurityGroupIngressRules", "Failed to revoke security group ingress rules %v for SecurityGroup %q: %v", rules, id, err)
+		record.Warnf(s.scope.AWSCluster, "FailedRevokeSecurityGroupIngressRules", "Failed to revoke security group ingress rules %v for SecurityGroup %q: %v", rules, id, err)
 		return errors.Wrapf(err, "failed to revoke security group %q ingress rules: %v", id, rules)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulRevokeSecurityGroupIngressRules", "Revoked security group ingress rules %v for SecurityGroup %q", rules, id)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulRevokeSecurityGroupIngressRules", "Revoked security group ingress rules %v for SecurityGroup %q", rules, id)
 	return nil
 }
 
@@ -287,10 +287,10 @@ func (s *Service) revokeAllSecurityGroupIngressRules(id string) error {
 				IpPermissions: sg.IpPermissions,
 			}
 			if _, err := s.scope.EC2.RevokeSecurityGroupIngress(revokeInput); err != nil {
-				record.Warnf(s.scope.Cluster, "FailedRevokeSecurityGroupIngressRules", "Failed to revoke all security group ingress rules for SecurityGroup %q: %v", *sg.GroupId, err)
+				record.Warnf(s.scope.AWSCluster, "FailedRevokeSecurityGroupIngressRules", "Failed to revoke all security group ingress rules for SecurityGroup %q: %v", *sg.GroupId, err)
 				return errors.Wrapf(err, "failed to revoke security group %q ingress rules", id)
 			}
-			record.Eventf(s.scope.Cluster, "SuccessfulRevokeSecurityGroupIngressRules", "Revoked all security group ingress rules for SecurityGroup %q", *sg.GroupId)
+			record.Eventf(s.scope.AWSCluster, "SuccessfulRevokeSecurityGroupIngressRules", "Revoked all security group ingress rules for SecurityGroup %q", *sg.GroupId)
 		}
 	}
 

--- a/pkg/cloud/services/ec2/subnets.go
+++ b/pkg/cloud/services/ec2/subnets.go
@@ -107,7 +107,7 @@ LoopExisting:
 					}
 					return true, nil
 				}, awserrors.SubnetNotFound); err != nil {
-					record.Warnf(s.scope.Cluster, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", exsn.ID, err)
+					record.Warnf(s.scope.AWSCluster, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", exsn.ID, err)
 					return errors.Wrapf(err, "failed to ensure tags on subnet %q", exsn.ID)
 				}
 
@@ -239,11 +239,11 @@ func (s *Service) createSubnet(sn *v1alpha2.SubnetSpec) (*v1alpha2.SubnetSpec, e
 	})
 
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedCreateSubnet", "Failed creating new managed Subnet %v", err)
+		record.Warnf(s.scope.AWSCluster, "FailedCreateSubnet", "Failed creating new managed Subnet %v", err)
 		return nil, errors.Wrap(err, "failed to create subnet")
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateSubnet", "Created new managed Subnet %q", *out.Subnet.SubnetId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateSubnet", "Created new managed Subnet %q", *out.Subnet.SubnetId)
 
 	wReq := &ec2.DescribeSubnetsInput{SubnetIds: []*string{out.Subnet.SubnetId}}
 	if err := s.scope.EC2.WaitUntilSubnetAvailable(wReq); err != nil {
@@ -259,11 +259,11 @@ func (s *Service) createSubnet(sn *v1alpha2.SubnetSpec) (*v1alpha2.SubnetSpec, e
 		}
 		return true, nil
 	}, awserrors.SubnetNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", *out.Subnet.SubnetId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", *out.Subnet.SubnetId, err)
 		return nil, errors.Wrapf(err, "failed to tag subnet %q", *out.Subnet.SubnetId)
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulTagSubnet", "Tagged managed Subnet %q", *out.Subnet.SubnetId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulTagSubnet", "Tagged managed Subnet %q", *out.Subnet.SubnetId)
 
 	if sn.IsPublic {
 		attReq := &ec2.ModifySubnetAttributeInput{
@@ -279,10 +279,10 @@ func (s *Service) createSubnet(sn *v1alpha2.SubnetSpec) (*v1alpha2.SubnetSpec, e
 			}
 			return true, nil
 		}, awserrors.SubnetNotFound); err != nil {
-			record.Warnf(s.scope.Cluster, "FailedModifySubnetAttributes", "Failed modifying managed Subnet %q attributes: %v", *out.Subnet.SubnetId, err)
+			record.Warnf(s.scope.AWSCluster, "FailedModifySubnetAttributes", "Failed modifying managed Subnet %q attributes: %v", *out.Subnet.SubnetId, err)
 			return nil, errors.Wrapf(err, "failed to set subnet %q attributes", *out.Subnet.SubnetId)
 		}
-		record.Eventf(s.scope.Cluster, "SuccessfulModifySubnetAttributes", "Modified managed Subnet %q attributes", *out.Subnet.SubnetId)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulModifySubnetAttributes", "Modified managed Subnet %q attributes", *out.Subnet.SubnetId)
 	}
 
 	s.scope.V(2).Info("Created new subnet in VPC with cidr and availability zone ",
@@ -305,12 +305,12 @@ func (s *Service) deleteSubnet(id string) error {
 	})
 
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedDeleteSubnet", "Failed to delete managed Subnet %q: %v", id, err)
+		record.Warnf(s.scope.AWSCluster, "FailedDeleteSubnet", "Failed to delete managed Subnet %q: %v", id, err)
 		return errors.Wrapf(err, "failed to delete subnet %q", id)
 	}
 
 	s.scope.V(2).Info("Deleted subnet in vpc", "subnet-id", id, "vpc-id", s.scope.VPC().ID)
-	record.Eventf(s.scope.Cluster, "SuccessfulDeleteSubnet", "Deleted managed Subnet %q", id)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteSubnet", "Deleted managed Subnet %q", id)
 	return nil
 }
 

--- a/pkg/cloud/services/ec2/vpc.go
+++ b/pkg/cloud/services/ec2/vpc.go
@@ -69,7 +69,7 @@ func (s *Service) reconcileVPC() error {
 		}
 		return true, nil
 	}, awserrors.VPCNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagVPC", "Failed to tag managed VPC %q: %v", vpc.ID, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagVPC", "Failed to tag managed VPC %q: %v", vpc.ID, err)
 		return errors.Wrapf(err, "failed to tag vpc %q", vpc.ID)
 	}
 
@@ -134,12 +134,12 @@ func (s *Service) ensureManagedVPCAttributes(vpc *v1alpha2.VPCSpec) error {
 	}
 
 	if len(errs) > 0 {
-		record.Warnf(s.scope.Cluster, "FailedSetVPCAttributes", "Failed to set managed VPC attributes for %q: %v", vpc.ID, err)
+		record.Warnf(s.scope.AWSCluster, "FailedSetVPCAttributes", "Failed to set managed VPC attributes for %q: %v", vpc.ID, err)
 		return kerrors.NewAggregate(errs)
 	}
 
 	if updated {
-		record.Eventf(s.scope.Cluster, "SuccessfulSetVPCAttributes", "Set managed VPC attributes for %q", vpc.ID)
+		record.Eventf(s.scope.AWSCluster, "SuccessfulSetVPCAttributes", "Set managed VPC attributes for %q", vpc.ID)
 	}
 
 	return nil
@@ -160,11 +160,11 @@ func (s *Service) createVPC() (*v1alpha2.VPCSpec, error) {
 
 	out, err := s.scope.EC2.CreateVpc(input)
 	if err != nil {
-		record.Warnf(s.scope.Cluster, "FailedCreateVPC", "Failed to create new managed VPC: %v", err)
+		record.Warnf(s.scope.AWSCluster, "FailedCreateVPC", "Failed to create new managed VPC: %v", err)
 		return nil, errors.Wrap(err, "failed to create vpc")
 	}
 
-	record.Eventf(s.scope.Cluster, "SuccessfulCreateVPC", "Created new managed VPC %q", *out.Vpc.VpcId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateVPC", "Created new managed VPC %q", *out.Vpc.VpcId)
 	s.scope.V(2).Info("Created new VPC with cidr", "vpc-id", *out.Vpc.VpcId, "cidr-block", *out.Vpc.CidrBlock)
 
 	// TODO: we should attempt to record the VPC ID as soon as possible by setting s.scope.VPC().ID
@@ -187,10 +187,10 @@ func (s *Service) createVPC() (*v1alpha2.VPCSpec, error) {
 		}
 		return true, nil
 	}, awserrors.VPCNotFound); err != nil {
-		record.Warnf(s.scope.Cluster, "FailedTagVPC", "Failed to tag managed VPC %q: %v", *out.Vpc.VpcId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedTagVPC", "Failed to tag managed VPC %q: %v", *out.Vpc.VpcId, err)
 		return nil, err
 	}
-	record.Eventf(s.scope.Cluster, "SuccesfulTagVPC", "Tagged managed VPC %q", *out.Vpc.VpcId)
+	record.Eventf(s.scope.AWSCluster, "SuccesfulTagVPC", "Tagged managed VPC %q", *out.Vpc.VpcId)
 
 	return &v1alpha2.VPCSpec{
 		ID:        *out.Vpc.VpcId,
@@ -226,12 +226,12 @@ func (s *Service) deleteVPC() error {
 			s.scope.V(4).Info("Skipping VPC deletion, VPC not found")
 			return nil
 		}
-		record.Warnf(s.scope.Cluster, "FailedDeleteVPC", "Failed to delete managed VPC %q: %v", vpc.ID, err)
+		record.Warnf(s.scope.AWSCluster, "FailedDeleteVPC", "Failed to delete managed VPC %q: %v", vpc.ID, err)
 		return errors.Wrapf(err, "failed to delete vpc %q", vpc.ID)
 	}
 
 	s.scope.V(2).Info("Deleted VPC", "vpc-id", vpc.ID)
-	record.Eventf(s.scope.Cluster, "SuccessfulDeleteVPC", "Deleted managed VPC %q", vpc.ID)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteVPC", "Deleted managed VPC %q", vpc.ID)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- record cluster-related events to AWSCluster instead of Cluster
- Fix a security group event to dereference pointer

**Release note**:
```release-note
NONE
```
