### PR TITLE
✨ LOAD_IMAGE to allow injecting locally built image into kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,10 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS 
 .PHONY: create-cluster-management
 create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS in a KIND management cluster.
 	kind create cluster --name=clusterapi
+	@if [ ! -z "${LOAD_IMAGE}" ]; then \
+		echo "loading ${LOAD_IMAGE} into kind cluster ..." && \
+		kind --name="clusterapi" load docker-image "${LOAD_IMAGE}"; \
+	fi
 	# Apply provider-components.
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Similar to what we did in https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/188 we should be able to build a local image and use that in `kind`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

