### PR TITLE
fix: use copy builtin correctly for security groups

### DIFF
--- a/pkg/cloud/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/services/cloudformation/bootstrap.go
@@ -175,6 +175,7 @@ func controllersPolicy(accountID, partition string) *iam.PolicyDocument {
 					"ec2:DescribeImages",
 					"ec2:DescribeNatGateways",
 					"ec2:DescribeNetworkInterfaces",
+					"ec2:DescribeNetworkInterfaceAttribute",
 					"ec2:DescribeRouteTables",
 					"ec2:DescribeSecurityGroups",
 					"ec2:DescribeSubnets",

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -622,7 +622,7 @@ func (s *Service) attachSecurityGroupsToNetworkInterface(groups []string, interf
 		return nil
 	}
 
-	s.scope.V(3).Info("Updating security groups", "groups", totalGroups)
+	s.scope.Info("Updating security groups", "groups", totalGroups)
 
 	input := &ec2.ModifyNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String(interfaceID),

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -608,8 +608,8 @@ func (s *Service) attachSecurityGroupsToNetworkInterface(groups []string, interf
 		return errors.Wrapf(err, "failed to look up network interface security groups: %+v", err)
 	}
 
-	var totalGroups []string
-	copy(existingGroups, totalGroups)
+	totalGroups := make([]string, len(existingGroups))
+	copy(totalGroups, existingGroups)
 
 	for _, group := range groups {
 		if !util.Contains(existingGroups, group) {
@@ -621,6 +621,8 @@ func (s *Service) attachSecurityGroupsToNetworkInterface(groups []string, interf
 	if len(existingGroups) == len(totalGroups) {
 		return nil
 	}
+
+	s.scope.V(3).Info("updating security groups", "groups", totalGroups)
 
 	input := &ec2.ModifyNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String(interfaceID),

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -622,7 +622,7 @@ func (s *Service) attachSecurityGroupsToNetworkInterface(groups []string, interf
 		return nil
 	}
 
-	s.scope.V(3).Info("updating security groups", "groups", totalGroups)
+	s.scope.V(3).Info("Updating security groups", "groups", totalGroups)
 
 	input := &ec2.ModifyNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String(interfaceID),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Turns out, the destination in the copy builtin is first!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1151 

