### PR TITLE
:bug: Actually apply explicitly specified subnet tags

### DIFF
--- a/pkg/cloud/services/ec2/subnets.go
+++ b/pkg/cloud/services/ec2/subnets.go
@@ -101,7 +101,7 @@ LoopExisting:
 				if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
 					if err := tags.Ensure(exsn.Tags, &tags.ApplyParams{
 						EC2Client:   s.scope.EC2,
-						BuildParams: s.getSubnetTagParams(exsn.ID, exsn.IsPublic),
+						BuildParams: s.getSubnetTagParams(exsn.ID, exsn.IsPublic, sn.Tags),
 					}); err != nil {
 						return false, err
 					}
@@ -253,7 +253,7 @@ func (s *Service) createSubnet(sn *infrav1.SubnetSpec) (*infrav1.SubnetSpec, err
 	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
 		if err := tags.Apply(&tags.ApplyParams{
 			EC2Client:   s.scope.EC2,
-			BuildParams: s.getSubnetTagParams(*out.Subnet.SubnetId, sn.IsPublic),
+			BuildParams: s.getSubnetTagParams(*out.Subnet.SubnetId, sn.IsPublic, sn.Tags),
 		}); err != nil {
 			return false, err
 		}
@@ -314,7 +314,7 @@ func (s *Service) deleteSubnet(id string) error {
 	return nil
 }
 
-func (s *Service) getSubnetTagParams(id string, public bool) infrav1.BuildParams {
+func (s *Service) getSubnetTagParams(id string, public bool, manualTags infrav1.Tags) infrav1.BuildParams {
 	var role string
 	additionalTags := s.scope.AdditionalTags()
 
@@ -326,6 +326,10 @@ func (s *Service) getSubnetTagParams(id string, public bool) infrav1.BuildParams
 
 	// Add tag needed for Service type=LoadBalancer
 	additionalTags[infrav1.NameKubernetesAWSCloudProviderPrefix+s.scope.Name()] = string(infrav1.ResourceLifecycleShared)
+
+	for k, v := range manualTags {
+		additionalTags[k] = v
+	}
 
 	var name strings.Builder
 	name.WriteString(s.scope.Name())


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
You can set your own subnet tags with `AWSClusterSpec.NetworkSpec.Subnets[].Tags`, but right now they're completely ignored. this actually applies them to created or modified subnets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1143 

