### PR TITLE
:running: Install cabpk and kcp components in e2e tests

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -112,9 +112,13 @@ if [[ ${CAPI_BRANCH} == "stable" ]]; then
   echo "Downloaded ${COMPONENTS_CLUSTER_API_GENERATED_FILE} from cluster-api stable branch - v0.2.5"
 elif [[ ${CAPI_BRANCH} == "dev" ]]; then
   kustomize build ../cluster-api/config/default > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+  kustomize build ../cluster-api/bootstrap/kubeadm/config/default > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+  kustomize build ../cluster-api/controlplane/kubeadm/config/default > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
   echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE} from cluster-api - ${CAPI_BRANCH}"
 else
   kustomize build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=${CAPI_BRANCH}" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+  kustomize build "github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/default/?ref=${CAPI_BRANCH}" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+  kustomize build "github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/default/?ref=${CAPI_BRANCH}" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
   echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE} from cluster-api - ${CAPI_BRANCH}"
 fi
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR installs the CABPK and KCP components from Cluster API repository for the e2e tests.

