### PR TITLE
:running: unit tests for deleting machines

### DIFF
--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -33,4 +33,7 @@ type EC2MachineInterface interface {
 	GetInstanceSecurityGroups(instanceID string) (map[string][]string, error)
 	UpdateInstanceSecurityGroups(id string, securityGroups []string) error
 	UpdateResourceTags(resourceID *string, create map[string]string, remove map[string]string) error
+
+	TerminateInstanceAndWait(instanceID string) error
+	DetachSecurityGroupsFromNetworkInterface(groups []string, interfaceID string) error
 }

--- a/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
@@ -65,6 +65,20 @@ func (mr *MockEC2MachineInterfaceMockRecorder) CreateInstance(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstance", reflect.TypeOf((*MockEC2MachineInterface)(nil).CreateInstance), arg0)
 }
 
+// DetachSecurityGroupsFromNetworkInterface mocks base method
+func (m *MockEC2MachineInterface) DetachSecurityGroupsFromNetworkInterface(arg0 []string, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachSecurityGroupsFromNetworkInterface", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachSecurityGroupsFromNetworkInterface indicates an expected call of DetachSecurityGroupsFromNetworkInterface
+func (mr *MockEC2MachineInterfaceMockRecorder) DetachSecurityGroupsFromNetworkInterface(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachSecurityGroupsFromNetworkInterface", reflect.TypeOf((*MockEC2MachineInterface)(nil).DetachSecurityGroupsFromNetworkInterface), arg0, arg1)
+}
+
 // GetCoreSecurityGroups mocks base method
 func (m *MockEC2MachineInterface) GetCoreSecurityGroups(arg0 *scope.MachineScope) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -137,6 +151,20 @@ func (m *MockEC2MachineInterface) TerminateInstance(arg0 string) error {
 func (mr *MockEC2MachineInterfaceMockRecorder) TerminateInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstance", reflect.TypeOf((*MockEC2MachineInterface)(nil).TerminateInstance), arg0)
+}
+
+// TerminateInstanceAndWait mocks base method
+func (m *MockEC2MachineInterface) TerminateInstanceAndWait(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TerminateInstanceAndWait", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TerminateInstanceAndWait indicates an expected call of TerminateInstanceAndWait
+func (mr *MockEC2MachineInterfaceMockRecorder) TerminateInstanceAndWait(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstanceAndWait", reflect.TypeOf((*MockEC2MachineInterface)(nil).TerminateInstanceAndWait), arg0)
 }
 
 // UpdateInstanceSecurityGroups mocks base method


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
The previous machine controller unit test only covered create. This covers delete as well. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1035 

I deleted the stubbed out ELB tests because I didn't think it was worth stubbing out that whole service for one test. Let me know if you disagree! 