### PR TITLE
[v1alpha1] :sparkles: Remove use of cloud-init module

### DIFF
--- a/pkg/cloud/aws/services/userdata/controlplane_init.go
+++ b/pkg/cloud/aws/services/userdata/controlplane_init.go
@@ -31,9 +31,8 @@ const (
 {{.ClusterConfiguration | Indent 6}}
       ---
 {{.InitConfiguration | Indent 6}}
-kubeadm:
-  operation: init
-  config: /tmp/kubeadm.yaml
+runcmd:
+- [kubeadm, init, --config, /tmp/kubeadm.yaml]
 `
 )
 

--- a/pkg/cloud/aws/services/userdata/controlplane_join.go
+++ b/pkg/cloud/aws/services/userdata/controlplane_join.go
@@ -23,14 +23,13 @@ import (
 const (
 	controlPlaneJoinCloudInit = `{{.Header}}
 {{template "files" .WriteFiles}}
--   path: /tmp/kubeadm-controlplane-join-config.yaml
+-   path: /tmp/kubeadm.yaml
     owner: root:root
     permissions: '0640'
     content: |
 {{.JoinConfiguration | Indent 6}}
-kubeadm:
-  operation: join
-  config: /tmp/kubeadm-controlplane-join-config.yaml
+runcmd:
+- [kubeadm, join, --config, /tmp/kubeadm.yaml]
 `
 )
 

--- a/pkg/cloud/aws/services/userdata/node.go
+++ b/pkg/cloud/aws/services/userdata/node.go
@@ -19,15 +19,14 @@ package userdata
 const (
 	nodeCloudInit = `{{.Header}}
 write_files:
--   path: /tmp/kubeadm-node.yaml
+-   path: /tmp/kubeadm.yaml
     owner: root:root
     permissions: '0640'
     content: |
       ---
 {{.JoinConfiguration | Indent 6}}
-kubeadm:
-  operation: join
-  config: /tmp/kubeadm-node.yaml
+runcmd:
+- [kubeadm, join, --config, /tmp/kubeadm.yaml]
 `
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the use of the custom kubeadm cloud init module
