### PR TITLE
🏃 Let GCB build release images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,6 @@ $(RELEASE_DIR):
 .PHONY: release
 release: clean-release  ## Builds and push container images using the latest git tag for the commit.
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
-	# Push the release image to the staging bucket first.
-	REGISTRY=$(STAGING_REGISTRY) TAG=$(RELEASE_TAG) \
-		$(MAKE) docker-build-all docker-push-all
 	# Set the manifest image to the production bucket.
 	MANIFEST_IMG=$(PROD_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \
 		$(MAKE) set-manifest-image

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,11 +6,10 @@
 2. Make sure your repo is clean by git's standards
 3. If this is a new minor release, create a new release branch and push to github, for example `release-0.2`
 4. run `go run cmd/release/main.go -version v0.1.2` but replace the version with the version you'd like.
-5. push the docker images that were generated with this release tool
-6. Edit the release notes and make sure the binaries uploaded return the correct version
-7. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter)
-8. Publish draft
-9. Email `kubernetes-sig-cluster-lifecycle@googlegroups.com` to announce the release
+5. Edit the release notes and make sure the binaries uploaded return the correct version
+6. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter)
+7. Publish draft
+8. Email `kubernetes-sig-cluster-lifecycle@googlegroups.com` to announce the release
 
 ## Manual
 


### PR DESCRIPTION
**What this PR does / why we need it**:
test-infra has been updated to use GCB to build release version images,
so we no longer need to do it here in the repo.

Requires https://github.com/kubernetes/test-infra/pull/15624

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

