### PR TITLE
:running: [e2e] Update ClusterLabelName usage

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -219,23 +219,23 @@ func makeMachineDeployment(namespace, mdName, awsMachineTemplateName, bootstrapC
 			Name:      mdName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				clusterv1.MachineClusterLabelName: clusterName,
-				"nodepool":                        mdName,
+				clusterv1.ClusterLabelName: clusterName,
+				"nodepool":                 mdName,
 			},
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
 			Replicas: &replicas,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					clusterv1.MachineClusterLabelName: clusterName,
-					"nodepool":                        mdName,
+					clusterv1.ClusterLabelName: clusterName,
+					"nodepool":                 mdName,
 				},
 			},
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
 					Labels: map[string]string{
-						clusterv1.MachineClusterLabelName: clusterName,
-						"nodepool":                        mdName,
+						clusterv1.ClusterLabelName: clusterName,
+						"nodepool":                 mdName,
 					},
 				},
 				Spec: clusterv1.MachineSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes up usage of old naming for the ClusterLabelName

