### PR TITLE
Automated cherry pick of #1250: LOAD_IMAGE to allow injecting locally built image into kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,10 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS 
 .PHONY: create-cluster-management
 create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS in a KIND management cluster.
 	kind create cluster --name=clusterapi
+	@if [ ! -z "${LOAD_IMAGE}" ]; then \
+		echo "loading ${LOAD_IMAGE} into kind cluster ..." && \
+		kind --name="clusterapi" load docker-image "${LOAD_IMAGE}"; \
+	fi
 	# Apply provider-components.
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \


### PR DESCRIPTION
Cherry pick of #1250 on release-0.4.

#1250: LOAD_IMAGE to allow injecting locally built image into kind

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.