### PR TITLE
🏃 [0.4] conformance: Fix gsutil usage, try capturing all VM logs

### DIFF
--- a/examples/controlplane/kustomizeversions.yaml
+++ b/examples/controlplane/kustomizeversions.yaml
@@ -20,11 +20,12 @@ spec:
 
       [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-      if ! gsutil version > /dev/null; then
-      curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
-      export PATH=$PATH:~/gcloud/google-cloud-sdk/bin
+      GSUTIL=gsutil
+      if ! command -v ${GSUTIL} > /dev/null; then
+        curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
+        GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
       fi
-      gsutil version
+      ${GSUTIL} version
 
       # This test installs debian packages that are a result of the CI and release builds.
       # It runs '... --version' commands to verify that the binaries are correctly installed
@@ -48,13 +49,13 @@ spec:
 
         for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
         echo "* downloading package: $CI_URL/$CI_PACKAGE.$PACKAGE_EXT"
-        gsutil cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
+        ${GSUTIL} cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
         ${SUDO} dpkg -i "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT" || echo "* ignoring expected 'dpkg -i' result"
         done
 
         for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
         echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-        gsutil cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
+        ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
         ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
         ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
         ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"
@@ -90,11 +91,12 @@ spec:
 
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-        if ! gsutil version > /dev/null; then
+        GSUTIL=gsutil
+        if ! command -v ${GSUTIL} > /dev/null; then
           curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
-          export PATH=$PATH:~/gcloud/google-cloud-sdk/bin
+          GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
         fi
-        gsutil version
+        ${GSUTIL} version
 
         # This test installs debian packages that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
@@ -118,13 +120,13 @@ spec:
 
           for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
           echo "* downloading package: $CI_URL/$CI_PACKAGE.$PACKAGE_EXT"
-          gsutil cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
+          ${GSUTIL} cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
           ${SUDO} dpkg -i "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT" || echo "* ignoring expected 'dpkg -i' result"
           done
 
           for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
           echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-          gsutil cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
+          ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
           ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
           ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
           ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"
@@ -160,11 +162,12 @@ spec:
 
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-        if ! gsutil version > /dev/null; then
-        curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
-        export PATH=$PATH:~/gcloud/google-cloud-sdk/bin
+        GSUTIL=gsutil
+        if ! command -v ${GSUTIL} > /dev/null; then
+          curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
+          GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
         fi
-        gsutil version
+        ${GSUTIL} version
 
         # This test installs debian packages that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
@@ -188,13 +191,13 @@ spec:
 
           for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
           echo "* downloading package: $CI_URL/$CI_PACKAGE.$PACKAGE_EXT"
-          gsutil cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
+          ${GSUTIL} cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
           ${SUDO} dpkg -i "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT" || echo "* ignoring expected 'dpkg -i' result"
           done
 
           for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
           echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-          gsutil cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
+          ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
           ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
           ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
           ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"

--- a/examples/machinedeployment/kustomizeversions.yaml
+++ b/examples/machinedeployment/kustomizeversions.yaml
@@ -20,11 +20,12 @@ spec:
 
           [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-          if ! gsutil version > /dev/null; then
-          curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
-          export PATH=$PATH:~/gcloud/google-cloud-sdk/bin
+          GSUTIL=gsutil
+          if ! command -v ${GSUTIL} > /dev/null; then
+            curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
+            GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
           fi
-          gsutil version
+          ${GSUTIL} version
 
           # This test installs debian packages that are a result of the CI and release builds.
           # It runs '... --version' commands to verify that the binaries are correctly installed
@@ -48,13 +49,13 @@ spec:
 
             for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading package: $CI_URL/$CI_PACKAGE.$PACKAGE_EXT"
-            gsutil cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
+            ${GSUTIL} cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
             ${SUDO} dpkg -i "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT" || echo "* ignoring expected 'dpkg -i' result"
             done
 
             for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
             echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-            gsutil cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
+            ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
             ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
             ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
             ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"

--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -64,7 +64,10 @@ dump-logs() {
   kind "export" logs --name="clusterapi" "${ARTIFACTS}/logs" || true
 
   jump_node=$(aws ec2 describe-instances --region $AWS_REGION --query "Reservations[*].Instances[*].PublicIpAddress" --output text | head -1)
-  for node in $(aws ec2 describe-instances --region $AWS_REGION --query "Reservations[*].Instances[*].PrivateIpAddress" --output text | tail -n +2)
+  # We used to pipe this output to 'tail -n +2' but for some reason this was sometimes (all the time?) only finding the
+  # bastion host. For now, omit the tail and gather logs for all VMs that have a private IP address. This will include
+  # the bastion, but that's better than not getting logs from all the VMs.
+  for node in $(aws ec2 describe-instances --region $AWS_REGION --query "Reservations[*].Instances[*].PrivateIpAddress" --output text)
   do
     echo "collecting logs from ${node} using jump host ${jump_node}"
     dir="${ARTIFACTS}/logs/${node}"

--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -63,11 +63,14 @@ dump-logs() {
   # export all logs from kind
   kind "export" logs --name="clusterapi" "${ARTIFACTS}/logs" || true
 
-  jump_node=$(aws ec2 describe-instances --region $AWS_REGION --query "Reservations[*].Instances[*].PublicIpAddress" --output text | head -1)
+  node_filters="Name=tag:sigs.k8s.io/cluster-api-provider-aws/cluster/${CLUSTER_NAME},Values=owned"
+  bastion_filters="${node_filters} Name=tag:sigs.k8s.io/cluster-api-provider-aws/role,Values=bastion"
+  jump_node=$(aws ec2 describe-instances --region $AWS_REGION --filters ${bastion_filters} --query "Reservations[*].Instances[*].PublicIpAddress" --output text | head -1)
+
   # We used to pipe this output to 'tail -n +2' but for some reason this was sometimes (all the time?) only finding the
   # bastion host. For now, omit the tail and gather logs for all VMs that have a private IP address. This will include
   # the bastion, but that's better than not getting logs from all the VMs.
-  for node in $(aws ec2 describe-instances --region $AWS_REGION --query "Reservations[*].Instances[*].PrivateIpAddress" --output text)
+  for node in $(aws ec2 describe-instances --region $AWS_REGION --filters ${node_filters} --query "Reservations[*].Instances[*].PrivateIpAddress" --output text)
   do
     echo "collecting logs from ${node} using jump host ${jump_node}"
     dir="${ARTIFACTS}/logs/${node}"


### PR DESCRIPTION
**What this PR does / why we need it**:
**Change 1**
When generating examples for the conformance tests, the
/tmp/kubeadm-bootstraph.sh preKubeadmCommand downloads gsutil if it does
not exist and adjusts $PATH accordingly. However, the script that
generates examples substitutes the values for environment variable
placeholders in the file, which means it will substitute whatever the
current value of $PATH is in your local environment.

Instead of trying to adjust $PATH, use a variable for gsutil to invoke
it.

**Change 2**
We've had an issue where we aren't always capturing the logs for the
control plane VMs, especially if the cluster fails to initialize;
instead, we've managed to capture just the bastion. This change removes
the code that filters out the first private IP address when grabbing
logs. We'll still end up getting the bastion logs, but hopefully we'll
also get the first control plane instance.

**Change 3**
Filter bastion and cluster VMs using tags

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/hold