### PR TITLE
WIP: :sparkles: Support specifying IngressCidrBlocks for control plane ELB

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -66,6 +66,12 @@ type AWSClusterSpec struct {
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer
 type AWSLoadBalancerSpec struct {
+
+	// Ingress rules associated with the load balancer's Security Group (defaults to
+	// 0.0.0.0/0 if not specified)
+	// +optional
+	IngressCidrBlocks []string `json:ingressCidrBlocks,omitempty"`
+
 	// Scheme sets the scheme of the load balancer (defaults to Internet-facing)
 	// +optional
 	Scheme *ClassicELBScheme `json:"scheme,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -53,6 +53,11 @@ spec:
                 description: ControlPlaneLoadBalancer is optional configuration for
                   customizing control plane behavior
                 properties:
+                  ingressCidrBlocks:
+                    description: Ingress CIDRs to allow access to the load balancer
+                    items:
+                      type: string
+                    type: array
                   scheme:
                     description: Scheme sets the scheme of the load balancer (defaults
                       to Internet-facing)

--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -371,6 +371,14 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 			},
 		}, nil
 	case infrav1.SecurityGroupControlPlane:
+		// check and see if ingress CIDR blocks were specified for the API-server/ELB
+		elbCidrBlocks := []string{anyIPv4CidrBlock}
+		controlPlaneLBSpec := s.scope.AWSCluster.AwsClusterSpec.ControlPlaneLoadBalancer
+
+		if controlPlaneLBSpec.IngressCidrBlock {
+			elbCidrBlocks = controlPlaneLBSpec.IngressCidrBlock
+		}
+
 		return infrav1.IngressRules{
 			s.defaultSSHIngressRule(s.scope.SecurityGroups()[infrav1.SecurityGroupBastion].ID),
 			{
@@ -378,7 +386,7 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 				Protocol:    infrav1.SecurityGroupProtocolTCP,
 				FromPort:    6443,
 				ToPort:      6443,
-				CidrBlocks:  []string{anyIPv4CidrBlock},
+				CidrBlocks:  elbCidrBlocks,
 			},
 			{
 				Description:            "etcd",


### PR DESCRIPTION
Currently the load balancer defaults to allow ingress from 0.0.0.0/0 by
default which is scary, but good for getting things started by default.

Introducing IngressCidr field to the AWSLoadBalancerSpec to allow end
users to specify an alternative security group rule for ELB.

TODO: add deep copy boiler plate code

Signed-off-by: Eric Ernst <eric.ernst@intel.com>

:running: ?? 

**What this PR does / why we need it**:

Allow end user to specify ingress rules for the load balancer(s).

**Which issue(s) this PR fixes** 

None.
