### PR TITLE
:warning: Update node instance profile to add support for Session Manager

### DIFF
--- a/pkg/cloud/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/services/cloudformation/bootstrap.go
@@ -263,10 +263,27 @@ func bootstrapSecretPolicy(partition string) iam.StatementEntry {
 	}
 }
 
+func sessionManagerPolicy() iam.StatementEntry {
+	return iam.StatementEntry{
+		Effect:   iam.EffectAllow,
+		Resource: iam.Resources{"*"},
+		Action: iam.Actions{
+			"ssm:UpdateInstanceInformation",
+			"ssmmessages:CreateControlChannel",
+			"ssmmessages:CreateDataChannel",
+			"ssmmessages:OpenControlChannel",
+			"ssmmessages:OpenDataChannel",
+			"s3:GetEncryptionConfiguration",
+		},
+	}
+}
+
 func nodePolicy(partition string) *iam.PolicyDocument {
 	policyDocument := cloudProviderNodeAwsPolicy()
 	policyDocument.Statement = append(
-		policyDocument.Statement, bootstrapSecretPolicy(partition),
+		policyDocument.Statement,
+		bootstrapSecretPolicy(partition),
+		sessionManagerPolicy(),
 	)
 	return policyDocument
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the node instance profile with the required policy to allow the use of AWS Session Manager for connecting with the instances created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1553 

