### PR TITLE
:running: [e2e] delete cloudformation stack on teardown

### DIFF
--- a/pkg/cloud/services/cloudformation/cloudformation.go
+++ b/pkg/cloud/services/cloudformation/cloudformation.go
@@ -70,6 +70,22 @@ func (s *Service) updateStack(stackName string, yaml string) error {
 	return nil
 }
 
+// DeleteStack deletes a cloudformation stack
+func (s *Service) DeleteStack(stackName string) error {
+	klog.V(2).Infof("deleting AWS CloudFormation stack %q", stackName)
+	if _, err := s.CFN.DeleteStack(&cfn.DeleteStackInput{StackName: aws.String(stackName)}); err != nil {
+		return errors.Wrap(err, "failed to delete AWS CloudFormation stack")
+	}
+
+	klog.V(2).Infof("waiting for stack %q to delete", stackName)
+	if err := s.CFN.WaitUntilStackDeleteComplete(&cfn.DescribeStacksInput{StackName: aws.String(stackName)}); err != nil {
+		return errors.Wrap(err, "failed to delete AWS CloudFormation stack")
+	}
+
+	klog.V(2).Infof("stack %q deleted", stackName)
+	return nil
+}
+
 // ShowStackResources prints out in tabular format the resources in the
 // stack
 func (s *Service) ShowStackResources(stackName string) error {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -164,6 +164,7 @@ var _ = AfterSuite(func() {
 	kindCluster.Teardown()
 	iamc := iam.New(sess)
 	iamc.DeleteAccessKey(&iam.DeleteAccessKeyInput{UserName: accessKey.UserName, AccessKeyId: accessKey.AccessKeyId})
+	deleteIAMRoles(sess)
 	os.RemoveAll(suiteTmpDir)
 })
 
@@ -228,6 +229,13 @@ func createIAMRoles(prov client.ConfigProvider, accountID string) {
 	cfnSvc := cloudformation.NewService(cfn.New(prov))
 	Expect(
 		cfnSvc.ReconcileBootstrapStack(stackName, accountID, "aws"),
+	).To(Succeed())
+}
+
+func deleteIAMRoles(prov client.ConfigProvider) {
+	cfnSvc := cloudformation.NewService(cfn.New(prov))
+	Expect(
+		cfnSvc.DeleteStack(stackName),
 	).To(Succeed())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On teardown of the e2e suite, delete the cloudformation stack