### PR TITLE
:running: [e2e] Forward port MachineDeployment to HEAD

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -205,7 +205,7 @@ func waitForMachineDeploymentRunning(namespace, machineDeploymentName string) {
 			if err := kindClient.Get(context.TODO(), apimachinerytypes.NamespacedName{Namespace: namespace, Name: machineDeploymentName}, machineDeployment); err != nil {
 				return false, err
 			}
-			return machineDeployment.Spec.Replicas == machineDeployment.Status.ReadyReplicas, nil
+			return *machineDeployment.Spec.Replicas == machineDeployment.Status.ReadyReplicas, nil
 		},
 		5*time.Minute, 15*time.Second,
 	).Should(BeTrue())

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -205,7 +205,7 @@ func waitForMachineDeploymentRunning(namespace, machineDeploymentName string) {
 			if err := kindClient.Get(context.TODO(), apimachinerytypes.NamespacedName{Namespace: namespace, Name: machineDeploymentName}, machineDeployment); err != nil {
 				return false, err
 			}
-			return machineDeployment.Status.Replicas == machineDeployment.Status.ReadyReplicas, nil
+			return machineDeployment.Spec.Replicas == machineDeployment.Status.ReadyReplicas, nil
 		},
 		5*time.Minute, 15*time.Second,
 	).Should(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:

Forward ports MachineDeployment e2e tests to HEAD from the `release-0.4` branch.
