### PR TITLE
:warning: Use multi-AZ as default example configuration 

### DIFF
--- a/examples/aws-region-az.sh
+++ b/examples/aws-region-az.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export AWS_REGION_AZA=${AWS_REGION}a
+export AWS_REGION_AZB=${AWS_REGION}a
+export AWS_REGION_AZC=${AWS_REGION}a
+
+REGIONMAPAZLIST="
+eu-north-1:eu-north-1a eu-north-1b eu-north-1c,
+ap-south-1:ap-south-1a ap-south-1b ap-south-1c,
+eu-west-3:eu-west-3a eu-west-3b eu-west-3c,
+eu-west-2:eu-west-2a eu-west-2b eu-west-2c,
+eu-west-1:eu-west-1a eu-west-1b eu-west-1c,
+ap-northeast-2:ap-northeast-2a ap-northeast-2b ap-northeast-2c,
+ap-northeast-1:ap-northeast-1a ap-northeast-1c ap-northeast-1d,
+sa-east-1:sa-east-1a sa-east-1b sa-east-1c,
+ca-central-1:ca-central-1a ca-central-1b,
+ap-east-1:ap-east-1a ap-east-1b ap-east-1c,
+ap-southeast-1:ap-southeast-1a ap-southeast-1b ap-southeast-1c,
+ap-southeast-2:ap-southeast-2a ap-southeast-2b ap-southeast-2c,
+eu-central-1:eu-central-1a eu-central-1b eu-central-1c,
+us-east-1:us-east-1a us-east-1b us-east-1c us-east-1d us-east-1e us-east-1f,
+us-east-2:us-east-2a us-east-2b us-east-2c,
+us-west-1:us-west-1b us-west-1c,
+us-west-2:us-west-2a us-west-2b us-west-2c us-west-2d,
+"
+
+function set_region_az_info() {
+  declare -a AZLIST='('$(echo $REGIONMAPAZLIST | tr ',' '\n' | grep $1 | cut -d":" -f2)')'
+  if [ ${#AZLIST[@]} -lt 3 ];
+  then
+    echo "this region not three AZ"
+    AWS_REGION_AZA=${AZLIST[0]}
+    AWS_REGION_AZB=${AZLIST[0]}
+    AWS_REGION_AZC=${AZLIST[0]}
+  else
+    AWS_REGION_AZA=${AZLIST[0]}
+    AWS_REGION_AZB=${AZLIST[1]}
+    AWS_REGION_AZC=${AZLIST[2]}
+  fi
+}

--- a/examples/cluster/cluster.yaml
+++ b/examples/cluster/cluster.yaml
@@ -6,7 +6,11 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: ["192.168.0.0/16"]
+      cidrBlocks:
+        - "192.168.0.0/16"
+    services:
+      cidrBlocks:
+        - "192.168.1.0/24"
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
     kind: AWSCluster
@@ -19,3 +23,23 @@ metadata:
 spec:
   region: ${AWS_REGION}
   sshKeyName: ${SSH_KEY_NAME}
+  networkSpec:
+    subnets:
+    - availabilityZone: ${AWS_REGION_AZA}
+      cidrBlock: "10.0.100.0/24"
+      isPublic: true
+    - availabilityZone: ${AWS_REGION_AZA}
+      cidrBlock: "10.0.101.0/24"
+      isPublic: false
+    - availabilityZone: ${AWS_REGION_AZB}
+      cidrBlock: "10.0.102.0/24"
+      isPublic: true
+    - availabilityZone: ${AWS_REGION_AZB}
+      cidrBlock: "10.0.103.0/24"
+      isPublic: false
+    - availabilityZone: ${AWS_REGION_AZC}
+      cidrBlock: "10.0.104.0/24"
+      isPublic: true
+    - availabilityZone: ${AWS_REGION_AZC}
+      cidrBlock: "10.0.105.0/24"
+      isPublic: false

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -25,6 +25,7 @@ spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
+  availabilityZone: ${AWS_REGION_AZA}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
 kind: KubeadmConfig
@@ -71,6 +72,7 @@ spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
+  availabilityZone: ${AWS_REGION_AZB}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
 kind: KubeadmConfig
@@ -111,6 +113,7 @@ spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
+  availabilityZone: ${AWS_REGION_AZC}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
 kind: KubeadmConfig

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -20,6 +20,10 @@ set -o nounset
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 OUTPUT_DIR=${OUTPUT_DIR:-${SOURCE_DIR}/_out}
 
+# import azinfo
+source $SOURCE_DIR/aws-region-az.sh
+set_region_az_info ${AWS_REGION}
+
 # Binaries
 ENVSUBST=${ENVSUBST:-envsubst}
 command -v "${ENVSUBST}" >/dev/null 2>&1 || echo -v "Cannot find ${ENVSUBST} in path."

--- a/hack/aws-region-az-fetch.sh
+++ b/hack/aws-region-az-fetch.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+type aws || exit
+
+echo "fetching region list and AZ list"
+for REGION in $(aws ec2 describe-regions --query "Regions[].{Name:RegionName}" --output text | paste -sd " " -);
+do
+  AZLIST=$(aws ec2 describe-availability-zones --region $REGION --query "AvailabilityZones[].{Name:ZoneName}" --output text | paste -sd " " -)
+  echo "$REGION:$AZLIST,"
+done


### PR DESCRIPTION
In most scenarios with availability requirements, customers will create clusters that fully support full-region fault tolerance.

TODO: Multiple private subnets share one natgw.

#967 

Signed-off-by: guohaowang <wangguohao.2009@gmail.com>
