### PR TITLE
🐛 Remove git branch from version info

### DIFF
--- a/cmd/versioninfo/versioninfo.go
+++ b/cmd/versioninfo/versioninfo.go
@@ -23,8 +23,6 @@ import (
 )
 
 var (
-	// GitBranch is the branch from which this binary was built
-	GitBranch string
 	// GitReleaseTag is the git tag from which this binary is released
 	GitReleaseTag string
 	// GitReleaseCommit is the commit corresponding to the GitReleaseTag
@@ -60,7 +58,6 @@ func printShortCleanVersionInfo() {
 func printVerboseVersionInfo() {
 	fmt.Println("Version Info:")
 	fmt.Printf("GitReleaseTag: %q, Major: %q, Minor: %q, GitRelaseCommit: %q\n", GitReleaseTag, GitMajor, GitMinor, GitReleaseCommit)
-	fmt.Printf("Git Branch: %q\n", GitBranch)
 	fmt.Printf("Git commit: %q\n", GitCommit)
 	fmt.Printf("Git tree state: %q\n", GitTreeState)
 }

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -67,7 +67,6 @@ version::get_version_vars() {
         fi
     fi
 
-    GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
     GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
     GIT_RELEASE_COMMIT=$(git rev-list -n 1  ${GIT_RELEASE_TAG} | head -c 14)
 }
@@ -91,7 +90,6 @@ version::ldflags() {
     add_ldflag "GitMajor" "${GIT_MAJOR}"
     add_ldflag "GitMinor" "${GIT_MINOR}"
     add_ldflag "GitVersion" "${GIT_VERSION}"
-    add_ldflag "GitBranch" "${GIT_BRANCH}"
     add_ldflag "GitReleaseTag" "${GIT_RELEASE_TAG}"
     add_ldflag "GitReleaseCommit" "${GIT_RELEASE_COMMIT}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove git branch from version info. This information is not really
relevant (a branch can have any name; what is important is the commit
and/or tag). It also breaks building the release versions of binaries.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1362

