### PR TITLE
Drop cabpk from manager tolerations patch

### DIFF
--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -2,20 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cabpk-controller-manager
-  namespace: cabpk-system
-spec:
-  template:
-    spec:
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - key: CriticalAddonsOnly
-          operator: Exists
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: capa-controller-manager
   namespace: capa-system
 spec:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
cabpk is not a separate controller any more. fixes a new problem after i hastily merged https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1302

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

