### PR TITLE
🐛 Generate event when instance fails to launch because no subnets available in an availability zone

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -159,8 +159,11 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*infrav1.Instance, 
 
 		sns := s.scope.Subnets().FilterPrivate().FilterByZone(*availabilityZone)
 		if len(sns) == 0 {
+			record.Warnf(scope.AWSMachine, "FailedCreate",
+				"Failed to create instance: no subnets available in availability zone %q", *availabilityZone)
+
 			return nil, awserrors.NewFailedDependency(
-				errors.Errorf("failed to run machine %q, no subnets available in availaibility zone %q",
+				errors.Errorf("failed to run machine %q, no subnets available in availability zone %q",
 					scope.Name(),
 					*availabilityZone,
 				),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
When a user specifies the `availabilityZone` or `failureDomain` in a `AWSMachine` and there are no available subnets to launch the EC2 instance, there are no events registered with the `AWSMachine`. This PR adds the event.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1425 

