### PR TITLE
🐛 [0.4] Fix deleting AWSCluster when VPC doesn't exist

### DIFF
--- a/pkg/cloud/services/ec2/vpc.go
+++ b/pkg/cloud/services/ec2/vpc.go
@@ -207,15 +207,6 @@ func (s *Service) deleteVPC() error {
 		return nil
 	}
 
-	vpc, err := s.describeVPC()
-	if err != nil {
-		if awserrors.IsNotFound(err) {
-			// If the VPC does not exist, nothing to do
-			return nil
-		}
-		return err
-	}
-
 	input := &ec2.DeleteVpcInput{
 		VpcId: aws.String(vpc.ID),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If a VPC cannot be created for an AWSCluster object (like when a VPC limit is reached), the controller will fail to delete the AWSCluster as certain AWS calls fail without a VPC id.

Backport of #1453 to release-0.4