### PR TITLE
:running: elb: Skip additional control plane registration if node not yet registered

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -528,6 +528,11 @@ func (r *AWSMachineReconciler) reconcileLBAttachment(machineScope *scope.Machine
 		return nil
 	}
 
+	if clusterScope.Cluster.Status.ControlPlaneInitialized && machineScope.Machine.Status.NodeRef == nil {
+		r.Log.Info("Control plane machine not registered as node, skipping ELB registration")
+		return nil
+	}
+
 	elbsvc := elb.NewService(clusterScope)
 	if err := elbsvc.RegisterInstanceWithAPIServerELB(i); err != nil {
 		r.Recorder.Eventf(machineScope.AWSMachine, corev1.EventTypeWarning, "FailedAttachControlPlaneELB",


### PR DESCRIPTION


Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Mirrors change made in CAPV: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/860
