### PR TITLE
:bug: Fix NPE when dealing with instance RootDeviceSize

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -424,7 +424,7 @@ func (r *AWSMachineReconciler) validateUpdate(spec *infrav1.AWSMachineSpec, i *i
 	}
 
 	// Root Device Size
-	if spec.RootDeviceSize > 0 && spec.RootDeviceSize != i.RootDeviceSize {
+	if spec.RootDeviceSize > 0 && i.RootDeviceSize > 0 && spec.RootDeviceSize != i.RootDeviceSize {
 		errs = append(errs, errors.Errorf("Root volume size cannot be mutated from %v to %v", i.RootDeviceSize, spec.RootDeviceSize))
 	}
 

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -577,12 +577,12 @@ func (s *Service) SDKToInstance(v *ec2.Instance) (*infrav1.Instance, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get root volume size for instance: %q", aws.StringValue(v.InstanceId))
 	}
-
-	i.RootDeviceID = aws.StringValue(rootDevice.VolumeId)
-	i.RootDeviceSize = aws.Int64Value(rootDevice.Size)
-
-	if len(rootDevice.Tags) > 0 {
-		i.RootDeviceTags = converters.TagsToMap(rootDevice.Tags)
+	if rootDevice != nil {
+		i.RootDeviceID = aws.StringValue(rootDevice.VolumeId)
+		i.RootDeviceSize = aws.Int64Value(rootDevice.Size)
+		if len(rootDevice.Tags) > 0 {
+			i.RootDeviceTags = converters.TagsToMap(rootDevice.Tags)
+		}
 	}
 
 	return i, nil


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR is a forward-port of #1444, where we make sure to check that the root device size returned is not nil before using it.
