### PR TITLE
:bug: Base64 the User Data retrieved from the bootstrap secret

### DIFF
--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -18,6 +18,7 @@ package scope
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -201,7 +202,7 @@ func (m *MachineScope) GetBootstrapData() (string, error) {
 		return "", errors.New("error retrieving bootstrap data: secret value key is missing")
 	}
 
-	return string(value), nil
+	return base64.StdEncoding.EncodeToString(value), nil
 }
 
 // Close the MachineScope by updating the machine spec, machine status.


### PR DESCRIPTION
**What this PR does / why we need it**:

With the bootstrap data moved to a secret, we were attempting to pass in a decoded string where the ec2 api expects the user data to be base64 encoded (client-go graciously decodes the contents of the secret).
