### PR TITLE
Normalize vars to have AWS_ prefix

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -306,8 +306,8 @@ create_cluster() {
   KUBERNETES_VERSION=$KUBERNETES_VERSION \
   IMAGE_ID=$image_id \
   AWS_SSH_KEY_NAME=$AWS_SSH_KEY_NAME \
-  CONTROL_PLANE_MACHINE_TYPE=m5.large \
-  NODE_MACHINE_TYPE=m5.large \
+  AWS_CONTROL_PLANE_MACHINE_TYPE=m5.large \
+  AWS_NODE_MACHINE_TYPE=m5.large \
   AWS_B64ENCODED_CREDENTIALS=$("${REPO_ROOT}"/bin/clusterawsadm alpha bootstrap encode-aws-credentials) \
   LOAD_IMAGE="${REGISTRY}/cluster-api-aws-controller-amd64:dev" CLUSTER_NAME="${CLUSTER_NAME}" \
     make create-cluster)

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -61,7 +61,7 @@ metadata:
 spec:
   template:
     spec:
-      instanceType: "${CONTROL_PLANE_MACHINE_TYPE}"
+      instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
 ---
@@ -95,7 +95,7 @@ metadata:
 spec:
   template:
     spec:
-      instanceType: "${NODE_MACHINE_TYPE}"
+      instanceType: "${AWS_NODE_MACHINE_TYPE}"
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
 ---


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Normalizes machine type vars to have the AWS_ prefix for multi-provider compatibility when using ~/.cluster-api/clusterctl.yaml for configuration. In line with https://github.com/kubernetes-sigs/cluster-api/pull/2628

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1631 

