### PR TITLE
[0.3] Backport: Refactor wait package to be capped to 10m and simplify

### DIFF
--- a/pkg/cloud/aws/services/ec2/eips.go
+++ b/pkg/cloud/aws/services/ec2/eips.go
@@ -54,7 +54,7 @@ func (s *Service) allocateAddress(role string) (string, error) {
 		return "", errors.Wrap(err, "failed to create Elastic IP address")
 	}
 
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
 			EC2Client: s.scope.EC2,
 			BuildParams: v1alpha1.BuildParams{
@@ -100,7 +100,7 @@ func (s *Service) releaseAddresses() error {
 			return errors.Errorf("failed to release elastic IP %q with allocation ID %q: Still associated with association ID %q", *ip.PublicIp, *ip.AllocationId, *ip.AssociationId)
 		}
 
-		err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		err := wait.PollWithRetryable(func() (bool, error) {
 			_, err := s.scope.EC2.ReleaseAddress(&ec2.ReleaseAddressInput{AllocationId: ip.AllocationId})
 			if err != nil {
 				return false, err

--- a/pkg/cloud/aws/services/ec2/gateways.go
+++ b/pkg/cloud/aws/services/ec2/gateways.go
@@ -60,7 +60,7 @@ func (s *Service) reconcileInternetGateways() error {
 	s.scope.VPC().InternetGatewayID = gateway.InternetGatewayId
 
 	// Make sure tags are up to date.
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := tags.Ensure(converters.TagsToMap(gateway.Tags), &tags.ApplyParams{
 			EC2Client:   s.scope.EC2,
 			BuildParams: s.getGatewayTagParams(*gateway.InternetGatewayId),
@@ -127,7 +127,7 @@ func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 	s.scope.Info("Created internet gateway for VPC", "vpc-id", s.scope.VPC().ID)
 
 	tagParams := s.getGatewayTagParams(*ig.InternetGateway.InternetGatewayId)
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
 			EC2Client:   s.scope.EC2,
 			BuildParams: tagParams,
@@ -144,7 +144,7 @@ func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 	// latest tag data rather than returning empty tags.
 	ig.InternetGateway.Tags = converters.MapToTags(v1alpha1.Build(tagParams))
 
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if _, err := s.scope.EC2.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
 			InternetGatewayId: ig.InternetGateway.InternetGatewayId,
 			VpcId:             aws.String(s.scope.VPC().ID),

--- a/pkg/cloud/aws/services/ec2/routetables.go
+++ b/pkg/cloud/aws/services/ec2/routetables.go
@@ -56,7 +56,7 @@ func (s *Service) reconcileRouteTables() error {
 			// TODO(vincepri): check that everything is in order, e.g. routes match the subnet type.
 
 			// Make sure tags are up to date.
-			if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+			if err := wait.PollWithRetryable(func() (bool, error) {
 				if err := tags.Ensure(converters.TagsToMap(rt.Tags), &tags.ApplyParams{
 					EC2Client:   s.scope.EC2,
 					BuildParams: s.getRouteTableTagParams(*rt.RouteTableId, sn.IsPublic),
@@ -97,7 +97,7 @@ func (s *Service) reconcileRouteTables() error {
 		}
 		record.Eventf(s.scope.Cluster, "SuccessfulCreateRouteTable", "Created managed RouteTable %q", rt.ID)
 
-		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		if err := wait.PollWithRetryable(func() (bool, error) {
 			if err := s.associateRouteTable(rt, sn.ID); err != nil {
 				return false, err
 			}
@@ -205,7 +205,7 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool)
 		return nil, errors.Wrapf(err, "failed to create route table in vpc %q", s.scope.VPC().ID)
 	}
 
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
 			EC2Client:   s.scope.EC2,
 			BuildParams: s.getRouteTableTagParams(*out.RouteTable.RouteTableId, isPublic),
@@ -218,7 +218,7 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool)
 	}
 
 	for _, route := range routes {
-		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		if err := wait.PollWithRetryable(func() (bool, error) {
 			if _, err := s.scope.EC2.CreateRoute(&ec2.CreateRouteInput{
 				RouteTableId:                out.RouteTable.RouteTableId,
 				DestinationCidrBlock:        route.DestinationCidrBlock,

--- a/pkg/cloud/aws/services/ec2/securitygroups.go
+++ b/pkg/cloud/aws/services/ec2/securitygroups.go
@@ -90,7 +90,7 @@ func (s *Service) reconcileSecurityGroups() error {
 		s.scope.SecurityGroups()[role] = existing
 
 		// Make sure tags are up to date.
-		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		if err := wait.PollWithRetryable(func() (bool, error) {
 			if err := tags.Ensure(existing.Tags, &tags.ApplyParams{
 				EC2Client:   s.scope.EC2,
 				BuildParams: s.getSecurityGroupTagParams(existing.Name, existing.ID, role),
@@ -120,7 +120,7 @@ func (s *Service) reconcileSecurityGroups() error {
 
 		toRevoke := current.Difference(want)
 		if len(toRevoke) > 0 {
-			if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+			if err := wait.PollWithRetryable(func() (bool, error) {
 				if err := s.revokeSecurityGroupIngressRules(sg.ID, toRevoke); err != nil {
 					return false, err
 				}
@@ -136,7 +136,7 @@ func (s *Service) reconcileSecurityGroups() error {
 
 		toAuthorize := want.Difference(current)
 		if len(toAuthorize) > 0 {
-			if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+			if err := wait.PollWithRetryable(func() (bool, error) {
 				if err := s.authorizeSecurityGroupIngressRules(sg.ID, toAuthorize); err != nil {
 					return false, err
 				}
@@ -228,7 +228,7 @@ func (s *Service) createSecurityGroup(role v1alpha1.SecurityGroupRole, input *ec
 	input.GroupId = out.GroupId
 
 	// Tag the security group.
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if _, err := s.scope.EC2.CreateTags(&ec2.CreateTagsInput{
 			Resources: []*string{out.GroupId},
 			Tags:      input.Tags,

--- a/pkg/cloud/aws/services/ec2/subnets.go
+++ b/pkg/cloud/aws/services/ec2/subnets.go
@@ -97,7 +97,7 @@ LoopExisting:
 				}
 
 				// Make sure tags are up to date.
-				if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+				if err := wait.PollWithRetryable(func() (bool, error) {
 					if err := tags.Ensure(exsn.Tags, &tags.ApplyParams{
 						EC2Client:   s.scope.EC2,
 						BuildParams: s.getSubnetTagParams(exsn.ID, exsn.IsPublic),
@@ -248,7 +248,7 @@ func (s *Service) createSubnet(sn *v1alpha1.SubnetSpec) (*v1alpha1.SubnetSpec, e
 		return nil, errors.Wrapf(err, "failed to wait for subnet %q", *out.Subnet.SubnetId)
 	}
 
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
 			EC2Client:   s.scope.EC2,
 			BuildParams: s.getSubnetTagParams(*out.Subnet.SubnetId, sn.IsPublic),
@@ -269,7 +269,7 @@ func (s *Service) createSubnet(sn *v1alpha1.SubnetSpec) (*v1alpha1.SubnetSpec, e
 			SubnetId: out.Subnet.SubnetId,
 		}
 
-		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		if err := wait.PollWithRetryable(func() (bool, error) {
 			if _, err := s.scope.EC2.ModifySubnetAttribute(attReq); err != nil {
 				return false, err
 			}

--- a/pkg/cloud/aws/services/ec2/vpc.go
+++ b/pkg/cloud/aws/services/ec2/vpc.go
@@ -59,7 +59,7 @@ func (s *Service) reconcileVPC() error {
 	}
 
 	// Make sure tags are up to date.
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := tags.Ensure(vpc.Tags, &tags.ApplyParams{
 			EC2Client:   s.scope.EC2,
 			BuildParams: s.getVPCTagParams(vpc.ID),
@@ -73,7 +73,7 @@ func (s *Service) reconcileVPC() error {
 	}
 
 	// Make sure attributes are configured
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := s.ensureManagedVPCAttributes(vpc); err != nil {
 			return false, err
 		}
@@ -159,7 +159,7 @@ func (s *Service) createVPC() (*v1alpha1.VPCSpec, error) {
 
 	// Apply tags so that we know this is a managed VPC.
 	tagParams := s.getVPCTagParams(*out.Vpc.VpcId)
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
 			EC2Client:   s.scope.EC2,
 			BuildParams: tagParams,

--- a/pkg/cloud/aws/services/elb/loadbalancer.go
+++ b/pkg/cloud/aws/services/elb/loadbalancer.go
@@ -197,7 +197,7 @@ func (s *Service) createClassicELB(spec *v1alpha1.ClassicELB) (*v1alpha1.Classic
 	}
 
 	if spec.HealthCheck != nil {
-		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		if err := wait.PollWithRetryable(func() (bool, error) {
 			if _, err := s.scope.ELB.ConfigureHealthCheck(&elb.ConfigureHealthCheckInput{
 				LoadBalancerName: aws.String(spec.Name),
 				HealthCheck: &elb.HealthCheck{
@@ -235,7 +235,7 @@ func (s *Service) configureAttributes(name string, attributes v1alpha1.ClassicEL
 		}
 	}
 
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+	if err := wait.PollWithRetryable(func() (bool, error) {
 		if _, err := s.scope.ELB.ModifyLoadBalancerAttributes(attrs); err != nil {
 			return false, err
 		}
@@ -267,7 +267,7 @@ func (s *Service) deleteClassicELBAndWait(name string) error {
 		LoadBalancerNames: aws.StringSlice([]string{name}),
 	}
 
-	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (done bool, err error) {
+	if err := wait.PollWithRetryable(func() (done bool, err error) {
 		out, err := s.scope.ELB.DescribeLoadBalancers(input)
 		if err != nil {
 			if code, ok := awserrors.Code(err); ok && code == awserrors.LoadBalancerNotFound {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
