### PR TITLE
:running: Update name of AWSMachineTemplate validating webhook

### DIFF
--- a/api/v1alpha3/awsmachinetemplate_webhook.go
+++ b/api/v1alpha3/awsmachinetemplate_webhook.go
@@ -31,7 +31,7 @@ func (r *AWSMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-awsmachinetemplate,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=awsmachinetemplates,versions=v1alpha3,name=vawsmachinetemplate.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-awsmachinetemplate,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=awsmachinetemplates,versions=v1alpha3,name=validation.awsmachine.infrastructure.x-k8s.io
 
 var _ webhook.Validator = &AWSMachineTemplate{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,7 +13,7 @@ webhooks:
       namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-awsmachinetemplate
   failurePolicy: Fail
-  name: vawsmachinetemplate.kb.io
+  name: validation.awsmachine.infrastructure.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**:
- Rename vawsmachinetemplate.kb.io to validating.awsmachine.infrastructure.x-k8s.io
