### PR TITLE
🐛 [0.4] Fix IMAGE_ID issue in examples

### DIFF
--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -23,8 +23,6 @@ metadata:
   name: ${CLUSTER_NAME}-controlplane-0
 spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
-  ami:
-    id: ${IMAGE_ID}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
 ---
@@ -71,8 +69,6 @@ metadata:
   name: ${CLUSTER_NAME}-controlplane-1
 spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
-  ami:
-    id: ${IMAGE_ID}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
 ---
@@ -113,8 +109,6 @@ metadata:
   name: ${CLUSTER_NAME}-controlplane-2
 spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
-  ami:
-    id: ${IMAGE_ID}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
 ---

--- a/examples/controlplane/kustomizeversions.yaml
+++ b/examples/controlplane/kustomizeversions.yaml
@@ -209,3 +209,27 @@ spec:
         echo "kubelet version: " $(kubelet --version)
 
         echo "$LINE_SEPARATOR"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachine
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-0
+spec:
+  ami:
+    id: ${IMAGE_ID}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachine
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-1
+spec:
+  ami:
+    id: ${IMAGE_ID}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachine
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-2
+spec:
+  ami:
+    id: ${IMAGE_ID}

--- a/examples/machinedeployment/kustomizeversions.yaml
+++ b/examples/machinedeployment/kustomizeversions.yaml
@@ -69,3 +69,13 @@ spec:
           echo "kubelet version: " $(kubelet --version)
 
           echo "$LINE_SEPARATOR"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      ami:
+        id: ${IMAGE_ID}

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -36,8 +36,6 @@ spec:
   template:
     spec:
       instanceType: ${NODE_MACHINE_TYPE}
-      ami:
-        id: ${IMAGE_ID}
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${SSH_KEY_NAME}"
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the ${IMAGE_ID} placeholder from the examples, as it's only used
for e2e conformance testing, and it's broken for example usage.

Use kustomize patches to handle the IMAGE_ID for e2e testing instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1300

