### PR TITLE
Fix to avoid updating tags when there is no change in them and add unit tests

### DIFF
--- a/api/v1alpha3/tags_test.go
+++ b/api/v1alpha3/tags_test.go
@@ -86,3 +86,79 @@ func TestTags_Merge(t *testing.T) {
 	}
 
 }
+
+func TestTags_Difference(t *testing.T) {
+	tests := []struct {
+		name     string
+		self     Tags
+		input    Tags
+		expected Tags
+	}{
+		{
+			name:     "self and input are nil",
+			self:     nil,
+			input:    nil,
+			expected: Tags{},
+		},
+		{
+			name: "input is nil",
+			self: Tags{
+				"a": "b",
+				"c": "d",
+			},
+			input: nil,
+			expected: Tags{
+				"a": "b",
+				"c": "d",
+			},
+		},
+		{
+			name: "similar input",
+			self: Tags{
+				"a": "b",
+				"c": "d",
+			},
+			input: Tags{
+				"a": "b",
+				"c": "d",
+			},
+			expected: Tags{},
+		},
+		{
+			name: "input with extra tags",
+			self: Tags{
+				"a": "b",
+				"c": "d",
+			},
+			input: Tags{
+				"a": "b",
+				"c": "d",
+				"e": "f",
+			},
+			expected: Tags{},
+		},
+		{
+			name: "same keys, different values",
+			self: Tags{
+				"a": "b",
+				"c": "d",
+			},
+			input: Tags{
+				"a": "b1",
+				"c": "d",
+				"e": "f",
+			},
+			expected: Tags{
+				"a": "b",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tc.self.Difference(tc.input)
+			if e, a := tc.expected, out; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %#v, got %#v", e, a)
+			}
+		})
+	}
+}

--- a/pkg/cloud/tags/tags.go
+++ b/pkg/cloud/tags/tags.go
@@ -54,9 +54,21 @@ func Apply(params *ApplyParams) error {
 
 // Ensure applies the tags if the current tags differ from the params.
 func Ensure(current infrav1.Tags, params *ApplyParams) error {
-	want := infrav1.Build(params.BuildParams)
-	if !current.Equals(want) {
+	diff := computeDiff(current, params.BuildParams)
+	if len(diff) > 0 {
 		return Apply(params)
 	}
 	return nil
+}
+
+func computeDiff(current infrav1.Tags, buildParams infrav1.BuildParams) infrav1.Tags {
+	want := infrav1.Build(buildParams)
+
+	// Some tags could be external set by some external entities
+	// and that means even if there is no change in cluster
+	// managed tags, tags would be updated as "current" and
+	// "want" would be different due to external tags.
+	// This fix makes sure that tags are updated only if
+	// there is a change in cluster managed tags.
+	return want.Difference(current)
 }

--- a/pkg/cloud/tags/tags_test.go
+++ b/pkg/cloud/tags/tags_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"reflect"
+	"testing"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+)
+
+func TestTags_ComputeDiff(t *testing.T) {
+	pName := "test"
+	pRole := "testrole"
+	bp := infrav1.BuildParams{Lifecycle: infrav1.ResourceLifecycleOwned,
+		ClusterName: "testcluster",
+		Name:        &pName,
+		Role:        &pRole,
+		Additional:  map[string]string{"k1": "v1"},
+	}
+
+	tests := []struct {
+		name     string
+		input    infrav1.Tags
+		expected infrav1.Tags
+	}{
+		{
+			name:  "input is nil",
+			input: nil,
+			expected: infrav1.Tags{"Name": pName,
+				"k1":                                  "v1",
+				infrav1.ClusterTagKey(bp.ClusterName): string(infrav1.ResourceLifecycleOwned),
+				infrav1.NameAWSClusterAPIRole:         pRole},
+		},
+		{
+			name: "same input",
+			input: infrav1.Tags{"Name": pName,
+				"k1":                                  "v1",
+				infrav1.ClusterTagKey(bp.ClusterName): string(infrav1.ResourceLifecycleOwned),
+				infrav1.NameAWSClusterAPIRole:         pRole},
+			expected: infrav1.Tags{},
+		},
+		{
+			name: "input with external tags",
+			input: infrav1.Tags{"Name": pName,
+				"k1":                                  "v1",
+				infrav1.ClusterTagKey(bp.ClusterName): string(infrav1.ResourceLifecycleOwned),
+				infrav1.NameAWSClusterAPIRole:         pRole,
+				"k2":                                  "v2"},
+			expected: infrav1.Tags{},
+		},
+		{
+			name: "input with modified values",
+			input: infrav1.Tags{"Name": pName,
+				"k1":                                  "v2",
+				infrav1.ClusterTagKey(bp.ClusterName): string(infrav1.ResourceLifecycleOwned),
+				infrav1.NameAWSClusterAPIRole:         "testrole2",
+				"k2":                                  "v2"},
+			expected: infrav1.Tags{"k1": "v1",
+				infrav1.NameAWSClusterAPIRole: pRole},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := computeDiff(tc.input, bp)
+			if e, a := tc.expected, out; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %#v, got %#v", e, a)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR fixes an issue where tags were being updated even there was no change in them. It happens when there are external tags on resources in addition to cluster managed tags.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1499 

@ncdc @detiber @vincepri @randomvariable @rudoi 