### PR TITLE
[WIP] :bug: Support chunking AWS secrets

### DIFF
--- a/api/v1alpha2/awsmachine_conversion_test.go
+++ b/api/v1alpha2/awsmachine_conversion_test.go
@@ -34,7 +34,7 @@ func TestConvertAWSMachine(t *testing.T) {
 				Spec: infrav1alpha3.AWSMachineSpec{
 					CloudInit: infrav1alpha3.CloudInit{
 						InsecureSkipSecretsManager: true,
-						SecretARN:                  "something",
+						SecretPrefix:               "something/",
 					},
 				},
 			}
@@ -42,7 +42,7 @@ func TestConvertAWSMachine(t *testing.T) {
 			g.Expect(dst.ConvertFrom(src)).To(Succeed())
 			restored := &infrav1alpha3.AWSMachine{}
 			g.Expect(dst.ConvertTo(restored)).To(Succeed())
-			g.Expect(restored.Spec.CloudInit.SecretARN).To(Equal(src.Spec.CloudInit.SecretARN))
+			g.Expect(restored.Spec.CloudInit.SecretPrefix).To(Equal(src.Spec.CloudInit.SecretPrefix))
 			g.Expect(restored.Spec.CloudInit.InsecureSkipSecretsManager).To(Equal(src.Spec.CloudInit.InsecureSkipSecretsManager))
 		})
 	})
@@ -51,7 +51,7 @@ func TestConvertAWSMachine(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{},
 			Spec: infrav1alpha3.AWSMachineSpec{
 				CloudInit: infrav1alpha3.CloudInit{
-					SecretARN: "something",
+					SecretPrefix: "something/",
 				},
 			},
 		}
@@ -59,14 +59,14 @@ func TestConvertAWSMachine(t *testing.T) {
 			Spec: AWSMachineSpec{
 				CloudInit: &CloudInit{
 					EnableSecureSecretsManager: true,
-					SecretARN:                  "something-else",
+					SecretPrefix:               "something-else/",
 				},
 			},
 		}
 		g.Expect(dst.ConvertFrom(src)).To(Succeed())
 		restored := &infrav1alpha3.AWSMachine{}
 		g.Expect(dst.ConvertTo(restored)).To(Succeed())
-		g.Expect(restored.Spec.CloudInit.SecretARN).To(Equal(src.Spec.CloudInit.SecretARN))
+		g.Expect(restored.Spec.CloudInit.SecretPrefix).To(Equal(src.Spec.CloudInit.SecretPrefix))
 	})
 	t.Run("should restore ImageLookupBaseOS", func(t *testing.T) {
 		src := &infrav1alpha3.AWSMachine{

--- a/api/v1alpha2/awsmachine_types.go
+++ b/api/v1alpha2/awsmachine_types.go
@@ -104,11 +104,15 @@ type CloudInit struct {
 	// +optional
 	EnableSecureSecretsManager bool `json:"enableSecureSecretsManager,omitempty"`
 
-	// SecretARN is the Amazon Resource Name of the secret. This is stored
+	// SecretPrefix is the prefix for the secret name. This is stored
 	// temporarily, and deleted when the machine registers as a node against
 	// the workload cluster.
 	// +optional
-	SecretARN string `json:"secretARN,omitempty"`
+	SecretPrefix string `json:"secretPrefix,omitempty"`
+
+	// TODO
+	// +optional
+	SecretCount int32 `json:"secretCount,omitempty"`
 }
 
 // AWSMachineStatus defines the observed state of AWSMachine

--- a/api/v1alpha2/awsmachine_types.go
+++ b/api/v1alpha2/awsmachine_types.go
@@ -104,15 +104,15 @@ type CloudInit struct {
 	// +optional
 	EnableSecureSecretsManager bool `json:"enableSecureSecretsManager,omitempty"`
 
+	// SecretCount is the number of secrets used to form the complete secret
+	// +optional
+	SecretCount int32 `json:"secretCount,omitempty"`
+
 	// SecretPrefix is the prefix for the secret name. This is stored
 	// temporarily, and deleted when the machine registers as a node against
 	// the workload cluster.
 	// +optional
 	SecretPrefix string `json:"secretPrefix,omitempty"`
-
-	// TODO
-	// +optional
-	SecretCount int32 `json:"secretCount,omitempty"`
 }
 
 // AWSMachineStatus defines the observed state of AWSMachine

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -894,15 +894,15 @@ func Convert_v1alpha3_ClassicELBListener_To_v1alpha2_ClassicELBListener(in *v1al
 
 func autoConvert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(in *CloudInit, out *v1alpha3.CloudInit, s conversion.Scope) error {
 	// WARNING: in.EnableSecureSecretsManager requires manual conversion: does not exist in peer-type
-	out.SecretPrefix = in.SecretPrefix
 	out.SecretCount = in.SecretCount
+	out.SecretPrefix = in.SecretPrefix
 	return nil
 }
 
 func autoConvert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(in *v1alpha3.CloudInit, out *CloudInit, s conversion.Scope) error {
 	// WARNING: in.InsecureSkipSecretsManager requires manual conversion: does not exist in peer-type
-	out.SecretPrefix = in.SecretPrefix
 	out.SecretCount = in.SecretCount
+	out.SecretPrefix = in.SecretPrefix
 	return nil
 }
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -172,16 +172,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*CloudInit)(nil), (*v1alpha3.CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(a.(*CloudInit), b.(*v1alpha3.CloudInit), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha3.CloudInit)(nil), (*CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(a.(*v1alpha3.CloudInit), b.(*CloudInit), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*Filter)(nil), (*v1alpha3.Filter)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha2_Filter_To_v1alpha3_Filter(a.(*Filter), b.(*v1alpha3.Filter), scope)
 	}); err != nil {
@@ -292,6 +282,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*CloudInit)(nil), (*v1alpha3.CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(a.(*CloudInit), b.(*v1alpha3.CloudInit), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1alpha3.AWSClusterSpec)(nil), (*AWSClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha3_AWSClusterSpec_To_v1alpha2_AWSClusterSpec(a.(*v1alpha3.AWSClusterSpec), b.(*AWSClusterSpec), scope)
 	}); err != nil {
@@ -324,6 +319,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1alpha3.ClassicELB)(nil), (*ClassicELB)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha3_ClassicELB_To_v1alpha2_ClassicELB(a.(*v1alpha3.ClassicELB), b.(*ClassicELB), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha3.CloudInit)(nil), (*CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(a.(*v1alpha3.CloudInit), b.(*CloudInit), scope)
 	}); err != nil {
 		return err
 	}
@@ -451,7 +451,7 @@ func autoConvert_v1alpha2_AWSClusterStatus_To_v1alpha3_AWSClusterStatus(in *AWSC
 	if err := Convert_v1alpha2_Network_To_v1alpha3_Network(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (./api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
 	out.Ready = in.Ready
 	// WARNING: in.APIEndpoints requires manual conversion: does not exist in peer-type
 	return nil
@@ -463,7 +463,7 @@ func autoConvert_v1alpha3_AWSClusterStatus_To_v1alpha2_AWSClusterStatus(in *v1al
 		return err
 	}
 	// WARNING: in.FailureDomains requires manual conversion: does not exist in peer-type
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs ./api/v1alpha2.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance)
 	return nil
 }
 
@@ -573,7 +573,7 @@ func autoConvert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachi
 	out.SSHKeyName = in.SSHKeyName
 	out.RootDeviceSize = in.RootDeviceSize
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*./api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
 	return nil
 }
 
@@ -594,7 +594,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	out.SSHKeyName = in.SSHKeyName
 	out.RootDeviceSize = in.RootDeviceSize
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *./api/v1alpha2.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
 	return nil
 }
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -172,6 +172,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddGeneratedConversionFunc((*CloudInit)(nil), (*v1alpha3.CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(a.(*CloudInit), b.(*v1alpha3.CloudInit), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddGeneratedConversionFunc((*v1alpha3.CloudInit)(nil), (*CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(a.(*v1alpha3.CloudInit), b.(*CloudInit), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddGeneratedConversionFunc((*Filter)(nil), (*v1alpha3.Filter)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha2_Filter_To_v1alpha3_Filter(a.(*Filter), b.(*v1alpha3.Filter), scope)
 	}); err != nil {
@@ -282,11 +292,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddConversionFunc((*CloudInit)(nil), (*v1alpha3.CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(a.(*CloudInit), b.(*v1alpha3.CloudInit), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddConversionFunc((*v1alpha3.AWSClusterSpec)(nil), (*AWSClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha3_AWSClusterSpec_To_v1alpha2_AWSClusterSpec(a.(*v1alpha3.AWSClusterSpec), b.(*AWSClusterSpec), scope)
 	}); err != nil {
@@ -319,11 +324,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1alpha3.ClassicELB)(nil), (*ClassicELB)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha3_ClassicELB_To_v1alpha2_ClassicELB(a.(*v1alpha3.ClassicELB), b.(*ClassicELB), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddConversionFunc((*v1alpha3.CloudInit)(nil), (*CloudInit)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(a.(*v1alpha3.CloudInit), b.(*CloudInit), scope)
 	}); err != nil {
 		return err
 	}
@@ -451,7 +451,7 @@ func autoConvert_v1alpha2_AWSClusterStatus_To_v1alpha3_AWSClusterStatus(in *AWSC
 	if err := Convert_v1alpha2_Network_To_v1alpha3_Network(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (./api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
 	out.Ready = in.Ready
 	// WARNING: in.APIEndpoints requires manual conversion: does not exist in peer-type
 	return nil
@@ -463,7 +463,7 @@ func autoConvert_v1alpha3_AWSClusterStatus_To_v1alpha2_AWSClusterStatus(in *v1al
 		return err
 	}
 	// WARNING: in.FailureDomains requires manual conversion: does not exist in peer-type
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs ./api/v1alpha2.Instance)
 	return nil
 }
 
@@ -573,7 +573,7 @@ func autoConvert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachi
 	out.SSHKeyName = in.SSHKeyName
 	out.RootDeviceSize = in.RootDeviceSize
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*./api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
 	return nil
 }
 
@@ -594,7 +594,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	out.SSHKeyName = in.SSHKeyName
 	out.RootDeviceSize = in.RootDeviceSize
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *./api/v1alpha2.CloudInit)
 	return nil
 }
 
@@ -894,13 +894,15 @@ func Convert_v1alpha3_ClassicELBListener_To_v1alpha2_ClassicELBListener(in *v1al
 
 func autoConvert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(in *CloudInit, out *v1alpha3.CloudInit, s conversion.Scope) error {
 	// WARNING: in.EnableSecureSecretsManager requires manual conversion: does not exist in peer-type
-	out.SecretARN = in.SecretARN
+	out.SecretPrefix = in.SecretPrefix
+	out.SecretCount = in.SecretCount
 	return nil
 }
 
 func autoConvert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(in *v1alpha3.CloudInit, out *CloudInit, s conversion.Scope) error {
 	// WARNING: in.InsecureSkipSecretsManager requires manual conversion: does not exist in peer-type
-	out.SecretARN = in.SecretARN
+	out.SecretPrefix = in.SecretPrefix
+	out.SecretCount = in.SecretCount
 	return nil
 }
 

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -108,15 +108,15 @@ type CloudInit struct {
 	// the userdata from Secrets Manager and additionally delete the secret.
 	InsecureSkipSecretsManager bool `json:"insecureSkipSecretsManager,omitempty"`
 
+	// SecretCount is the number of secrets used to form the complete secret
+	// +optional
+	SecretCount int32 `json:"secretCount,omitempty"`
+
 	// SecretPrefix is the prefix for the secret name. This is stored
 	// temporarily, and deleted when the machine registers as a node against
 	// the workload cluster.
 	// +optional
 	SecretPrefix string `json:"secretPrefix,omitempty"`
-
-	// TODO
-	// +optional
-	SecretCount int32 `json:"secretCount,omitempty"`
 }
 
 // AWSMachineStatus defines the observed state of AWSMachine

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -108,11 +108,15 @@ type CloudInit struct {
 	// the userdata from Secrets Manager and additionally delete the secret.
 	InsecureSkipSecretsManager bool `json:"insecureSkipSecretsManager,omitempty"`
 
-	// SecretARN is the Amazon Resource Name of the secret. This is stored
+	// SecretPrefix is the prefix for the secret name. This is stored
 	// temporarily, and deleted when the machine registers as a node against
 	// the workload cluster.
 	// +optional
-	SecretARN string `json:"secretARN,omitempty"`
+	SecretPrefix string `json:"secretPrefix,omitempty"`
+
+	// TODO
+	// +optional
+	SecretCount int32 `json:"secretCount,omitempty"`
 }
 
 // AWSMachineStatus defines the observed state of AWSMachine

--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -83,10 +83,12 @@ func (r *AWSMachine) ValidateUpdate(old runtime.Object) error {
 	// allow changes to secretARN
 	if cloudInit, ok := oldAWSMachineSpec["cloudInit"].(map[string]interface{}); ok {
 		delete(cloudInit, "secretPrefix")
+		delete(cloudInit, "secretCount")
 	}
 
 	if cloudInit, ok := newAWSMachineSpec["cloudInit"].(map[string]interface{}); ok {
 		delete(cloudInit, "secretPrefix")
+		delete(cloudInit, "secretCount")
 	}
 
 	if !reflect.DeepEqual(oldAWSMachineSpec, newAWSMachineSpec) {
@@ -99,8 +101,13 @@ func (r *AWSMachine) ValidateUpdate(old runtime.Object) error {
 func (r *AWSMachine) validateCloudInitSecret() field.ErrorList {
 	var allErrs field.ErrorList
 
-	if r.Spec.CloudInit.SecretPrefix != "" && r.Spec.CloudInit.InsecureSkipSecretsManager {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "cloudInit", "secretPrefix"), "cannot be set if spec.cloudInit.insecureSkipSecretsManager is true"))
+	if r.Spec.CloudInit.InsecureSkipSecretsManager {
+		if r.Spec.CloudInit.SecretPrefix != "" {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "cloudInit", "secretPrefix"), "cannot be set if spec.cloudInit.insecureSkipSecretsManager is true"))
+		}
+		if r.Spec.CloudInit.SecretCount != 0 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "cloudInit", "secretCount"), "cannot be set if spec.cloudInit.insecureSkipSecretsManager is true"))
+		}
 	}
 
 	return allErrs

--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -99,8 +99,8 @@ func (r *AWSMachine) ValidateUpdate(old runtime.Object) error {
 func (r *AWSMachine) validateCloudInitSecret() field.ErrorList {
 	var allErrs field.ErrorList
 
-	if r.Spec.CloudInit.SecretARN != "" && r.Spec.CloudInit.InsecureSkipSecretsManager {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "cloudInit", "secretARN"), "cannot be set if spec.cloudInit.insecureSkipSecretsManager is true"))
+	if r.Spec.CloudInit.SecretPrefix != "" && r.Spec.CloudInit.InsecureSkipSecretsManager {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "cloudInit", "secretPrefix"), "cannot be set if spec.cloudInit.insecureSkipSecretsManager is true"))
 	}
 
 	return allErrs

--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -82,11 +82,11 @@ func (r *AWSMachine) ValidateUpdate(old runtime.Object) error {
 
 	// allow changes to secretARN
 	if cloudInit, ok := oldAWSMachineSpec["cloudInit"].(map[string]interface{}); ok {
-		delete(cloudInit, "secretARN")
+		delete(cloudInit, "secretPrefix")
 	}
 
 	if cloudInit, ok := newAWSMachineSpec["cloudInit"].(map[string]interface{}); ok {
-		delete(cloudInit, "secretARN")
+		delete(cloudInit, "secretPrefix")
 	}
 
 	if !reflect.DeepEqual(oldAWSMachineSpec, newAWSMachineSpec) {

--- a/api/v1alpha3/awsmachine_webhook_test.go
+++ b/api/v1alpha3/awsmachine_webhook_test.go
@@ -50,7 +50,7 @@ func TestAWSMachine_ValidateUpdate(t *testing.T) {
 						},
 					},
 					CloudInit: CloudInit{
-						SecretARN: "test",
+						SecretPrefix: "test/",
 					},
 				},
 			},

--- a/api/v1alpha3/awsmachinetemplate_webhook.go
+++ b/api/v1alpha3/awsmachinetemplate_webhook.go
@@ -41,8 +41,8 @@ func (r *AWSMachineTemplate) ValidateCreate() error {
 	var allErrs field.ErrorList
 	spec := r.Spec.Template.Spec
 
-	if spec.CloudInit.SecretARN != "" {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "template", "spec", "cloudInit", "secretARN"), "cannot be set in templates"))
+	if spec.CloudInit.SecretPrefix != "" {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "template", "spec", "cloudInit", "secretPrefix"), "cannot be set in templates"))
 	}
 
 	if spec.ProviderID != nil {

--- a/api/v1alpha3/awsmachinetemplate_webhook_test.go
+++ b/api/v1alpha3/awsmachinetemplate_webhook_test.go
@@ -51,7 +51,7 @@ func TestAWSMachineTemplateInvalid(t *testing.T) {
 					Template: AWSMachineTemplateResource{
 						Spec: AWSMachineSpec{
 							CloudInit: CloudInit{
-								SecretARN: "something",
+								SecretPrefix: "something/",
 							},
 						},
 					},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -137,9 +137,13 @@ spec:
                       boothook shell script is prepended to download the userdata
                       from Secrets Manager and additionally delete the secret.
                     type: boolean
-                  secretARN:
-                    description: SecretARN is the Amazon Resource Name of the secret.
-                      This is stored temporarily, and deleted when the machine registers
+                  secretCount:
+                    description: TODO
+                    format: int32
+                    type: integer
+                  secretPrefix:
+                    description: SecretPrefix is the prefix for the secret name. This
+                      is stored temporarily, and deleted when the machine registers
                       as a node against the workload cluster.
                     type: string
                 type: object
@@ -405,9 +409,13 @@ spec:
                       download the userdata from Secrets Manager and additionally
                       delete the secret.
                     type: boolean
-                  secretARN:
-                    description: SecretARN is the Amazon Resource Name of the secret.
-                      This is stored temporarily, and deleted when the machine registers
+                  secretCount:
+                    description: TODO
+                    format: int32
+                    type: integer
+                  secretPrefix:
+                    description: SecretPrefix is the prefix for the secret name. This
+                      is stored temporarily, and deleted when the machine registers
                       as a node against the workload cluster.
                     type: string
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -138,7 +138,8 @@ spec:
                       from Secrets Manager and additionally delete the secret.
                     type: boolean
                   secretCount:
-                    description: TODO
+                    description: SecretCount is the number of secrets used to form
+                      the complete secret
                     format: int32
                     type: integer
                   secretPrefix:
@@ -410,7 +411,8 @@ spec:
                       delete the secret.
                     type: boolean
                   secretCount:
-                    description: TODO
+                    description: SecretCount is the number of secrets used to form
+                      the complete secret
                     format: int32
                     type: integer
                   secretPrefix:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -150,11 +150,14 @@ spec:
                               the userdata from Secrets Manager and additionally delete
                               the secret.
                             type: boolean
-                          secretARN:
-                            description: SecretARN is the Amazon Resource Name of
-                              the secret. This is stored temporarily, and deleted
-                              when the machine registers as a node against the workload
-                              cluster.
+                          secretCount:
+                            description: TODO
+                            format: int32
+                            type: integer
+                          secretPrefix:
+                            description: SecretPrefix is the prefix for the secret
+                              name. This is stored temporarily, and deleted when the
+                              machine registers as a node against the workload cluster.
                             type: string
                         type: object
                       iamInstanceProfile:
@@ -365,11 +368,14 @@ spec:
                               is prepended to download the userdata from Secrets Manager
                               and additionally delete the secret.
                             type: boolean
-                          secretARN:
-                            description: SecretARN is the Amazon Resource Name of
-                              the secret. This is stored temporarily, and deleted
-                              when the machine registers as a node against the workload
-                              cluster.
+                          secretCount:
+                            description: TODO
+                            format: int32
+                            type: integer
+                          secretPrefix:
+                            description: SecretPrefix is the prefix for the secret
+                              name. This is stored temporarily, and deleted when the
+                              machine registers as a node against the workload cluster.
                             type: string
                         type: object
                       failureDomain:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -151,7 +151,8 @@ spec:
                               the secret.
                             type: boolean
                           secretCount:
-                            description: TODO
+                            description: SecretCount is the number of secrets used
+                              to form the complete secret
                             format: int32
                             type: integer
                           secretPrefix:
@@ -369,7 +370,8 @@ spec:
                               and additionally delete the secret.
                             type: boolean
                           secretCount:
-                            description: TODO
+                            description: SecretCount is the number of secrets used
+                              to form the complete secret
                             format: int32
                             type: integer
                           secretPrefix:

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -420,9 +420,9 @@ func (r *AWSMachineReconciler) deleteEncryptedBootstrapDataSecret(machineScope *
 	if !machineScope.HasFailed() && machineScope.InstanceIsOperational() && machineScope.Machine.Status.NodeRef == nil && !machineScope.AWSMachineIsDeleted() {
 		return nil
 	}
-	machineScope.Info("Deleting unneeded entry from AWS Secrets Manager", "secretARN", machineScope.GetSecretARNs())
+	machineScope.Info("Deleting unneeded entry from AWS Secrets Manager", "secretPrefix", machineScope.GetSecretPrefix())
 	if err := secretSvc.Delete(machineScope); err != nil {
-		machineScope.Info("Unable to delete entry from AWS Secrets Manager containing encrypted userdata", "secretARN", machineScope.GetSecretARNs())
+		machineScope.Info("Unable to delete entry from AWS Secrets Manager containing encrypted userdata", "secretPrefix", machineScope.GetSecretPrefix())
 		r.Recorder.Eventf(machineScope.AWSMachine, corev1.EventTypeWarning, "FailedDeleteEncryptedBootstrapDataSecret", "AWS Secret Manager entry containing userdata not deleted")
 		return err
 	}

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -205,7 +205,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 			It("should try to create a new machine if none exists", func() {
 				expectedErr := errors.New("Invalid instance")
 				ec2Svc.EXPECT().InstanceIfExists(gomock.Any()).Return(nil, nil)
-				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return("testARN", nil).Times(1)
+				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return("test/", int32(1), nil).Times(1)
 				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
 
 				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
@@ -222,7 +222,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				instance.State = infrav1.InstanceStatePending
 
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
-				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return("testARN", nil).Times(1)
+				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return("test/", int32(1), nil).Times(1)
 				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil)
 			})
 
@@ -385,11 +385,11 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 	Context("secrets management lifecycle", func() {
 		var instance *infrav1.Instance
-		arn := "testARN"
+		secretPrefix := "test/secret/"
 		When("creating EC2 instances", func() {
 			BeforeEach(func() {
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
-				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(arn, nil).Times(1)
+				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(1), nil).Times(1)
 				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
 			})
 
@@ -398,7 +398,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 					clusterv1.MachineControlPlaneLabelName: "",
 				}
 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-				Expect(ms.AWSMachine.Spec.CloudInit.SecretARN).To(Equal(arn))
+				Expect(ms.AWSMachine.Spec.CloudInit.SecretPrefix).To(Equal(secretPrefix))
 			})
 		})
 
@@ -415,7 +415,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				}
 
 				ms.AWSMachine.Spec.CloudInit = infrav1.CloudInit{
-					SecretARN: "secret",
+					SecretPrefix: "secret/",
 				}
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
 				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
@@ -456,7 +456,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 					ID: "myMachine",
 				}
 				ms.AWSMachine.Spec.CloudInit = infrav1.CloudInit{
-					SecretARN: "secret",
+					SecretPrefix: "secret/",
 				}
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
 				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -186,22 +186,30 @@ func (m *MachineScope) UseSecretsManager() bool {
 	return !m.AWSMachine.Spec.CloudInit.InsecureSkipSecretsManager
 }
 
-// GetSecretARN returns the Amazon Resource Name for the secret belonging
+// GetSecretPrefix returns the prefix for the secrets belonging
 // to the AWSMachine in AWS Secrets Manager
-func (m *MachineScope) GetSecretARN() string {
-	return m.AWSMachine.Spec.CloudInit.SecretARN
+func (m *MachineScope) GetSecretPrefix() string {
+	return m.AWSMachine.Spec.CloudInit.SecretPrefix
 }
 
-// SetSecretARN sets the Amazon Resource Name for the secret belonging
+// SetSecretPrefix sets the prefix for the secrets belonging
 // to the AWSMachine in AWS Secrets Manager
-func (m *MachineScope) SetSecretARN(value string) {
-	m.AWSMachine.Spec.CloudInit.SecretARN = value
+func (m *MachineScope) SetSecretPrefix(value string) {
+	m.AWSMachine.Spec.CloudInit.SecretPrefix = value
 }
 
-// DeleteSecretARN deletes the AMazon Resource Name for the secret belonging
+// DeleteSecretARNs deletes the prefix for the secret belonging
 // to the AWSMachine in AWS Secrets Manager
-func (m *MachineScope) DeleteSecretARN() {
-	m.AWSMachine.Spec.CloudInit.SecretARN = ""
+func (m *MachineScope) DeleteSecretPrefix() {
+	m.AWSMachine.Spec.CloudInit.SecretPrefix = ""
+}
+
+func (m *MachineScope) GetSecretCount() int32 {
+	return m.AWSMachine.Spec.CloudInit.SecretCount
+}
+
+func (m *MachineScope) SetSecretCount(i int32) {
+	m.AWSMachine.Spec.CloudInit.SecretCount = i
 }
 
 // SetAddresses sets the AWSMachine address status.

--- a/pkg/cloud/scope/machine_test.go
+++ b/pkg/cloud/scope/machine_test.go
@@ -183,8 +183,8 @@ func TestGetSecretARNDefaultIsNil(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if scope.GetSecretARN() != "" {
-		t.Fatalf("GetSecretARN should be empty string")
+	if scope.GetSecretARNs() != "" {
+		t.Fatalf("GetSecretARNs should be empty string")
 	}
 }
 
@@ -195,10 +195,10 @@ func TestSetSecretARN(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scope.SetSecretARN(secretARN)
-	val := scope.GetSecretARN()
+	scope.SetSecretARNs(secretARN)
+	val := scope.GetSecretARNs()
 
 	if val != secretARN {
-		t.Fatalf("GetSecretARN does not equal %s: %s", secretARN, val)
+		t.Fatalf("GetSecretARNs does not equal %s: %s", secretARN, val)
 	}
 }

--- a/pkg/cloud/scope/machine_test.go
+++ b/pkg/cloud/scope/machine_test.go
@@ -183,22 +183,21 @@ func TestGetSecretARNDefaultIsNil(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if scope.GetSecretARNs() != "" {
-		t.Fatalf("GetSecretARNs should be empty string")
+	if scope.GetSecretPrefix() != "" {
+		t.Fatalf("GetSecretPrefix should be empty string")
 	}
 }
 
 func TestSetSecretARN(t *testing.T) {
-	secretARN := "secretARN"
+	prefix := "secret/"
 	scope, err := setupMachineScope()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	scope.SetSecretARNs(secretARN)
-	val := scope.GetSecretARNs()
-
-	if val != secretARN {
-		t.Fatalf("GetSecretARNs does not equal %s: %s", secretARN, val)
+	scope.SetSecretPrefix(prefix)
+	val := scope.GetSecretPrefix()
+	if val != prefix {
+		t.Fatalf("prefix does not equal %s: %s", prefix, val)
 	}
 }

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -42,5 +42,5 @@ type EC2MachineInterface interface {
 // machine actuator
 type SecretsManagerInterface interface {
 	Delete(m *scope.MachineScope) error
-	Create(m *scope.MachineScope, data []byte) (string, error)
+	Create(m *scope.MachineScope, data []byte) (string, int32, error)
 }

--- a/pkg/cloud/services/mock_services/secretsmanager_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/secretsmanager_machine_interface_mock.go
@@ -50,12 +50,13 @@ func (m *MockSecretsManagerInterface) EXPECT() *MockSecretsManagerInterfaceMockR
 }
 
 // Create mocks base method
-func (m *MockSecretsManagerInterface) Create(arg0 *scope.MachineScope, arg1 []byte) (string, error) {
+func (m *MockSecretsManagerInterface) Create(arg0 *scope.MachineScope, arg1 []byte) (string, int32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int32)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Create indicates an expected call of Create

--- a/pkg/cloud/services/secretsmanager/cloudinit.go
+++ b/pkg/cloud/services/secretsmanager/cloudinit.go
@@ -67,7 +67,7 @@ func GenerateCloudInitMIMEDocument(secretPrefix string, chunks int32, region str
 
 	scriptVariables := scriptVariables{
 		SecretPrefix: secretPrefix,
-		Chunks:       chunks - 1,
+		Chunks:       chunks,
 		Region:       region,
 	}
 

--- a/pkg/cloud/services/secretsmanager/cloudinit.go
+++ b/pkg/cloud/services/secretsmanager/cloudinit.go
@@ -48,14 +48,15 @@ var (
 )
 
 type scriptVariables struct {
-	SecretID string
-	Region   string
+	SecretPrefix string
+	Chunks       int32
+	Region       string
 }
 
 // GenerateCloudInitMIMEDocument creates a multi-part MIME document including a script boothook to
 // download userdata from AWS Secrets Manager and then restart cloud-init, and an include part
 // specifying the on disk location of the new userdata
-func GenerateCloudInitMIMEDocument(secretID, region string) ([]byte, error) {
+func GenerateCloudInitMIMEDocument(secretPrefix string, chunks int32, region string) ([]byte, error) {
 	var buf bytes.Buffer
 	mpWriter := multipart.NewWriter(&buf)
 	buf.WriteString(fmt.Sprintf(multipartHeader, mpWriter.Boundary()))
@@ -65,8 +66,9 @@ func GenerateCloudInitMIMEDocument(secretID, region string) ([]byte, error) {
 	}
 
 	scriptVariables := scriptVariables{
-		SecretID: secretID,
-		Region:   region,
+		SecretPrefix: secretPrefix,
+		Chunks:       chunks,
+		Region:       region,
 	}
 
 	var scriptBuf bytes.Buffer

--- a/pkg/cloud/services/secretsmanager/cloudinit.go
+++ b/pkg/cloud/services/secretsmanager/cloudinit.go
@@ -67,7 +67,7 @@ func GenerateCloudInitMIMEDocument(secretPrefix string, chunks int32, region str
 
 	scriptVariables := scriptVariables{
 		SecretPrefix: secretPrefix,
-		Chunks:       chunks,
+		Chunks:       chunks - 1,
 		Region:       region,
 	}
 

--- a/pkg/cloud/services/secretsmanager/cloudinit_test.go
+++ b/pkg/cloud/services/secretsmanager/cloudinit_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestGenerateCloudInitMIMEDocument(t *testing.T) {
 	secretARN := "secretARN"
-	doc, _ := GenerateCloudInitMIMEDocument(secretARN, "eu-west-1")
+	doc, _ := GenerateCloudInitMIMEDocument(secretARN, 1, "eu-west-1")
 
 	_, err := mail.ReadMessage(bytes.NewBuffer(doc))
 	if err != nil {

--- a/pkg/cloud/services/secretsmanager/secret_fetch_script.go
+++ b/pkg/cloud/services/secretsmanager/secret_fetch_script.go
@@ -33,8 +33,13 @@ const secretFetchScript = `#!/bin/bash
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 REGION="{{.Region}}"
-SECRET_ID="{{.SecretID}}"
+SECRET_PREFIX="{{.SecretPrefix}}"
+CHUNKS="{{.Chunks}}"
 FILE="/etc/secret-userdata.txt"
 
 # Log an error and exit.
@@ -42,110 +47,130 @@ FILE="/etc/secret-userdata.txt"
 #   $1 Message to log with the error
 #   $2 The error code to return
 log::error_exit() {
-	local message="${1}"
-	local code="${2}"
+  local message="${1}"
+  local code="${2}"
 
-	log::error "${message}"
-	log::error "aws.cluster.x-k8s.io encrypted cloud-init script $0 exiting with status ${code}"
-	exit "${code}"
+  log::error "${message}"
+  log::error "aws.cluster.x-k8s.io encrypted cloud-init script $0 exiting with status ${code}"
+  exit "${code}"
 }
 
 log::success_exit() {
-	log::info "aws.cluster.x-k8s.io encrypted cloud-init script $0 finished"
-	exit 0
+  log::info "aws.cluster.x-k8s.io encrypted cloud-init script $0 finished"
+  exit 0
 }
 
 # Log an error but keep going.
 log::error() {
-	local message="${1}"
-	timestamp=$(date --iso-8601=seconds)
-	echo "!!! [${timestamp}] ${1}" >&2
-	shift
-	for message; do
-		echo "    ${message}" >&2
-	done
+  local message="${1}"
+  timestamp=$(date --iso-8601=seconds)
+  echo "!!! [${timestamp}] ${1}" >&2
+  shift
+  for message; do
+    echo "    ${message}" >&2
+  done
 }
 
 # Print a status line.  Formatted to show up in a stream of output.
 log::info() {
-	timestamp=$(date --iso-8601=seconds)
-	echo "+++ [${timestamp}] ${1}"
-	shift
-	for message; do
-		echo "    ${message}"
-	done
+  timestamp=$(date --iso-8601=seconds)
+  echo "+++ [${timestamp}] ${1}"
+  shift
+  for message; do
+    echo "    ${message}"
+  done
 }
 
 check_aws_command() {
-	local command="${1}"
-	local code="${2}"
-	local out="${3}"
-	local sanitised="${out//[$'\t\r\n']/}"
-	case ${code} in
-	"0")
-		log::info "AWS CLI reported successful execution for ${command}"
-		;;
-	"2")
-		log::error "AWS CLI reported that it could not parse ${command}"
-		log::error "${sanitised}"
-		;;
-	"130")
-		log::error "AWS CLI reported SIGINT signal during ${command}"
-		log::error "${sanitised}"
-		;;
-	"255")
-		log::error "AWS CLI reported service error for ${command}"
-		log::error "${sanitised}"
-		;;
-	*)
-		log::error "AWS CLI reported unknown error ${code} for ${command}"
-		log::error "${sanitised}"
-		;;
-	esac
+  local command="${1}"
+  local code="${2}"
+  local out="${3}"
+  local sanitised="${out//[$'\t\r\n']/}"
+  case ${code} in
+  "0")
+    log::info "AWS CLI reported successful execution for ${command}"
+    ;;
+  "2")
+    log::error "AWS CLI reported that it could not parse ${command}"
+    log::error "${sanitised}"
+    ;;
+  "130")
+    log::error "AWS CLI reported SIGINT signal during ${command}"
+    log::error "${sanitised}"
+    ;;
+  "255")
+    log::error "AWS CLI reported service error for ${command}"
+    log::error "${sanitised}"
+    ;;
+  *)
+    log::error "AWS CLI reported unknown error ${code} for ${command}"
+    log::error "${sanitised}"
+    ;;
+  esac
 }
 
 delete_secret_value() {
-	local out
-	log::info "deleting secret from AWS Secrets Manager"
-	out=$(
-		set +e
-		aws secretsmanager --region ${REGION} delete-secret --force-delete-without-recovery --secret-id ${SECRET_ID} 2>&1
-	)
-	local delete_return=$?
-	check_aws_command "SecretsManager::DeleteSecret" "${delete_return}" "${out}"
-	if [ ${delete_return} -ne 0 ]; then
-		log::error_exit "Could not delete secret value" 2
-	fi
+  local id="${SECRET_PREFIX}-${1}"
+  local out
+  log::info "deleting secret from AWS Secrets Manager"
+  out=$(
+    set +e
+    aws secretsmanager --region ${REGION} delete-secret --force-delete-without-recovery --secret-id "${id}" 2>&1
+  )
+  local delete_return=$?
+  check_aws_command "SecretsManager::DeleteSecret" "${delete_return}" "${out}"
+  if [ ${delete_return} -ne 0 ]; then
+    log::error_exit "Could not delete secret value" 2
+  fi
 }
 
 log::info "aws.cluster.x-k8s.io encrypted cloud-init script $0 started"
 umask 006
 if test -f "${FILE}"; then
-	log::info "encrypted userdata already written to disk"
-	log::success_exit
+  log::info "encrypted userdata already written to disk"
+  log::success_exit
 fi
 
-log::info "getting userdata from AWS Secrets Manager"
-log::info "getting secret value from AWS Secrets Manager"
-BINARY_DATA=$(
-	set +e
-	aws secretsmanager --region ${REGION} get-secret-value --output text --query 'SecretBinary' --secret-id ${SECRET_ID} 2>&1
-)
-GET_RETURN=$?
-check_aws_command "SecretsManager::GetSecretValue" "$?" "${BINARY_DATA}"
-if [ ${GET_RETURN} -ne 0 ]; then
-	log::error "could not get secret value, deleting secret"
-	delete_secret_value
-	log::error_exit "could not get secret value, but secret was deleted" 1
-fi
+BINARY_DATA=""
+get_secret_value() {
+  local chunk=$1
+  local id="${SECRET_PREFIX}-${chunk}"
 
-delete_secret_value
+  log::info "getting userdata from AWS Secrets Manager"
+  log::info "getting secret value from AWS Secrets Manager"
+
+  local data
+  data=$(
+    set +e
+    aws secretsmanager --region ${REGION} get-secret-value --output text --query 'SecretBinary' --secret-id "${id}" 2>&1
+  )
+  local get_return=$?
+  check_aws_command "SecretsManager::GetSecretValue" "${get_return}" "${data}"
+  if [ ${get_return} -ne 0 ]; then
+    log::error "could not get secret value, deleting secret"
+    delete_secret_value "$chunk"
+    log::error_exit "could not get secret value, but secret was deleted" 1
+  fi
+
+  local data_decoded
+  data_decoded="$(echo "${data}" | base64 -d)"
+  BINARY_DATA+="${data_decoded}"
+}
+
+
+for i in $(seq 0 ${CHUNKS}); do
+    get_secret_value "$i"
+done
+
+for i in $(seq 0 ${CHUNKS}); do
+  delete_secret_value "$i"
+done
 
 log::info "decoding and decompressing userdata"
-UNZIPPED=$(echo "${BINARY_DATA}" | base64 -d | gunzip)
+UNZIPPED=$(echo "${BINARY_DATA}" | gunzip)
 GUNZIP_RETURN=$?
 if [ ${GUNZIP_RETURN} -ne 0 ]; then
-	log::error_exit "could not get unzip data" 4
+  log::error_exit "could not get unzip data" 4
 fi
 
 log::info "writing userdata to ${FILE}"


### PR DESCRIPTION
**What this PR does / why we need it**:
AWS has a 10kb limit on binary secret data (base64 encoded). This chunks
secrets to stay under the 10kb limit and stitches them back together in
the VM during cloud-init.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1531 

