### PR TITLE
:running: Patch up e2e tests

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -285,7 +285,7 @@ func waitForClusterInfrastructureReady(namespace, name string) {
 			}
 			return cluster.Status.InfrastructureReady, nil
 		},
-		10*time.Minute, 15*time.Second,
+		15*time.Minute, 15*time.Second,
 	).Should(BeTrue())
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/helpers/scheme"
 	"sigs.k8s.io/cluster-api/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha2"
 )
 
 func TestE2e(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix missing reference to `bootstrapv1`
- Increase timeout in waitForClusterInfrastructureReady
