### PR TITLE
✨  Specified measurement unit for rootdevicesize comment

### DIFF
--- a/api/v1alpha2/awsmachine_types.go
+++ b/api/v1alpha2/awsmachine_types.go
@@ -79,7 +79,7 @@ type AWSMachineSpec struct {
 	// SSHKeyName is the name of the ssh key to attach to the instance.
 	SSHKeyName string `json:"sshKeyName,omitempty"`
 
-	// RootDeviceSize is the size of the root volume.
+	// RootDeviceSize is the size of the root volume in gigabytes(GB).
 	// +optional
 	RootDeviceSize int64 `json:"rootDeviceSize,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -141,7 +141,7 @@ spec:
                 2. Cluster/flavor setting 3. Subnet default'
               type: boolean
             rootDeviceSize:
-              description: RootDeviceSize is the size of the root volume.
+              description: RootDeviceSize is the size of the root volume in gigabytes(GB).
               format: int64
               type: integer
             sshKeyName:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -152,7 +152,8 @@ spec:
                         1. This field if set 2. Cluster/flavor setting 3. Subnet default'
                       type: boolean
                     rootDeviceSize:
-                      description: RootDeviceSize is the size of the root volume.
+                      description: RootDeviceSize is the size of the root volume in
+                        gigabytes(GB).
                       format: int64
                       type: integer
                     sshKeyName:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a small addition to the RootDeviceSize comment in AWSMachineSpec type to specify what measurement unit (GBs) are used by this field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1118 

