### PR TITLE
✨add omitempty to networking types that may be empty

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -327,7 +327,7 @@ type SecurityGroup struct {
 
 	// IngressRules is the inbound rules associated with the security group.
 	// +optional
-	IngressRules IngressRules `json:"ingressRule"`
+	IngressRules IngressRules `json:"ingressRule,omitempty"`
 
 	// Tags is a map of tags associated with the security group.
 	Tags Tags `json:"tags,omitempty"`
@@ -370,11 +370,11 @@ type IngressRule struct {
 
 	// List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
 	// +optional
-	CidrBlocks []string `json:"cidrBlocks"`
+	CidrBlocks []string `json:"cidrBlocks,omitempty"`
 
 	// The security group id to allow access from. Cannot be specified with CidrBlocks.
 	// +optional
-	SourceSecurityGroupIDs []string `json:"sourceSecurityGroupIds"`
+	SourceSecurityGroupIDs []string `json:"sourceSecurityGroupIds,omitempty"`
 }
 
 // String returns a string representation of the ingress rule.

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -329,7 +329,7 @@ type SecurityGroup struct {
 
 	// IngressRules is the inbound rules associated with the security group.
 	// +optional
-	IngressRules IngressRules `json:"ingressRule"`
+	IngressRules IngressRules `json:"ingressRule,omitempty"`
 
 	// Tags is a map of tags associated with the security group.
 	Tags Tags `json:"tags,omitempty"`
@@ -372,11 +372,11 @@ type IngressRule struct {
 
 	// List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
 	// +optional
-	CidrBlocks []string `json:"cidrBlocks"`
+	CidrBlocks []string `json:"cidrBlocks,omitempty"`
 
 	// The security group id to allow access from. Cannot be specified with CidrBlocks.
 	// +optional
-	SourceSecurityGroupIDs []string `json:"sourceSecurityGroupIds"`
+	SourceSecurityGroupIDs []string `json:"sourceSecurityGroupIds,omitempty"`
 }
 
 // String returns a string representation of the ingress rule.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Adds omitempty to some types that may be empty. Go will produce `null` otherwise.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1554 

