### PR TITLE
:bug: Add NoCredentialProviders to list of authentication errors

### DIFF
--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -100,7 +100,7 @@ func recordAWSPermissionsIssue(target runtime.Object) func(r *request.Request) {
 	return func(r *request.Request) {
 		if awsErr, ok := r.Error.(awserr.Error); ok {
 			switch awsErr.Code() {
-			case "AuthFailure", "UnauthorizedOperation":
+			case "AuthFailure", "UnauthorizedOperation", "NoCredentialProviders":
 				record.Warnf(target, awsErr.Code(), "Operation %s failed with a credentials or permission issue", r.Operation.Name)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Handles case most commonly seen during AWS role assumption where no credentials exist, role assumption has failed and an error needs to be bubbled up to the consumer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1343

Testing this is a little non-trivial due to needing to pass the recorder down into the AWS request handler. An attempt was made in #1349