### PR TITLE
🐛 Add omitempty to RouteTableID

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -224,7 +224,7 @@ type SubnetSpec struct {
 
 	// RouteTableID is the routing table id associated with the subnet.
 	// +optional
-	RouteTableID *string `json:"routeTableId"`
+	RouteTableID *string `json:"routeTableId,omitempty"`
 
 	// NatGatewayID is the NAT gateway id associated with the subnet.
 	// Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add omitempty to RouteTableID. Without this, if you leave the field nil
and try to use a go client (client-go / controller-runtime) to create an
AWSCluster, it will fail with the error

spec.networkSpec.subnets.routeTableId in body must be of type string:
\"null\"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1195

