### PR TITLE
:sparkles: Adds more e2e functional tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-integration: ## Run integration tests
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests
 	PULL_POLICY=IfNotPresent $(MAKE) docker-build
-	cd $(TEST_E2E_DIR); go test -v -tags=e2e -timeout=2h . -args -ginkgo.v -ginkgo.focus "functional tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	cd $(TEST_E2E_DIR); go test -v -tags=e2e -timeout=3h . -args -ginkgo.v -ginkgo.focus "functional tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: test-conformance
 test-conformance: ## Run conformance test on workload cluster

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -79,10 +79,10 @@ var _ = Describe("conformance tests", func() {
 			instanceType := "t3.large"
 
 			By("Creating a cluster with single control plane")
-			makeSingleControlPlaneCluster(namespace, clusterName, awsClusterName, cpAWSMachinePrefix, cpBootstrapConfigPrefix, cpMachinePrefix, instanceType, testTmpDir)
+			makeSingleControlPlaneCluster(namespace, clusterName, awsClusterName, cpAWSMachinePrefix, cpBootstrapConfigPrefix, cpMachinePrefix, instanceType, testTmpDir, false)
 
 			By("Deploying a MachineDeployment")
-			createMachineDeployment(namespace, clusterName, machineDeploymentName, awsMachineTemplateName, mdBootstrapConfig, instanceType, 2)
+			createMachineDeployment(namespace, clusterName, machineDeploymentName, awsMachineTemplateName, mdBootstrapConfig, instanceType, 2, nil, nil)
 
 			By("Running conformance on the workload cluster")
 			err := runConformance(testTmpDir, namespace, clusterName)


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Adds Create/Delete multiple workload clusters test scenario

- clusters in different namespaces
- clusters within same namespace

2. Adds e2e tests for delete machine lifecycle
- delete a machine using kindclient
- wait for the MachineDeployment to be reconciled

3. Adds e2e tests for multi AZ deployment
- Deploy ControlPlane and MachineDeployment in new AZ
- Deploy ControlPlane and MachineDeployment in new AZ using subnet-id