### PR TITLE
:running: Update e2e tests for SSHKeyName change to pointer

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v11.0.1-0.20190704100234-640d9f240853+incompatible
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/cluster-api v0.3.0-rc.3
 	sigs.k8s.io/cluster-api-provider-aws v0.4.8
 	sigs.k8s.io/controller-runtime v0.5.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the e2e tests now that SSHKeyName is a pointer.

/milestone v0.5.0
