### PR TITLE
:bug: Fix panic in getAPIServerClassicELBSpec

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -267,9 +267,12 @@ func (s *Service) getAPIServerClassicELBSpec() (*infrav1.ClassicELB, error) {
 		},
 		SecurityGroupIDs: []string{s.scope.SecurityGroups()[infrav1.SecurityGroupAPIServerLB].ID},
 		Attributes: infrav1.ClassicELBAttributes{
-			IdleTimeout:            10 * time.Minute,
-			CrossZoneLoadBalancing: s.scope.AWSCluster.Spec.ControlPlaneLoadBalancer.CrossZoneLoadBalancing,
+			IdleTimeout: 10 * time.Minute,
 		},
+	}
+
+	if s.scope.AWSCluster.Spec.ControlPlaneLoadBalancer != nil {
+		res.Attributes.CrossZoneLoadBalancing = s.scope.AWSCluster.Spec.ControlPlaneLoadBalancer.CrossZoneLoadBalancing
 	}
 
 	res.Tags = infrav1.Build(infrav1.BuildParams{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a nil pointer exception in getAPIServerClassicELBSpec if
AWSCluster.Spec.ControlPlaneLoadBalancer is not set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1520
