### PR TITLE
:warning: 1156 allow no key pair v1alpha3 2020

### DIFF
--- a/api/v1alpha2/awscluster_conversion_test.go
+++ b/api/v1alpha2/awscluster_conversion_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+)
+
+func TestConvertAWSCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("from hub", func(t *testing.T) {
+		t.Run("should restore SSHKeyName, retaining a nil value", func(t *testing.T) {
+			src := &infrav1alpha3.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: infrav1alpha3.AWSClusterSpec{
+					SSHKeyName: nil,
+				},
+			}
+			dst := &AWSCluster{}
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			restored := &infrav1alpha3.AWSCluster{}
+			g.Expect(dst.ConvertTo(restored)).To(Succeed())
+			g.Expect(restored.Spec.SSHKeyName).To(BeNil())
+		})
+	})
+
+}

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -24,7 +24,8 @@ import (
 	time "time"
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	v1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
@@ -409,7 +410,9 @@ func autoConvert_v1alpha2_AWSClusterSpec_To_v1alpha3_AWSClusterSpec(in *AWSClust
 		return err
 	}
 	out.Region = in.Region
-	out.SSHKeyName = in.SSHKeyName
+	if err := v1.Convert_string_To_Pointer_string(&in.SSHKeyName, &out.SSHKeyName, s); err != nil {
+		return err
+	}
 	out.AdditionalTags = *(*v1alpha3.Tags)(unsafe.Pointer(&in.AdditionalTags))
 	if in.ControlPlaneLoadBalancer != nil {
 		in, out := &in.ControlPlaneLoadBalancer, &out.ControlPlaneLoadBalancer
@@ -429,7 +432,9 @@ func autoConvert_v1alpha3_AWSClusterSpec_To_v1alpha2_AWSClusterSpec(in *v1alpha3
 		return err
 	}
 	out.Region = in.Region
-	out.SSHKeyName = in.SSHKeyName
+	if err := v1.Convert_Pointer_string_To_string(&in.SSHKeyName, &out.SSHKeyName, s); err != nil {
+		return err
+	}
 	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
 	out.AdditionalTags = *(*Tags)(unsafe.Pointer(&in.AdditionalTags))
 	if in.ControlPlaneLoadBalancer != nil {
@@ -570,7 +575,9 @@ func autoConvert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachi
 	out.AdditionalSecurityGroups = *(*[]v1alpha3.AWSResourceReference)(unsafe.Pointer(&in.AdditionalSecurityGroups))
 	// WARNING: in.AvailabilityZone requires manual conversion: does not exist in peer-type
 	out.Subnet = (*v1alpha3.AWSResourceReference)(unsafe.Pointer(in.Subnet))
-	out.SSHKeyName = in.SSHKeyName
+	if err := v1.Convert_string_To_Pointer_string(&in.SSHKeyName, &out.SSHKeyName, s); err != nil {
+		return err
+	}
 	// WARNING: in.RootDeviceSize requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
@@ -591,7 +598,9 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	out.AdditionalSecurityGroups = *(*[]AWSResourceReference)(unsafe.Pointer(&in.AdditionalSecurityGroups))
 	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	out.Subnet = (*AWSResourceReference)(unsafe.Pointer(in.Subnet))
-	out.SSHKeyName = in.SSHKeyName
+	if err := v1.Convert_Pointer_string_To_string(&in.SSHKeyName, &out.SSHKeyName, s); err != nil {
+		return err
+	}
 	// WARNING: in.RootVolume requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
@@ -600,7 +609,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 
 func autoConvert_v1alpha2_AWSMachineStatus_To_v1alpha3_AWSMachineStatus(in *AWSMachineStatus, out *v1alpha3.AWSMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*v1alpha3.InstanceState)(unsafe.Pointer(in.InstanceState))
 	// WARNING: in.ErrorReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.ErrorMessage requires manual conversion: does not exist in peer-type
@@ -609,7 +618,7 @@ func autoConvert_v1alpha2_AWSMachineStatus_To_v1alpha3_AWSMachineStatus(in *AWSM
 
 func autoConvert_v1alpha3_AWSMachineStatus_To_v1alpha2_AWSMachineStatus(in *v1alpha3.AWSMachineStatus, out *AWSMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*InstanceState)(unsafe.Pointer(in.InstanceState))
 	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureMessage requires manual conversion: does not exist in peer-type
@@ -968,7 +977,7 @@ func autoConvert_v1alpha2_Instance_To_v1alpha3_Instance(in *Instance, out *v1alp
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
 	out.UserData = (*string)(unsafe.Pointer(in.UserData))
 	out.IAMProfile = in.IAMProfile
-	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.PrivateIP = (*string)(unsafe.Pointer(in.PrivateIP))
 	out.PublicIP = (*string)(unsafe.Pointer(in.PublicIP))
 	out.ENASupport = (*bool)(unsafe.Pointer(in.ENASupport))
@@ -989,7 +998,7 @@ func autoConvert_v1alpha3_Instance_To_v1alpha2_Instance(in *v1alpha3.Instance, o
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
 	out.UserData = (*string)(unsafe.Pointer(in.UserData))
 	out.IAMProfile = in.IAMProfile
-	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.PrivateIP = (*string)(unsafe.Pointer(in.PrivateIP))
 	out.PublicIP = (*string)(unsafe.Pointer(in.PublicIP))
 	out.ENASupport = (*bool)(unsafe.Pointer(in.ENASupport))

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -35,8 +35,9 @@ type AWSClusterSpec struct {
 	// The AWS Region the cluster lives in.
 	Region string `json:"region,omitempty"`
 
-	// SSHKeyName is the name of the ssh key to attach to the bastion host.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	// SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
+	// +optional
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -80,8 +80,9 @@ type AWSMachineSpec struct {
 	// +optional
 	Subnet *AWSResourceReference `json:"subnet,omitempty"`
 
-	// SSHKeyName is the name of the ssh key to attach to the instance.
-	SSHKeyName string `json:"sshKeyName,omitempty"`
+	// SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
+	// +optional
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// RootVolume encapsulates the configuration options for the root volume
 	// +optional

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *AWSClusterList) DeepCopyObject() runtime.Object {
 func (in *AWSClusterSpec) DeepCopyInto(out *AWSClusterSpec) {
 	*out = *in
 	in.NetworkSpec.DeepCopyInto(&out.NetworkSpec)
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
+	}
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags
@@ -260,6 +265,11 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SSHKeyName != nil {
+		in, out := &in.SSHKeyName, &out.SSHKeyName
+		*out = new(string)
+		**out = **in
 	}
 	if in.RootVolume != nil {
 		in, out := &in.RootVolume, &out.RootVolume

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -596,7 +596,8 @@ spec:
                 type: string
               sshKeyName:
                 description: SSHKeyName is the name of the ssh key to attach to the
-                  bastion host.
+                  bastion host. Valid values are empty string (do not use SSH keys),
+                  a valid SSH key name, or omitted (use the default SSH key name)
                 type: string
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -493,7 +493,8 @@ spec:
                 type: object
               sshKeyName:
                 description: SSHKeyName is the name of the ssh key to attach to the
-                  instance.
+                  instance. Valid values are empty string (do not use SSH keys), a
+                  valid SSH key name, or omitted (use the default SSH key name)
                 type: string
               subnet:
                 description: Subnet is a reference to the subnet to use for this instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -454,7 +454,9 @@ spec:
                         type: object
                       sshKeyName:
                         description: SSHKeyName is the name of the ssh key to attach
-                          to the instance.
+                          to the instance. Valid values are empty string (do not use
+                          SSH keys), a valid SSH key name, or omitted (use the default
+                          SSH key name)
                         type: string
                       subnet:
                         description: Subnet is a reference to the subnet to use for


### PR DESCRIPTION
**What this PR does / why we need it**: Allows instances to be provisioned with no SSH key pair specified. Organizations which have policies denying the use of SSH key pairs can now set the SSH key name value to "" to launch instances without a key pair set. A nil value still sets the default key pair name.

Fixes #1156 

