### PR TITLE
:sparkles: Improves e2e tests by using version flags

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -214,7 +214,6 @@ func waitForMachineDeploymentRunning(namespace, machineDeploymentName string) {
 
 func makeMachineDeployment(namespace, mdName, awsMachineTemplateName, bootstrapConfigName, clusterName string, replicas int32) {
 	fmt.Fprintf(GinkgoWriter, "Creating MachineDeployment %s/%s\n", namespace, mdName)
-	k8s_version := "v1.16.0"
 	machineDeployment := &clusterv1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mdName,
@@ -254,7 +253,7 @@ func makeMachineDeployment(namespace, mdName, awsMachineTemplateName, bootstrapC
 						Name:       awsMachineTemplateName,
 						Namespace:  namespace,
 					},
-					Version: &k8s_version,
+					Version: k8sVersion,
 				},
 			},
 		},
@@ -505,7 +504,6 @@ func waitForAWSMachineReady(namespace, name string) {
 
 func makeMachine(namespace, name, awsMachineName, bootstrapConfigName, clusterName string) {
 	fmt.Fprintf(GinkgoWriter, "Creating Machine %s/%s\n", namespace, name)
-	k8s_version := "v1.16.0"
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -530,7 +528,7 @@ func makeMachine(namespace, name, awsMachineName, bootstrapConfigName, clusterNa
 				Name:       awsMachineName,
 				Namespace:  namespace,
 			},
-			Version: &k8s_version,
+			Version: k8sVersion,
 		},
 	}
 	Expect(kindClient.Create(context.TODO(), machine)).To(Succeed())

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -162,7 +162,7 @@ func runConformance(tmpDir, namespace, clusterName string) error {
 		return errors.Wrap(err, "couldn't create sonobuoy config file")
 	}
 
-	sbConfig := sonobuoyConfig{SonobuoyVersion: "v0.16.2", K8sVersion: apiVersion.GitVersion}
+	sbConfig := sonobuoyConfig{SonobuoyVersion: *sonobuoyVersion, K8sVersion: apiVersion.GitVersion}
 	err = tmpl.Execute(fileP, sbConfig)
 	if err != nil {
 		return errors.Wrap(err, "couldn't execute template")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -94,6 +94,8 @@ var (
 	cabpkComponents = capiFlag.DefineOrLookupStringFlag("cabpkComponents", "https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/"+CABPK_VERSION+"/bootstrap-components.yaml", "URL to CAPI components to load")
 	capaComponents  = capiFlag.DefineOrLookupStringFlag("capaComponents", "", "capa components to load")
 	kustomizeBinary = capiFlag.DefineOrLookupStringFlag("kustomizeBinary", "kustomize", "path to the kustomize binary")
+	k8sVersion      = capiFlag.DefineOrLookupStringFlag("k8sVersion", "v1.16.0", "kubernetes version to test on")
+	sonobuoyVersion = capiFlag.DefineOrLookupStringFlag("sonobuoyVersion", "v0.16.2", "sonobuoy version")
 
 	kindCluster  kind.Cluster
 	kindClient   crclient.Client


### PR DESCRIPTION
**What this PR does**:
* Adds flags to set the kubernetes version of workload clusters to test up on.
* Adds flags to set sonobuoy version to run conformance

**Why we need it**
Helps to run conformance/functional tests on latest kuberentes versions easily
