### PR TITLE
🐛 make create-cluster: Improve cert-manager wait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,9 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS 
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		wait --for=condition=Ready --namespace=cert-manager --timeout=15m pods --all
 	# Wait for webhook servers to be ready to take requests
-	sleep 10
+	kubectl \
+		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
+		wait --for=condition=Available --timeout=5m apiservice v1beta1.webhook.cert-manager.io
 	# Apply provider-components.
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \

--- a/Makefile
+++ b/Makefile
@@ -306,12 +306,6 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS 
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/cert-manager.yaml
-	# Wait for cert-manager pods to be created
-	sleep 20
-	# Wait for cert-manager pods to be ready.
-	kubectl \
-		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
-		wait --for=condition=Ready --namespace=cert-manager --timeout=15m pods --all
 	# Wait for webhook servers to be ready to take requests
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \

--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,14 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS 
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/provider-components.yaml
+	# Wait for CAPI pod
+	kubectl \
+		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
+		wait --for=condition=Ready --timeout=5m -n capi-system pod -l control-plane=cluster-api-controller-manager
+    # Wait for CAPA pod
+	kubectl \
+		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
+		wait --for=condition=Ready --timeout=5m -n capa-system pod -l control-plane=capa-controller-manager
 	# Create Cluster.
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \

--- a/examples/machinedeployment/kustomizeconfig.yaml
+++ b/examples/machinedeployment/kustomizeconfig.yaml
@@ -1,11 +1,11 @@
 namespace:
 - kind: MachineDeployment
   group: cluster.x-k8s.io
-  version: v1alpha2
+  version: v1alpha3
   path: spec/template/spec/infrastructureRef/namespace
   create: true
 - kind: MachineDeployment
   group: cluster.x-k8s.io
-  version: v1alpha2
+  version: v1alpha3
   path: spec/template/spec/bootstrap/configRef/namespace
   create: true

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of sleeping 10 seconds and hoping that cert-manager is ready,
use 'kubectl wait' to wait for the cert-manager webhook apiservice.

Also fix a conformance issue where the apiVersion of the MachineDeployment was wrong (v1a1 instead of v1a2).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1383

