### PR TITLE
✨ Add addresses to machine status

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
@@ -501,6 +503,9 @@ type Instance struct {
 
 	// The name of the IAM instance profile associated with the instance, if applicable.
 	IAMProfile string `json:"iamProfile,omitempty"`
+
+	// Addresses contains the AWS instance associated addresses.
+	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
 
 	// The private IPv4 address assigned to the instance.
 	PrivateIP *string `json:"privateIp,omitempty"`

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -655,6 +655,11 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Addresses != nil {
+		in, out := &in.Addresses, &out.Addresses
+		*out = make([]v1.NodeAddress, len(*in))
+		copy(*out, *in)
+	}
 	if in.PrivateIP != nil {
 		in, out := &in.PrivateIP, &out.PrivateIP
 		*out = new(string)

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
@@ -501,6 +503,9 @@ type Instance struct {
 
 	// The name of the IAM instance profile associated with the instance, if applicable.
 	IAMProfile string `json:"iamProfile,omitempty"`
+
+	// Addresses contains the AWS instance associated addresses.
+	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
 
 	// The private IPv4 address assigned to the instance.
 	PrivateIP *string `json:"privateIp,omitempty"`

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -655,6 +655,11 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Addresses != nil {
+		in, out := &in.Addresses, &out.Addresses
+		*out = make([]v1.NodeAddress, len(*in))
+		copy(*out, *in)
+	}
 	if in.PrivateIP != nil {
 		in, out := &in.PrivateIP, &out.PrivateIP
 		*out = new(string)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -153,6 +153,24 @@ spec:
               bastion:
                 description: Instance describes an AWS instance.
                 properties:
+                  addresses:
+                    description: Addresses contains the AWS instance associated addresses.
+                    items:
+                      description: NodeAddress contains information for the node's
+                        address.
+                      properties:
+                        address:
+                          description: The node address.
+                          type: string
+                        type:
+                          description: Node address type, one of Hostname, ExternalIP
+                            or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
                   ebsOptimized:
                     description: Indicates whether the instance is optimized for Amazon
                       EBS I/O.
@@ -560,6 +578,24 @@ spec:
               bastion:
                 description: Instance describes an AWS instance.
                 properties:
+                  addresses:
+                    description: Addresses contains the AWS instance associated addresses.
+                    items:
+                      description: NodeAddress contains information for the node's
+                        address.
+                      properties:
+                        address:
+                          description: The node address.
+                          type: string
+                        type:
+                          description: Node address type, one of Hostname, ExternalIP
+                            or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
                   ebsOptimized:
                     description: Indicates whether the instance is optimized for Amazon
                       EBS I/O.

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -321,6 +321,8 @@ func (r *AWSMachineReconciler) reconcileNormal(ctx context.Context, machineScope
 	// TODO(vincepri): Remove this annotation when clusterctl is no longer relevant.
 	machineScope.SetAnnotation("cluster-api-provider-aws", "true")
 
+	machineScope.SetAddresses(instance.Addresses)
+
 	switch instance.State {
 	case infrav1.InstanceStateRunning:
 		machineScope.Info("Machine instance is running", "instance-id", *machineScope.GetInstanceID())

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/klogr"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
@@ -170,6 +171,11 @@ func (m *MachineScope) SetAnnotation(key, value string) {
 		m.AWSMachine.Annotations = map[string]string{}
 	}
 	m.AWSMachine.Annotations[key] = value
+}
+
+// SetAddresses sets the AWSMachine address status.
+func (m *MachineScope) SetAddresses(addrs []corev1.NodeAddress) {
+	m.AWSMachine.Status.Addresses = addrs
 }
 
 // Close the MachineScope by updating the machine spec, machine status.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is pretty similar to one merged in the GCP provider a few hours ago. 

It will add the ability to fish out the internal and external IPs
associated with an awsmachine resource and populate those values in
.status.addresses.

Happy to backport to release-0.4 after merge as well.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
