### PR TITLE
:sparkles: Update predicate handling

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -17,24 +17,43 @@ limitations under the License.
 package controllers
 
 import (
+	"strings"
+
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// TODO: Move to Cluster API
-var pausePredicates = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		return !isPaused(nil, e.MetaNew)
-	},
-	CreateFunc: func(e event.CreateEvent) bool {
-		return !isPaused(nil, e.Meta)
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return !isPaused(nil, e.Meta)
-	},
+func pausedPredicates(logger logr.Logger) predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return processIfUnpaused(logger.WithValues("predicate", "updateEvent"), e.ObjectNew, e.MetaNew)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return processIfUnpaused(logger.WithValues("predicate", "createEvent"), e.Object, e.Meta)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return processIfUnpaused(logger.WithValues("predicate", "deleteEvent"), e.Object, e.Meta)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return processIfUnpaused(logger.WithValues("predicate", "genericEvent"), e.Object, e.Meta)
+		},
+	}
+}
+
+func processIfUnpaused(logger logr.Logger, obj runtime.Object, meta metav1.Object) bool {
+	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
+	log := logger.WithValues("namespace", meta.GetNamespace(), kind, meta.GetName())
+	if isPaused(nil, meta) {
+		log.V(4).Info("Resource is paused, will not attempt to map resource")
+		return false
+	}
+	log.V(4).Info("Resource is not paused, will attempt to map resource")
+	return true
 }
 
 // TODO: Fix up Cluster API's clusterutil.IsPaused function


### PR DESCRIPTION
**What this PR does / why we need it**:

- Improve logging for predicate handling
- Improve logging for objectMapper functions
- Add triggering reconciliation on Cluster.Status.InfrastructureReady becoming available

**Which issue(s) this PR fixes**:
Fixes #

