### PR TITLE
✨Increase AWSCluster and AWSMachine default concurrency

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,13 +92,13 @@ func main() {
 
 	flag.IntVar(&awsClusterConcurrency,
 		"awscluster-concurrency",
-		1,
+		2,
 		"Number of AWSClusters to process simultaneously",
 	)
 
 	flag.IntVar(&awsMachineConcurrency,
 		"awsmachine-concurrency",
-		1,
+		2,
 		"Number of AWSMachines to process simultaneously",
 	)
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
As discussed on [slack](https://kubernetes.slack.com/archives/CD6U2V71N/p1570024727095600), and seeing lots of user confusion, this PR increased the default concurrency for the reconcilers.

