### PR TITLE
🏃 [0.4] conformance: use the right bucket for released vs ci

### DIFF
--- a/examples/controlplane/kustomizeversions.yaml
+++ b/examples/controlplane/kustomizeversions.yaml
@@ -38,7 +38,14 @@ spec:
       if [[ "${CI_VERSION}" != "" ]]; then
         CI_DIR=/tmp/k8s-ci
         mkdir -p $CI_DIR
-        CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+
+        # If it's a released version, we need to pull from the release bucket
+        if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
+          CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
+        else
+          CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+        fi
+
         declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
         PACKAGE_EXT="deb"
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
@@ -108,7 +115,14 @@ spec:
         if [[ "${CI_VERSION}" != "" ]]; then
           CI_DIR=/tmp/k8s-ci
           mkdir -p $CI_DIR
-          CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+
+          # If it's a released version, we need to pull from the release bucket
+          if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
+            CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
+          else
+            CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+          fi
+
           declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
           PACKAGE_EXT="deb"
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
@@ -178,7 +192,14 @@ spec:
         if [[ "${CI_VERSION}" != "" ]]; then
           CI_DIR=/tmp/k8s-ci
           mkdir -p $CI_DIR
-          CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+
+          # If it's a released version, we need to pull from the release bucket
+          if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
+            CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
+          else
+            CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+          fi
+
           declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
           PACKAGE_EXT="deb"
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")

--- a/examples/machinedeployment/kustomizeversions.yaml
+++ b/examples/machinedeployment/kustomizeversions.yaml
@@ -38,7 +38,14 @@ spec:
           if [[ "${CI_VERSION}" != "" ]]; then
             CI_DIR=/tmp/k8s-ci
             mkdir -p $CI_DIR
-            CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+
+            # If it's a released version, we need to pull from the release bucket
+            if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
+              CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
+            else
+              CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
+            fi
+
             declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
             PACKAGE_EXT="deb"
             declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")


### PR DESCRIPTION
**What this PR does / why we need it**:
If CI_VERSION is a released version such as v1.16.3, we need to use a
different GCS bucket to download the artifacts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This might f-i-x #1389

/cc @dims @vincepri 
/assign @dims @vincepri 
/milestone v0.4.x