### PR TITLE
✨ Allow passing in parameters to ci-conformance.sh

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -84,7 +84,7 @@ if grep -iqF "$(echo "${AWS_ACCESS_KEY_ID-}" | \
 fi
 
 # TODO(dims): remove "SKIP_INIT_IMAGE" once we fix problem building images in CI
-hack/ci/e2e-conformance.sh --verbose --skip-init-image --use-ci-artifacts
+hack/ci/e2e-conformance.sh --verbose --skip-init-image $*
 test_status="${?}"
 
 # If Boskos is being used then release the AWS account back to Boskos.


### PR DESCRIPTION
we should pass in "--use-ci-artifacts" only in the jobs we want to test against k/k CI master artifacts

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

