### PR TITLE
:bug: add a default bastion AMI for the eu-north-1 (Stockholm) region

### DIFF
--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -160,6 +160,8 @@ func (s *Service) defaultBastionAMILookup(region string) string {
 		return "ami-79aeae19"
 	case "us-west-2":
 		return "ami-1ee65166"
+	case "eu-north-1":
+		return "ami-7dd85203"
 	default:
 		return "unknown region"
 	}


### PR DESCRIPTION
The added AMI is "ami-7dd85203":

  Zone: eu-north-1
  Name: xenial
  Version: 16.04 LTS
  Arch: amd64
  Instance Type: hvm:ebs-ssd
  Release: 20190913
  AMI-ID: ami-7dd85203
  AKI-ID: hvm

**What this PR does / why we need it**:
At the moment there is no default bastion AMI for the `eu-north-1` region.


