### PR TITLE
:bug: Disassociate Elastic IPs on deletion, if still associated

### DIFF
--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -37,6 +37,7 @@ const (
 	LoadBalancerNotFound    = "LoadBalancerNotFound"
 	ResourceNotFound        = "InvalidResourceID.NotFound"
 	InvalidSubnet           = "InvalidSubnet"
+	AssociationIDNotFound   = "InvalidAssociationID.NotFound"
 )
 
 var _ error = &EC2Error{}

--- a/pkg/cloud/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/services/cloudformation/bootstrap.go
@@ -184,6 +184,7 @@ func controllersPolicy(accountID, partition string) *iam.PolicyDocument {
 					"ec2:DescribeVolumes",
 					"ec2:DetachInternetGateway",
 					"ec2:DisassociateRouteTable",
+					"ec2:DisassociateAddress",
 					"ec2:ModifyInstanceAttribute",
 					"ec2:ModifyNetworkInterfaceAttribute",
 					"ec2:ModifySubnetAttribute",


### PR DESCRIPTION
Cherry pick of #1258 on release-0.4.

#1258: eip.go: Disassociate Elastic IPs if still associated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.