### PR TITLE
🐛 secrets manager: fix error handling when creating secrets (0.4 canonical)

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -448,57 +448,54 @@ func (r *AWSMachineReconciler) getOrCreate(scope *scope.MachineScope, ec2svc ser
 		return nil, err
 	}
 
-	if instance == nil {
-		scope.Info("Creating EC2 instance")
-		// Create a new AWSMachine instance if we couldn't find a running instance.
+	// If we find an instance, return it
+	if instance != nil {
+		return instance, nil
+	}
+	// Otherwise create a new instance
+	scope.Info("Creating EC2 instance")
 
-		userData, err := scope.GetRawBootstrapData()
+	userData, err := scope.GetRawBootstrapData()
+	if err != nil {
+		r.Recorder.Eventf(scope.AWSMachine, corev1.EventTypeWarning, "FailedGetBootstrapData", err.Error())
+		return nil, err
+	}
+
+	if scope.UseSecretsManager() {
+		compressedUserData, err := userdata.GzipBytes(userData)
 		if err != nil {
-			r.Recorder.Eventf(scope.AWSMachine, corev1.EventTypeWarning, "FailedGetBootstrapData", err.Error())
 			return nil, err
 		}
-
-		if scope.UseSecretsManager() {
-			compressedUserData, err := userdata.GzipBytes(userData)
-			if err != nil {
+		prefix, chunks, serviceErr := secretSvc.Create(scope, compressedUserData)
+		// Only persist the AWS Secrets Manager entries if there is at least one
+		if chunks > 0 {
+			if err := scope.SetSecretPrefix(prefix); err != nil {
 				return nil, err
 			}
-			// Do an initial check in case manager was terminated prematurely
-			if scope.GetSecretPrefix() == "" {
-				prefix, chunks, err := secretSvc.Create(scope, compressedUserData)
-				if err := scope.SetSecretPrefix(prefix); err != nil {
-					return nil, err
-				}
-				if err := scope.SetSecretCount(chunks); err != nil {
-					return nil, err
-				}
-				if err != nil {
-					r.Recorder.Eventf(scope.AWSMachine, corev1.EventTypeWarning, "FailedCreateAWSSecretsManagerSecrets", err.Error())
-					scope.Error(err, "Failed to create AWS Secret entry", "secretPrefix", prefix)
-					delErr := secretSvc.Delete(scope)
-					if delErr != nil {
-						scope.Error(delErr, "Failed to clean up AWS Secret entries", "secretPrefix", prefix)
-						return nil, delErr
-					}
-					return nil, err
-				}
-			}
-			// Register the Secret ARN immediately to avoid orphaning AWS resources on delete
-			if err := scope.PatchObject(); err != nil {
+			if err := scope.SetSecretCount(chunks); err != nil {
 				return nil, err
 			}
-			encryptedCloudInit, err := secretsmanager.GenerateCloudInitMIMEDocument(scope.GetSecretPrefix(), scope.GetSecretCount(), scope.AWSCluster.Spec.Region)
-			if err != nil {
-				r.Recorder.Eventf(scope.AWSMachine, corev1.EventTypeWarning, "FailedGenerateAWSSecretsManagerCloudInit", err.Error())
-				return nil, err
-			}
-			userData = encryptedCloudInit
 		}
-
-		instance, err = ec2svc.CreateInstance(scope, userData)
+		// Register the Secret ARN immediately to avoid orphaning whatever AWS resources have been created
+		if err := scope.PatchObject(); err != nil {
+			return nil, err
+		}
+		if serviceErr != nil {
+			r.Recorder.Eventf(scope.AWSMachine, corev1.EventTypeWarning, "FailedCreateAWSSecretsManagerSecrets", serviceErr.Error())
+			scope.Error(serviceErr, "Failed to create AWS Secret entry", "secretPrefix", prefix)
+			return nil, serviceErr
+		}
+		encryptedCloudInit, err := secretsmanager.GenerateCloudInitMIMEDocument(scope.GetSecretPrefix(), scope.GetSecretCount(), scope.AWSCluster.Spec.Region)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create AWSMachine instance")
+			r.Recorder.Eventf(scope.AWSMachine, corev1.EventTypeWarning, "FailedGenerateAWSSecretsManagerCloudInit", err.Error())
+			return nil, err
 		}
+		userData = encryptedCloudInit
+	}
+
+	instance, err = ec2svc.CreateInstance(scope, userData)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create AWSMachine instance")
 	}
 
 	return instance, nil

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -413,16 +413,15 @@ var _ = Describe("AWSMachineReconciler", func() {
 					SecretPrefix:               "secret",
 					SecretCount:                5,
 				}
-				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
-				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
+				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
 			})
 
 			It("should delete the secret if the instance is running", func() {
 				instance.State = infrav1.InstanceStateRunning
 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
 					Return(map[string][]string{"eid": {}}, nil).Times(1)
-				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
 			})
 
@@ -435,12 +434,14 @@ var _ = Describe("AWSMachineReconciler", func() {
 			It("should delete the secret if the AWSMachine is deleted", func() {
 				instance.State = infrav1.InstanceStateRunning
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs)
 			})
 
 			It("should delete the secret if the AWSMachine is in a failure condition", func() {
 				ms.AWSMachine.Status.ErrorReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs)
 			})
 
@@ -456,8 +457,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 					SecretPrefix:               "secret",
 					SecretCount:                5,
 				}
-				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
-				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
+				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
 			})
 
 			It("should not delete the secret if the instance is running", func() {
@@ -478,15 +478,44 @@ var _ = Describe("AWSMachineReconciler", func() {
 			It("should delete the secret if the AWSMachine is deleted", func() {
 				instance.State = infrav1.InstanceStateRunning
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs)
 			})
 
 			It("should delete the secret if the AWSMachine is in a failure condition", func() {
 				ms.AWSMachine.Status.ErrorReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs)
 			})
+		})
 
+		When("there is an intermittent connection issue and no secret could be stored", func() {
+			BeforeEach(func() {
+				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
+			})
+			It("should error and then succeed on the second reconciliation", func() {
+				ms.AWSMachine.Spec.CloudInit = &infrav1.CloudInit{
+					EnableSecureSecretsManager: true,
+				}
+				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(0), errors.New("connection error")).Times(1)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				Expect(err).ToNot(BeNil())
+				Expect(ms.GetSecretPrefix()).To(Equal(""))
+				Expect(ms.GetSecretCount()).To(Equal(int32(0)))
+				instance = &infrav1.Instance{
+					ID: "myMachine",
+				}
+				instance.State = infrav1.InstanceStatePending
+				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(10), nil).Times(1)
+				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
+				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
+				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
+				_, err = reconciler.reconcileNormal(context.Background(), ms, cs)
+				Expect(err).To(BeNil())
+				Expect(ms.GetSecretPrefix()).To(Equal(secretPrefix))
+				Expect(ms.GetSecretCount()).To(Equal(int32(10)))
+			})
 		})
 
 	})

--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,5 @@ require (
 	sigs.k8s.io/controller-runtime v0.3.0
 	sigs.k8s.io/yaml v1.1.0
 )
+
+replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190918200256-06eb1244587a

--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -39,6 +39,7 @@ const (
 	InvalidSubnet           = "InvalidSubnet"
 	AssociationIDNotFound   = "InvalidAssociationID.NotFound"
 	InvalidInstanceID       = "InvalidInstanceID.NotFound"
+	ResourceExists          = "ResourceExistsException"
 )
 
 var _ error = &EC2Error{}
@@ -85,6 +86,13 @@ func NewConflict(err error) error {
 		err:  err,
 		Code: http.StatusConflict,
 	}
+}
+
+func IsResourceExists(err error) bool {
+	if code, ok := Code(err); ok {
+		return code == ResourceExists
+	}
+	return false
 }
 
 // NewFailedDependency returns a new error which indicates that a dependency failure status

--- a/pkg/cloud/services/secretsmanager/secret.go
+++ b/pkg/cloud/services/secretsmanager/secret.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 )
 
 const (
@@ -37,6 +38,13 @@ const (
 	// but the aws sdk handles encoding for us, so we can't send a full 10240.
 	maxSecretSizeBytes = 7000
 )
+
+var retryableErrors = []string{
+	// Returned when the secret is scheduled for deletion
+	secretsmanager.ErrCodeInvalidRequestException,
+	// Returned during retries of deletes prior to recreation
+	secretsmanager.ErrCodeResourceNotFoundException,
+}
 
 // Create stores data in AWS Secrets Manager for a given machine, chunking at 10kb per secret. The prefix of the secret
 // ARN and the number of chunks are returned.
@@ -53,20 +61,19 @@ func (s *Service) Create(m *scope.MachineScope, data []byte) (string, int32, err
 	})
 
 	// Build the prefix.
-	prefix := path.Join(entryPrefix, string(uuid.NewUUID()))
-
+	prefix := m.GetSecretPrefix()
+	if prefix == "" {
+		prefix = path.Join(entryPrefix, string(uuid.NewUUID()))
+	}
 	// Split the data into chunks and create the secrets on demand.
 	var err error
 	chunks := int32(0)
 	splitBytes(data, maxSecretSizeBytes, func(chunk []byte) {
 		name := fmt.Sprintf("%s-%d", prefix, chunks)
-		_, callErr := s.scope.SecretsManager.CreateSecret(&secretsmanager.CreateSecretInput{
-			Name:         aws.String(name),
-			SecretBinary: chunk,
-			Tags:         converters.MapToSecretsManagerTags(tags),
-		})
-		if callErr != nil {
-			err = kerrors.NewAggregate([]error{callErr})
+		retryFunc := func() (bool, error) { return s.retryableCreateSecret(name, chunk, tags) }
+		// Default timeout is 5 mins, but if Secrets Manager has got to the state where the timeout is reached,
+		// makes sense to slow down machine creation until AWS weather improves.
+		if err = wait.WaitForWithRetryable(wait.NewBackoff(), retryFunc, retryableErrors...); err != nil {
 			return
 		}
 		chunks++
@@ -75,23 +82,43 @@ func (s *Service) Create(m *scope.MachineScope, data []byte) (string, int32, err
 	return prefix, chunks, err
 }
 
+// retryableCreateSecret is a function to be passed into a waiter. In a separate function for ease of reading
+func (s *Service) retryableCreateSecret(name string, chunk []byte, tags infrav1.Tags) (bool, error) {
+	_, err := s.scope.SecretsManager.CreateSecret(&secretsmanager.CreateSecretInput{
+		Name:         aws.String(name),
+		SecretBinary: chunk,
+		Tags:         converters.MapToSecretsManagerTags(tags),
+	})
+	// If the secret already exists, delete it, return request to retry, as deletes are eventually consistent
+	if awserrors.IsResourceExists(err) {
+		return false, s.forceDeleteSecretEntry(name)
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, err
+}
+
+// forceDeleteSecretEntry deletes a single secret, ignoring if it is absent
+func (s *Service) forceDeleteSecretEntry(name string) error {
+	_, err := s.scope.SecretsManager.DeleteSecret(&secretsmanager.DeleteSecretInput{
+		SecretId:                   aws.String(name),
+		ForceDeleteWithoutRecovery: aws.Bool(true),
+	})
+	if awserrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 // Delete the secret belonging to a machine from AWS Secrets Manager
 func (s *Service) Delete(m *scope.MachineScope) error {
-	var errors []error
-
+	var errs []error
 	for i := int32(0); i < m.GetSecretCount(); i++ {
-		_, err := s.scope.SecretsManager.DeleteSecret(&secretsmanager.DeleteSecretInput{
-			SecretId:                   aws.String(fmt.Sprintf("%s-%d", m.GetSecretPrefix(), i)),
-			ForceDeleteWithoutRecovery: aws.Bool(true),
-		})
-
-		if awserrors.IsNotFound(err) {
-			continue
-		}
-		if err != nil {
-			errors = append(errors, err)
+		if err := s.forceDeleteSecretEntry(fmt.Sprintf("%s-%d", m.GetSecretPrefix(), i)); err != nil {
+			errs = append(errs, err)
 		}
 	}
 
-	return kerrors.NewAggregate(errors)
+	return kerrors.NewAggregate(errs)
 }

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -1171,12 +1171,6 @@ func makeJoinBootstrapConfigTemplate(namespace, name string) {
 							KubeletExtraArgs: map[string]string{"cloud-provider": "aws"},
 						},
 					},
-					Files: []bootstrapv1.File{
-						{
-							Path:    "/tmp/userdata-length-test.txt",
-							Content: apirand.String(20000),
-						},
-					},
 				},
 			},
 		},
@@ -1483,6 +1477,12 @@ func makeInitBootstrapConfig(namespace, name string) {
 					KubeletExtraArgs: map[string]string{"cloud-provider": "aws"},
 				},
 			},
+			Files: []bootstrapv1.File{
+				{
+					Path:    "/tmp/userdata-length-test.txt",
+					Content: apirand.String(20000),
+				},
+			},
 		},
 	}
 	Expect(kindClient.Create(context.TODO(), config)).To(Succeed())
@@ -1499,6 +1499,9 @@ func makeAWSMachine(namespace, name, instanceType string, az, subnetId *string) 
 			InstanceType:       instanceType,
 			IAMInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io",
 			SSHKeyName:         keyPairName,
+			CloudInit: &infrav1.CloudInit{
+				EnableSecureSecretsManager: true,
+			},
 		},
 	}
 	if az != nil {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -94,7 +94,7 @@ var (
 	cabpkComponents = capiFlag.DefineOrLookupStringFlag("cabpkComponents", "https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/"+CABPK_VERSION+"/bootstrap-components.yaml", "URL to CAPI components to load")
 	capaComponents  = capiFlag.DefineOrLookupStringFlag("capaComponents", "", "capa components to load")
 	kustomizeBinary = capiFlag.DefineOrLookupStringFlag("kustomizeBinary", "kustomize", "path to the kustomize binary")
-	k8sVersion      = capiFlag.DefineOrLookupStringFlag("k8sVersion", "v1.16.0", "kubernetes version to test on")
+	k8sVersion      = capiFlag.DefineOrLookupStringFlag("k8sVersion", "v1.17.2", "kubernetes version to test on")
 	sonobuoyVersion = capiFlag.DefineOrLookupStringFlag("sonobuoyVersion", "v0.16.2", "sonobuoy version")
 
 	kindCluster  kind.Cluster


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1561

Updates state machine of secrets to handle intermittent failures by retrying creation of secrets, and making sure secrets are deleted prior to creation.