### PR TITLE
:sparkles: Add support for extra AWS policies in clusterawsadm

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -29,6 +29,16 @@ After these are set run this command to get you up and running:
 clusterawsadm alpha bootstrap create-stack
 ```
 
+You can optionally specify additional AWS policies (they can be user or AWS managed, but must already exists) in the call to `create-stack` (and `generate-cloudformation`) if required, e.g.
+
+```
+clusterawsadm alpha bootstrap create-stack \
+  --extra-controlplane-policies arn:aws:iam::<AWS_ACCOUNT>:policy/my-policy,arn:aws:iam::aws:policy/AmazonEC2FullAccess \
+  --extra-node-policies arn:aws:iam::<AWS_ACCOUNT>:policy/my-other-policy
+```
+
+These will be added to the control plane and node roles respectively when they are created.
+
 ### Without `clusterawsadm`
 
 This is not a recommended route as the policies are very specific and will


### PR DESCRIPTION
**What this PR does / why we need it**:
Convenience feature to allow users to specify extra policies to the control plane and node roles that `clusterawsadm` creates.

**Which issue(s) this PR fixes**:
Fixes #1390 

Signed-off-by: John Harris <joharris@vmware.com>