### PR TITLE
🏃 Verify LoadBalancer dyanamically provisioned on service creation and deleted after cluster deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-integration: ## Run integration tests
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests
 	PULL_POLICY=IfNotPresent $(MAKE) docker-build
-	cd $(TEST_E2E_DIR); go test -v -tags=e2e -timeout=1h . -args -ginkgo.v -ginkgo.focus "functional tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	cd $(TEST_E2E_DIR); go test -v -tags=e2e -timeout=2h . -args -ginkgo.v -ginkgo.focus "functional tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: test-conformance
 test-conformance: ## Run conformance test on workload cluster

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -76,25 +76,10 @@ var _ = Describe("conformance tests", func() {
 
 	Describe("conformance on workload cluster", func() {
 		It("It should pass k8s certified-conformance tests", func() {
-			By("Creating an AWSCluster")
-			makeAWSCluster(namespace, awsClusterName)
+			instanceType := "t3.large"
 
-			By("Creating a Cluster")
-			makeCluster(namespace, clusterName, awsClusterName)
-
-			By("Ensuring Cluster Infrastructure Reports as Ready")
-			waitForClusterInfrastructureReady(namespace, clusterName)
-
-			By("Creating the initial Control Plane Machine")
-			awsMachineName := cpAWSMachinePrefix + "-0"
-			bootstrapConfigName := cpBootstrapConfigPrefix + "-0"
-			machineName := cpMachinePrefix + "-0"
-			instanceType := "m5.large"
-			createInitialControlPlaneMachine(namespace, clusterName, machineName, awsMachineName, bootstrapConfigName, instanceType)
-
-			By("Deploying CNI to created Cluster")
-			deployCNI(testTmpDir, namespace, clusterName, *cniManifests)
-			waitForMachineNodeReady(namespace, machineName)
+			By("Creating a cluster with single control plane")
+			makeSingleControlPlaneCluster(namespace, clusterName, awsClusterName, cpAWSMachinePrefix, cpBootstrapConfigPrefix, cpMachinePrefix, instanceType, testTmpDir)
 
 			By("Deploying a MachineDeployment")
 			createMachineDeployment(namespace, clusterName, machineDeploymentName, awsMachineTemplateName, mdBootstrapConfig, instanceType, 2)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -178,9 +178,9 @@ var _ = AfterSuite(func() {
 })
 
 func retrieveAllLogs() {
-	capiLogs := retrieveLogs(capiNamespace, capiDeploymentName)
-	cabpkLogs := retrieveLogs(cabpkNamespace, cabpkDeploymentName)
-	capaLogs := retrieveLogs(capaNamespace, capaDeploymentName)
+	capiLogs := retrieveCapiLogs()
+	cabpkLogs := retrieveCabpkLogs()
+	capaLogs := retrieveCapaLogs()
 
 	// If running in prow, output the logs to the artifacts path
 	artifactPath, exists := os.LookupEnv("ARTIFACTS")
@@ -194,6 +194,18 @@ func retrieveAllLogs() {
 	fmt.Fprintf(GinkgoWriter, "CAPI Logs:\n%s\n", capiLogs)
 	fmt.Fprintf(GinkgoWriter, "CABPK Logs:\n%s\n", cabpkLogs)
 	fmt.Fprintf(GinkgoWriter, "CAPA Logs:\n%s\n", capaLogs)
+}
+
+func retrieveCapaLogs() string {
+	return retrieveLogs(capaNamespace, capaDeploymentName)
+}
+
+func retrieveCapiLogs() string {
+	return retrieveLogs(capiNamespace, capiDeploymentName)
+}
+
+func retrieveCabpkLogs() string {
+	return retrieveLogs(cabpkNamespace, cabpkDeploymentName)
 }
 
 func retrieveLogs(namespace, deploymentName string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Existing E2E tests, doesn't cover verification of dynamically provisioned Load Balancer deletion after cluster removal
This PR covers the 
1. Deploy a Load balancer service on infra cluster
2. Verify Load balancer provisioned
3. Verify Load balancer deleted on deleting the cluster
4. Deploy statefulset on infra cluster
5. Verify volumes are dynamically provisioned
6. Verify dynamically provisioned volumes retained on cluster deletion
Executed the tests locally and all the tests succeeded.

