### PR TITLE
🐛 fix error handling when creating AWS secrets

### DIFF
--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -41,6 +41,6 @@ type EC2MachineInterface interface {
 // SecretsManagerInterface encapsulated the methods exposed to the
 // machine actuator
 type SecretsManagerInterface interface {
-	Delete(m *scope.MachineScope) error
+	Delete(prefix string, chunkCount int32) error
 	Create(m *scope.MachineScope, data []byte) (string, int32, error)
 }

--- a/pkg/cloud/services/mock_services/secretsmanager_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/secretsmanager_machine_interface_mock.go
@@ -66,15 +66,15 @@ func (mr *MockSecretsManagerInterfaceMockRecorder) Create(arg0, arg1 interface{}
 }
 
 // Delete mocks base method
-func (m *MockSecretsManagerInterface) Delete(arg0 *scope.MachineScope) error {
+func (m *MockSecretsManagerInterface) Delete(arg0 string, arg1 int32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete
-func (mr *MockSecretsManagerInterfaceMockRecorder) Delete(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsManagerInterfaceMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSecretsManagerInterface)(nil).Delete), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSecretsManagerInterface)(nil).Delete), arg0, arg1)
 }

--- a/pkg/cloud/services/secretsmanager/secret.go
+++ b/pkg/cloud/services/secretsmanager/secret.go
@@ -75,12 +75,12 @@ func (s *Service) Create(m *scope.MachineScope, data []byte) (string, int32, err
 }
 
 // Delete the secret belonging to a machine from AWS Secrets Manager
-func (s *Service) Delete(m *scope.MachineScope) error {
+func (s *Service) Delete(prefix string, chunkCount int32) error {
 	var errors []error
 
-	for i := int32(0); i < m.GetSecretCount(); i++ {
+	for i := int32(0); i < chunkCount; i++ {
 		_, err := s.scope.SecretsManager.DeleteSecret(&secretsmanager.DeleteSecretInput{
-			SecretId:                   aws.String(fmt.Sprintf("%s-%d", m.GetSecretPrefix(), i)),
+			SecretId:                   aws.String(fmt.Sprintf("%s-%d", prefix, i)),
 			ForceDeleteWithoutRecovery: aws.Bool(true),
 		})
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Does not persist partially created secrets to the API server, instead immediately attempt deletion and return.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1561 

