### PR TITLE
:running: Do not set xtrace in hack/ensure-kind.sh

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -18,8 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-set -x
-
 GOPATH_BIN="$(go env GOPATH)/bin/"
 MINIMUM_KIND_VERSION=v0.6.1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not set xtrace in hack/ensure-kind.sh

