### PR TITLE
🐛 POC same cluster name different namespaces

### DIFF
--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -140,7 +140,7 @@ func (s *ClusterScope) SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.Se
 
 // Name returns the cluster name.
 func (s *ClusterScope) Name() string {
-	return s.Cluster.Name
+	return fmt.Sprintf("%s-%s", s.Cluster.Name, s.Cluster.Namespace)
 }
 
 // Namespace returns the cluster namespace.


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

/hold

This isn't the actual change we want, but it's proof enough to show that we need a way to identify a cluster beyond using just the name. With this one line change I was able to fix kubernetes-sigs/cluster-api#1554 bug.

![Screen Shot 2019-11-15 at 3 14 16 PM](https://user-images.githubusercontent.com/98927/68972819-a7dfe080-07ba-11ea-9c4b-57403b1af191.png)

I think this raises a bigger point in how we identify clusters. I'm wondering if we should expose an `Identifier` method on a CAPI Cluster and then mandate that anytime you need to identify a cluster you use that method in order to account for same name different namespaces.


