### PR TITLE
:sparkles: Add printer columns

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -68,6 +68,11 @@ type AWSClusterStatus struct {
 // +kubebuilder:resource:path=awsclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSCluster belongs"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for EC2 instances"
+// +kubebuilder:printcolumn:name="VPC",type="string",JSONPath=".spec.networkSpec.vpc.id",description="AWS VPC the cluster is using"
+// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.apiEndpoints[0]",description="API Endpoint",priority=1
+// +kubebuilder:printcolumn:name="Bastion IP",type="string",JSONPath=".status.bastion.publicIp",description="Bastion IP address for breakglass access"
 
 // AWSCluster is the Schema for the awsclusters API
 type AWSCluster struct {

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -146,6 +146,11 @@ type AWSMachineStatus struct {
 // +kubebuilder:resource:path=awsmachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSMachine belongs"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="EC2 instance state"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
+// +kubebuilder:printcolumn:name="InstanceID",type="string",JSONPath=".spec.providerID",description="EC2 instance ID"
+// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this AWSMachine"
 
 // AWSMachine is the Schema for the awsmachines API
 type AWSMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -396,7 +396,29 @@ spec:
   - name: v1alpha2
     served: true
     storage: false
-  - name: v1alpha3
+  - additionalPrinterColumns:
+    - JSONPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      description: Cluster to which this AWSCluster belongs
+      name: Cluster
+      type: string
+    - JSONPath: .status.ready
+      description: Cluster infrastructure is ready for EC2 instances
+      name: Ready
+      type: string
+    - JSONPath: .spec.networkSpec.vpc.id
+      description: AWS VPC the cluster is using
+      name: VPC
+      type: string
+    - JSONPath: .status.apiEndpoints[0]
+      description: API Endpoint
+      name: Endpoint
+      priority: 1
+      type: string
+    - JSONPath: .status.bastion.publicIp
+      description: Bastion IP address for breakglass access
+      name: Bastion IP
+      type: string
+    name: v1alpha3
     served: true
     storage: true
 status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -254,7 +254,28 @@ spec:
   - name: v1alpha2
     served: true
     storage: false
-  - name: v1alpha3
+  - additionalPrinterColumns:
+    - JSONPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      description: Cluster to which this AWSMachine belongs
+      name: Cluster
+      type: string
+    - JSONPath: .status.instanceState
+      description: EC2 instance state
+      name: State
+      type: string
+    - JSONPath: .status.ready
+      description: Machine ready status
+      name: Ready
+      type: string
+    - JSONPath: .spec.providerID
+      description: EC2 instance ID
+      name: InstanceID
+      type: string
+    - JSONPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      description: Machine object which owns with this AWSMachine
+      name: Machine
+      type: string
+    name: v1alpha3
     served: true
     storage: true
 status:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds printer columns for AWSMachine and AWSCluster.

Example output:
```
[$] took 5s ➜ k get awsmachine
NAME                      CLUSTER    STATE     READY   INSTANCEID                    MACHINE
aws-test-controlplane-0   aws-test   running   true    aws:////i-06ef85a7726924b87   aws-test-controlplane-0
aws-test-worker-4bfdg     aws-test   running   true    aws:////i-07ade4576a2a4c226   aws-test-worker-cf6b4ff76-h7qlb
aws-test-worker-f62c4     aws-test   running   true    aws:////i-06e4de3f93f0f5c66   aws-test-worker-cf6b4ff76-vqrkb
aws-test-worker-n6zkx     aws-test   running   true    aws:////i-05e33c9b2dfe2c1b0   aws-test-worker-cf6b4ff76-v22h7
```

```
[$] took 5s ➜ k get awscluster
NAME       READY   VPC                     BASTION IP
aws-test   true    vpc-037dc72ec11380b85   1.2.3.4
```

```
[$] took 5s ➜ k get awscluster -o wide
NAME       READY   VPC                     ENDPOINT                                                                        BASTION IP
aws-test   true    vpc-037dc72ec11380b85   map[host:aws-test-apiserver-123456789.eu-west-1.elb.amazonaws.com port:6443]   5.6.7.8
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1227 

Apologies to @amila-ku. It was being annoying enough not having this that fixing it seemed important enough to do.

