### PR TITLE
:bug: Use latest Calico manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ create-cluster: $(CLUSTERCTL) $(ENVSUBST) ## Create a development Kubernetes clu
 	timeout 300 bash -c "while ! kubectl --kubeconfig=./kubeconfig get nodes | grep master; do sleep 1; done"
 
 	# Deploy calico
-	kubectl --kubeconfig=./kubeconfig apply -f https://docs.projectcalico.org/v3.12/manifests/calico.yaml
+	kubectl --kubeconfig=./kubeconfig apply -f https://docs.projectcalico.org/manifests/calico.yaml
 
 .PHONY: kind-reset
 kind-reset: ## Destroys the "clusterapi" kind cluster.

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 var (
-	cniManifests  = capiFlag.DefineOrLookupStringFlag("cniManifests", "https://docs.projectcalico.org/v3.12/manifests/calico.yaml", "URL to CNI manifests to load")
+	cniManifests  = capiFlag.DefineOrLookupStringFlag("cniManifests", "https://docs.projectcalico.org/manifests/calico.yaml", "URL to CNI manifests to load")
 	kubectlBinary = capiFlag.DefineOrLookupStringFlag("kubectlBinary", "kubectl", "path to the kubectl binary")
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch to using latest Calico manifests instead of hard-coding 3.12, as
Calico appears to only have a single versioned manifest available at a
time, and that will break us every time Calico releases a new version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1622 
