### PR TITLE
:sparkles: update metrics port

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -13,7 +13,7 @@ spec:
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
+        - "--upstream=http://127.0.0.1:9090/"
         - "--logtostderr=true"
         - "--v=10"
         ports:
@@ -21,4 +21,4 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
+        - "--metrics-addr=127.0.0.1:9090"

--- a/config/default/manager_prometheus_metrics_patch.yaml
+++ b/config/default/manager_prometheus_metrics_patch.yaml
@@ -14,6 +14,6 @@ spec:
       # Expose the prometheus metrics on default port
       - name: manager
         ports:
-        - containerPort: 8080
+        - containerPort: 9090
           name: metrics
           protocol: TCP

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	flag.StringVar(
 		&metricsAddr,
 		"metrics-addr",
-		":8080",
+		":9090",
 		"The address the metric endpoint binds to.",
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update metrics port based on the conversation here: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1487#discussion_r368115144


/assign @ncdc @vincepri 
