### PR TITLE
🏃Add automation to test cluster creation with name length more than 22 characters

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -431,6 +431,17 @@ var _ = Describe("functional tests", func() {
 			deleteCluster(setup.namespace, setup.clusterName)
 		})
 	})
+
+	Describe("Create cluster with name having more than 22 characters", func() {
+		It("Cluster should be provisioned and deleted", func() {
+			By("Creating a workload cluster with single control plane")
+			setup.clusterName = "test-" + util.RandomString(20)
+			makeSingleControlPlaneCluster(setup)
+
+			By("Deleting the Cluster")
+			deleteCluster(setup.namespace, setup.clusterName)
+		})
+	})
 })
 
 func updateMachineDeploymentInfra(setup testSetup) {


### PR DESCRIPTION

Added automation to test creating cluster with name more than 22 characters.

Verifies that Cluster provisioned and control plane initialized

