### PR TITLE
:running: [e2e] Fix up MachineDeployment for latest v1alpha3 changes

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -219,26 +219,25 @@ func makeMachineDeployment(namespace, mdName, awsMachineTemplateName, bootstrapC
 			Name:      mdName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				clusterv1.ClusterLabelName: clusterName,
-				"nodepool":                 mdName,
+				"nodepool": mdName,
 			},
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
 			Replicas: &replicas,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					clusterv1.ClusterLabelName: clusterName,
-					"nodepool":                 mdName,
+					"nodepool": mdName,
 				},
 			},
+			ClusterName: clusterName,
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
 					Labels: map[string]string{
-						clusterv1.ClusterLabelName: clusterName,
-						"nodepool":                 mdName,
+						"nodepool": mdName,
 					},
 				},
 				Spec: clusterv1.MachineSpec{
+					ClusterName: clusterName,
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
 							Kind:       "KubeadmConfigTemplate",


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes up the use of MachineDeployment in the e2e suite.
