### PR TITLE
:bug: Ensure that leader election is still enabled after applying auth proxy

### DIFF
--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -22,3 +22,4 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where leader election was no longer enabled for the controller manager

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1594 
/milestone v0.5.0-rc.0

