### PR TITLE
🐛 Fix typo in SuccessfulTagVPC event name

### DIFF
--- a/pkg/cloud/services/ec2/vpc.go
+++ b/pkg/cloud/services/ec2/vpc.go
@@ -190,7 +190,7 @@ func (s *Service) createVPC() (*infrav1.VPCSpec, error) {
 		record.Warnf(s.scope.AWSCluster, "FailedTagVPC", "Failed to tag managed VPC %q: %v", *out.Vpc.VpcId, err)
 		return nil, err
 	}
-	record.Eventf(s.scope.AWSCluster, "SuccesfulTagVPC", "Tagged managed VPC %q", *out.Vpc.VpcId)
+	record.Eventf(s.scope.AWSCluster, "SuccessfulTagVPC", "Tagged managed VPC %q", *out.Vpc.VpcId)
 
 	return &infrav1.VPCSpec{
 		ID:        *out.Vpc.VpcId,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes a typo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Question for the team -- Is this the right process for fixing a typo?  I found it when working on an event related issue.  Wasn't sure if it was a good idea to include it in an unrelated PR or use a separate PR.