### PR TITLE
✨ add clusterctl-settings.json

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -1,0 +1,8 @@
+{
+  "name": "aws",
+  "config": {
+    "componentsFile": "infrastructure-components.yaml",
+    "nextVersion": "v0.5.0",
+    "type": "InfrastructureProvider"
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the clusterctl-settings.json so the AWs provider can be tested with clusterctl even if now there are no published releases for v1alpha3

XRef #https://github.com/kubernetes-sigs/cluster-api/pull/2027

