### PR TITLE
🐛 Fix deleting AWSCluster when VPC doesn't exist

### DIFF
--- a/pkg/cloud/services/ec2/vpc.go
+++ b/pkg/cloud/services/ec2/vpc.go
@@ -207,15 +207,6 @@ func (s *Service) deleteVPC() error {
 		return nil
 	}
 
-	vpc, err := s.describeVPC()
-	if err != nil {
-		if awserrors.IsNotFound(err) {
-			// If the VPC does not exist, nothing to do
-			return nil
-		}
-		return err
-	}
-
 	input := &ec2.DeleteVpcInput{
 		VpcId: aws.String(vpc.ID),
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
If a VPC cannot be created for an AWSCluster object (like when a VPC limit is reached), the controller will fail to delete the AWSCluster as certain AWS calls fail without a VPC id.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1375 

