### PR TITLE
⚠️ ELB uses separate security group

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -311,6 +311,9 @@ var (
 	// SecurityGroupControlPlane defines a Kubernetes control plane node role
 	SecurityGroupControlPlane = SecurityGroupRole("controlplane")
 
+	// SecurityGroupAPIServerLB defines a Kubernetes API Server Load Balancer role
+	SecurityGroupAPIServerLB = SecurityGroupRole("apiserver-lb")
+
 	// SecurityGroupLB defines a container for the cloud provider to inject its load balancer ingress rules
 	SecurityGroupLB = SecurityGroupRole("lb")
 )

--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -62,6 +62,7 @@ func (s *Service) reconcileSecurityGroups() error {
 	// Declare all security group roles that the reconcile loop takes care of.
 	roles := []infrav1.SecurityGroupRole{
 		infrav1.SecurityGroupBastion,
+		infrav1.SecurityGroupAPIServerLB,
 		infrav1.SecurityGroupLB,
 		infrav1.SecurityGroupControlPlane,
 		infrav1.SecurityGroupNode,
@@ -456,6 +457,16 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 					s.scope.SecurityGroups()[infrav1.SecurityGroupNode].ID,
 					s.scope.SecurityGroups()[infrav1.SecurityGroupControlPlane].ID,
 				},
+			},
+		}, nil
+	case infrav1.SecurityGroupAPIServerLB:
+		return infrav1.IngressRules{
+			{
+				Description: "Kubernetes API",
+				Protocol:    infrav1.SecurityGroupProtocolTCP,
+				FromPort:    s.scope.APIServerPort(),
+				ToPort:      s.scope.APIServerPort(),
+				CidrBlocks:  []string{anyIPv4CidrBlock},
 			},
 		}, nil
 	case infrav1.SecurityGroupLB:

--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -379,7 +379,11 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 				Protocol:    infrav1.SecurityGroupProtocolTCP,
 				FromPort:    6443,
 				ToPort:      6443,
-				CidrBlocks:  []string{anyIPv4CidrBlock},
+				SourceSecurityGroupIDs: []string{
+					s.scope.SecurityGroups()[infrav1.SecurityGroupAPIServerLB].ID,
+					s.scope.SecurityGroups()[infrav1.SecurityGroupControlPlane].ID,
+					s.scope.SecurityGroups()[infrav1.SecurityGroupNode].ID,
+				},
 			},
 			{
 				Description:            "etcd",

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -249,7 +249,7 @@ func (s *Service) getAPIServerClassicELBSpec() (*infrav1.ClassicELB, error) {
 			HealthyThreshold:   5,
 			UnhealthyThreshold: 3,
 		},
-		SecurityGroupIDs: []string{s.scope.SecurityGroups()[infrav1.SecurityGroupControlPlane].ID},
+		SecurityGroupIDs: []string{s.scope.SecurityGroups()[infrav1.SecurityGroupAPIServerLB].ID},
 		Attributes: infrav1.ClassicELBAttributes{
 			IdleTimeout: 10 * time.Minute,
 		},

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb"
 	rgapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
@@ -81,6 +82,17 @@ func (s *Service) ReconcileLoadbalancers() error {
 		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to attach apiserver load balancer %q to subnets", apiELB.Name)
+		}
+	}
+
+	// Reconcile the security groups from the spec and the ones currently attached to the load balancer
+	if !sets.NewString(apiELB.SecurityGroupIDs...).Equal(sets.NewString(spec.SecurityGroupIDs...)) {
+		_, err := s.scope.ELB.ApplySecurityGroupsToLoadBalancer(&elb.ApplySecurityGroupsToLoadBalancerInput{
+			LoadBalancerName: &apiELB.Name,
+			SecurityGroups:   aws.StringSlice(spec.SecurityGroupIDs),
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to apply security groups to load balancer %q", apiELB.Name)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #1456 on release-0.4.

#1456: ELB for API Server to use separate security group

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.