### PR TITLE
🏃 Sync cluster-api-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,7 @@ aliases:
     - justinsb
     - ncdc
     - vincepri
+    - chuckha
   cluster-api-aws-maintainers:
     - chuckha
     - detiber


### PR DESCRIPTION
**What this PR does / why we need it**:
Sync the cluster-api-maintainers alias with what is currently in
cluster-api.