### PR TITLE
🐛fix-failing-test

### DIFF
--- a/hack/ci/ci-bootstrap.yaml
+++ b/hack/ci/ci-bootstrap.yaml
@@ -22,7 +22,7 @@ files:
       fi
       ${GSUTIL} version
 
-      # This test installs debian packages that are a result of the CI and release builds.
+      # This test installs release packages or binaries that are a result of the CI and release builds.
       # It runs '... --version' commands to verify that the binaries are correctly installed
       # and finally uninstalls the packages.
       # For the release packages it tests all versions in the support skew.
@@ -36,7 +36,6 @@ files:
         mkdir -p $CI_DIR
 
         declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        PACKAGE_EXT="deb"
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
 
@@ -65,10 +64,13 @@ files:
           CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
 
           for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading package: $CI_URL/$CI_PACKAGE.$PACKAGE_EXT"
-            ${GSUTIL} cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
-            ${SUDO} dpkg -i "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT" || echo "* ignoring expected 'dpkg -i' result"
+            echo "* downloading binary: $CI_URL/$CI_PACKAGE"
+            ${GSUTIL} cp "$CI_URL/$CI_PACKAGE" "$CI_DIR/$CI_PACKAGE"
+            chmod +x "$CI_DIR/$CI_PACKAGE"
+            mv "$CI_DIR/$CI_PACKAGE" "/usr/bin/$CI_PACKAGE"
           done
+
+          systemctl restart kubelet
         fi
 
         for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the problem introduced by https://github.com/kubernetes/kubernetes/pull/87585 (no more .deb generated on CI)

**Which issue(s) this PR fixes** :
Fixes https://github.com/kubernetes/kubernetes/issues/87961

