### PR TITLE
:bug: Add unique label for MachineDeployment example

### DIFF
--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -4,15 +4,18 @@ metadata:
   name: ${CLUSTER_NAME}-md-0
   labels:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
 spec:
   replicas: 1
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      nodepool: nodepool-0
   template:
     metadata:
       labels:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        nodepool: nodepool-0
     spec:
       version: ${KUBERNETES_VERSION}
       bootstrap:


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a unique label for the Machine Deployment example, otherwise MachineSets for additional MachineDeployments would also match the same label selector

**Release note**:
```release-note
NONE
```
