### PR TITLE
Adds the capa-aggregated-manager-role

### DIFF
--- a/config/rbac/aggregated_role.yaml
+++ b/config/rbac/aggregated_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregated-manager-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cluster.x-k8s.io/aggregate-to-manager: "true"
+rules: []

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- aggregated_role.yaml
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes the error below in CAPA logs:
```
E0219 09:46:31.795354       7 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1alpha3.AWSCluster: awsclusters.infrastructure.cluster.x-k8s.io is forbidden: User "system:serviceaccount:capa-system:default" cannot list resource "awsclusters" in API group "infrastructure.cluster.x-k8s.io" at the cluster scope: RBAC: clusterrole.rbac.authorization.k8s.io "aggregated-manager-role" not found
```

I got this error after merging the PRs below:
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1577
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1575