### PR TITLE
🏃 Bump AWSMachine concurrency to 10, AWSCluster to 5

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,13 +103,13 @@ func main() {
 
 	flag.IntVar(&awsClusterConcurrency,
 		"awscluster-concurrency",
-		2,
+		5,
 		"Number of AWSClusters to process simultaneously",
 	)
 
 	flag.IntVar(&awsMachineConcurrency,
 		"awsmachine-concurrency",
-		2,
+		10,
 		"Number of AWSMachines to process simultaneously",
 	)
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->


/milestone v0.5.0
/assign @detiber 
