### PR TITLE
use a default value for AWS_REGION when creating examples

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -37,6 +37,15 @@ export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"
 export NODE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"
 export SSH_KEY_NAME="${SSH_KEY_NAME:-default}"
 
+# Check if AWS_REGION variable exists. If not, set this to some random region
+if [ -z "${AWS_REGION+x}" ]
+then
+  echo "AWS_REGION variable is empty using us-east-1 as default"
+  export AWS_REGION="us-east-1"
+else
+  echo "AWS_REGION is set to $AWS_REGION"
+fi
+
 # Outputs.
 COMPONENTS_CLUSTER_API_GENERATED_FILE=${SOURCE_DIR}/provider-components/provider-components-cluster-api.yaml
 COMPONENTS_AWS_GENERATED_FILE=${SOURCE_DIR}/provider-components/provider-components-aws.yaml


### PR DESCRIPTION
When I run `make generate-examples` I get the following error. 

```
./examples/generate.sh
Generated /home/manohar/kubernetes/cluster-api-provider-aws/examples/_out/cert-manager.yaml
Error: environment variable "AWS_REGION" not found
Usage:
  clusterawsadm alpha bootstrap encode-aws-credentials [flags]
Flags:
  -h, --help   help for encode-aws-credentials
Global Flags:
      --partition string   AWS partition, for AWS GovCloud (US) it is aws-us-gov (default "aws")
environment variable "AWS_REGION" not found
Makefile:182: recipe for target 'generate-examples' failed
make: *** [generate-examples] Error 1
```
This means that the environment variable `AWS_REGION` is not set. 

Since this is only for the sake of generating examples, we can use any default for this variable. If variable is already set, we can continue with already existing value. 

So made changes to check if the variable exists and set to `us-east-1` if the variables doesn't exist.

