### PR TITLE
:sparkles: Support cluster names > 22 characters in length

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect
-	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect
+	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7
 	golang.org/x/net v0.0.0-20191021144547-ec77196f6094
 	golang.org/x/sys v0.0.0-20190911201528-7ad0cfa0b7b5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package elb
+
+import (
+	"testing"
+)
+
+func TestGenerateELBName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "test",
+			expected: "test-apiserver",
+		},
+		{
+			name:     "0123456789012345678901",
+			expected: "0123456789012345678901-apiserver",
+		},
+		{
+			name:     "01234567890123456789012",
+			expected: "26o3cjil5at5qn27vukn5x09b3ql-k8s",
+		},
+		{
+			name:     "anotherverylongtoolongname",
+			expected: "t8gnrbbifaaf5d0k4xmwui3xwvip-k8s",
+		},
+		{
+			name:     "anotherverylongtoolongnameanotherverylongtoolongname",
+			expected: "tph1huzox1f10z9ow1inrootjws8-k8s",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			elbName, err := GenerateELBName(tt.name)
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			if elbName != tt.expected {
+				t.Errorf("expected ELB name: %v, got name: %v", tt.expected, elbName)
+			}
+
+			if len(elbName) > 32 {
+				t.Errorf("ELB name too long: %v vs. %s", len(elbName), "32")
+			}
+
+		})
+	}
+}

--- a/pkg/internal/hash/base36.go
+++ b/pkg/internal/hash/base36.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/blake2b"
+)
+
+const base36set = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+// Base36TruncatedHash returns a consistent hash using blake2b
+// and truncating the byte values to alphanumeric only
+// of a fixed length specified by the consumer.
+func Base36TruncatedHash(str string, len int) (string, error) {
+	hasher, err := blake2b.New(len, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create hash function")
+	}
+
+	hasher.Write([]byte(str))
+	return base36Truncate(hasher.Sum(nil)), nil
+}
+
+// base36Truncate returns a string that is base36 compliant
+// It is not an encoding since it returns a same-length string
+// for any byte value
+func base36Truncate(bytes []byte) string {
+	var chars string
+	for _, bite := range bytes {
+		idx := int(bite) % 36
+		chars = chars + string(base36set[idx])
+	}
+
+	return chars
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
* Replaces "." in the ELB name with "-" making them compatible with the ELB API.
* Additionally, if the original, computed ELB name is more than 32 characters, then
  use a truncated form of Blake2b to compute a consistent hash formatted ELB name.
  Think this approach has a sufficiently low risk of collisions. "apiserver" suffix is
  replaced with "k8s" to regain some entropy. Names arrive in the format of:
    * `26o3cjil5at5qn27vukn5x09b3ql-k8s`
    * `t8gnrbbifaaf5d0k4xmwui3xwvip-k8s`
  etc...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #977 
Fixes #889

