### PR TITLE
🐛 Persist AWSCluster/AWSMachine finalizers immediately to prevent orphaned AWS resources

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -278,6 +278,10 @@ func (r *AWSMachineReconciler) reconcileNormal(ctx context.Context, machineScope
 	if !util.Contains(machineScope.AWSMachine.Finalizers, infrav1.MachineFinalizer) {
 		machineScope.V(1).Info("Adding Cluster API Provider AWS finalizer")
 		machineScope.AWSMachine.Finalizers = append(machineScope.AWSMachine.Finalizers, infrav1.MachineFinalizer)
+		// Register the finalizer immediately to avoid orphaning AWS resources on delete
+		if err := machineScope.PatchObject(); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	if !machineScope.Cluster.Status.InfrastructureReady {

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	"k8s.io/utils/pointer"
@@ -60,9 +61,16 @@ var _ = Describe("AWSMachineReconciler", func() {
 		klog.SetOutput(GinkgoWriter)
 		var err error
 
+		awsMachine := &infrav1.AWSMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: infrav1.AWSMachineSpec{},
+		}
+
 		ms, err = scope.NewMachineScope(
 			scope.MachineScopeParams{
-				Client: fake.NewFakeClient(),
+				Client: fake.NewFakeClient([]runtime.Object{awsMachine}...),
 				Cluster: &clusterv1.Cluster{
 					Status: clusterv1.ClusterStatus{
 						InfrastructureReady: true,
@@ -76,7 +84,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 					},
 				},
 				AWSCluster: &infrav1.AWSCluster{},
-				AWSMachine: &infrav1.AWSMachine{},
+				AWSMachine: awsMachine,
 			},
 		)
 		Expect(err).To(BeNil())

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -188,9 +188,14 @@ func (s *ClusterScope) ListOptionsLabelSelector() client.ListOption {
 	})
 }
 
+// PatchObject persists the cluster configuration and status.
+func (s *ClusterScope) PatchObject() error {
+	return s.patchHelper.Patch(context.TODO(), s.AWSCluster)
+}
+
 // Close closes the current scope persisting the cluster configuration and status.
 func (s *ClusterScope) Close() error {
-	return s.patchHelper.Patch(context.TODO(), s.AWSCluster)
+	return s.PatchObject()
 }
 
 // AdditionalTags returns AdditionalTags from the scope's AWSCluster. The returned value will never be nil.

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -205,9 +205,14 @@ func (m *MachineScope) GetBootstrapData() (string, error) {
 	return base64.StdEncoding.EncodeToString(value), nil
 }
 
+// PatchObject persists the machine spec and status.
+func (m *MachineScope) PatchObject() error {
+	return m.patchHelper.Patch(context.TODO(), m.AWSMachine)
+}
+
 // Close the MachineScope by updating the machine spec, machine status.
 func (m *MachineScope) Close() error {
-	return m.patchHelper.Patch(context.TODO(), m.AWSMachine)
+	return m.PatchObject()
 }
 
 // AdditionalTags merges AdditionalTags from the scope's AWSCluster and AWSMachine. If the same key is present in both,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
If Cluster/AWSCluster resources are created and deleted relatively quickly (seconds up to a minute or so) the AWS resources in the VPC are orphaned as the AWSCluster is deleted without destroying the resources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1454

