### PR TITLE
:sparkles: Add support for applying custom tags to all AWS resources we manage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ examples/provider-components-base.yaml
 examples/provider-components/provider-components-*.yaml
 config/samples
 manager_image_patch.yaml-e
+
+.DS_Store

--- a/api/v1alpha2/tags.go
+++ b/api/v1alpha2/tags.go
@@ -61,6 +61,13 @@ func (t Tags) Difference(other Tags) Tags {
 	return res
 }
 
+// Merge merges in tags from other. If a tag already exists, it is replaced by the tag in other.
+func (t Tags) Merge(other Tags) {
+	for k, v := range other {
+		t[k] = v
+	}
+}
+
 // ResourceLifecycle configures the lifecycle of a resource
 type ResourceLifecycle string
 

--- a/api/v1alpha2/tags_test.go
+++ b/api/v1alpha2/tags_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTags_Merge(t *testing.T) {
+	tests := []struct {
+		name     string
+		other    Tags
+		expected Tags
+	}{
+		{
+			name:  "nil other",
+			other: nil,
+			expected: Tags{
+				"a": "b",
+				"c": "d",
+			},
+		},
+		{
+			name:  "empty other",
+			other: Tags{},
+			expected: Tags{
+				"a": "b",
+				"c": "d",
+			},
+		},
+		{
+			name: "disjoint",
+			other: Tags{
+				"1": "2",
+				"3": "4",
+			},
+			expected: Tags{
+				"a": "b",
+				"c": "d",
+				"1": "2",
+				"3": "4",
+			},
+		},
+		{
+			name: "overlapping, other wins",
+			other: Tags{
+				"1": "2",
+				"3": "4",
+				"a": "hello",
+			},
+			expected: Tags{
+				"a": "hello",
+				"c": "d",
+				"1": "2",
+				"3": "4",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tags := Tags{
+				"a": "b",
+				"c": "d",
+			}
+
+			tags.Merge(tc.other)
+			if e, a := tc.expected, tags; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %#v, got %#v", e, a)
+			}
+		})
+	}
+
+}

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -126,6 +126,7 @@ func (r *AWSMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 		Client:     r.Client,
 		Cluster:    cluster,
 		Machine:    machine,
+		AWSCluster: awsCluster,
 		AWSMachine: awsMachine,
 	})
 	if err != nil {

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -312,7 +312,7 @@ func (r *AWSMachineReconciler) reconcileNormal(ctx context.Context, machineScope
 	}
 
 	// Ensure that the tags are correct.
-	_, err = r.ensureTags(ec2svc, machineScope.AWSMachine, machineScope.GetInstanceID(), machineScope.AWSMachine.Spec.AdditionalTags)
+	_, err = r.ensureTags(ec2svc, machineScope.AWSMachine, machineScope.GetInstanceID(), machineScope.AdditionalTags())
 	if err != nil {
 		return reconcile.Result{}, errors.Errorf("failed to ensure tags: %+v", err)
 	}

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -144,3 +144,12 @@ func (s *ClusterScope) ListOptionsLabelSelector() client.ListOption {
 func (s *ClusterScope) Close() error {
 	return s.patchHelper.Patch(context.TODO(), s.AWSCluster)
 }
+
+// AdditionalTags returns AdditionalTags from the scope's AWSCluster. The returned value will never be nil.
+func (s *ClusterScope) AdditionalTags() infrav1.Tags {
+	if s.AWSCluster.Spec.AdditionalTags == nil {
+		s.AWSCluster.Spec.AdditionalTags = infrav1.Tags{}
+	}
+
+	return s.AWSCluster.Spec.AdditionalTags
+}

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -152,6 +152,7 @@ func (s *Service) getDefaultBastion() *infrav1.Instance {
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Name:        aws.String(name),
 			Role:        aws.String(infrav1.BastionRoleTagValue),
+			Additional:  s.scope.AdditionalTags(),
 		}),
 	}
 

--- a/pkg/cloud/services/ec2/eips.go
+++ b/pkg/cloud/services/ec2/eips.go
@@ -63,6 +63,7 @@ func (s *Service) allocateAddress(role string) (string, error) {
 				Lifecycle:   infrav1.ResourceLifecycleOwned,
 				Name:        aws.String(fmt.Sprintf("%s-eip-%s", s.scope.Name(), role)),
 				Role:        aws.String(role),
+				Additional:  s.scope.AdditionalTags(),
 			},
 		}); err != nil {
 			return false, err

--- a/pkg/cloud/services/ec2/gateways.go
+++ b/pkg/cloud/services/ec2/gateways.go
@@ -188,5 +188,6 @@ func (s *Service) getGatewayTagParams(id string) infrav1.BuildParams {
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        aws.String(name),
 		Role:        aws.String(infrav1.CommonRoleTagValue),
+		Additional:  s.scope.AdditionalTags(),
 	}
 }

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -108,14 +108,17 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*infrav1.Instance, 
 		RootDeviceSize: scope.AWSMachine.Spec.RootDeviceSize,
 	}
 
+	// Make sure to use the MachineScope here to get the merger of AWSCluster and AWSMachine tags
+	additionalTags := scope.AdditionalTags()
+	// Set the cloud provider tag
+	additionalTags[infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name())] = string(infrav1.ResourceLifecycleOwned)
+
 	input.Tags = infrav1.Build(infrav1.BuildParams{
 		ClusterName: s.scope.Name(),
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        aws.String(scope.Name()),
 		Role:        aws.String(scope.Role()),
-		Additional: infrav1.Tags{
-			infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name()): string(infrav1.ResourceLifecycleOwned),
-		},
+		Additional:  additionalTags,
 	})
 
 	var err error

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -461,6 +461,18 @@ func TestCreateInstance(t *testing.T) {
 				},
 			}
 
+			awsCluster := &infrav1.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: clusterv1.GroupVersion.String(),
+							Kind:       "Cluster",
+							Name:       "test1",
+						},
+					},
+				},
+			}
+
 			machine := &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test1",
@@ -498,6 +510,7 @@ func TestCreateInstance(t *testing.T) {
 				Cluster:    cluster,
 				Machine:    machine,
 				AWSMachine: awsMachine,
+				AWSCluster: awsCluster,
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)

--- a/pkg/cloud/services/ec2/natgateways.go
+++ b/pkg/cloud/services/ec2/natgateways.go
@@ -155,6 +155,7 @@ func (s *Service) getNatGatewayTagParams(id string) infrav1.BuildParams {
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        aws.String(name),
 		Role:        aws.String(infrav1.CommonRoleTagValue),
+		Additional:  s.scope.AdditionalTags(),
 	}
 }
 

--- a/pkg/cloud/services/ec2/routetables.go
+++ b/pkg/cloud/services/ec2/routetables.go
@@ -299,5 +299,6 @@ func (s *Service) getRouteTableTagParams(id string, public bool) infrav1.BuildPa
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        aws.String(name.String()),
 		Role:        aws.String(infrav1.CommonRoleTagValue),
+		Additional:  s.scope.AdditionalTags(),
 	}
 }

--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -430,7 +430,7 @@ func (s *Service) getDefaultSecurityGroup(role infrav1.SecurityGroupRole) *ec2.S
 }
 
 func (s *Service) getSecurityGroupTagParams(name string, id string, role infrav1.SecurityGroupRole) infrav1.BuildParams {
-	additional := infrav1.Tags{}
+	additional := s.scope.AdditionalTags()
 	if role == infrav1.SecurityGroupLB {
 		additional[infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name())] = string(infrav1.ResourceLifecycleOwned)
 	}

--- a/pkg/cloud/services/ec2/subnets.go
+++ b/pkg/cloud/services/ec2/subnets.go
@@ -316,7 +316,7 @@ func (s *Service) deleteSubnet(id string) error {
 
 func (s *Service) getSubnetTagParams(id string, public bool) infrav1.BuildParams {
 	var role string
-	var additionalTags infrav1.Tags
+	additionalTags := s.scope.AdditionalTags()
 
 	if public {
 		role = infrav1.PublicRoleTagValue
@@ -325,9 +325,7 @@ func (s *Service) getSubnetTagParams(id string, public bool) infrav1.BuildParams
 	}
 
 	// Add tag needed for Service type=LoadBalancer
-	additionalTags = infrav1.Tags{
-		infrav1.NameKubernetesAWSCloudProviderPrefix + s.scope.Name(): string(infrav1.ResourceLifecycleShared),
-	}
+	additionalTags[infrav1.NameKubernetesAWSCloudProviderPrefix+s.scope.Name()] = string(infrav1.ResourceLifecycleShared)
 
 	var name strings.Builder
 	name.WriteString(s.scope.Name())

--- a/pkg/cloud/services/ec2/vpc.go
+++ b/pkg/cloud/services/ec2/vpc.go
@@ -286,5 +286,6 @@ func (s *Service) getVPCTagParams(id string) infrav1.BuildParams {
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        aws.String(name),
 		Role:        aws.String(infrav1.CommonRoleTagValue),
+		Additional:  s.scope.AdditionalTags(),
 	}
 }

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -164,6 +164,7 @@ func (s *Service) getAPIServerClassicELBSpec() *infrav1.ClassicELB {
 		ClusterName: s.scope.Name(),
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Role:        aws.String(infrav1.APIServerRoleTagValue),
+		Additional:  s.scope.AdditionalTags(),
 	})
 
 	for _, sn := range s.scope.Subnets().FilterPublic() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for applying custom tags to all AWS resources we manage. Every tag in AWSCluster.Spec.AdditionalTags is applied to all AWS resources we manage. For ec2 instances, we process tags in both AWSCluster and AWSMachine, with those in AWSMachine taking precedence if the same tag is present in both.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1105 

/kind feature
/priority important-soon
/milestone v0.4.x