### PR TITLE
🏃 Context cleanups

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -414,7 +414,7 @@ func (r *AWSMachineReconciler) AWSClusterToAWSMachines(o handler.MapObject) []ct
 	}
 	log := r.Log.WithValues("AWSCluster", c.Name, "Namespace", c.Namespace)
 
-	cluster, err := util.GetOwnerCluster(context.Background(), r.Client, c.ObjectMeta)
+	cluster, err := util.GetOwnerCluster(context.TODO(), r.Client, c.ObjectMeta)
 	switch {
 	case apierrors.IsNotFound(err) || cluster == nil:
 		return result
@@ -425,7 +425,7 @@ func (r *AWSMachineReconciler) AWSClusterToAWSMachines(o handler.MapObject) []ct
 
 	labels := map[string]string{clusterv1.MachineClusterLabelName: cluster.Name}
 	machineList := &clusterv1.MachineList{}
-	if err := r.List(context.Background(), machineList, client.InNamespace(c.Namespace), client.MatchingLabels(labels)); err != nil {
+	if err := r.List(context.TODO(), machineList, client.InNamespace(c.Namespace), client.MatchingLabels(labels)); err != nil {
 		log.Error(err, "failed to list Machines")
 		return nil
 	}

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -142,5 +142,5 @@ func (s *ClusterScope) ListOptionsLabelSelector() client.ListOption {
 
 // Close closes the current scope persisting the cluster configuration and status.
 func (s *ClusterScope) Close() error {
-	return s.patchHelper.Patch(context.Background(), s.AWSCluster)
+	return s.patchHelper.Patch(context.TODO(), s.AWSCluster)
 }

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -168,5 +168,5 @@ func (m *MachineScope) SetAnnotation(key, value string) {
 
 // Close the MachineScope by updating the machine spec, machine status.
 func (m *MachineScope) Close() error {
-	return m.patchHelper.Patch(context.Background(), m.AWSMachine)
+	return m.patchHelper.Patch(context.TODO(), m.AWSMachine)
 }


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adheres to the standard that the program should only use one context and `context.TODO()` everywhere a context is not available.

