### PR TITLE
:bug: cloudformation: Add tag permission for secretsmanager

### DIFF
--- a/pkg/cloud/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/services/cloudformation/bootstrap.go
@@ -239,6 +239,7 @@ func controllersPolicy(accountID, partition string) *iam.PolicyDocument {
 				Action: iam.Actions{
 					"secretsmanager:CreateSecret",
 					"secretsmanager:DeleteSecret",
+					"secretsmanager:TagResource",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Adds the required tag permission for AWS Secrets Manager.

Tested via the `bootstrapper.cluster-api-provider-aws.sigs.k8s.io` user

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1523 

