### PR TITLE
🐛capi's local-overrides.py can't find a kustomization.yaml

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -3,6 +3,7 @@
   "config": {
     "componentsFile": "infrastructure-components.yaml",
     "nextVersion": "v0.5.0",
-    "type": "InfrastructureProvider"
+    "type": "InfrastructureProvider",
+    "configFolder": "config/default"
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

To fix CAPI's `local-overrides.py`, otherwise it will try to do 
```
kustomize build ../cluster-api-provider-aws/config
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/tmp/projects/cluster-api-provider-aws/config'
```