### PR TITLE
🐛 fix clusterctl-settings.json

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -1,8 +1,7 @@
 {
-  "name": "aws",
+  "name": "infrastructure-aws",
   "config": {
     "componentsFile": "infrastructure-components.yaml",
-    "nextVersion": "v0.5.0",
-    "type": "InfrastructureProvider"
+    "nextVersion": "v0.5.0"
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes clusterctl-settings.json after changes introduced by https://github.com/kubernetes-sigs/cluster-api/pull/2355

/assing @vincepri 
/assing @randomvariable 

