### PR TITLE
🏃 [0.4] Make conformance cluster names unique by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,9 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS 
 	-p ./examples/_out/provider-components.yaml \
 	-a ./examples/addons.yaml
 
+# This is used in the get-kubeconfig call below in the create-cluster-management target. It may be overridden by the
+# e2e-conformance.sh script, which is why we need it as a variable here.
+CLUSTER_NAME ?= test1
 
 .PHONY: create-cluster-management
 create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS in a KIND management cluster.
@@ -336,7 +339,7 @@ create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes clus
 		alpha phases get-kubeconfig -v=3 \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		--namespace=default \
-		--cluster-name=test1
+		--cluster-name=$(CLUSTER_NAME)
 	# Apply addons on the target cluster, waiting for the control-plane to become available.
 	$(CLUSTERCTL) \
 		alpha phases apply-addons -v=3 \
@@ -348,12 +351,12 @@ create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes clus
 		create -f examples/_out/machinedeployment.yaml
 
 .PHONY: delete-cluster
-delete-cluster: $(CLUSTERCTL) ## Deletes the development Kubernetes Cluster "test1"
+delete-cluster: $(CLUSTERCTL) ## Deletes the development Kubernetes Cluster "$CLUSTER_NAME"
 	$(CLUSTERCTL) \
 	delete cluster -v 4 \
 	--bootstrap-type kind \
 	--bootstrap-flags="name=clusterapi" \
-	--cluster test1 \
+	--cluster $(CLUSTER_NAME) \
 	--kubeconfig ./kubeconfig \
 	-p ./examples/_out/provider-components.yaml \
 

--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -20,7 +20,7 @@ set -o errexit -o nounset -o pipefail
 
 REGISTRY=${REGISTRY:-"gcr.io/"$(gcloud config get-value project)}
 AWS_REGION=${AWS_REGION:-"us-east-1"}
-CLUSTER_NAME=${CLUSTER_NAME:-test1}
+CLUSTER_NAME=${CLUSTER_NAME:-"test-$(date +%s)"}
 SSH_KEY_NAME=${SSH_KEY_NAME:-"${CLUSTER_NAME}-key"}
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.16.1"}
 TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%SZ")
@@ -43,7 +43,7 @@ dump-logs() {
   # dump all the info from the CAPI related CRDs
   kubectl --kubeconfig=$(kind get kubeconfig-path --name="clusterapi") get \
   clusters,awsclusters,machines,awsmachines,kubeadmconfigs,machinedeployments,awsmachinetemplates,kubeadmconfigtemplates,machinesets \
-  --all-namespaces -o yaml >> "${ARTIFACTS}/logs/capg.info" || true
+  --all-namespaces -o yaml >> "${ARTIFACTS}/logs/capa.info" || true
 
   # dump images info
   echo "images in docker" >> "${ARTIFACTS}/logs/images.info"
@@ -85,8 +85,8 @@ function ssh-to-node() {
   local cmd="$3"
 
   ssh_key_pem="/tmp/${SSH_KEY_NAME}.pem"
-  scp -i $ssh_key_pem $ssh_key_pem "ubuntu@${jump}:$ssh_key_pem"
   ssh_params="-o LogLevel=quiet -o ConnectTimeout=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+  scp $ssh_params -i $ssh_key_pem $ssh_key_pem "ubuntu@${jump}:$ssh_key_pem"
   ssh $ssh_params -i $ssh_key_pem \
     -o "ProxyCommand ssh $ssh_params -W %h:%p -i $ssh_key_pem ubuntu@${jump}" \
     ubuntu@${node} "${cmd}"
@@ -288,7 +288,7 @@ create_cluster() {
   KIND_IS_UP=true
 
   # Load the newly built image into kind and start the cluster
-  LOAD_IMAGE="${REGISTRY}/cluster-api-aws-controller-amd64:dev" \
+  LOAD_IMAGE="${REGISTRY}/cluster-api-aws-controller-amd64:dev" CLUSTER_NAME="${CLUSTER_NAME}" \
     make create-cluster-management
 
   # Wait till all machines are running (bail out at 30 mins)


### PR DESCRIPTION
*What this PR does / why we need it**:
Make conformance cluster names unique by default, so we have a better chance of being able to retrieve logs from the VMs (it's broken currently because there's already a keypair for test1, and because each run is not generating a new keypair, it's unable to retrieve).

This is a manual backport of #1388 to release-0.4.

/hold