### PR TITLE
[wip] :sparkles: Add tests for authentication, make local recorders for scopes

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -78,6 +78,7 @@ func (r *AWSClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 		Logger:     log,
 		Cluster:    cluster,
 		AWSCluster: awsCluster,
+		Recorder:   r.Recorder,
 	})
 	if err != nil {
 		return reconcile.Result{}, errors.Errorf("failed to create scope: %+v", err)

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -120,6 +120,7 @@ func (r *AWSMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 		Logger:     logger,
 		Cluster:    cluster,
 		AWSCluster: awsCluster,
+		Recorder:   r.Recorder,
 	})
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/cloud/scope/mock/session.go
+++ b/pkg/cloud/scope/mock/session.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mock // nolint
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// NewMockStatusSessionForRegion is a mock session which always returns the same HTTP status
+func NewMockStatusSessionForRegion(status int, region string) *session.Session {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+
+	return session.Must(session.NewSession(&aws.Config{
+		DisableSSL: aws.Bool(true),
+		Endpoint:   aws.String(server.URL),
+		Region:     aws.String(region),
+	}))
+}

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -19,6 +19,7 @@ package ec2
 import (
 	"testing"
 
+	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -71,6 +72,7 @@ func TestAMIs(t *testing.T) {
 				AWSClients: scope.AWSClients{
 					EC2: ec2Mock,
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("did not expect err: %v", err)
@@ -132,6 +134,7 @@ func TestAMIsWithInvalidCreationDate(t *testing.T) {
 				AWSClients: scope.AWSClients{
 					EC2: ec2Mock,
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("did not expect err: %v", err)

--- a/pkg/cloud/services/ec2/gateways_test.go
+++ b/pkg/cloud/services/ec2/gateways_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface" //nolint
@@ -119,6 +120,7 @@ func TestReconcileInternetGateways(t *testing.T) {
 						NetworkSpec: *tc.input,
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 
 			if err != nil {

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
@@ -143,6 +144,7 @@ func TestInstanceIfExists(t *testing.T) {
 						},
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)
@@ -213,6 +215,7 @@ func TestTerminateInstance(t *testing.T) {
 				},
 				Cluster:    &clusterv1.Cluster{},
 				AWSCluster: &infrav1.AWSCluster{},
+				Recorder:   record.NewFakeRecorder(1),
 			})
 
 			if err != nil {
@@ -842,6 +845,7 @@ func TestCreateInstance(t *testing.T) {
 				},
 				Cluster:    cluster,
 				AWSCluster: tc.awsCluster,
+				Recorder:   record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)

--- a/pkg/cloud/services/ec2/natgateways_test.go
+++ b/pkg/cloud/services/ec2/natgateways_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
@@ -309,6 +310,7 @@ func TestReconcileNatGateways(t *testing.T) {
 						},
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)

--- a/pkg/cloud/services/ec2/routetables_test.go
+++ b/pkg/cloud/services/ec2/routetables_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
@@ -161,6 +162,7 @@ func TestReconcileRouteTables(t *testing.T) {
 						NetworkSpec: *tc.input,
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 
 			if err != nil {

--- a/pkg/cloud/services/ec2/securitygroups_test.go
+++ b/pkg/cloud/services/ec2/securitygroups_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
@@ -225,6 +226,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 						NetworkSpec: *tc.input,
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 
 			if err != nil {

--- a/pkg/cloud/services/ec2/subnets_test.go
+++ b/pkg/cloud/services/ec2/subnets_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
@@ -521,6 +522,7 @@ func TestReconcileSubnets(t *testing.T) {
 						NetworkSpec: *tc.input,
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)
@@ -689,6 +691,7 @@ func TestDiscoverSubnets(t *testing.T) {
 						NetworkSpec: *tc.input,
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)

--- a/pkg/cloud/services/ec2/vpc_test.go
+++ b/pkg/cloud/services/ec2/vpc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
@@ -176,6 +177,7 @@ func TestReconcileVPC(t *testing.T) {
 						},
 					},
 				},
+				Recorder: record.NewFakeRecorder(1),
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Scope structs modified to accept replacement AWS sessions, to allow a fake HTTP server to be used for the AWS client, and exercise the credential provider chain code.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1343

