### PR TITLE
✨ AWSCluster: Allow setting ImageLookupOrg at the cluster level

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -45,6 +45,12 @@ type AWSClusterSpec struct {
 	// ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior
 	// +optional
 	ControlPlaneLoadBalancer *AWSLoadBalancerSpec `json:"controlPlaneLoadBalancer,omitempty"`
+
+	// ImageLookupOrg is the AWS Organization ID to look up machine images when a
+	// machine does not specify an AMI. When set, this will be used for all
+	// cluster machines unless a machine specifies a different ImageLookupOrg.
+	// +optional
+	ImageLookupOrg string `json:"imageLookupOrg,omitempty"`
 }
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -17,77 +17,103 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: AWSCluster is the Schema for the awsclusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AWSClusterSpec defines the desired state of AWSCluster
-          properties:
-            additionalTags:
-              additionalProperties:
-                type: string
-              description: AdditionalTags is an optional set of tags to add to AWS
-                resources managed by the AWS provider, in addition to the ones added
-                by default.
-              type: object
-            controlPlaneLoadBalancer:
-              description: ControlPlaneLoadBalancer is optional configuration for
-                customizing control plane behavior
-              properties:
-                scheme:
-                  description: Scheme sets the scheme of the load balancer (defaults
-                    to Internet-facing)
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: AWSCluster is the Schema for the awsclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSClusterSpec defines the desired state of AWSCluster
+            properties:
+              additionalTags:
+                additionalProperties:
                   type: string
-              type: object
-            networkSpec:
-              description: NetworkSpec encapsulates all things related to AWS network.
-              properties:
-                subnets:
-                  description: Subnets configuration.
-                  items:
-                    description: SubnetSpec configures an AWS Subnet.
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              controlPlaneLoadBalancer:
+                description: ControlPlaneLoadBalancer is optional configuration for
+                  customizing control plane behavior
+                properties:
+                  scheme:
+                    description: Scheme sets the scheme of the load balancer (defaults
+                      to Internet-facing)
+                    type: string
+                type: object
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
                     properties:
-                      availabilityZone:
-                        description: AvailabilityZone defines the availability zone
-                          to use for this subnet in the cluster's region.
-                        type: string
                       cidrBlock:
                         description: CidrBlock is the CIDR block to be used when the
-                          provider creates a managed VPC.
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
                         type: string
                       id:
-                        description: ID defines a unique identifier to reference this
-                          resource.
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
                         type: string
-                      isPublic:
-                        description: IsPublic defines the subnet as a public subnet.
-                          A subnet is public when it is associated with a route table
-                          that has a route to an internet gateway.
-                        type: boolean
-                      natGatewayId:
-                        description: NatGatewayID is the NAT gateway id associated
-                          with the subnet. Ignored unless the subnet is managed by
-                          the provider, in which case this is set on the public subnet
-                          where the NAT gateway resides. It is then used to determine
-                          routes for private subnets in the same AZ as the public
-                          subnet.
-                        type: string
-                      routeTableId:
-                        description: RouteTableID is the routing table id associated
-                          with the subnet.
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
                         type: string
                       tags:
                         additionalProperties:
@@ -95,305 +121,281 @@ spec:
                         description: Tags is a collection of tags describing the resource.
                         type: object
                     type: object
-                  type: array
-                vpc:
-                  description: VPC configuration.
-                  properties:
-                    cidrBlock:
-                      description: CidrBlock is the CIDR block to be used when the
-                        provider creates a managed VPC. Defaults to 10.0.0.0/16.
-                      type: string
-                    id:
-                      description: ID is the vpc-id of the VPC this provider should
-                        use to create resources.
-                      type: string
-                    internetGatewayId:
-                      description: InternetGatewayID is the id of the internet gateway
-                        associated with the VPC.
-                      type: string
-                    tags:
-                      additionalProperties:
-                        type: string
-                      description: Tags is a collection of tags describing the resource.
-                      type: object
-                  type: object
-              type: object
-            region:
-              description: The AWS Region the cluster lives in.
-              type: string
-            sshKeyName:
-              description: SSHKeyName is the name of the ssh key to attach to the
-                bastion host.
-              type: string
-          type: object
-        status:
-          description: AWSClusterStatus defines the observed state of AWSCluster
-          properties:
-            apiEndpoints:
-              description: APIEndpoints represents the endpoints to communicate with
-                the control plane.
-              items:
-                description: APIEndpoint represents a reachable Kubernetes API endpoint.
-                properties:
-                  host:
-                    description: The hostname on which the API server is serving.
-                    type: string
-                  port:
-                    description: The port on which the API server is serving.
-                    type: integer
-                required:
-                - host
-                - port
                 type: object
-              type: array
-            bastion:
-              description: Instance describes an AWS instance.
-              properties:
-                ebsOptimized:
-                  description: Indicates whether the instance is optimized for Amazon
-                    EBS I/O.
-                  type: boolean
-                enaSupport:
-                  description: Specifies whether enhanced networking with ENA is enabled.
-                  type: boolean
-                iamProfile:
-                  description: The name of the IAM instance profile associated with
-                    the instance, if applicable.
-                  type: string
-                id:
-                  type: string
-                imageId:
-                  description: The ID of the AMI used to launch the instance.
-                  type: string
-                instanceState:
-                  description: The current state of the instance.
-                  type: string
-                networkInterfaces:
-                  description: Specifies ENIs attached to instance
-                  items:
-                    type: string
-                  type: array
-                privateIp:
-                  description: The private IPv4 address assigned to the instance.
-                  type: string
-                publicIp:
-                  description: The public IPv4 address assigned to the instance, if
-                    applicable.
-                  type: string
-                rootDeviceSize:
-                  description: Specifies size (in Gi) of the root storage device
-                  format: int64
-                  type: integer
-                securityGroupIds:
-                  description: SecurityGroupIDs are one or more security group IDs
-                    this instance belongs to.
-                  items:
-                    type: string
-                  type: array
-                sshKeyName:
-                  description: The name of the SSH key pair.
-                  type: string
-                subnetId:
-                  description: The ID of the subnet of the instance.
-                  type: string
-                tags:
-                  additionalProperties:
-                    type: string
-                  description: The tags associated with the instance.
-                  type: object
-                type:
-                  description: The instance type.
-                  type: string
-                userData:
-                  description: UserData is the raw data script passed to the instance
-                    which is run upon bootstrap. This field must not be base64 encoded
-                    and should only be used when running a new instance.
-                  type: string
-              required:
-              - id
-              type: object
-            network:
-              description: Network encapsulates AWS networking resources.
-              properties:
-                apiServerElb:
-                  description: APIServerELB is the Kubernetes api server classic load
-                    balancer.
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host.
+                type: string
+            type: object
+          status:
+            description: AWSClusterStatus defines the observed state of AWSCluster
+            properties:
+              apiEndpoints:
+                description: APIEndpoints represents the endpoints to communicate
+                  with the control plane.
+                items:
+                  description: APIEndpoint represents a reachable Kubernetes API endpoint.
                   properties:
-                    attributes:
-                      description: Attributes defines extra attributes associated
-                        with the load balancer.
-                      properties:
-                        idleTimeout:
-                          description: IdleTimeout is time that the connection is
-                            allowed to be idle (no data has been sent over the connection)
-                            before it is closed by the load balancer.
-                          format: int64
-                          type: integer
-                      type: object
-                    dnsName:
-                      description: DNSName is the dns name of the load balancer.
+                    host:
+                      description: The hostname on which the API server is serving.
                       type: string
-                    healthChecks:
-                      description: HealthCheck is the classic elb health check associated
-                        with the load balancer.
-                      properties:
-                        healthyThreshold:
-                          format: int64
-                          type: integer
-                        interval:
-                          description: A Duration represents the elapsed time between
-                            two instants as an int64 nanosecond count. The representation
-                            limits the largest representable duration to approximately
-                            290 years.
-                          format: int64
-                          type: integer
-                        target:
-                          type: string
-                        timeout:
-                          description: A Duration represents the elapsed time between
-                            two instants as an int64 nanosecond count. The representation
-                            limits the largest representable duration to approximately
-                            290 years.
-                          format: int64
-                          type: integer
-                        unhealthyThreshold:
-                          format: int64
-                          type: integer
-                      required:
-                      - healthyThreshold
-                      - interval
-                      - target
-                      - timeout
-                      - unhealthyThreshold
-                      type: object
-                    listeners:
-                      description: Listeners is an array of classic elb listeners
-                        associated with the load balancer. There must be at least
-                        one.
-                      items:
-                        description: ClassicELBListener defines an AWS classic load
-                          balancer listener.
-                        properties:
-                          instancePort:
-                            format: int64
-                            type: integer
-                          instanceProtocol:
-                            description: ClassicELBProtocol defines listener protocols
-                              for a classic load balancer.
-                            type: string
-                          port:
-                            format: int64
-                            type: integer
-                          protocol:
-                            description: ClassicELBProtocol defines listener protocols
-                              for a classic load balancer.
-                            type: string
-                        required:
-                        - instancePort
-                        - instanceProtocol
-                        - port
-                        - protocol
-                        type: object
-                      type: array
-                    name:
-                      description: The name of the load balancer. It must be unique
-                        within the set of load balancers defined in the region. It
-                        also serves as identifier.
-                      type: string
-                    scheme:
-                      description: Scheme is the load balancer scheme, either internet-facing
-                        or private.
-                      type: string
-                    securityGroupIds:
-                      description: SecurityGroupIDs is an array of security groups
-                        assigned to the load balancer.
-                      items:
-                        type: string
-                      type: array
-                    subnetIds:
-                      description: SubnetIDs is an array of subnets in the VPC attached
-                        to the load balancer.
-                      items:
-                        type: string
-                      type: array
-                    tags:
-                      additionalProperties:
-                        type: string
-                      description: Tags is a map of tags associated with the load
-                        balancer.
-                      type: object
+                    port:
+                      description: The port on which the API server is serving.
+                      type: integer
+                  required:
+                  - host
+                  - port
                   type: object
-                securityGroups:
-                  additionalProperties:
-                    description: SecurityGroup defines an AWS security group.
+                type: array
+              bastion:
+                description: Instance describes an AWS instance.
+                properties:
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootDeviceSize:
+                    description: Specifies size (in Gi) of the root storage device
+                    format: int64
+                    type: integer
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                required:
+                - id
+                type: object
+              network:
+                description: Network encapsulates AWS networking resources.
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
                     properties:
-                      id:
-                        description: ID is a unique identifier.
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
                         type: string
-                      ingressRule:
-                        description: IngressRules is the inbound rules associated
-                          with the security group.
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
                         items:
-                          description: IngressRule defines an AWS ingress rule for
-                            security groups.
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
                           properties:
-                            cidrBlocks:
-                              description: List of CIDR blocks to allow access from.
-                                Cannot be specified with SourceSecurityGroupID.
-                              items:
-                                type: string
-                              type: array
-                            description:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
                               type: string
-                            fromPort:
+                            port:
                               format: int64
                               type: integer
                             protocol:
-                              description: SecurityGroupProtocol defines the protocol
-                                type for a security group rule.
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
                               type: string
-                            sourceSecurityGroupIds:
-                              description: The security group id to allow access from.
-                                Cannot be specified with CidrBlocks.
-                              items:
-                                type: string
-                              type: array
-                            toPort:
-                              format: int64
-                              type: integer
                           required:
-                          - description
-                          - fromPort
+                          - instancePort
+                          - instanceProtocol
+                          - port
                           - protocol
-                          - toPort
                           type: object
                         type: array
                       name:
-                        description: Name is the security group name.
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
                         type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
                       tags:
                         additionalProperties:
                           type: string
-                        description: Tags is a map of tags associated with the security
-                          group.
+                        description: Tags is a map of tags associated with the load
+                          balancer.
                         type: object
-                    required:
-                    - id
-                    - name
                     type: object
-                  description: SecurityGroups is a map from the role/kind of the security
-                    group to its unique name, if any.
-                  type: object
-              type: object
-            ready:
-              type: boolean
-          required:
-          - ready
-          type: object
-      type: object
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              ready:
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
     served: true
     storage: false
   - additionalPrinterColumns:
@@ -419,6 +421,388 @@ spec:
       name: Bastion IP
       type: string
     name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSCluster is the Schema for the awsclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSClusterSpec defines the desired state of AWSCluster
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              controlPlaneLoadBalancer:
+                description: ControlPlaneLoadBalancer is optional configuration for
+                  customizing control plane behavior
+                properties:
+                  scheme:
+                    description: Scheme sets the scheme of the load balancer (defaults
+                      to Internet-facing)
+                    type: string
+                type: object
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg.
+                type: string
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
+                    properties:
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                        type: string
+                      id:
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
+                        type: string
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    type: object
+                type: object
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host.
+                type: string
+            type: object
+          status:
+            description: AWSClusterStatus defines the observed state of AWSCluster
+            properties:
+              apiEndpoints:
+                description: APIEndpoints represents the endpoints to communicate
+                  with the control plane.
+                items:
+                  description: APIEndpoint represents a reachable Kubernetes API endpoint.
+                  properties:
+                    host:
+                      description: The hostname on which the API server is serving.
+                      type: string
+                    port:
+                      description: The port on which the API server is serving.
+                      type: integer
+                  required:
+                  - host
+                  - port
+                  type: object
+                type: array
+              bastion:
+                description: Instance describes an AWS instance.
+                properties:
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootDeviceSize:
+                    description: Specifies size (in Gi) of the root storage device
+                    format: int64
+                    type: integer
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                required:
+                - id
+                type: object
+              network:
+                description: Network encapsulates AWS networking resources.
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
+                    properties:
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
+                        type: string
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
+                        items:
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
+                          properties:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                            port:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                          required:
+                          - instancePort
+                          - instanceProtocol
+                          - port
+                          - protocol
+                          type: object
+                        type: array
+                      name:
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load
+                          balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              ready:
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -128,7 +128,11 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*infrav1.Instance, 
 	if scope.AWSMachine.Spec.AMI.ID != nil {
 		input.ImageID = *scope.AWSMachine.Spec.AMI.ID
 	} else {
-		input.ImageID, err = s.defaultAMILookup(scope.AWSMachine.Spec.ImageLookupOrg, "ubuntu", "18.04", *scope.Machine.Spec.Version)
+		imageLookupOrg := scope.AWSMachine.Spec.ImageLookupOrg
+		if imageLookupOrg == "" {
+			imageLookupOrg = scope.AWSCluster.Spec.ImageLookupOrg
+		}
+		input.ImageID, err = s.defaultAMILookup(imageLookupOrg, "ubuntu", "18.04", *scope.Machine.Spec.Version)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR adds a new field, `ImageLookupOrg`, to the `AWSClusterSpec` struct. The `ImageLookupOrg` field can be used to override the organization ID used when looking up AMIs for machines. Note that the `ImageLookupOrg` is only used when a machine does not specify an AMI ID.

With this change, the `ImageLookupOrg` can be set at the cluster-level or at the machine-level. The machine-level `ImageLookupOrg` takes precedence over the cluster-level `ImageLookupOrg`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1292  

