### PR TITLE
Use TCP so that we can support different ciphers easily for v1alpha3.

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -255,7 +255,7 @@ func (s *Service) getAPIServerClassicELBSpec() (*infrav1.ClassicELB, error) {
 			},
 		},
 		HealthCheck: &infrav1.ClassicELBHealthCheck{
-			Target:             fmt.Sprintf("%v:%d", infrav1.ClassicELBProtocolSSL, 6443),
+			Target:             fmt.Sprintf("%v:%d", infrav1.ClassicELBProtocolTCP, 6443),
 			Interval:           10 * time.Second,
 			Timeout:            5 * time.Second,
 			HealthyThreshold:   5,


### PR DESCRIPTION
🐛 (:bug:, patch and bugfixes)

**What this PR does / why we need it**:

USes TCP rather then SSL, so that we can support any arbitrary APISErver Cipher.  Otherwise, we need to alignt the ELB Ciphers with those in the APIServer, Scheduler, KCM, Kubelet, and so on.

**What issue this fixes**

https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1657

(undos the work in #1658, which i think was valuable, but we can live without for the timebeing, correct me if im missing something)