### PR TITLE
:sparkles: Support cluster names > 22 characters in length

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
+	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7
+	golang.org/x/net v0.0.0-20191021144547-ec77196f6094
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190918200256-06eb1244587a

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQ
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190909003024-a7b16738d86b h1:XfVGCX+0T4WOStkaOsJRllbsiImhB2jgVBGc9L0lPGc=
 golang.org/x/net v0.0.0-20190909003024-a7b16738d86b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094 h1:5O4U9trLjNpuhpynaDsqwCk+Tw6seqJz1EbqbnzHrc8=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/internal/hash"
 )
 
 // ResourceGroups are filtered by ARN identifier: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax
@@ -42,7 +43,11 @@ func (s *Service) ReconcileLoadbalancers() error {
 	s.scope.V(2).Info("Reconciling load balancers")
 
 	// Get default api server spec.
-	spec := s.getAPIServerClassicELBSpec()
+	spec, err := s.getAPIServerClassicELBSpec()
+
+	if err != nil {
+		return err
+	}
 
 	// Describe or create.
 	apiELB, err := s.describeClassicELB(spec.Name)
@@ -84,7 +89,11 @@ func (s *Service) ReconcileLoadbalancers() error {
 
 // GetAPIServerDNSName returns the DNS name endpoint for the API server
 func (s *Service) GetAPIServerDNSName() (string, error) {
-	apiELB, err := s.describeClassicELB(GenerateELBName(s.scope.Name(), infrav1.APIServerRoleTagValue))
+	elbName, err := GenerateELBName(s.scope.Name())
+	if err != nil {
+		return "", err
+	}
+	apiELB, err := s.describeClassicELB(elbName)
 	if err != nil {
 		return "", err
 	}
@@ -137,7 +146,10 @@ func (s *Service) RegisterInstanceWithClassicELB(instanceID string, loadBalancer
 
 // RegisterInstanceWithAPIServerELB registers an instance with a classic ELB
 func (s *Service) RegisterInstanceWithAPIServerELB(i *infrav1.Instance) error {
-	name := GenerateELBName(s.scope.Name(), infrav1.APIServerRoleTagValue)
+	name, err := GenerateELBName(s.scope.Name())
+	if err != nil {
+		return err
+	}
 	out, err := s.describeClassicELB(name)
 	if err != nil {
 		return err
@@ -169,14 +181,49 @@ func (s *Service) RegisterInstanceWithAPIServerELB(i *infrav1.Instance) error {
 	return nil
 }
 
-// GenerateELBName generates a formatted ELB name
-func GenerateELBName(clusterName string, elbName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, elbName)
+// GenerateELBName generates a formatted ELB name via either
+// concatenating the cluster name to the "-apiserver" suffix
+// or computing a hash for clusters with names above 32 characters.
+func GenerateELBName(clusterName string) (string, error) {
+	standardELBName := generateStandardELBName(clusterName)
+	if len(standardELBName) <= 32 {
+		return standardELBName, nil
+	}
+
+	elbName, err := generateHashedELBName(clusterName)
+	if err != nil {
+		return "", err
+	}
+
+	return elbName, nil
 }
 
-func (s *Service) getAPIServerClassicELBSpec() *infrav1.ClassicELB {
+// generateStandardELBName generates a formatted ELB name based on cluster
+// and ELB name
+func generateStandardELBName(clusterName string) string {
+	elbCompatibleClusterName := strings.Replace(clusterName, ".", "-", -1)
+	return fmt.Sprintf("%s-%s", elbCompatibleClusterName, infrav1.APIServerRoleTagValue)
+}
+
+// generateHashedELBName generates a 32-character hashed name based on cluster
+// and ELB name
+func generateHashedELBName(clusterName string) (string, error) {
+	// hashSize = 32 - length of "k8s" - length of "-" = 28
+	shortName, err := hash.Base36TruncatedHash(clusterName, 28)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create ELB name")
+	}
+
+	return fmt.Sprintf("%s-%s", shortName, "k8s"), nil
+}
+
+func (s *Service) getAPIServerClassicELBSpec() (*infrav1.ClassicELB, error) {
+	elbName, err := GenerateELBName(s.scope.Name())
+	if err != nil {
+		return nil, err
+	}
 	res := &infrav1.ClassicELB{
-		Name:   GenerateELBName(s.scope.Name(), infrav1.APIServerRoleTagValue),
+		Name:   elbName,
 		Scheme: s.scope.ControlPlaneLoadBalancerScheme(),
 		Listeners: []*infrav1.ClassicELBListener{
 			{
@@ -215,7 +262,7 @@ func (s *Service) getAPIServerClassicELBSpec() *infrav1.ClassicELB {
 		}
 	}
 
-	return res
+	return res, nil
 }
 
 func (s *Service) createClassicELB(spec *infrav1.ClassicELB) (*infrav1.ClassicELB, error) {

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package elb
+
+import (
+	"testing"
+)
+
+func TestGenerateELBName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "test",
+			expected: "test-apiserver",
+		},
+		{
+			name:     "0123456789012345678901",
+			expected: "0123456789012345678901-apiserver",
+		},
+		{
+			name:     "01234567890123456789012",
+			expected: "26o3cjil5at5qn27vukn5x09b3ql-k8s",
+		},
+		{
+			name:     "anotherverylongtoolongname",
+			expected: "t8gnrbbifaaf5d0k4xmwui3xwvip-k8s",
+		},
+		{
+			name:     "anotherverylongtoolongnameanotherverylongtoolongname",
+			expected: "tph1huzox1f10z9ow1inrootjws8-k8s",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			elbName, err := GenerateELBName(tt.name)
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			if elbName != tt.expected {
+				t.Errorf("expected ELB name: %v, got name: %v", tt.expected, elbName)
+			}
+
+			if len(elbName) > 32 {
+				t.Errorf("ELB name too long: %v vs. %s", len(elbName), "32")
+			}
+
+		})
+	}
+}

--- a/pkg/internal/hash/base36.go
+++ b/pkg/internal/hash/base36.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/blake2b"
+)
+
+const base36set = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+// Base36TruncatedHash returns a consistent hash using blake2b
+// and truncating the byte values to alphanumeric only
+// of a fixed length specified by the consumer.
+func Base36TruncatedHash(str string, len int) (string, error) {
+	hasher, err := blake2b.New(len, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create hash function")
+	}
+
+	hasher.Write([]byte(str))
+	return base36Truncate(hasher.Sum(nil)), nil
+}
+
+// base36Truncate returns a string that is base36 compliant
+// It is not an encoding since it returns a same-length string
+// for any byte value
+func base36Truncate(bytes []byte) string {
+	var chars string
+	for _, bite := range bytes {
+		idx := int(bite) % 36
+		chars = chars + string(base36set[idx])
+	}
+
+	return chars
+}


### PR DESCRIPTION
Cherry pick of #1290 on release-0.4.

#1290: consistently hash ELB names when above 32 characters in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.