### PR TITLE
:sparkles: Apply elb-related tags to managed subnets

### DIFF
--- a/pkg/cloud/services/ec2/subnets.go
+++ b/pkg/cloud/services/ec2/subnets.go
@@ -35,6 +35,9 @@ import (
 const (
 	defaultPrivateSubnetCidr = "10.0.0.0/24"
 	defaultPublicSubnetCidr  = "10.0.1.0/24"
+
+	internalLoadBalancerTag = "kubernetes.io/role/internal-elb"
+	externalLoadBalancerTag = "kubernetes.io/role/elb"
 )
 
 func (s *Service) reconcileSubnets() error {
@@ -320,8 +323,10 @@ func (s *Service) getSubnetTagParams(id string, public bool) infrav1.BuildParams
 
 	if public {
 		role = infrav1.PublicRoleTagValue
+		additionalTags[externalLoadBalancerTag] = "1"
 	} else {
 		role = infrav1.PrivateRoleTagValue
+		additionalTags[internalLoadBalancerTag] = "1"
 	}
 
 	// Add tag needed for Service type=LoadBalancer

--- a/pkg/cloud/services/ec2/subnets_test.go
+++ b/pkg/cloud/services/ec2/subnets_test.go
@@ -44,8 +44,6 @@ const (
 )
 
 func TestReconcileSubnets(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 
 	testCases := []struct {
 		name   string
@@ -158,6 +156,10 @@ func TestReconcileSubnets(t *testing.T) {
 
 				m.WaitUntilSubnetAvailable(gomock.Any())
 
+				// Tags for existing private subnets
+				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+					Return(nil, nil)
+				// Tags for new subnets
 				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(nil, nil)
 
@@ -491,6 +493,10 @@ func TestReconcileSubnets(t *testing.T) {
 
 				m.WaitUntilSubnetAvailable(gomock.Any())
 
+				// Private subnet
+				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+					Return(nil, nil)
+				// Public subnet
 				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(nil, nil)
 			},
@@ -499,6 +505,8 @@ func TestReconcileSubnets(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 			ec2Mock := mock_ec2iface.NewMockEC2API(mockCtrl)
 			elbMock := mock_elbiface.NewMockELBAPI(mockCtrl)
 
@@ -531,9 +539,6 @@ func TestReconcileSubnets(t *testing.T) {
 }
 
 func TestDiscoverSubnets(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
 	testCases := []struct {
 		name   string
 		input  *infrav1.NetworkSpec
@@ -641,7 +646,6 @@ func TestDiscoverSubnets(t *testing.T) {
 						},
 					}),
 					gomock.Any()).Return(nil)
-
 			},
 			expect: []*infrav1.SubnetSpec{
 				{
@@ -669,6 +673,8 @@ func TestDiscoverSubnets(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 			ec2Mock := mock_ec2iface.NewMockEC2API(mockCtrl)
 			elbMock := mock_elbiface.NewMockELBAPI(mockCtrl)
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Amazon requires [certain tags](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html) on subnets for ALBs and other resources to be provisioned. This causes us to always set those tags. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1142 

