### PR TITLE
:warning: instances do not require an SSH keypair

### DIFF
--- a/api/v1alpha2/awscluster_conversion.go
+++ b/api/v1alpha2/awscluster_conversion.go
@@ -127,6 +127,9 @@ func Convert_v1alpha2_AWSClusterSpec_To_v1alpha3_AWSClusterSpec(in *AWSClusterSp
 	// Manually convert Bastion.
 	out.Bastion.Enabled = !in.DisableBastionHost
 
+	// Manually convert SSHKeyName
+	out.SSHKeyName = &in.SSHKeyName
+
 	return nil
 }
 

--- a/api/v1alpha2/awsmachine_conversion.go
+++ b/api/v1alpha2/awsmachine_conversion.go
@@ -87,6 +87,9 @@ func Convert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachineSp
 	// Manually convert dst.Spec.FailureDomain.
 	out.FailureDomain = in.AvailabilityZone
 
+	// Manually convert SSHKeyName
+	out.SSHKeyName = &in .SSHKeyName
+
 	if in.CloudInit == nil {
 		out.CloudInit.InsecureSkipSecretsManager = true
 	} else if err := Convert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(in.CloudInit, &out.CloudInit, s); err != nil {

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -36,7 +36,7 @@ type AWSClusterSpec struct {
 	Region string `json:"region,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the bastion host.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -81,7 +81,7 @@ type AWSMachineSpec struct {
 	Subnet *AWSResourceReference `json:"subnet,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the instance.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// RootVolume encapsulates the configuration options for the root volume
 	// +optional

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *AWSClusterList) DeepCopyObject() runtime.Object {
 func (in *AWSClusterSpec) DeepCopyInto(out *AWSClusterSpec) {
 	*out = *in
 	in.NetworkSpec.DeepCopyInto(&out.NetworkSpec)
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
+	}
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags
@@ -260,6 +265,11 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
 	}
 	if in.RootVolume != nil {
 		in, out := &in.RootVolume, &out.RootVolume

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -139,9 +139,16 @@ func (s *Service) getDefaultBastion() *infrav1.Instance {
 	name := fmt.Sprintf("%s-bastion", s.scope.Name())
 	userData, _ := userdata.NewBastion(&userdata.BastionInput{})
 
-	keyName := defaultSSHKeyName
-	if s.scope.AWSCluster.Spec.SSHKeyName != "" {
-		keyName = s.scope.AWSCluster.Spec.SSHKeyName
+	// If SSHKeyName WAS NOT provided (nil) then use the defaultSSHKeyName
+	// If SSHKeyName WAS provided _but is an empty string_, do not set a key pair
+	// Otherwise (SSHKeyName WAS provided and is NOT an empty string), use the provided key pair name
+	var keyName string
+	if s.scope.AWSCluster.Spec.SSHKeyName != nil {
+		if *s.scope.AWSCluster.Spec.SSHKeyName != "" {
+			keyName = *s.scope.AWSCluster.Spec.SSHKeyName
+		}
+	} else {
+		keyName = defaultSSHKeyName
 	}
 
 	i := &infrav1.Instance{

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -210,11 +210,19 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 	input.SecurityGroupIDs = append(input.SecurityGroupIDs, ids...)
 
 	// Pick SSH key, if any.
-	input.SSHKeyName = aws.String(defaultSSHKeyName)
-	if scope.AWSMachine.Spec.SSHKeyName != "" {
-		input.SSHKeyName = aws.String(scope.AWSMachine.Spec.SSHKeyName)
-	} else if scope.AWSCluster.Spec.SSHKeyName != "" {
-		input.SSHKeyName = aws.String(scope.AWSCluster.Spec.SSHKeyName)
+	// If SSHKeyName WAS NOT provided (nil) then use the defaultSSHKeyName
+	// If SSHKeyName WAS provided *but is an empty string*, do not set a key pair
+	// Otherwise (SSHKeyName WAS provided and is NOT an empty string), use the provided key pair name
+	if scope.AWSMachine.Spec.SSHKeyName != nil {
+		if *scope.AWSMachine.Spec.SSHKeyName != "" {
+			input.SSHKeyName = scope.AWSMachine.Spec.SSHKeyName
+		}
+	} else if scope.AWSCluster.Spec.SSHKeyName != nil {
+		if *scope.AWSCluster.Spec.SSHKeyName != "" {
+			input.SSHKeyName = scope.AWSCluster.Spec.SSHKeyName
+		}
+	} else {
+		input.SSHKeyName = aws.String(defaultSSHKeyName)
 	}
 
 	s.scope.V(2).Info("Running instance", "machine-role", scope.Role())


### PR DESCRIPTION
**What this PR does / why we need it**: Allows instances to be provisioned with no SSH key pair specified. Organizations which have policies denying the use of SSH key pairs can now set the SSH key name value to "" to launch instances without a key pair set. A nil value still sets the default key pair name.

Fixes #1156
