### PR TITLE
🐛 Fix IMAGE_ID issue in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,8 +293,10 @@ release-notes: $(RELEASE_NOTES)
 ## Development
 ## --------------------------------------
 
+# NOTE: do not add 'generate-exmaples' as a prerequisite of this target. It will break e2e conformance testing.
 .PHONY: create-cluster-management
-create-cluster-management: $(CLUSTERCTL) generate-examples ## Create a development Kubernetes cluster on AWS in a KIND management cluster.
+create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS in a KIND management cluster.
+	@if [[ ! -f examples/_out/cert-manager.yaml ]]; then echo "Examples are missing. Run 'make generate-examples' first."; exit 1; fi
 	kind create cluster --name=clusterapi
 	@if [ ! -z "${LOAD_IMAGE}" ]; then \
 		echo "loading ${LOAD_IMAGE} into kind cluster ..." && \

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -24,8 +24,6 @@ metadata:
   name: ${CLUSTER_NAME}-controlplane-0
 spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
-  ami:
-    id: ${IMAGE_ID}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
 ---
@@ -72,8 +70,6 @@ metadata:
   name: ${CLUSTER_NAME}-controlplane-1
 spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
-  ami:
-    id: ${IMAGE_ID}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
 ---
@@ -114,8 +110,6 @@ metadata:
   name: ${CLUSTER_NAME}-controlplane-2
 spec:
   instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
-  ami:
-    id: ${IMAGE_ID}
   iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
   sshKeyName: "${SSH_KEY_NAME}"
 ---

--- a/examples/controlplane/kustomizeversions.yaml
+++ b/examples/controlplane/kustomizeversions.yaml
@@ -209,3 +209,27 @@ spec:
         echo "kubelet version: " $(kubelet --version)
 
         echo "$LINE_SEPARATOR"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachine
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-0
+spec:
+  ami:
+    id: ${IMAGE_ID}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachine
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-1
+spec:
+  ami:
+    id: ${IMAGE_ID}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachine
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-2
+spec:
+  ami:
+    id: ${IMAGE_ID}

--- a/examples/machinedeployment/kustomizeversions.yaml
+++ b/examples/machinedeployment/kustomizeversions.yaml
@@ -69,3 +69,13 @@ spec:
           echo "kubelet version: " $(kubelet --version)
 
           echo "$LINE_SEPARATOR"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      ami:
+        id: ${IMAGE_ID}

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -24,10 +24,10 @@ spec:
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: ${CLUSTER_NAME}-md-0
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -35,8 +35,6 @@ spec:
   template:
     spec:
       instanceType: ${NODE_MACHINE_TYPE}
-      ami:
-        id: ${IMAGE_ID}
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${SSH_KEY_NAME}"
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the ${IMAGE_ID} placeholder from the examples, as it's only used
for e2e conformance testing, and it's broken for example usage.

Use kustomize patches to handle the IMAGE_ID for e2e testing instead.

Cherry-pick of #1336 for `master`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #