### PR TITLE
Update tolerations patch

### DIFF
--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -30,8 +30,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cluster-api-controller-manager
-  namespace: cluster-api-system
+  name: capi-controller-manager
+  namespace: capi-system
 spec:
   template:
     spec:


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This patch updates the manager toleration patch to account for an upstream change to the CAPI manager deployment (https://github.com/kubernetes-sigs/cluster-api/pull/1332).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```