### PR TITLE
Revert "🏃 [0.4] conformance: use the right bucket for released vs ci"

### DIFF
--- a/examples/controlplane/kustomizeversions.yaml
+++ b/examples/controlplane/kustomizeversions.yaml
@@ -39,14 +39,7 @@ spec:
       if [[ "${CI_VERSION}" != "" ]]; then
         CI_DIR=/tmp/k8s-ci
         mkdir -p $CI_DIR
-
-        # If it's a released version, we need to pull from the release bucket
-        if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
-          CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
-        else
-          CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-        fi
-
+        CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
         declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
         PACKAGE_EXT="deb"
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
@@ -117,14 +110,7 @@ spec:
         if [[ "${CI_VERSION}" != "" ]]; then
           CI_DIR=/tmp/k8s-ci
           mkdir -p $CI_DIR
-
-          # If it's a released version, we need to pull from the release bucket
-          if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
-            CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
-          else
-            CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-          fi
-
+          CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
           declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
           PACKAGE_EXT="deb"
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
@@ -195,14 +181,7 @@ spec:
         if [[ "${CI_VERSION}" != "" ]]; then
           CI_DIR=/tmp/k8s-ci
           mkdir -p $CI_DIR
-
-          # If it's a released version, we need to pull from the release bucket
-          if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
-            CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
-          else
-            CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-          fi
-
+          CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
           declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
           PACKAGE_EXT="deb"
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")

--- a/examples/machinedeployment/kustomizeversions.yaml
+++ b/examples/machinedeployment/kustomizeversions.yaml
@@ -39,14 +39,7 @@ spec:
           if [[ "${CI_VERSION}" != "" ]]; then
             CI_DIR=/tmp/k8s-ci
             mkdir -p $CI_DIR
-
-            # If it's a released version, we need to pull from the release bucket
-            if [[ "${CI_VERSION}" =~ v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
-              CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
-            else
-              CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-            fi
-
+            CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
             declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
             PACKAGE_EXT="deb"
             declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-aws#1397