### PR TITLE
:bug: Revise wait backoff parameters

### DIFF
--- a/pkg/cloud/services/wait/wait.go
+++ b/pkg/cloud/services/wait/wait.go
@@ -35,14 +35,15 @@ import (
 // for use with AWS services.
 func NewBackoff() wait.Backoff {
 	// Return a exponential backoff configuration which
-	// returns durations for a total time of ~10m.
-	// Example: 1s, 2s, 4s, 8s, 16s, 20s, ... 20s — for a total of N steps.
+	// returns durations for a total time of ~5m.
+	// Example: 1s, 1.7s, 2.9s, 5s, 8.6s, 14.6s, 25s, 42.8s, 73.1s ... 125s
+	// Jitter is added as a random fraction of the duration multiplied by the
+	// jitter factor.
 	return wait.Backoff{
 		Duration: time.Second,
-		Factor:   2,
-		Steps:    32,
-		Jitter:   4,
-		Cap:      20 * time.Second,
+		Factor:   1.71,
+		Steps:    10,
+		Jitter:   0.4,
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Revises the exponential backoff parameters such that the retries are not cancelled
after 20s.

These parameters are chosen so that the maximum retry time is 300s +/- 120s.

The wait method from API machinery continues to be employed, and is compared to the
[Full Jitter and Decorrelated Jitter approach using the AWS concurrent client sample simulation](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) below.

![image](https://user-images.githubusercontent.com/1441070/67718695-2e797d00-f9c8-11e9-8d04-ae69d3db5eef.png)

These parameters compare well to the Full Jitter method, which is one of the recommended approaches. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1283 

