### PR TITLE
🐛fix: use clusterScope's port in APIEndpoint

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -166,10 +166,11 @@ func reconcileNormal(clusterScope *scope.ClusterScope) (reconcile.Result, error)
 	}
 
 	// Set APIEndpoints so the Cluster API Cluster Controller can pull them
+	// TODO: should we get the Port from the first listener on the ELB?
 	awsCluster.Status.APIEndpoints = []infrav1.APIEndpoint{
 		{
 			Host: awsCluster.Status.Network.APIServerELB.DNSName,
-			Port: int(awsCluster.Status.Network.APIServerELB.Listeners[0].Port),
+			Port: int(clusterScope.APIServerPort()),
 		},
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Currently the reconciler requeues when the apiserver DNS name is not set. If the DNS is set, the port of the first listener is grabbed. Turns out we were not actually grabbing the listeners...

So there's an `index out of range` panic :D