### PR TITLE
:running: [e2e] Fix region handling for e2e tests

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -446,7 +446,7 @@ func makeAWSCluster(namespace, name string) {
 			Namespace: namespace,
 		},
 		Spec: infrav1.AWSClusterSpec{
-			Region:     "us-east-1",
+			Region:     region,
 			SSHKeyName: keyPairName,
 		},
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -90,6 +90,7 @@ var (
 	sess        client.ConfigProvider
 	accountID   string
 	suiteTmpDir string
+	region string
 )
 
 var _ = BeforeSuite(func() {
@@ -98,6 +99,13 @@ var _ = BeforeSuite(func() {
 	var err error
 	suiteTmpDir, err = ioutil.TempDir("", "capa-e2e-suite")
 	Expect(err).NotTo(HaveOccurred())
+
+	// still needed as defaults.CredChain doesn't contain region
+	region, ok := os.LookupEnv("AWS_REGION")
+	if !ok {
+		fmt.Fprintf(GinkgoWriter, "Environment variable AWS_REGION not found")
+		Expect(ok).To(BeTrue())
+	}
 
 	kindCluster = kind.Cluster{
 		Name: "capa-test-" + util.RandomString(6),
@@ -284,13 +292,7 @@ func generateB64Credentials() (string, error) {
 		return "", err
 	}
 
-	// still needed as defaults.CredChain doesn't contain region
-	region, ok := os.LookupEnv("AWS_REGION")
-	if !ok {
-		return "", fmt.Errorf("Environment variable AWS_REGION not found")
-	}
 	creds.Region = region
-
 	creds.AccessKeyID = chainCreds.AccessKeyID
 	creds.SecretAccessKey = chainCreds.SecretAccessKey
 	creds.SessionToken = chainCreds.SessionToken


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes region mismatch between keypair creation and Cluster creation
