### PR TITLE
:warning: machines can be provisioned without SSH key pairs

### DIFF
--- a/api/v1alpha2/awscluster_types.go
+++ b/api/v1alpha2/awscluster_types.go
@@ -35,7 +35,7 @@ type AWSClusterSpec struct {
 	Region string `json:"region,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the bastion host.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the
 	// ones added by default.

--- a/api/v1alpha2/awsmachine_types.go
+++ b/api/v1alpha2/awsmachine_types.go
@@ -77,7 +77,7 @@ type AWSMachineSpec struct {
 	Subnet *AWSResourceReference `json:"subnet,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the instance.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// RootDeviceSize is the size of the root volume in gigabytes(GB).
 	// +optional

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -104,6 +104,11 @@ func (in *AWSClusterList) DeepCopyObject() runtime.Object {
 func (in *AWSClusterSpec) DeepCopyInto(out *AWSClusterSpec) {
 	*out = *in
 	in.NetworkSpec.DeepCopyInto(&out.NetworkSpec)
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
+	}
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags
 		*out = make(Tags, len(*in))
@@ -266,6 +271,11 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
 	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -36,7 +36,11 @@ type AWSClusterSpec struct {
 	Region string `json:"region,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the bastion host.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	// If nil, will use a default SSH key pair name
+	// If empty string, will NOT set an SSH key pair
+	// Otherwise, will set the SSH key pair name
+	// +optional
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -88,7 +88,11 @@ type AWSMachineSpec struct {
 	Subnet *AWSResourceReference `json:"subnet,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the instance.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	// If nil, will use a default SSH key pair name
+	// If empty string, will NOT set an SSH key pair
+	// Otherwise, will set the SSH key pair name
+	// +optional
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// RootDeviceSize is the size of the root volume in gigabytes(GB).
 	// +optional

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *AWSClusterList) DeepCopyObject() runtime.Object {
 func (in *AWSClusterSpec) DeepCopyInto(out *AWSClusterSpec) {
 	*out = *in
 	in.NetworkSpec.DeepCopyInto(&out.NetworkSpec)
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
+	}
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags
@@ -265,6 +270,11 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
 	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -588,7 +588,9 @@ spec:
                 type: string
               sshKeyName:
                 description: SSHKeyName is the name of the ssh key to attach to the
-                  bastion host.
+                  bastion host. If nil, will use a default SSH key pair name If empty
+                  string, will NOT set an SSH key pair Otherwise, will set the SSH
+                  key pair name
                 type: string
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -429,7 +429,9 @@ spec:
                 type: integer
               sshKeyName:
                 description: SSHKeyName is the name of the ssh key to attach to the
-                  instance.
+                  instance. If nil, will use a default SSH key pair name If empty
+                  string, will NOT set an SSH key pair Otherwise, will set the SSH
+                  key pair name
                 type: string
               subnet:
                 description: Subnet is a reference to the subnet to use for this instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -389,7 +389,9 @@ spec:
                         type: integer
                       sshKeyName:
                         description: SSHKeyName is the name of the ssh key to attach
-                          to the instance.
+                          to the instance. If nil, will use a default SSH key pair
+                          name If empty string, will NOT set an SSH key pair Otherwise,
+                          will set the SSH key pair name
                         type: string
                       subnet:
                         description: Subnet is a reference to the subnet to use for

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -139,9 +139,16 @@ func (s *Service) getDefaultBastion() *infrav1.Instance {
 	name := fmt.Sprintf("%s-bastion", s.scope.Name())
 	userData, _ := userdata.NewBastion(&userdata.BastionInput{})
 
-	keyName := defaultSSHKeyName
-	if s.scope.AWSCluster.Spec.SSHKeyName != "" {
-		keyName = s.scope.AWSCluster.Spec.SSHKeyName
+	// If SSHKeyName WAS NOT provided (nil) then use the defaultSSHKeyName
+	// If SSHKeyName WAS provided _but is an empty string_, do not set a key pair
+	// Otherwise (SSHKeyName WAS provided and is NOT an empty string), use the provided key pair name
+	var keyName string
+	if s.scope.AWSCluster.Spec.SSHKeyName != nil {
+		if *s.scope.AWSCluster.Spec.SSHKeyName != "" {
+			keyName = *s.scope.AWSCluster.Spec.SSHKeyName
+		}
+	} else {
+		keyName = defaultSSHKeyName
 	}
 
 	i := &infrav1.Instance{


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows instances to be provisioned with no SSH key pair specified. Organizations which have policies denying the use of SSH key pairs can now set the SSH key name value to "" to launch instances without a key pair set. A nil value still sets the default key pair name.

Fixes #1156
