### PR TITLE
🐛 make create-cluster: use --decode for base64 decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on AWS 
 	# Wait for the kubeconfig to become available.
 	timeout 300 bash -c "while ! kubectl get secrets | grep $(CLUSTER_NAME)-kubeconfig; do sleep 1; done"
 	# Get kubeconfig and store it locally.
-	kubectl get secrets $(CLUSTER_NAME)-kubeconfig -o json | jq -r .data.value | base64 -D > ./kubeconfig
+	kubectl get secrets $(CLUSTER_NAME)-kubeconfig -o json | jq -r .data.value | base64 --decode > ./kubeconfig
 	# Apply addons on the target cluster, waiting for the control-plane to become available.
 	timeout 300 bash -c "while ! kubectl --kubeconfig=./kubeconfig get nodes | grep master; do sleep 1; done"
 	kubectl --kubeconfig=./kubeconfig apply -f examples/addons.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
make create-cluster: use --decode for base64 decoding

The -D flag for base64 decoding is not available in *nix variants. Use
--decode instead, which is cross-platform compatible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1414 

/kind failing-test
/kind bug
/priority critical-urgent
/milestone v0.5.0
