### PR TITLE
🐛 Add a check whether the AWS credential file is present at startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,6 +130,17 @@ func main() {
 		}()
 	}
 
+	// Fail fast if the AWS credentials are not present.
+	awsCredentialsPath := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if len(awsCredentialsPath) == 0 {
+		awsCredentialsPath = "/home/.aws/credentials"
+	}
+	_, err := os.Stat(awsCredentialsPath)
+	if err != nil {
+		setupLog.Error(err, "AWS credentials not found")
+		os.Exit(1)
+	}
+
 	ctrl.SetLogger(klogr.New())
 	// Machine and cluster operations can create enough events to trigger the event recorder spam filter
 	// Setting the burst size higher ensures all events will be recorded and submitted to the API


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, a misconfigured (or missing) AWS credential secret will not cause any error until the controller tries to reconcile a cluster. Even then the issue does not cause a change in the controller status, and can only be derived from the controller logs:
```
controller.go:218] controller-runtime/controller "msg"="Reconciler error" "error"="failed to reconcile network for AWSCluster default/mycluster: failed to describe VPCs: failed to query ec2 for VPCs: NoCredentialProviders: no valid providers in chain. Deprecated.\n\tFor verbose messaging see aws.Config.CredentialsChainVerboseErrors"  "controller"="awscluster" "request"={"Namespace":"default","Name":"mycluster"}
```

This PR adds a small check in the initialization phase to ensure that the expected credential file has been provisioned.
