### PR TITLE
:running: Remove hardcoded 3h timeout from hack/heartbeat_account.py

### DIFF
--- a/hack/heartbeat_account.py
+++ b/hack/heartbeat_account.py
@@ -26,9 +26,7 @@ BOSKOS_RESOURCE_NAME=os.environ['BOSKOS_RESOURCE_NAME']
 USER = "cluster-api-provider-aws"
 
 if __name__ == "__main__":
-    count = 0
-    # keep sending heart beat for 3 hours
-    while count < 180:
+    while True:
         conn = httplib.HTTPConnection(BOSKOS_HOST)
         print "POST-ing heartbeat for resource %s to %s" % (BOSKOS_RESOURCE_NAME, BOSKOS_HOST)
         conn.request("POST", "/update?%s" % urllib.urlencode({
@@ -44,4 +42,3 @@ if __name__ == "__main__":
         conn.close()
         # sleep for a minute
         time.sleep(60)
-        count = count + 1

--- a/scripts/ci-e2e-conformance.sh
+++ b/scripts/ci-e2e-conformance.sh
@@ -38,6 +38,13 @@ source "${REPO_ROOT}/hack/ensure-kubectl.sh"
 # shellcheck source=../hack/ensure-kustomize.sh
 source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
+# our exit handler (trap)
+cleanup() {
+  # stop boskos heartbeat
+  [[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
+}
+trap cleanup EXIT
+
 # If BOSKOS_HOST is set then acquire an AWS account from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then
   # Check out the account from Boskos and store the produced environment
@@ -77,7 +84,6 @@ test_status="${?}"
 
 # If Boskos is being used then release the AWS account back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || hack/checkin_account.py
-[[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
 
 # The janitor is typically not run as part of the e2e process, but rather
 # in a parallel process via a service on the same cluster that runs Prow and

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -38,6 +38,13 @@ source "${REPO_ROOT}/hack/ensure-kubectl.sh"
 # shellcheck source=../hack/ensure-kustomize.sh
 source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
+# our exit handler (trap)
+cleanup() {
+  # stop boskos heartbeat
+  [[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
+}
+trap cleanup EXIT
+
 # If BOSKOS_HOST is set then acquire an AWS account from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then
   # Check out the account from Boskos and store the produced environment
@@ -77,7 +84,6 @@ test_status="${?}"
 
 # If Boskos is being used then release the AWS account back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || hack/checkin_account.py
-[[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
 
 # The janitor is typically not run as part of the e2e process, but rather
 # in a parallel process via a service on the same cluster that runs Prow and


### PR DESCRIPTION
**What this PR does / why we need it**:
Backports #1518 to the `release-0.4` branch

