### PR TITLE
:warning: machines can be provisioned without SSH key pairs

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -35,7 +35,11 @@ type AWSClusterSpec struct {
 	Region string `json:"region,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the bastion host.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	// If nil, will use a default SSH key pair name
+	// If empty string, will NOT set an SSH key pair
+	// Otherwise, will set the SSH key pair name
+	// +optional
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the
 	// ones added by default.

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -77,7 +77,11 @@ type AWSMachineSpec struct {
 	Subnet *AWSResourceReference `json:"subnet,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the instance.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	// If nil, will use a default SSH key pair name
+	// If empty string, will NOT set an SSH key pair
+	// Otherwise, will set the SSH key pair name
+	// +optional
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// RootDeviceSize is the size of the root volume in gigabytes(GB).
 	// +optional

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -104,6 +104,11 @@ func (in *AWSClusterList) DeepCopyObject() runtime.Object {
 func (in *AWSClusterSpec) DeepCopyInto(out *AWSClusterSpec) {
 	*out = *in
 	in.NetworkSpec.DeepCopyInto(&out.NetworkSpec)
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
+	}
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags
 		*out = make(Tags, len(*in))
@@ -266,6 +271,11 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
 	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -17,77 +17,103 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: AWSCluster is the Schema for the awsclusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AWSClusterSpec defines the desired state of AWSCluster
-          properties:
-            additionalTags:
-              additionalProperties:
-                type: string
-              description: AdditionalTags is an optional set of tags to add to AWS
-                resources managed by the AWS provider, in addition to the ones added
-                by default.
-              type: object
-            controlPlaneLoadBalancer:
-              description: ControlPlaneLoadBalancer is optional configuration for
-                customizing control plane behavior
-              properties:
-                scheme:
-                  description: Scheme sets the scheme of the load balancer (defaults
-                    to Internet-facing)
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: AWSCluster is the Schema for the awsclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSClusterSpec defines the desired state of AWSCluster
+            properties:
+              additionalTags:
+                additionalProperties:
                   type: string
-              type: object
-            networkSpec:
-              description: NetworkSpec encapsulates all things related to AWS network.
-              properties:
-                subnets:
-                  description: Subnets configuration.
-                  items:
-                    description: SubnetSpec configures an AWS Subnet.
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              controlPlaneLoadBalancer:
+                description: ControlPlaneLoadBalancer is optional configuration for
+                  customizing control plane behavior
+                properties:
+                  scheme:
+                    description: Scheme sets the scheme of the load balancer (defaults
+                      to Internet-facing)
+                    type: string
+                type: object
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
                     properties:
-                      availabilityZone:
-                        description: AvailabilityZone defines the availability zone
-                          to use for this subnet in the cluster's region.
-                        type: string
                       cidrBlock:
                         description: CidrBlock is the CIDR block to be used when the
-                          provider creates a managed VPC.
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
                         type: string
                       id:
-                        description: ID defines a unique identifier to reference this
-                          resource.
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
                         type: string
-                      isPublic:
-                        description: IsPublic defines the subnet as a public subnet.
-                          A subnet is public when it is associated with a route table
-                          that has a route to an internet gateway.
-                        type: boolean
-                      natGatewayId:
-                        description: NatGatewayID is the NAT gateway id associated
-                          with the subnet. Ignored unless the subnet is managed by
-                          the provider, in which case this is set on the public subnet
-                          where the NAT gateway resides. It is then used to determine
-                          routes for private subnets in the same AZ as the public
-                          subnet.
-                        type: string
-                      routeTableId:
-                        description: RouteTableID is the routing table id associated
-                          with the subnet.
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
                         type: string
                       tags:
                         additionalProperties:
@@ -95,308 +121,662 @@ spec:
                         description: Tags is a collection of tags describing the resource.
                         type: object
                     type: object
-                  type: array
-                vpc:
-                  description: VPC configuration.
-                  properties:
-                    cidrBlock:
-                      description: CidrBlock is the CIDR block to be used when the
-                        provider creates a managed VPC. Defaults to 10.0.0.0/16.
-                      type: string
-                    id:
-                      description: ID is the vpc-id of the VPC this provider should
-                        use to create resources.
-                      type: string
-                    internetGatewayId:
-                      description: InternetGatewayID is the id of the internet gateway
-                        associated with the VPC.
-                      type: string
-                    tags:
-                      additionalProperties:
-                        type: string
-                      description: Tags is a collection of tags describing the resource.
-                      type: object
-                  type: object
-              type: object
-            region:
-              description: The AWS Region the cluster lives in.
-              type: string
-            sshKeyName:
-              description: SSHKeyName is the name of the ssh key to attach to the
-                bastion host.
-              type: string
-          type: object
-        status:
-          description: AWSClusterStatus defines the observed state of AWSCluster
-          properties:
-            apiEndpoints:
-              description: APIEndpoints represents the endpoints to communicate with
-                the control plane.
-              items:
-                description: APIEndpoint represents a reachable Kubernetes API endpoint.
-                properties:
-                  host:
-                    description: The hostname on which the API server is serving.
-                    type: string
-                  port:
-                    description: The port on which the API server is serving.
-                    type: integer
-                required:
-                - host
-                - port
                 type: object
-              type: array
-            bastion:
-              description: Instance describes an AWS instance.
-              properties:
-                ebsOptimized:
-                  description: Indicates whether the instance is optimized for Amazon
-                    EBS I/O.
-                  type: boolean
-                enaSupport:
-                  description: Specifies whether enhanced networking with ENA is enabled.
-                  type: boolean
-                iamProfile:
-                  description: The name of the IAM instance profile associated with
-                    the instance, if applicable.
-                  type: string
-                id:
-                  type: string
-                imageId:
-                  description: The ID of the AMI used to launch the instance.
-                  type: string
-                instanceState:
-                  description: The current state of the instance.
-                  type: string
-                networkInterfaces:
-                  description: Specifies ENIs attached to instance
-                  items:
-                    type: string
-                  type: array
-                privateIp:
-                  description: The private IPv4 address assigned to the instance.
-                  type: string
-                publicIp:
-                  description: The public IPv4 address assigned to the instance, if
-                    applicable.
-                  type: string
-                rootDeviceSize:
-                  description: Specifies size (in Gi) of the root storage device
-                  format: int64
-                  type: integer
-                securityGroupIds:
-                  description: SecurityGroupIDs are one or more security group IDs
-                    this instance belongs to.
-                  items:
-                    type: string
-                  type: array
-                sshKeyName:
-                  description: The name of the SSH key pair.
-                  type: string
-                subnetId:
-                  description: The ID of the subnet of the instance.
-                  type: string
-                tags:
-                  additionalProperties:
-                    type: string
-                  description: The tags associated with the instance.
-                  type: object
-                type:
-                  description: The instance type.
-                  type: string
-                userData:
-                  description: UserData is the raw data script passed to the instance
-                    which is run upon bootstrap. This field must not be base64 encoded
-                    and should only be used when running a new instance.
-                  type: string
-              required:
-              - id
-              type: object
-            network:
-              description: Network encapsulates AWS networking resources.
-              properties:
-                apiServerElb:
-                  description: APIServerELB is the Kubernetes api server classic load
-                    balancer.
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host.
+                type: string
+            type: object
+          status:
+            description: AWSClusterStatus defines the observed state of AWSCluster
+            properties:
+              apiEndpoints:
+                description: APIEndpoints represents the endpoints to communicate
+                  with the control plane.
+                items:
+                  description: APIEndpoint represents a reachable Kubernetes API endpoint.
                   properties:
-                    attributes:
-                      description: Attributes defines extra attributes associated
-                        with the load balancer.
-                      properties:
-                        idleTimeout:
-                          description: IdleTimeout is time that the connection is
-                            allowed to be idle (no data has been sent over the connection)
-                            before it is closed by the load balancer.
-                          format: int64
-                          type: integer
-                      type: object
-                    dnsName:
-                      description: DNSName is the dns name of the load balancer.
+                    host:
+                      description: The hostname on which the API server is serving.
                       type: string
-                    healthChecks:
-                      description: HealthCheck is the classic elb health check associated
-                        with the load balancer.
-                      properties:
-                        healthyThreshold:
-                          format: int64
-                          type: integer
-                        interval:
-                          description: A Duration represents the elapsed time between
-                            two instants as an int64 nanosecond count. The representation
-                            limits the largest representable duration to approximately
-                            290 years.
-                          format: int64
-                          type: integer
-                        target:
-                          type: string
-                        timeout:
-                          description: A Duration represents the elapsed time between
-                            two instants as an int64 nanosecond count. The representation
-                            limits the largest representable duration to approximately
-                            290 years.
-                          format: int64
-                          type: integer
-                        unhealthyThreshold:
-                          format: int64
-                          type: integer
-                      required:
-                      - healthyThreshold
-                      - interval
-                      - target
-                      - timeout
-                      - unhealthyThreshold
-                      type: object
-                    listeners:
-                      description: Listeners is an array of classic elb listeners
-                        associated with the load balancer. There must be at least
-                        one.
-                      items:
-                        description: ClassicELBListener defines an AWS classic load
-                          balancer listener.
-                        properties:
-                          instancePort:
-                            format: int64
-                            type: integer
-                          instanceProtocol:
-                            description: ClassicELBProtocol defines listener protocols
-                              for a classic load balancer.
-                            type: string
-                          port:
-                            format: int64
-                            type: integer
-                          protocol:
-                            description: ClassicELBProtocol defines listener protocols
-                              for a classic load balancer.
-                            type: string
-                        required:
-                        - instancePort
-                        - instanceProtocol
-                        - port
-                        - protocol
-                        type: object
-                      type: array
-                    name:
-                      description: The name of the load balancer. It must be unique
-                        within the set of load balancers defined in the region. It
-                        also serves as identifier.
-                      type: string
-                    scheme:
-                      description: Scheme is the load balancer scheme, either internet-facing
-                        or private.
-                      type: string
-                    securityGroupIds:
-                      description: SecurityGroupIDs is an array of security groups
-                        assigned to the load balancer.
-                      items:
-                        type: string
-                      type: array
-                    subnetIds:
-                      description: SubnetIDs is an array of subnets in the VPC attached
-                        to the load balancer.
-                      items:
-                        type: string
-                      type: array
-                    tags:
-                      additionalProperties:
-                        type: string
-                      description: Tags is a map of tags associated with the load
-                        balancer.
-                      type: object
+                    port:
+                      description: The port on which the API server is serving.
+                      type: integer
+                  required:
+                  - host
+                  - port
                   type: object
-                securityGroups:
-                  additionalProperties:
-                    description: SecurityGroup defines an AWS security group.
+                type: array
+              bastion:
+                description: Instance describes an AWS instance.
+                properties:
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootDeviceSize:
+                    description: Specifies size (in Gi) of the root storage device
+                    format: int64
+                    type: integer
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                required:
+                - id
+                type: object
+              network:
+                description: Network encapsulates AWS networking resources.
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
                     properties:
-                      id:
-                        description: ID is a unique identifier.
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
                         type: string
-                      ingressRule:
-                        description: IngressRules is the inbound rules associated
-                          with the security group.
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
                         items:
-                          description: IngressRule defines an AWS ingress rule for
-                            security groups.
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
                           properties:
-                            cidrBlocks:
-                              description: List of CIDR blocks to allow access from.
-                                Cannot be specified with SourceSecurityGroupID.
-                              items:
-                                type: string
-                              type: array
-                            description:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
                               type: string
-                            fromPort:
+                            port:
                               format: int64
                               type: integer
                             protocol:
-                              description: SecurityGroupProtocol defines the protocol
-                                type for a security group rule.
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
                               type: string
-                            sourceSecurityGroupIds:
-                              description: The security group id to allow access from.
-                                Cannot be specified with CidrBlocks.
-                              items:
-                                type: string
-                              type: array
-                            toPort:
-                              format: int64
-                              type: integer
                           required:
-                          - description
-                          - fromPort
+                          - instancePort
+                          - instanceProtocol
+                          - port
                           - protocol
-                          - toPort
                           type: object
                         type: array
                       name:
-                        description: Name is the security group name.
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load
+                          balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              ready:
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSCluster is the Schema for the awsclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSClusterSpec defines the desired state of AWSCluster
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              controlPlaneLoadBalancer:
+                description: ControlPlaneLoadBalancer is optional configuration for
+                  customizing control plane behavior
+                properties:
+                  scheme:
+                    description: Scheme sets the scheme of the load balancer (defaults
+                      to Internet-facing)
+                    type: string
+                type: object
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
+                    properties:
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                        type: string
+                      id:
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
+                        type: string
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
                         type: string
                       tags:
                         additionalProperties:
                           type: string
-                        description: Tags is a map of tags associated with the security
-                          group.
+                        description: Tags is a collection of tags describing the resource.
                         type: object
-                    required:
-                    - id
-                    - name
                     type: object
-                  description: SecurityGroups is a map from the role/kind of the security
-                    group to its unique name, if any.
+                type: object
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host. If nil, will use a default SSH key pair name If empty
+                  string, will NOT set an SSH key pair Otherwise, will set the SSH
+                  key pair name
+                type: string
+            type: object
+          status:
+            description: AWSClusterStatus defines the observed state of AWSCluster
+            properties:
+              apiEndpoints:
+                description: APIEndpoints represents the endpoints to communicate
+                  with the control plane.
+                items:
+                  description: APIEndpoint represents a reachable Kubernetes API endpoint.
+                  properties:
+                    host:
+                      description: The hostname on which the API server is serving.
+                      type: string
+                    port:
+                      description: The port on which the API server is serving.
+                      type: integer
+                  required:
+                  - host
+                  - port
                   type: object
-              type: object
-            ready:
-              type: boolean
-          required:
-          - ready
-          type: object
-      type: object
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: false
-  - name: v1alpha3
+                type: array
+              bastion:
+                description: Instance describes an AWS instance.
+                properties:
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootDeviceSize:
+                    description: Specifies size (in Gi) of the root storage device
+                    format: int64
+                    type: integer
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                required:
+                - id
+                type: object
+              network:
+                description: Network encapsulates AWS networking resources.
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
+                    properties:
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
+                        type: string
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
+                        items:
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
+                          properties:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                            port:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                          required:
+                          - instancePort
+                          - instanceProtocol
+                          - port
+                          - protocol
+                          type: object
+                        type: array
+                      name:
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load
+                          balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              ready:
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -17,35 +17,79 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: AWSMachine is the Schema for the awsmachines API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AWSMachineSpec defines the desired state of AWSMachine
-          properties:
-            additionalSecurityGroups:
-              description: AdditionalSecurityGroups is an array of references to security
-                groups that should be applied to the instance. These security groups
-                would be set in addition to any security groups defined at the cluster
-                level or in the actuator.
-              items:
-                description: AWSResourceReference is a reference to a specific AWS
-                  resource by ID, ARN, or filters. Only one of ID, ARN or Filters
-                  may be specified. Specifying more than one will result in a validation
-                  error.
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: AWSMachine is the Schema for the awsmachines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineSpec defines the desired state of AWSMachine
+            properties:
+              additionalSecurityGroups:
+                description: AdditionalSecurityGroups is an array of references to
+                  security groups that should be applied to the instance. These security
+                  groups would be set in addition to any security groups defined at
+                  the cluster level or in the actuator.
+                items:
+                  description: AWSResourceReference is a reference to a specific AWS
+                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
+                    may be specified. Specifying more than one will result in a validation
+                    error.
+                  properties:
+                    arn:
+                      description: ARN of resource
+                      type: string
+                    filters:
+                      description: 'Filters is a set of key/value pairs used to identify
+                        a resource They are applied according to the rules defined
+                        by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                      items:
+                        description: Filter is a filter used to identify an AWS resource
+                        properties:
+                          name:
+                            description: Name of the filter. Filter names are case-sensitive.
+                            type: string
+                          values:
+                            description: Values includes one or more filter values.
+                              Filter values are case-sensitive.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        - values
+                        type: object
+                      type: array
+                    id:
+                      description: ID of resource
+                      type: string
+                  type: object
+                type: array
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to an
+                  instance, in addition to the ones added by default by the AWS provider.
+                  If both the AWSCluster and the AWSMachine specify the same tag name
+                  with different values, the AWSMachine's value takes precedence.
+                type: object
+              ami:
+                description: AMI is the reference to the AMI from which to create
+                  the machine instance.
                 properties:
                   arn:
                     description: ARN of resource
@@ -75,186 +119,376 @@ spec:
                     description: ID of resource
                     type: string
                 type: object
-              type: array
-            additionalTags:
-              additionalProperties:
+              availabilityZone:
+                description: AvailabilityZone is references the AWS availability zone
+                  to use for this instance. If multiple subnets are matched for the
+                  availability zone, the first one return is picked.
                 type: string
-              description: AdditionalTags is an optional set of tags to add to an
-                instance, in addition to the ones added by default by the AWS provider.
-                If both the AWSCluster and the AWSMachine specify the same tag name
-                with different values, the AWSMachine's value takes precedence.
-              type: object
-            ami:
-              description: AMI is the reference to the AMI from which to create the
-                machine instance.
-              properties:
-                arn:
-                  description: ARN of resource
-                  type: string
-                filters:
-                  description: 'Filters is a set of key/value pairs used to identify
-                    a resource They are applied according to the rules defined by
-                    the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
-                  items:
-                    description: Filter is a filter used to identify an AWS resource
-                    properties:
-                      name:
-                        description: Name of the filter. Filter names are case-sensitive.
-                        type: string
-                      values:
-                        description: Values includes one or more filter values. Filter
-                          values are case-sensitive.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - name
-                    - values
-                    type: object
-                  type: array
-                id:
-                  description: ID of resource
-                  type: string
-              type: object
-            availabilityZone:
-              description: AvailabilityZone is references the AWS availability zone
-                to use for this instance. If multiple subnets are matched for the
-                availability zone, the first one return is picked.
-              type: string
-            iamInstanceProfile:
-              description: IAMInstanceProfile is a name of an IAM instance profile
-                to assign to the instance
-              type: string
-            imageLookupOrg:
-              description: ImageLookupOrg is the AWS Organization ID to use for image
-                lookup if AMI is not set.
-              type: string
-            instanceType:
-              description: 'InstanceType is the type of instance to create. Example:
-                m4.xlarge'
-              type: string
-            networkInterfaces:
-              description: NetworkInterfaces is a list of ENIs to associate with the
-                instance. A maximum of 2 may be specified.
-              items:
+              iamInstanceProfile:
+                description: IAMInstanceProfile is a name of an IAM instance profile
+                  to assign to the instance
                 type: string
-              maxItems: 2
-              type: array
-            providerID:
-              description: ProviderID is the unique identifier as specified by the
-                cloud provider.
-              type: string
-            publicIP:
-              description: 'PublicIP specifies whether the instance should get a public
-                IP. Precedence for this setting is as follows: 1. This field if set
-                2. Cluster/flavor setting 3. Subnet default'
-              type: boolean
-            rootDeviceSize:
-              description: RootDeviceSize is the size of the root volume in gigabytes(GB).
-              format: int64
-              type: integer
-            sshKeyName:
-              description: SSHKeyName is the name of the ssh key to attach to the
-                instance.
-              type: string
-            subnet:
-              description: Subnet is a reference to the subnet to use for this instance.
-                If not specified, the cluster subnet will be used.
-              properties:
-                arn:
-                  description: ARN of resource
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to use for
+                  image lookup if AMI is not set.
+                type: string
+              instanceType:
+                description: 'InstanceType is the type of instance to create. Example:
+                  m4.xlarge'
+                type: string
+              networkInterfaces:
+                description: NetworkInterfaces is a list of ENIs to associate with
+                  the instance. A maximum of 2 may be specified.
+                items:
                   type: string
-                filters:
-                  description: 'Filters is a set of key/value pairs used to identify
-                    a resource They are applied according to the rules defined by
-                    the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
-                  items:
-                    description: Filter is a filter used to identify an AWS resource
-                    properties:
-                      name:
-                        description: Name of the filter. Filter names are case-sensitive.
-                        type: string
-                      values:
-                        description: Values includes one or more filter values. Filter
-                          values are case-sensitive.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - name
-                    - values
-                    type: object
-                  type: array
-                id:
-                  description: ID of resource
-                  type: string
-              type: object
-          type: object
-        status:
-          description: AWSMachineStatus defines the observed state of AWSMachine
-          properties:
-            addresses:
-              description: Addresses contains the AWS instance associated addresses.
-              items:
-                description: NodeAddress contains information for the node's address.
+                maxItems: 2
+                type: array
+              providerID:
+                description: ProviderID is the unique identifier as specified by the
+                  cloud provider.
+                type: string
+              publicIP:
+                description: 'PublicIP specifies whether the instance should get a
+                  public IP. Precedence for this setting is as follows: 1. This field
+                  if set 2. Cluster/flavor setting 3. Subnet default'
+                type: boolean
+              rootDeviceSize:
+                description: RootDeviceSize is the size of the root volume in gigabytes(GB).
+                format: int64
+                type: integer
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  instance.
+                type: string
+              subnet:
+                description: Subnet is a reference to the subnet to use for this instance.
+                  If not specified, the cluster subnet will be used.
                 properties:
-                  address:
-                    description: The node address.
+                  arn:
+                    description: ARN of resource
                     type: string
-                  type:
-                    description: Node address type, one of Hostname, ExternalIP or
-                      InternalIP.
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
                     type: string
-                required:
-                - address
-                - type
                 type: object
-              type: array
-            errorMessage:
-              description: "ErrorMessage will be set in the event that there is a
-                terminal problem reconciling the Machine and will contain a more verbose
-                string suitable for logging and human consumption. \n This field should
-                not be set for transitive errors that a controller faces that are
-                expected to be fixed automatically over time (like service outages),
-                but instead indicate that something is fundamentally wrong with the
-                Machine's spec or the configuration of the controller, and that manual
-                intervention is required. Examples of terminal errors would be invalid
-                combinations of settings in the spec, values that are unsupported
-                by the controller, or the responsible controller itself being critically
-                misconfigured. \n Any transient errors that occur during the reconciliation
-                of Machines can be added as events to the Machine object and/or logged
-                in the controller's output."
-              type: string
-            errorReason:
-              description: "ErrorReason will be set in the event that there is a terminal
-                problem reconciling the Machine and will contain a succinct value
-                suitable for machine interpretation. \n This field should not be set
-                for transitive errors that a controller faces that are expected to
-                be fixed automatically over time (like service outages), but instead
-                indicate that something is fundamentally wrong with the Machine's
-                spec or the configuration of the controller, and that manual intervention
-                is required. Examples of terminal errors would be invalid combinations
-                of settings in the spec, values that are unsupported by the controller,
-                or the responsible controller itself being critically misconfigured.
-                \n Any transient errors that occur during the reconciliation of Machines
-                can be added as events to the Machine object and/or logged in the
-                controller's output."
-              type: string
-            instanceState:
-              description: InstanceState is the state of the AWS instance for this
-                machine.
-              type: string
-            ready:
-              description: Ready is true when the provider resource is ready.
-              type: boolean
-          type: object
-      type: object
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
+            type: object
+          status:
+            description: AWSMachineStatus defines the observed state of AWSMachine
+            properties:
+              addresses:
+                description: Addresses contains the AWS instance associated addresses.
+                items:
+                  description: NodeAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The node address.
+                      type: string
+                    type:
+                      description: Node address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              errorMessage:
+                description: "ErrorMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              errorReason:
+                description: "ErrorReason will be set in the event that there is a
+                  terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              instanceState:
+                description: InstanceState is the state of the AWS instance for this
+                  machine.
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
     served: true
     storage: false
   - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSMachine is the Schema for the awsmachines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineSpec defines the desired state of AWSMachine
+            properties:
+              additionalSecurityGroups:
+                description: AdditionalSecurityGroups is an array of references to
+                  security groups that should be applied to the instance. These security
+                  groups would be set in addition to any security groups defined at
+                  the cluster level or in the actuator.
+                items:
+                  description: AWSResourceReference is a reference to a specific AWS
+                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
+                    may be specified. Specifying more than one will result in a validation
+                    error.
+                  properties:
+                    arn:
+                      description: ARN of resource
+                      type: string
+                    filters:
+                      description: 'Filters is a set of key/value pairs used to identify
+                        a resource They are applied according to the rules defined
+                        by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                      items:
+                        description: Filter is a filter used to identify an AWS resource
+                        properties:
+                          name:
+                            description: Name of the filter. Filter names are case-sensitive.
+                            type: string
+                          values:
+                            description: Values includes one or more filter values.
+                              Filter values are case-sensitive.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        - values
+                        type: object
+                      type: array
+                    id:
+                      description: ID of resource
+                      type: string
+                  type: object
+                type: array
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to an
+                  instance, in addition to the ones added by default by the AWS provider.
+                  If both the AWSCluster and the AWSMachine specify the same tag name
+                  with different values, the AWSMachine's value takes precedence.
+                type: object
+              ami:
+                description: AMI is the reference to the AMI from which to create
+                  the machine instance.
+                properties:
+                  arn:
+                    description: ARN of resource
+                    type: string
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
+              availabilityZone:
+                description: AvailabilityZone is references the AWS availability zone
+                  to use for this instance. If multiple subnets are matched for the
+                  availability zone, the first one return is picked.
+                type: string
+              iamInstanceProfile:
+                description: IAMInstanceProfile is a name of an IAM instance profile
+                  to assign to the instance
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to use for
+                  image lookup if AMI is not set.
+                type: string
+              instanceType:
+                description: 'InstanceType is the type of instance to create. Example:
+                  m4.xlarge'
+                type: string
+              networkInterfaces:
+                description: NetworkInterfaces is a list of ENIs to associate with
+                  the instance. A maximum of 2 may be specified.
+                items:
+                  type: string
+                maxItems: 2
+                type: array
+              providerID:
+                description: ProviderID is the unique identifier as specified by the
+                  cloud provider.
+                type: string
+              publicIP:
+                description: 'PublicIP specifies whether the instance should get a
+                  public IP. Precedence for this setting is as follows: 1. This field
+                  if set 2. Cluster/flavor setting 3. Subnet default'
+                type: boolean
+              rootDeviceSize:
+                description: RootDeviceSize is the size of the root volume in gigabytes(GB).
+                format: int64
+                type: integer
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  instance. If nil, will use a default SSH key pair name If empty
+                  string, will NOT set an SSH key pair Otherwise, will set the SSH
+                  key pair name
+                type: string
+              subnet:
+                description: Subnet is a reference to the subnet to use for this instance.
+                  If not specified, the cluster subnet will be used.
+                properties:
+                  arn:
+                    description: ARN of resource
+                    type: string
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
+            type: object
+          status:
+            description: AWSMachineStatus defines the observed state of AWSMachine
+            properties:
+              addresses:
+                description: Addresses contains the AWS instance associated addresses.
+                items:
+                  description: NodeAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The node address.
+                      type: string
+                    type:
+                      description: Node address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              errorMessage:
+                description: "ErrorMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              errorReason:
+                description: "ErrorReason will be set in the event that there is a
+                  terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              instanceState:
+                description: InstanceState is the state of the AWS instance for this
+                  machine.
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -15,43 +15,91 @@ spec:
     plural: awsmachinetemplates
     singular: awsmachinetemplate
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: AWSMachineTemplate is the Schema for the awsmachinetemplates API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate
-          properties:
-            template:
-              description: AWSMachineTemplateResource describes the data needed to
-                create am AWSMachine from a template
-              properties:
-                spec:
-                  description: Spec is the specification of the desired behavior of
-                    the machine.
-                  properties:
-                    additionalSecurityGroups:
-                      description: AdditionalSecurityGroups is an array of references
-                        to security groups that should be applied to the instance.
-                        These security groups would be set in addition to any security
-                        groups defined at the cluster level or in the actuator.
-                      items:
-                        description: AWSResourceReference is a reference to a specific
-                          AWS resource by ID, ARN, or filters. Only one of ID, ARN
-                          or Filters may be specified. Specifying more than one will
-                          result in a validation error.
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: AWSMachineTemplate is the Schema for the awsmachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate
+            properties:
+              template:
+                description: AWSMachineTemplateResource describes the data needed
+                  to create am AWSMachine from a template
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      additionalSecurityGroups:
+                        description: AdditionalSecurityGroups is an array of references
+                          to security groups that should be applied to the instance.
+                          These security groups would be set in addition to any security
+                          groups defined at the cluster level or in the actuator.
+                        items:
+                          description: AWSResourceReference is a reference to a specific
+                            AWS resource by ID, ARN, or filters. Only one of ID, ARN
+                            or Filters may be specified. Specifying more than one
+                            will result in a validation error.
+                          properties:
+                            arn:
+                              description: ARN of resource
+                              type: string
+                            filters:
+                              description: 'Filters is a set of key/value pairs used
+                                to identify a resource They are applied according
+                                to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                              items:
+                                description: Filter is a filter used to identify an
+                                  AWS resource
+                                properties:
+                                  name:
+                                    description: Name of the filter. Filter names
+                                      are case-sensitive.
+                                    type: string
+                                  values:
+                                    description: Values includes one or more filter
+                                      values. Filter values are case-sensitive.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - name
+                                - values
+                                type: object
+                              type: array
+                            id:
+                              description: ID of resource
+                              type: string
+                          type: object
+                        type: array
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is an optional set of tags to
+                          add to an instance, in addition to the ones added by default
+                          by the AWS provider. If both the AWSCluster and the AWSMachine
+                          specify the same tag name with different values, the AWSMachine's
+                          value takes precedence.
+                        type: object
+                      ami:
+                        description: AMI is the reference to the AMI from which to
+                          create the machine instance.
                         properties:
                           arn:
                             description: ARN of resource
@@ -83,141 +131,296 @@ spec:
                             description: ID of resource
                             type: string
                         type: object
-                      type: array
-                    additionalTags:
-                      additionalProperties:
+                      availabilityZone:
+                        description: AvailabilityZone is references the AWS availability
+                          zone to use for this instance. If multiple subnets are matched
+                          for the availability zone, the first one return is picked.
                         type: string
-                      description: AdditionalTags is an optional set of tags to add
-                        to an instance, in addition to the ones added by default by
-                        the AWS provider. If both the AWSCluster and the AWSMachine
-                        specify the same tag name with different values, the AWSMachine's
-                        value takes precedence.
-                      type: object
-                    ami:
-                      description: AMI is the reference to the AMI from which to create
-                        the machine instance.
-                      properties:
-                        arn:
-                          description: ARN of resource
-                          type: string
-                        filters:
-                          description: 'Filters is a set of key/value pairs used to
-                            identify a resource They are applied according to the
-                            rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
-                          items:
-                            description: Filter is a filter used to identify an AWS
-                              resource
-                            properties:
-                              name:
-                                description: Name of the filter. Filter names are
-                                  case-sensitive.
-                                type: string
-                              values:
-                                description: Values includes one or more filter values.
-                                  Filter values are case-sensitive.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - name
-                            - values
-                            type: object
-                          type: array
-                        id:
-                          description: ID of resource
-                          type: string
-                      type: object
-                    availabilityZone:
-                      description: AvailabilityZone is references the AWS availability
-                        zone to use for this instance. If multiple subnets are matched
-                        for the availability zone, the first one return is picked.
-                      type: string
-                    iamInstanceProfile:
-                      description: IAMInstanceProfile is a name of an IAM instance
-                        profile to assign to the instance
-                      type: string
-                    imageLookupOrg:
-                      description: ImageLookupOrg is the AWS Organization ID to use
-                        for image lookup if AMI is not set.
-                      type: string
-                    instanceType:
-                      description: 'InstanceType is the type of instance to create.
-                        Example: m4.xlarge'
-                      type: string
-                    networkInterfaces:
-                      description: NetworkInterfaces is a list of ENIs to associate
-                        with the instance. A maximum of 2 may be specified.
-                      items:
+                      iamInstanceProfile:
+                        description: IAMInstanceProfile is a name of an IAM instance
+                          profile to assign to the instance
                         type: string
-                      maxItems: 2
-                      type: array
-                    providerID:
-                      description: ProviderID is the unique identifier as specified
-                        by the cloud provider.
-                      type: string
-                    publicIP:
-                      description: 'PublicIP specifies whether the instance should
-                        get a public IP. Precedence for this setting is as follows:
-                        1. This field if set 2. Cluster/flavor setting 3. Subnet default'
-                      type: boolean
-                    rootDeviceSize:
-                      description: RootDeviceSize is the size of the root volume in
-                        gigabytes(GB).
-                      format: int64
-                      type: integer
-                    sshKeyName:
-                      description: SSHKeyName is the name of the ssh key to attach
-                        to the instance.
-                      type: string
-                    subnet:
-                      description: Subnet is a reference to the subnet to use for
-                        this instance. If not specified, the cluster subnet will be
-                        used.
-                      properties:
-                        arn:
-                          description: ARN of resource
+                      imageLookupOrg:
+                        description: ImageLookupOrg is the AWS Organization ID to
+                          use for image lookup if AMI is not set.
+                        type: string
+                      instanceType:
+                        description: 'InstanceType is the type of instance to create.
+                          Example: m4.xlarge'
+                        type: string
+                      networkInterfaces:
+                        description: NetworkInterfaces is a list of ENIs to associate
+                          with the instance. A maximum of 2 may be specified.
+                        items:
                           type: string
-                        filters:
-                          description: 'Filters is a set of key/value pairs used to
-                            identify a resource They are applied according to the
-                            rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
-                          items:
-                            description: Filter is a filter used to identify an AWS
-                              resource
-                            properties:
-                              name:
-                                description: Name of the filter. Filter names are
-                                  case-sensitive.
-                                type: string
-                              values:
-                                description: Values includes one or more filter values.
-                                  Filter values are case-sensitive.
-                                items:
+                        maxItems: 2
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      publicIP:
+                        description: 'PublicIP specifies whether the instance should
+                          get a public IP. Precedence for this setting is as follows:
+                          1. This field if set 2. Cluster/flavor setting 3. Subnet
+                          default'
+                        type: boolean
+                      rootDeviceSize:
+                        description: RootDeviceSize is the size of the root volume
+                          in gigabytes(GB).
+                        format: int64
+                        type: integer
+                      sshKeyName:
+                        description: SSHKeyName is the name of the ssh key to attach
+                          to the instance.
+                        type: string
+                      subnet:
+                        description: Subnet is a reference to the subnet to use for
+                          this instance. If not specified, the cluster subnet will
+                          be used.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
                                   type: string
-                                type: array
-                            required:
-                            - name
-                            - values
-                            type: object
-                          type: array
-                        id:
-                          description: ID of resource
-                          type: string
-                      type: object
-                  type: object
-              required:
-              - spec
-              type: object
-          required:
-          - template
-          type: object
-      type: object
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
     served: true
     storage: false
   - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSMachineTemplate is the Schema for the awsmachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate
+            properties:
+              template:
+                description: AWSMachineTemplateResource describes the data needed
+                  to create am AWSMachine from a template
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      additionalSecurityGroups:
+                        description: AdditionalSecurityGroups is an array of references
+                          to security groups that should be applied to the instance.
+                          These security groups would be set in addition to any security
+                          groups defined at the cluster level or in the actuator.
+                        items:
+                          description: AWSResourceReference is a reference to a specific
+                            AWS resource by ID, ARN, or filters. Only one of ID, ARN
+                            or Filters may be specified. Specifying more than one
+                            will result in a validation error.
+                          properties:
+                            arn:
+                              description: ARN of resource
+                              type: string
+                            filters:
+                              description: 'Filters is a set of key/value pairs used
+                                to identify a resource They are applied according
+                                to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                              items:
+                                description: Filter is a filter used to identify an
+                                  AWS resource
+                                properties:
+                                  name:
+                                    description: Name of the filter. Filter names
+                                      are case-sensitive.
+                                    type: string
+                                  values:
+                                    description: Values includes one or more filter
+                                      values. Filter values are case-sensitive.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - name
+                                - values
+                                type: object
+                              type: array
+                            id:
+                              description: ID of resource
+                              type: string
+                          type: object
+                        type: array
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is an optional set of tags to
+                          add to an instance, in addition to the ones added by default
+                          by the AWS provider. If both the AWSCluster and the AWSMachine
+                          specify the same tag name with different values, the AWSMachine's
+                          value takes precedence.
+                        type: object
+                      ami:
+                        description: AMI is the reference to the AMI from which to
+                          create the machine instance.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                      availabilityZone:
+                        description: AvailabilityZone is references the AWS availability
+                          zone to use for this instance. If multiple subnets are matched
+                          for the availability zone, the first one return is picked.
+                        type: string
+                      iamInstanceProfile:
+                        description: IAMInstanceProfile is a name of an IAM instance
+                          profile to assign to the instance
+                        type: string
+                      imageLookupOrg:
+                        description: ImageLookupOrg is the AWS Organization ID to
+                          use for image lookup if AMI is not set.
+                        type: string
+                      instanceType:
+                        description: 'InstanceType is the type of instance to create.
+                          Example: m4.xlarge'
+                        type: string
+                      networkInterfaces:
+                        description: NetworkInterfaces is a list of ENIs to associate
+                          with the instance. A maximum of 2 may be specified.
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      publicIP:
+                        description: 'PublicIP specifies whether the instance should
+                          get a public IP. Precedence for this setting is as follows:
+                          1. This field if set 2. Cluster/flavor setting 3. Subnet
+                          default'
+                        type: boolean
+                      rootDeviceSize:
+                        description: RootDeviceSize is the size of the root volume
+                          in gigabytes(GB).
+                        format: int64
+                        type: integer
+                      sshKeyName:
+                        description: SSHKeyName is the name of the ssh key to attach
+                          to the instance. If nil, will use a default SSH key pair
+                          name If empty string, will NOT set an SSH key pair Otherwise,
+                          will set the SSH key pair name
+                        type: string
+                      subnet:
+                        description: Subnet is a reference to the subnet to use for
+                          this instance. If not specified, the cluster subnet will
+                          be used.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -401,8 +401,14 @@ func (r *AWSMachineReconciler) validateUpdate(spec *infrav1.AWSMachineSpec, i *i
 	}
 
 	// SSH Key Name (also account for default)
-	if spec.SSHKeyName != aws.StringValue(i.SSHKeyName) && spec.SSHKeyName != "" {
-		errs = append(errs, errors.Errorf("SSH key name cannot be mutated from %q to %q", aws.StringValue(i.SSHKeyName), spec.SSHKeyName))
+	if spec.SSHKeyName == nil && i.SSHKeyName != nil {
+		errs = append(errs, errors.Errorf("SSH key name cannot be mutated from %q to nil", aws.StringValue(i.SSHKeyName)))
+	} else if spec.SSHKeyName != nil && *spec.SSHKeyName != "" && i.SSHKeyName == nil {
+		errs = append(errs, errors.Errorf("SSH key name cannot be mutated from nil to %q", *spec.SSHKeyName))
+	} else if spec.SSHKeyName != nil && i.SSHKeyName != nil {
+		if *spec.SSHKeyName != aws.StringValue(i.SSHKeyName) {
+			errs = append(errs, errors.Errorf("SSH key name cannot be mutated from %q to %q", aws.StringValue(i.SSHKeyName), *spec.SSHKeyName))
+		}
 	}
 
 	// Root Device Size

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -133,9 +133,16 @@ func (s *Service) getDefaultBastion() *infrav1.Instance {
 	name := fmt.Sprintf("%s-bastion", s.scope.Name())
 	userData, _ := userdata.NewBastion(&userdata.BastionInput{})
 
-	keyName := defaultSSHKeyName
-	if s.scope.AWSCluster.Spec.SSHKeyName != "" {
-		keyName = s.scope.AWSCluster.Spec.SSHKeyName
+	// If SSHKeyName WAS NOT provided (nil) then use the defaultSSHKeyName
+	// If SSHKeyName WAS provided _but is an empty string_, do not set a key pair
+	// Otherwise (SSHKeyName WAS provided and is NOT an empty string), use the provided key pair name
+	var keyName string
+	if s.scope.AWSCluster.Spec.SSHKeyName != nil {
+		if *s.scope.AWSCluster.Spec.SSHKeyName != "" {
+			keyName = *s.scope.AWSCluster.Spec.SSHKeyName
+		}
+	} else {
+		keyName = defaultSSHKeyName
 	}
 
 	i := &infrav1.Instance{

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -177,11 +177,19 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*infrav1.Instance, 
 	input.SecurityGroupIDs = append(input.SecurityGroupIDs, ids...)
 
 	// Pick SSH key, if any.
-	input.SSHKeyName = aws.String(defaultSSHKeyName)
-	if scope.AWSMachine.Spec.SSHKeyName != "" {
-		input.SSHKeyName = aws.String(scope.AWSMachine.Spec.SSHKeyName)
-	} else if scope.AWSCluster.Spec.SSHKeyName != "" {
-		input.SSHKeyName = aws.String(scope.AWSCluster.Spec.SSHKeyName)
+	// If SSHKeyName WAS NOT provided (nil) then use the defaultSSHKeyName
+	// If SSHKeyName WAS provided *but is an empty string*, do not set a key pair
+	// Otherwise (SSHKeyName WAS provided and is NOT an empty string), use the provided key pair name
+	if scope.AWSMachine.Spec.SSHKeyName != nil {
+		if *scope.AWSMachine.Spec.SSHKeyName != "" {
+			input.SSHKeyName = scope.AWSMachine.Spec.SSHKeyName
+		}
+	} else if scope.AWSMachine.Spec.SSHKeyName != nil {
+		if *scope.AWSCluster.Spec.SSHKeyName != "" {
+			input.SSHKeyName = scope.AWSCluster.Spec.SSHKeyName
+		}
+	} else {
+		input.SSHKeyName = aws.String(defaultSSHKeyName)
 	}
 
 	s.scope.V(2).Info("Running instance", "machine-role", scope.Role())


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows instances to be provisioned with no SSH key pair specified. Organizations which have policies denying the use of SSH key pairs can now set the SSH key name value to `""` to launch instances without a key pair set. A `nil` value still sets the default key pair name.

Fixes #1156

