### PR TITLE
:running: [e2e] reinitialize the kindClient after deploying the cluster api components

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -148,6 +148,10 @@ var _ = BeforeSuite(func() {
 
 	// Verify capa components are deployed
 	common.WaitDeployment(kindClient, capaNamespace, capaDeploymentName)
+
+	// Recreate kindClient so that it knows about the cluster api types
+	kindClient, err = crclient.New(kindCluster.RestConfig(), crclient.Options{Scheme: setupScheme()})
+	Expect(err).NotTo(HaveOccurred())
 }, setupTimeout)
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
reinitialize the kindClient after deploying the cluster api components