### PR TITLE
🐛 tagging: skip non-existing root device when tagging

### DIFF
--- a/controllers/awsmachine_tags.go
+++ b/controllers/awsmachine_tags.go
@@ -68,6 +68,11 @@ func (r *AWSMachineReconciler) ensureTags(svc service.EC2MachineInterface, machi
 }
 
 func (r *AWSMachineReconciler) ensureRootDeviceTags(svc service.EC2MachineInterface, instance *infrav1.Instance, additionalTags map[string]string) error {
+	// Do not attempt to tag if the root device ID is not present (e.g. EC2 instance state Pending)
+	if instance.RootDeviceID == "" {
+		return nil
+	}
+
 	input := make(map[string]interface{})
 	for k, v := range instance.RootDeviceTags {
 		input[k] = v


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Introduction of Secrets Manager brought in new EC2 instance state handling, widening the states in which instance tagging is created. However, EBS root volumes shouldn't be tagged when the instance is Pending.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1564 

