### PR TITLE
⚠️ Update control plane security group rule to remove 0.0.0.0/0 ingress CIDR

### DIFF
--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -379,7 +379,11 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 				Protocol:    infrav1.SecurityGroupProtocolTCP,
 				FromPort:    6443,
 				ToPort:      6443,
-				CidrBlocks:  []string{anyIPv4CidrBlock},
+				SourceSecurityGroupIDs: []string{
+					s.scope.SecurityGroups()[infrav1.SecurityGroupAPIServerLB].ID,
+					s.scope.SecurityGroups()[infrav1.SecurityGroupControlPlane].ID,
+					s.scope.SecurityGroups()[infrav1.SecurityGroupNode].ID,
+				},
 			},
 			{
 				Description:            "etcd",

--- a/pkg/cloud/services/ec2/securitygroups_test.go
+++ b/pkg/cloud/services/ec2/securitygroups_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
@@ -277,6 +278,30 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				t.Fatalf("got an unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestControlPlaneSecurityGroupNotOpenToAnyCIDR(t *testing.T) {
+	scope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+		Cluster: &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+		},
+		AWSCluster: &infrav1.AWSCluster{},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create test context: %v", err)
+	}
+
+	s := NewService(scope)
+	rules, err := s.getSecurityGroupIngressRules(infrav1.SecurityGroupControlPlane)
+	if err != nil {
+		t.Fatalf("Failed to lookup controlplane security group ingress rules: %v", err)
+	}
+
+	for _, r := range rules {
+		if sets.NewString(r.CidrBlocks...).Has(anyIPv4CidrBlock) {
+			t.Fatal("Ingress rule allows any CIDR block")
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
With the ELB  now using a separate security group, it makes sense to further lock down the ingress rules for the control plane security group and remove the 0.0.0.0/0 ingress CIDR rule. Inbound access to allowed on port 6443 for the 3 security groups:
* Control Plane
* Nodes
* API Server Load Balancer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1478 

