### PR TITLE
🐛Add cert-manager to output of generate-examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ release-notes: $(RELEASE_NOTES)
 ## --------------------------------------
 
 .PHONY: create-cluster-management
-create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS in a KIND management cluster.
+create-cluster-management: $(CLUSTERCTL) generate-examples ## Create a development Kubernetes cluster on AWS in a KIND management cluster.
 	kind create cluster --name=clusterapi
 	@if [ ! -z "${LOAD_IMAGE}" ]; then \
 		echo "loading ${LOAD_IMAGE} into kind cluster ..." && \
@@ -303,7 +303,7 @@ create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes clus
 	# Install cert manager.
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
-		create -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
+		create -f examples/_out/cert-manager.yaml
 	# Wait for cert-manager pods to be created
 	sleep 20
 	# Wait for cert-manager pods to be ready.

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -42,6 +42,7 @@ COMPONENTS_CLUSTER_API_GENERATED_FILE=${SOURCE_DIR}/provider-components/provider
 COMPONENTS_AWS_GENERATED_FILE=${SOURCE_DIR}/provider-components/provider-components-aws.yaml
 
 PROVIDER_COMPONENTS_GENERATED_FILE=${OUTPUT_DIR}/provider-components.yaml
+CERTMANAGER_COMPONENTS_GENERATED_FILE=${OUTPUT_DIR}/cert-manager.yaml
 CLUSTER_GENERATED_FILE=${OUTPUT_DIR}/cluster.yaml
 CONTROLPLANE_GENERATED_FILE=${OUTPUT_DIR}/controlplane.yaml
 MACHINEDEPLOYMENT_GENERATED_FILE=${OUTPUT_DIR}/machinedeployment.yaml
@@ -83,6 +84,10 @@ fi
 
 mkdir -p "${OUTPUT_DIR}"
 
+# Download cert-manager component
+curl -sL https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml > "${CERTMANAGER_COMPONENTS_GENERATED_FILE}"
+echo "Generated ${CERTMANAGER_COMPONENTS_GENERATED_FILE}"
+
 # Generate AWS Credentials.
 AWS_B64ENCODED_CREDENTIALS="$(${CLUSTERAWSADM} alpha bootstrap encode-aws-credentials)"
 export AWS_B64ENCODED_CREDENTIALS
@@ -103,7 +108,7 @@ echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 CAPI_BRANCH=${CAPI_BRANCH:-"master"}
 if [[ ${CAPI_BRANCH} == "stable" ]]; then
   # TODO(vincepri): Fix the version once the first v0.3.x is released.
-  curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.5/cluster-api-components.yaml > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+  curl -sL https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.5/cluster-api-components.yaml > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
   echo "Downloaded ${COMPONENTS_CLUSTER_API_GENERATED_FILE} from cluster-api stable branch - v0.2.5"
 else
   kustomize build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=${CAPI_BRANCH}" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
@@ -121,3 +126,5 @@ echo "WARNING: ${PROVIDER_COMPONENTS_GENERATED_FILE} includes AWS credentials"
 
 # Patch kubernetes version
 sed -i'' -e 's|kubernetesVersion: .*|kubernetesVersion: '$KUBERNETES_VERSION'|' examples/_out/controlplane.yaml
+
+echo "NOTE: Ensure that the cert-manager components are running before creating the provider-components, cluster and control-plane."


### PR DESCRIPTION
cert-manager components is required by the capa-controller-manager. The
user should create cert-manager components before creating capa
control-plane.

Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR creates `examples/_out/cert-manager.yaml` when running `make generate-examples`.
This PR improves the user experience for those using the `make generate-examples` command to understand how to deploy capa control plane.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1233 

