### PR TITLE
✨ Default cluster ready to false

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -96,6 +96,7 @@ type AWSLoadBalancerSpec struct {
 
 // AWSClusterStatus defines the observed state of AWSCluster
 type AWSClusterStatus struct {
+	// +kubebuilder:default=false
 	Ready          bool                     `json:"ready"`
 	Network        Network                  `json:"network,omitempty"`
 	FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -920,6 +920,7 @@ spec:
                     type: object
                 type: object
               ready:
+                default: false
                 type: boolean
             required:
             - ready


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes seeing a bunch of log messages complaining that ready is a required field

```
[capa-controller-manager-79775956fb-sg76v manager] E0402 15:58:22.915432     267 controller.go:258] controller-runtime/controller "msg"="Reconciler error" "error"="AWSCluster.infrastructure.cluster.x-k8s.io \"test\" is invalid: status.ready: Required value"  "controller"="awscluster" "request"={"Namespace":"default","Name":"test"}
```