### PR TITLE
Add instructions for existing AWS infrastructure

### DIFF
--- a/docs/existing-aws-infrastructure.md
+++ b/docs/existing-aws-infrastructure.md
@@ -7,45 +7,27 @@ Normally, Cluster API will create infrastructure on AWS when standing up a new w
 In order to have Cluster API consume existing AWS infrastructure, you will need to have already created the following resources:
 
 * A VPC
-* One or more private subnets (subnets that do not automatically assign a public IP address to EC2 instances)
+* One or more private subnets (subnets that do not have a route to an Internet gateway)
 * A public subnet in the same Availability Zone (AZ) for each private subnet (this is required for NAT gateways to function properly)
 * A NAT gateway for each private subnet, along with associated Elastic IP addresses
 * An Internet gateway for all public subnets
 * Route table associations that provide connectivity to the Internet through a NAT gateway (for private subnets) or the Internet gateway (for public subnets)
 
-You will need the following information, which can be obtained either via the AWS Management Console or using the AWS CLI:
+Note that a public subnet (and associated Internet gateway) are required for the control plane of the workload cluster.
 
-1. The ID of the VPC
-2. The IDs of the subnets in the VPC that you want Cluster API to use
+You will need the ID of the VPC that Cluster API should use. This information is available via the AWS Management Console or the AWS CLI. It is not necessary to have a list of the subnet IDs; Cluster API will discover the subnets if the VPC ID is provided.
 
 Note that there is no need to create an Elastic Load Balancer (ELB), security groups, or EC2 instances; Cluster API will take care of these items.
 
 ## Tagging AWS Resources
 
-In order for Cluster API to properly recognize and consume existing AWS resources, these resources must be tagged with a specific set of tags. The list below provides the tags that must be present; in this list, `<cluster-name>` refers to the name of cluster as specified in the `metadata.name` field of the Cluster object (or manifest). Here are the tags that are required:
+Cluster API itself does tag AWS resources it creates. The `sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>` (where `<cluster-name>` matches the `metadata.name` field of the Cluster object) tag, with a value of `owned`, tells Cluster API that it has ownership of the resource and is able to modify the resource and manage the lifecycle of the resource.
 
-    sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>
-    sigs.k8s.io/cluster-api-provider-aws/role
+When consuming existing AWS infrastructure, Cluster API does not require any tags to be present. The absence of the tags on an AWS resource indicates to Cluster API that it should not modify the resource or attempt to manage the lifecycle of the resource.
 
-These two tags should be present on the following AWS resources:
+However, the AWS cloud provider _does_ require certain tags in order to function properly. Specifically, all subnets where Kubernetes nodes reside should have the `kubernetes.io/cluster/<cluster-name>` tag present. Private subnets should also have the `kubernetes.io/role/internal-elb` tag with a value of 1, and public subnets should have the `kubernetes.io/role/elb` tag with a value of 1. These latter two tags help the cloud provider understand which subnets to use when creating load balancers.
 
-* VPC
-* All subnets that Cluster API will utilize (private and public)
-* Route tables
-* Internet gateway
-* NAT gateways
-* Elastic IPs assigned to NAT gateways
-
-For the `sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>` tag, a value of "owned" is used by Cluster API itself to indicate resources are owned by a specific cluster, and that the lifecycle of the resource is tied to the lifecycle of the cluster. Cluster API recognizes a value of "shared" to indicate a resource may be shared between multiple clusters, and the lifecycle of said resource is not tied to any particular cluster. In this situation---where AWS infrastructure is _not_ being managed by Cluster API---the value should be something **other** than "owned". Using "shared" is acceptable.
-
-For the `sigs.k8s.io/cluster-api-provider-aws/role` tag, Cluster API uses a variety of values to indicate resources are associated with a particular role. Here are the tag values that should be used:
-
-* VPC, route tables, Internet gateway, and NAT gateways should use the value "common".
-* Public subnets should use the value "public".
-* Private subnets should use the value "private".
-* Elastic IPs (for use by the NAT gateways) should use the value "apiserver".
-
-Additionally, for proper operation of the AWS cloud provider, all subnets where Kubernetes nodes reside should also have the `kubernetes.io/cluster/<cluster-name>` tag present.
+Finally, if the controller manager isn't started with the `--configure-cloud-routes: "false"` parameter, the route table(s) will also need the `kubernetes.io/cluster/<cluster-name>` tag. (This parameter can be added by customizing the `KubeadmConfigSpec` object of the `KubeadmControlPlane` object.)
 
 ## Configuring the AWSCluster Specification
 
@@ -56,20 +38,35 @@ spec:
   networkSpec:
     vpc:
       id: vpc-0425c335226437144
-    subnets:
-      - id: subnet-07758a9bc904d06af
-      - id: subnet-0a3507a5ad2c5c8c3
-      - id: subnet-02ad6429dd0532452
-      - id: subnet-02b300779e9d895cf
-      - id: subnet-03d8f353b289b025f
-      - id: subnet-0a2fe03b0d88fa078
 ```
 
-When you use `kubectl apply` to apply the Cluster and AWSCluster specifications to the management cluster, Cluster API will use the specified VPC ID and specified subnet IDs, and will not create a new VPC, new subnets, or other associated resources. It _will_, however, create a new ELB and new security groups.
+Although the `networkSpec` does support specifying all the subnet IDs, as mentioned earlier this is not required. It is currently not possible to force Cluster API to use a "subset" of available subnets by providing the list of subnet IDs.
 
-## Configuring the AWSMachine Specification (Optional)
+When you use `kubectl apply` to apply the Cluster and AWSCluster specifications to the management cluster, Cluster API will use the specified VPC ID, will discover the associated subnet IDs, and will not create a new VPC, new subnets, or other associated resources. It _will_, however, create a new ELB and new security groups.
 
-To distribute EC2 instances across different subnets or different AZs, you can add information to the AWSMachine specification. This is optional; without it, Cluster API will deploy to the first private subnet it discovers.
+## Placing EC2 Instances in Specific AZs
+
+To distribute EC2 instances across multiple AZs, you can add information to the Machine specification. This is optional and only necessary if control over AZ placement is desired.
+
+To tell Cluster API that an EC2 instance should be placed in a particular AZ but allow Cluster API to select which subnet in that AZ can be used, add this to the Machine specification:
+
+```yaml
+spec:
+  failureDomain: "us-west-2a"
+```
+
+If using a MachineDeployment, specify AZ placement like so:
+
+```yaml
+spec:
+  template:
+    spec:
+      failureDomain: "us-west-2b"
+```
+
+Note that all replicas within a MachineDeployment will reside in the same AZ.
+
+## Placing EC2 Instances in Specific Subnets
 
 To specify that an EC2 instance should be placed in a specific subnet, add this to the AWSMachine specification:
 
@@ -79,14 +76,17 @@ spec:
     id: subnet-0a3507a5ad2c5c8c3
 ```
 
-To tell Cluster API that an EC2 instance should be placed in a particular AZ but allow Cluster API to select which subnet in that AZ can be used, add this to the AWSMachine specification:
+When using MachineDeployments, users can control subnet selection by adding information to the AWSMachineTemplate associated with that MachineDeployment, like this:
 
 ```yaml
 spec:
-  availabilityZone: "us-west-2a"
+  template:
+    spec:
+      subnet:
+        id: subnet-0a3507a5ad2c5c8c3
 ```
 
-These two settings are mutually exclusive. You may use only one or the other, not both.
+Users may either specify `failureDomain` on the Machine or MachineDeployment objects, _or_ users may explicitly specify subnet IDs on the AWSMachine or AWSMachineTemplate objects. The two settings are mutually exclusive.
 
 ## Caveats/Notes
 

--- a/docs/existing-aws-infrastructure.md
+++ b/docs/existing-aws-infrastructure.md
@@ -13,7 +13,7 @@ In order to have Cluster API consume existing AWS infrastructure, you will need 
 * An Internet gateway for all public subnets
 * Route table associations that provide connectivity to the Internet through a NAT gateway (for private subnets) or the Internet gateway (for public subnets)
 
-Note that a public subnet (and associated Internet gateway) are required for the control plane of the workload cluster.
+Note that a public subnet (and associated Internet gateway) are required even if the control plane of the workload cluster is set to use an internal load balancer.
 
 You will need the ID of the VPC that Cluster API should use. This information is available via the AWS Management Console or the AWS CLI. It is not necessary to have a list of the subnet IDs; Cluster API will discover the subnets if the VPC ID is provided.
 
@@ -21,11 +21,11 @@ Note that there is no need to create an Elastic Load Balancer (ELB), security gr
 
 ## Tagging AWS Resources
 
-Cluster API itself does tag AWS resources it creates. The `sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>` (where `<cluster-name>` matches the `metadata.name` field of the Cluster object) tag, with a value of `owned`, tells Cluster API that it has ownership of the resource and is able to modify the resource and manage the lifecycle of the resource.
+Cluster API itself does tag AWS resources it creates. The `sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>` (where `<cluster-name>` matches the `metadata.name` field of the Cluster object) tag, with a value of `owned`, tells Cluster API that it has ownership of the resource. In this case, Cluster API will modify and manage the lifecycle of the resource.
 
-When consuming existing AWS infrastructure, Cluster API does not require any tags to be present. The absence of the tags on an AWS resource indicates to Cluster API that it should not modify the resource or attempt to manage the lifecycle of the resource.
+When consuming existing AWS infrastructure, the Cluster API AWS provider does not require any tags to be present. The absence of the tags on an AWS resource indicates to Cluster API that it should not modify the resource or attempt to manage the lifecycle of the resource.
 
-However, the AWS cloud provider _does_ require certain tags in order to function properly. Specifically, all subnets where Kubernetes nodes reside should have the `kubernetes.io/cluster/<cluster-name>` tag present. Private subnets should also have the `kubernetes.io/role/internal-elb` tag with a value of 1, and public subnets should have the `kubernetes.io/role/elb` tag with a value of 1. These latter two tags help the cloud provider understand which subnets to use when creating load balancers.
+However, the built-in Kubernetes AWS cloud provider _does_ require certain tags in order to function properly. Specifically, all subnets where Kubernetes nodes reside should have the `kubernetes.io/cluster/<cluster-name>` tag present. Private subnets should also have the `kubernetes.io/role/internal-elb` tag with a value of 1, and public subnets should have the `kubernetes.io/role/elb` tag with a value of 1. These latter two tags help the cloud provider understand which subnets to use when creating load balancers.
 
 Finally, if the controller manager isn't started with the `--configure-cloud-routes: "false"` parameter, the route table(s) will also need the `kubernetes.io/cluster/<cluster-name>` tag. (This parameter can be added by customizing the `KubeadmConfigSpec` object of the `KubeadmControlPlane` object.)
 
@@ -86,7 +86,7 @@ spec:
         id: subnet-0a3507a5ad2c5c8c3
 ```
 
-Users may either specify `failureDomain` on the Machine or MachineDeployment objects, _or_ users may explicitly specify subnet IDs on the AWSMachine or AWSMachineTemplate objects. The two settings are mutually exclusive.
+Users may either specify `failureDomain` on the Machine or MachineDeployment objects, _or_ users may explicitly specify subnet IDs on the AWSMachine or AWSMachineTemplate objects. If both are specified, the subnet ID is used and the `failureDomain` is ignored.
 
 ## Caveats/Notes
 

--- a/docs/existing-aws-infrastructure.md
+++ b/docs/existing-aws-infrastructure.md
@@ -1,0 +1,93 @@
+# Consuming Existing AWS Infrastructure
+
+Normally, Cluster API will create infrastructure on AWS when standing up a new workload cluster. However, it is possible to have Cluster API re-use existing AWS infrastructure instead of creating its own infrastructure. Follow the instructions below to configure Cluster API to consume existing AWS infrastructure.
+
+## Prerequisites
+
+In order to have Cluster API consume existing AWS infrastructure, you will need to have already created the following resources:
+
+* A VPC
+* One or more private subnets (subnets that do not automatically assign a public IP address to EC2 instances)
+* A public subnet in the same Availability Zone (AZ) for each private subnet (this is required for NAT gateways to function properly)
+* A NAT gateway for each private subnet, along with associated Elastic IP addresses
+* An Internet gateway for all public subnets
+* Route table associations that provide connectivity to the Internet through a NAT gateway (for private subnets) or the Internet gateway (for public subnets)
+
+You will need the following information, which can be obtained either via the AWS Management Console or using the AWS CLI:
+
+1. The ID of the VPC
+2. The IDs of the subnets in the VPC that you want Cluster API to use
+
+Note that there is no need to create an Elastic Load Balancer (ELB), security groups, or EC2 instances; Cluster API will take care of these items.
+
+## Tagging AWS Resources
+
+In order for Cluster API to properly recognize and consume existing AWS resources, these resources must be tagged with a specific set of tags. The list below provides the tags that must be present; in this list, `<cluster-name>` refers to the name of cluster as specified in the `metadata.name` field of the Cluster object (or manifest). Here are the tags that are required:
+
+    sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>
+    sigs.k8s.io/cluster-api-provider-aws/role
+
+The values of these tags are immaterial. For the first tag, Cluster API itself uses values of "owned" to indicate a resource that was created by Cluster API and should be destroyed by Cluster API. In the case of consuming existing infrastructure, any value other than "owned" is acceptable. Using the value "unmanaged" is not uncommon.
+
+For the second tag, Cluster API uses the value "common"; you can use that value in this use case as well. **[NEED TO VERIFY]**
+
+Additionally, for proper operation of the AWS cloud provider, your resources should also have the `kubernetes.io/cluster/<cluster-name>` tag present as well.
+
+The tags should be present on the following AWS resources:
+
+* VPC
+* All subnets that Cluster API
+* Route tables
+* Internet gateway
+* NAT gateways
+* Elastic IPs assigned to NAT gateways
+
+
+
+## Configuring the AWSCluster Specification
+
+Specifying existing infrastructure for Cluster API to use takes place in the specification for the AWSCluster object. Specifically, you will need to add an entry with the VPC ID and the IDs of all applicable subnets into the `networkSpec` field. Here is an example:
+
+```yaml
+spec:
+  networkSpec:
+    vpc:
+      id: vpc-0425c335226437144
+    subnets:
+      - id: subnet-07758a9bc904d06af
+      - id: subnet-0a3507a5ad2c5c8c3
+      - id: subnet-02ad6429dd0532452
+      - id: subnet-02b300779e9d895cf
+      - id: subnet-03d8f353b289b025f
+      - id: subnet-0a2fe03b0d88fa078
+```
+
+When you use `kubectl apply` to apply the Cluster and AWSCluster specifications to the management cluster, Cluster API will use the specified VPC ID and specified subnet IDs, and will not create a new VPC, new subnets, or other associated resources. It _will_, however, create a new ELB and new security groups.
+
+## Configuring the AWSMachine Specification (Optional)
+
+**[NEED TO DOUBLE-CHECK THIS WHOLE SECTION]**
+
+To distribute EC2 instances across different subnets or different AZs, you can add information to the AWSMachine specification. This is optional; without it, Cluster API will deploy to the first private subnet it discovers.
+
+To specify that an EC2 instance should be placed in a specific subnet, add this to the AWSMachine specification:
+
+```yaml
+spec:
+  subnet:
+    id: subnet-0a3507a5ad2c5c8c3
+```
+
+To tell Cluster API that an EC2 instance should be placed in a particular AZ but allow Cluster API to select which subnet in that AZ can be used, add this to the AWSMachine specification:
+
+```yaml
+spec:
+  availabilityZone: "us-west-2a"
+```
+
+These two settings are mutually exclusive. You may use only one or the other, not both.
+
+## Caveats/Notes
+
+* If both public and private subnets are available in an AZ, CAPI will choose the private subnet in the AZ over the public subnet.
+* If you configure CAPI to use existing infrastructure as outlined above, CAPI will _not_ create an SSH bastion host. Combined with the previous bullet, this means you must make sure you have established some form of connectivity to the instances that CAPI will create.


### PR DESCRIPTION
This PR adds instructions for re-using existing AWS infrastructure. This includes information on configuring existing AWS resources as well as instructions for properly configuring CAPI manifests.

**What this PR does / why we need it**:
This PR adds a document explaining how users can use or consume existing AWS infrastructure with Cluster API, and updates the `docs/README.md` document with a link to the new document.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1511 
