### PR TITLE
:running: Tweak e2e timeout for waitForClusterInfrastructureReady

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -285,7 +285,7 @@ func waitForClusterInfrastructureReady(namespace, name string) {
 			}
 			return cluster.Status.InfrastructureReady, nil
 		},
-		10*time.Minute, 15*time.Second,
+		15*time.Minute, 15*time.Second,
 	).Should(BeTrue())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Attempts to resolve the current e2e failures around timing out while waiting for the cluster infrastructure to be ready

