### PR TITLE
🐛Do not attempt to log NAT gateway ID when creation fails

### DIFF
--- a/pkg/cloud/services/ec2/natgateways.go
+++ b/pkg/cloud/services/ec2/natgateways.go
@@ -175,7 +175,7 @@ func (s *Service) createNatGateway(subnetID string) (*ec2.NatGateway, error) {
 		}
 		return true, nil
 	}, awserrors.InvalidSubnet); err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedCreateNATGateway", "Failed to create new NAT Gateway %q: %v", *out.NatGateway.NatGatewayId, err)
+		record.Warnf(s.scope.AWSCluster, "FailedCreateNATGateway", "Failed to create new NAT Gateway: %v", err)
 		return nil, errors.Wrapf(err, "failed to create NAT gateway for subnet ID %q", subnetID)
 	}
 	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateNATGateway", "Created new NAT Gateway %q", *out.NatGateway.NatGatewayId)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
To avoid a nil pointer dereference error, do not attempt to log the NAT
gateway ID when we get an error back from the AWS client.

**Which issue(s) this PR fixes**
Fixes #1209 

