### PR TITLE
🏃 Automate cluster creation when vpc limit was already hit

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -368,7 +369,84 @@ var _ = Describe("functional tests", func() {
 			deleteCluster(setup.namespace, setup.clusterName)
 		})
 	})
+
+	Describe("Creating cluster after reaching vpc maximum limit", func() {
+		It("Cluster created after reaching vpc limit should be in provisioning", func() {
+			By("Create clusters till vpc limit")
+			sess = getSession()
+			limit := getElasticIPsLimit()
+			var vpcsCreated []string
+			sess = getSession()
+			for getCurrentVPCsCount() < limit {
+				vpcsCreated = append(vpcsCreated, createVPC("10.0.0.0/16"))
+			}
+
+			By("Creating cluster beyond vpc limit")
+			Expect(createCluster(setup.namespace, setup.clusterName, setup.awsClusterName, setup.multipleAZ)).Should(BeFalse())
+			Expect(getClusterStatus(setup.namespace, setup.clusterName)).Should(Equal(string(clusterv1.ClusterPhaseProvisioning)))
+
+			By("Checking cluster gets provisioned when resources available")
+			if len(vpcsCreated) > 0 {
+				deleteVPCs(vpcsCreated)
+				Expect(waitForClusterInfrastructureReady(setup.namespace, setup.clusterName)).Should(BeTrue())
+			}
+
+			By("Deleting the cluster")
+			deleteCluster(setup.namespace, setup.clusterName)
+		})
+	})
 })
+
+func deleteVPCs(vpcIds []string) {
+	ec2Client := ec2.New(sess)
+	for _, vpcId := range vpcIds {
+		input := &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpcId),
+		}
+		_, err := ec2Client.DeleteVpc(input)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func createVPC(cidrblock string) string {
+	ec2Client := ec2.New(sess)
+	input := &ec2.CreateVpcInput{
+		CidrBlock: aws.String(cidrblock),
+	}
+	result, err := ec2Client.CreateVpc(input)
+	Expect(err).NotTo(HaveOccurred())
+	return *result.Vpc.VpcId
+}
+
+func getClusterStatus(namespace, clusterName string) string {
+	cluster := &clusterv1.Cluster{}
+	if err := kindClient.Get(context.TODO(), apimachinerytypes.NamespacedName{Namespace: namespace, Name: clusterName}, cluster); nil == err {
+		return cluster.Status.Phase
+	}
+	return ""
+}
+
+func getElasticIPsLimit() int {
+	ec2Client := ec2.New(sess)
+	input := &ec2.DescribeAccountAttributesInput{
+		AttributeNames: []*string{
+			aws.String("vpc-max-elastic-ips"),
+		},
+	}
+	result, err := ec2Client.DescribeAccountAttributes(input)
+	Expect(err).NotTo(HaveOccurred())
+	res, err := strconv.Atoi(*result.AccountAttributes[0].AttributeValues[0].AttributeValue)
+	Expect(err).NotTo(HaveOccurred())
+	return res
+}
+
+func getCurrentVPCsCount() int {
+	ec2Client := ec2.New(sess)
+	input := &ec2.DescribeVpcsInput{}
+	result, err := ec2Client.DescribeVpcs(input)
+	Expect(err).NotTo(HaveOccurred())
+	return len(result.Vpcs)
+}
 
 func getAvailabilityZones() []*ec2.AvailabilityZone {
 	ec2Client := ec2.New(getSession())
@@ -665,15 +743,20 @@ func getAvailabilityZone() []*ec2.AvailabilityZone {
 	return azs.AvailabilityZones
 }
 
-func makeSingleControlPlaneCluster(setup testSetup) crclient.Client {
+func createCluster(namespace, clusterName, awsClusterName string, multiAZ bool) bool {
 	By("Creating an AWSCluster")
-	makeAWSCluster(setup.namespace, setup.awsClusterName, setup.multipleAZ)
+	makeAWSCluster(namespace, awsClusterName, multiAZ)
 
 	By("Creating a Cluster")
-	makeCluster(setup.namespace, setup.clusterName, setup.awsClusterName)
+	makeCluster(namespace, clusterName, awsClusterName)
 
 	By("Ensuring Cluster Infrastructure Reports as Ready")
-	waitForClusterInfrastructureReady(setup.namespace, setup.clusterName)
+	return waitForClusterInfrastructureReady(namespace, clusterName)
+}
+
+func makeSingleControlPlaneCluster(setup testSetup) crclient.Client {
+
+	Expect(createCluster(setup.namespace, setup.clusterName, setup.awsClusterName, setup.multipleAZ)).Should(BeTrue())
 
 	By("Creating the initial Control Plane Machine")
 	awsMachineName := setup.cpAWSMachinePrefix + "-0"
@@ -742,7 +825,7 @@ func isErrorEventExists(namespace, machineDeploymentName, eventReason, errorMsg 
 				break
 			}
 		}
-		if false == exists {
+		if !exists {
 			return false
 		}
 	}
@@ -1081,18 +1164,19 @@ func waitForAWSMachineRunning(namespace, name string) {
 	).Should(BeTrue())
 }
 
-func waitForClusterInfrastructureReady(namespace, name string) {
+func waitForClusterInfrastructureReady(namespace, name string) bool {
 	fmt.Fprintf(GinkgoWriter, "Ensuring infrastructure is ready for cluster %s/%s\n", namespace, name)
-	Eventually(
-		func() (bool, error) {
-			cluster := &clusterv1.Cluster{}
-			if err := kindClient.Get(context.TODO(), apimachinerytypes.NamespacedName{Namespace: namespace, Name: name}, cluster); err != nil {
-				return false, err
+	endTime := time.Now().Add(15 * time.Minute)
+	for time.Now().Before(endTime) {
+		cluster := &clusterv1.Cluster{}
+		if err := kindClient.Get(context.TODO(), apimachinerytypes.NamespacedName{Namespace: namespace, Name: name}, cluster); nil == err {
+			if cluster.Status.InfrastructureReady {
+				return true
 			}
-			return cluster.Status.InfrastructureReady, nil
-		},
-		15*time.Minute, 15*time.Second,
-	).Should(BeTrue())
+		}
+		time.Sleep(15 * time.Second)
+	}
+	return false
 }
 
 func waitForMachineBootstrapReady(namespace, name string) {


### PR DESCRIPTION
Added automation to test creating a cluster when VPC limit was already reached.

This will verify cluster is in provisioning state till the VPC resources
were available and will provisioned during reconciliation after freeing
current VPCs

Executed the test locally and passed