### PR TITLE
✨ Backport clusterctl labels to CAPA components

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,8 +12,8 @@ namespace: capa-system
 namePrefix: capa-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "infrastructure-aws"
 
 resources:
 - ../crd


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR backports the clusterctl labels to v1alpha2 version of CAPA.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref https://github.com/kubernetes-sigs/cluster-api/pull/2112
Ref https://github.com/kubernetes-sigs/cluster-api/issues/1989

**Special notes for your reviewer**:
[Slack conversation for context](https://kubernetes.slack.com/archives/C8TSNPY4T/p1582129372253200)

/assign @fabriziopandini 
/assign @randomvariable 