### PR TITLE
Automated cherry pick of #1299: We should propagate any errors during create-stack

### DIFF
--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -126,14 +126,14 @@ func createStackCmd() *cobra.Command {
 			})
 			if err != nil {
 				fmt.Printf("Error: %v", err)
-				return nil
+				return err
 			}
 
 			stsSvc := sts.NewService(awssts.New(sess))
 			accountID, stsErr := stsSvc.AccountID()
 			if stsErr != nil {
 				fmt.Printf("Error: %v", stsErr)
-				return nil
+				return err
 			}
 
 			cfnSvc := cloudformation.NewService(cfn.New(sess))
@@ -141,7 +141,7 @@ func createStackCmd() *cobra.Command {
 			err = cfnSvc.ReconcileBootstrapStack(stackName, accountID, partition)
 			if err != nil {
 				fmt.Printf("Error: %v", err)
-				return nil
+				return err
 			}
 
 			return cfnSvc.ShowStackResources(stackName)


### PR DESCRIPTION
Cherry pick of #1299 on release-0.4.

#1299: We should propagate any errors during create-stack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.