### PR TITLE
🏃 Initialize CR logger earlier

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,6 +135,8 @@ func main() {
 
 	flag.Parse()
 
+	ctrl.SetLogger(klogr.New())
+
 	if watchNamespace != "" {
 		setupLog.Info("Watching cluster-api objects only in namespace for reconciliation", "namespace", watchNamespace)
 	}
@@ -146,7 +148,6 @@ func main() {
 		}()
 	}
 
-	ctrl.SetLogger(klogr.New())
 	// Machine and cluster operations can create enough events to trigger the event recorder spam filter
 	// Setting the burst size higher ensures all events will be recorded and submitted to the API
 	broadcaster := cgrecord.NewBroadcasterWithCorrelatorOptions(cgrecord.CorrelatorOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:
Initialize the controller-runtime logger as soon as we're done parsing
flags, so we don't lose some of the setupLog output that is currently
going to nowhere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

