### PR TITLE
🐛Fix a leak of AWS Tags from between Machine and Cluster resources

### DIFF
--- a/api/v1alpha2/awscluster_types.go
+++ b/api/v1alpha2/awscluster_types.go
@@ -40,7 +40,7 @@ type AWSClusterSpec struct {
 	// AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the
 	// ones added by default.
 	// +optional
-	AdditionalTags map[string]string `json:"additionalTags,omitempty"`
+	AdditionalTags Tags `json:"additionalTags,omitempty"`
 }
 
 // AWSClusterStatus defines the observed state of AWSCluster

--- a/api/v1alpha2/awsmachine_types.go
+++ b/api/v1alpha2/awsmachine_types.go
@@ -46,7 +46,7 @@ type AWSMachineSpec struct {
 	// AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the
 	// AWSMachine's value takes precedence.
 	// +optional
-	AdditionalTags map[string]string `json:"additionalTags,omitempty"`
+	AdditionalTags Tags `json:"additionalTags,omitempty"`
 
 	// IAMInstanceProfile is a name of an IAM instance profile to assign to the instance
 	// +optional

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -449,6 +449,7 @@ func autoConvert_v1alpha2_Instance_To_v1alpha1_Instance(in *Instance, out *v1alp
 	out.ENASupport = (*bool)(unsafe.Pointer(in.ENASupport))
 	out.EBSOptimized = (*bool)(unsafe.Pointer(in.EBSOptimized))
 	out.RootDeviceSize = in.RootDeviceSize
+	// WARNING: in.NetworkInterfaces requires manual conversion: does not exist in peer-type
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	return nil
 }

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -650,6 +650,11 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NetworkInterfaces != nil {
+		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(map[string]string, len(*in))

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -106,7 +106,7 @@ func (in *AWSClusterSpec) DeepCopyInto(out *AWSClusterSpec) {
 	in.NetworkSpec.DeepCopyInto(&out.NetworkSpec)
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags
-		*out = make(map[string]string, len(*in))
+		*out = make(Tags, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -215,7 +215,7 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 	in.AMI.DeepCopyInto(&out.AMI)
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags
-		*out = make(map[string]string, len(*in))
+		*out = make(Tags, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -158,7 +158,7 @@ spec:
                   description: The current state of the instance.
                   type: string
                 networkInterfaces:
-                  description: Specifies ENIs to attach to instance
+                  description: Specifies ENIs attached to instance
                   items:
                     type: string
                   type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -132,8 +132,8 @@ spec:
                 m4.xlarge'
               type: string
             networkInterfaces:
-              description: NetworkInterfaces is a list of ENI's to associate with
-                the instance. A maximum of 2 may be specified.
+              description: NetworkInterfaces is a list of ENIs to associate with the
+                instance. A maximum of 2 may be specified.
               items:
                 type: string
               maxItems: 2

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -143,7 +143,7 @@ spec:
                         Example: m4.xlarge'
                       type: string
                     networkInterfaces:
-                      description: NetworkInterfaces is a list of ENI's to associate
+                      description: NetworkInterfaces is a list of ENIs to associate
                         with the instance. A maximum of 2 may be specified.
                       items:
                         type: string

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -170,7 +170,7 @@ func (s *ClusterScope) AdditionalTags() infrav1.Tags {
 		s.AWSCluster.Spec.AdditionalTags = infrav1.Tags{}
 	}
 
-	return infrav1.Tags(s.AWSCluster.Spec.AdditionalTags).DeepCopy()
+	return s.AWSCluster.Spec.AdditionalTags.DeepCopy()
 }
 
 // APIServerPort returns the APIServerPort to use when creating the load balancer.

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -170,7 +170,7 @@ func (s *ClusterScope) AdditionalTags() infrav1.Tags {
 		s.AWSCluster.Spec.AdditionalTags = infrav1.Tags{}
 	}
 
-	return s.AWSCluster.Spec.AdditionalTags
+	return infrav1.Tags(s.AWSCluster.Spec.AdditionalTags).DeepCopy()
 }
 
 // APIServerPort returns the APIServerPort to use when creating the load balancer.

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -180,9 +180,11 @@ func (m *MachineScope) Close() error {
 // AdditionalTags merges AdditionalTags from the scope's AWSCluster and AWSMachine. If the same key is present in both,
 // the value from AWSMachine takes precedence. The returned Tags will never be nil.
 func (m *MachineScope) AdditionalTags() infrav1.Tags {
-	var tags infrav1.Tags = make(infrav1.Tags)
+	tags := make(infrav1.Tags)
 
+	// Start with the cluster-wide tags...
 	tags.Merge(m.AWSCluster.Spec.AdditionalTags)
+	// ... and merge in the Machine's
 	tags.Merge(m.AWSMachine.Spec.AdditionalTags)
 
 	return tags

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -180,11 +180,9 @@ func (m *MachineScope) Close() error {
 // AdditionalTags merges AdditionalTags from the scope's AWSCluster and AWSMachine. If the same key is present in both,
 // the value from AWSMachine takes precedence. The returned Tags will never be nil.
 func (m *MachineScope) AdditionalTags() infrav1.Tags {
-	var tags infrav1.Tags = m.AWSCluster.Spec.AdditionalTags
-	if tags == nil {
-		tags = infrav1.Tags{}
-	}
+	var tags infrav1.Tags = make(infrav1.Tags)
 
+	tags.Merge(m.AWSCluster.Spec.AdditionalTags)
 	tags.Merge(m.AWSMachine.Spec.AdditionalTags)
 
 	return tags

--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -62,9 +62,9 @@ func (s *Service) reconcileSecurityGroups() error {
 	// Declare all security group roles that the reconcile loop takes care of.
 	roles := []infrav1.SecurityGroupRole{
 		infrav1.SecurityGroupBastion,
+		infrav1.SecurityGroupLB,
 		infrav1.SecurityGroupControlPlane,
 		infrav1.SecurityGroupNode,
-		infrav1.SecurityGroupLB,
 	}
 
 	// First iteration makes sure that the security group are valid and fully created.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Fixes a "leak" where the load balancer security groups' tags were being applied to other security groups because maps are secret pointers.

There's a test for the security group issue specifically, but I think I fixed/prevented some other odd behaviors around merging a Machine's tags into the cluster-level Scope.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
