### PR TITLE
:running: [e2e] fix missing kindClient

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -128,6 +128,9 @@ var _ = BeforeSuite(func() {
 	kindCluster.Setup()
 	loadManagerImage(kindCluster)
 
+	kindClient, err = crclient.New(kindCluster.RestConfig(), crclient.Options{Scheme: setupScheme()})
+	Expect(err).NotTo(HaveOccurred())
+
 	// Deploy the CAPI components
 	common.DeployCAPIComponents(kindCluster)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes the missing kindClient initialization that was missed in backporting

