### PR TITLE
:book: Update roadmap for delayed v1alpha4

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,34 +6,22 @@ This roadmap is a constant work in progress, subject to frequent revision. Dates
 
 - Documentation improvements
 
-## v0.5 (v1alpha3) ~ March 2020
-
-- Updates for Cluster API v1alpha3
-- Add support for `clusterctl` v2
-- [Disable creation of bastion host by default](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/947)
-- [Ability to configure node disks](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1403)
-- [SSM integration (alternative to bastion host)](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1553)
-- [Encrypted user-data](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1387)
-- [Support for cross-zone load balancing](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1416)
-- [Private API-server load balancer](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/873)
-
-## v0.6 (v1alpha4) ~ July 2020
-
-- Consume Cluster API e2e testing framework
+## v0.5.x (v1alpha3+) - June/July 2020
+- [Consume Cluster API e2e testing framework](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1435)
 - [Supporting multiple AWS accounts as Kubernetes objects](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1552)
-- [Multiple topologies](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1484)
 - [Bootstrap failure detection](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/972)
 - [Improved status conditions](https://github.com/kubernetes-sigs/cluster-api/issues/1658)
+- [Spot instances support](https://github.com/kubernetes-sigs/cluster-api/issues/1876)
+
+## v0.6 (v1alpha4) ~ Q4 2020
+
+- [Multiple topologies](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1484)
 - [Machine load balancer implementation](https://github.com/kubernetes-sigs/cluster-api/issues/1250)
 - SNS/SQS-based updates from CloudWatch Events so we don’t have to poll AWS for updates
 
-## v0.6 (v1alpha5? v1beta1?) ~ November 2020
-
-- ?
-
 ## TBD
 
-- Implement MachinePools - Autoscaling groups and spot instances
+- Implement MachinePools - Autoscaling groups and instances
 - Dual stack IPv4/IPv6 support
 - Windows nodes
 - Support for GPU instances and Elastic GPU

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@ This roadmap is a constant work in progress, subject to frequent revision. Dates
 - [Supporting multiple AWS accounts as Kubernetes objects](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1552)
 - [Bootstrap failure detection](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/972)
 - [Improved status conditions](https://github.com/kubernetes-sigs/cluster-api/issues/1658)
-- [Spot instances support](https://github.com/kubernetes-sigs/cluster-api/issues/1876)
+- [Spot instances support for Machines](https://github.com/kubernetes-sigs/cluster-api/issues/1876)
 
 ## v0.6 (v1alpha4) ~ Q4 2020
 
@@ -22,6 +22,8 @@ This roadmap is a constant work in progress, subject to frequent revision. Dates
 ## TBD
 
 - Implement MachinePools - Autoscaling groups and instances
+- Spot instance support for MachinePool ASG/Instance implementation
+- MachinePool implementation backed by Spot Fleet
 - Dual stack IPv4/IPv6 support
 - Windows nodes
 - Support for GPU instances and Elastic GPU


### PR DESCRIPTION
**What this PR does / why we need it**:

Updating roadmap to account for delaying any breaking API changes in favor of adding additional features without breaking changes.
