### PR TITLE
:bug: Backport: Fix when AWS return InvalidInstanceID.NotFound with statusCode 400

### DIFF
--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -38,6 +38,7 @@ const (
 	ResourceNotFound        = "InvalidResourceID.NotFound"
 	InvalidSubnet           = "InvalidSubnet"
 	AssociationIDNotFound   = "InvalidAssociationID.NotFound"
+	InvalidInstanceID       = "InvalidInstanceID.NotFound"
 )
 
 var _ error = &EC2Error{}
@@ -125,10 +126,13 @@ func IsSDKError(err error) (ok bool) {
 func IsInvalidNotFoundError(err error) bool {
 	if code, ok := Code(err); ok {
 		switch code {
-		case "InvalidVpcID.NotFound":
+		case VPCNotFound:
+			return true
+		case InvalidInstanceID:
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -141,6 +145,7 @@ func ReasonForError(err error) int {
 	return -1
 }
 
+// IsIgnorableSecurityGroupError checks for errors in SG that can be ignored and then return nil.
 func IsIgnorableSecurityGroupError(err error) error {
 	if code, ok := Code(err); ok {
 		switch code {

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -52,6 +53,25 @@ func TestInstanceIfExists(t *testing.T) {
 					InstanceIds: []*string{aws.String("hello")},
 				})).
 					Return(nil, awserrors.NewNotFound(errors.New("not found")))
+			},
+			check: func(instance *infrav1.Instance, err error) {
+				if err != nil {
+					t.Fatalf("did not expect error: %v", err)
+				}
+
+				if instance != nil {
+					t.Fatalf("Did not expect anything but got something: %+v", instance)
+				}
+			},
+		},
+		{
+			name:       "does not exist with bad request error",
+			instanceID: "hello-does-not-exist",
+			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				m.DescribeInstances(gomock.Eq(&ec2.DescribeInstancesInput{
+					InstanceIds: []*string{aws.String("hello-does-not-exist")},
+				})).
+					Return(nil, awserr.New(awserrors.InvalidInstanceID, "does not exist", nil))
 			},
 			check: func(instance *infrav1.Instance, err error) {
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport to release 0.4 per request here: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1480#issuecomment-573704288


/assign @ncdc 

