### PR TITLE
Sets the kustomize_dir

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -4,6 +4,7 @@
     "image": "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller",
     "live_reload_deps": [
       "main.go", "go.mod", "go.sum", "api", "cmd", "controllers", "pkg"
-    ]
+    ],
+    "kustomize_dir": "./config/default"
   }
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes the error below:
```
  RESOURCE NAME                                                                                                                               CONTAINER •  UPDATE STATUS  •    AS OF
▼ ● (Tiltfile) ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ N/A             • <15s ago
    HISTORY: EDITED FILES Tiltfile                                                                                                                        Error    (8.0s) • <15s ago
    ERROR:
         <builtin>: in kustomize
       Error: command ["kustomize" "build" "/Users/mvillacorta/git/newrelic/cluster-api-provider-aws/config"] failed.
       error: exit status 1
       stdout: ""
       stderr: "Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory
       '/Users/mvillacorta/git/newrelic/cluster-api-provider-aws/config'\n"
```

Related to: https://github.com/kubernetes-sigs/cluster-api/pull/2349