### PR TITLE
:sparkles: Control plane load balancer scheme can be set in cluster network spec

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -169,6 +169,10 @@ type NetworkSpec struct {
 	// Subnets configuration.
 	// +optional
 	Subnets Subnets `json:"subnets,omitempty"`
+
+	// ControlPlaneLoadBalancerScheme (defaults to Internet-facing)
+	// +optional
+	ControlPlaneLoadBalancerScheme ClassicELBScheme `json:"controlPlaneLoadBalancerScheme,omitempty""`
 }
 
 // APIEndpoint represents a reachable Kubernetes API endpoint.

--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -172,7 +172,7 @@ type NetworkSpec struct {
 
 	// ControlPlaneLoadBalancerScheme (defaults to Internet-facing)
 	// +optional
-	ControlPlaneLoadBalancerScheme ClassicELBScheme `json:"controlPlaneLoadBalancerScheme,omitempty""`
+	ControlPlaneLoadBalancerScheme *ClassicELBScheme `json:"controlPlaneLoadBalancerScheme,omitempty""`
 }
 
 // APIEndpoint represents a reachable Kubernetes API endpoint.

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -146,6 +146,14 @@ func (s *ClusterScope) Region() string {
 	return s.AWSCluster.Spec.Region
 }
 
+// ControlPlaneLoadBalancerScheme returns the Classic ELB scheme (public or internal facing)
+func (s *ClusterScope) ControlPlaneLoadBalancerScheme() infrav1.ClassicELBScheme {
+	if s.AWSCluster.Spec.NetworkSpec.ControlPlaneLoadBalancerScheme == "" {
+		return infrav1.ClassicELBSchemeInternetFacing
+	}
+	return s.AWSCluster.Spec.NetworkSpec.ControlPlaneLoadBalancerScheme
+}
+
 // ControlPlaneConfigMapName returns the name of the ConfigMap used to
 // coordinate the bootstrapping of control plane nodes.
 func (s *ClusterScope) ControlPlaneConfigMapName() string {

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -165,7 +165,7 @@ func GenerateELBName(clusterName string, elbName string) string {
 func (s *Service) getAPIServerClassicELBSpec() *infrav1.ClassicELB {
 	res := &infrav1.ClassicELB{
 		Name:   GenerateELBName(s.scope.Name(), infrav1.APIServerRoleTagValue),
-		Scheme: infrav1.ClassicELBSchemeInternetFacing,
+		Scheme: s.scope.ControlPlaneLoadBalancerScheme(),
 		Listeners: []*infrav1.ClassicELBListener{
 			{
 				Protocol:         infrav1.ClassicELBProtocolTCP,


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the control plane load balancer is always created with the `Internet-facing` scheme. Private VPCs need to be able to set the scheme to `internal`. This PR adds an optional property `ControlPlaneLoadBalancerScheme` to the `NetworkSpec` type. The value defaults to `Internet-facing` for backwards compatibility but can be set to `internal` to support private VPCs.

Fixes #873

