### PR TITLE
✨ Customizable Image Lookup Format

### DIFF
--- a/api/v1alpha2/awscluster_conversion.go
+++ b/api/v1alpha2/awscluster_conversion.go
@@ -53,6 +53,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error { // nolint
 		dst.Spec.SSHKeyName = nil
 	}
 
+	dst.Spec.ImageLookupFormat = restored.Spec.ImageLookupFormat
 	dst.Spec.ImageLookupOrg = restored.Spec.ImageLookupOrg
 	dst.Spec.ImageLookupBaseOS = restored.Spec.ImageLookupBaseOS
 	if restored.Spec.ControlPlaneLoadBalancer != nil {

--- a/api/v1alpha2/awscluster_conversion.go
+++ b/api/v1alpha2/awscluster_conversion.go
@@ -53,7 +53,9 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error { // nolint
 		dst.Spec.SSHKeyName = nil
 	}
 
-	dst.Spec.ImageLookupFormat = restored.Spec.ImageLookupFormat
+	if restored.Spec.ImageLookupFormat != nil {
+		dst.Spec.ImageLookupFormat = restored.Spec.ImageLookupFormat
+	}
 	dst.Spec.ImageLookupOrg = restored.Spec.ImageLookupOrg
 	dst.Spec.ImageLookupBaseOS = restored.Spec.ImageLookupBaseOS
 	if restored.Spec.ControlPlaneLoadBalancer != nil {

--- a/api/v1alpha2/awscluster_conversion.go
+++ b/api/v1alpha2/awscluster_conversion.go
@@ -53,9 +53,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error { // nolint
 		dst.Spec.SSHKeyName = nil
 	}
 
-	if restored.Spec.ImageLookupFormat != nil {
-		dst.Spec.ImageLookupFormat = restored.Spec.ImageLookupFormat
-	}
+	dst.Spec.ImageLookupFormat = restored.Spec.ImageLookupFormat
 	dst.Spec.ImageLookupOrg = restored.Spec.ImageLookupOrg
 	dst.Spec.ImageLookupBaseOS = restored.Spec.ImageLookupBaseOS
 	if restored.Spec.ControlPlaneLoadBalancer != nil {

--- a/api/v1alpha2/awsmachine_conversion.go
+++ b/api/v1alpha2/awsmachine_conversion.go
@@ -43,6 +43,7 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error { // nolint
 }
 
 func restoreAWSMachineSpec(restored *infrav1alpha3.AWSMachineSpec, dst *infrav1alpha3.AWSMachineSpec) {
+	dst.ImageLookupFormat = restored.ImageLookupFormat
 	dst.ImageLookupBaseOS = restored.ImageLookupBaseOS
 
 	// Note this may override the manual conversion in Convert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec.
@@ -139,7 +140,7 @@ func Convert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *infrav1alpha
 		out.RootDeviceSize = in.RootVolume.Size
 	}
 
-	// Discards ImageLookupBaseOS
+	// Discards ImageLookupBaseOS & ImageLookupFormat
 
 	return nil
 }

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -457,7 +457,7 @@ func autoConvert_v1alpha2_AWSClusterStatus_To_v1alpha3_AWSClusterStatus(in *AWSC
 	if err := Convert_v1alpha2_Network_To_v1alpha3_Network(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (./api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
 	out.Ready = in.Ready
 	// WARNING: in.APIEndpoints requires manual conversion: does not exist in peer-type
 	return nil
@@ -469,7 +469,7 @@ func autoConvert_v1alpha3_AWSClusterStatus_To_v1alpha2_AWSClusterStatus(in *v1al
 		return err
 	}
 	// WARNING: in.FailureDomains requires manual conversion: does not exist in peer-type
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs ./api/v1alpha2.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance)
 	return nil
 }
 
@@ -581,7 +581,7 @@ func autoConvert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachi
 	}
 	// WARNING: in.RootDeviceSize requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*./api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
 	return nil
 }
 
@@ -606,7 +606,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	// WARNING: in.RootVolume requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	// WARNING: in.UncompressedUserData requires manual conversion: does not exist in peer-type
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *./api/v1alpha2.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
 	return nil
 }
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -446,6 +446,7 @@ func autoConvert_v1alpha3_AWSClusterSpec_To_v1alpha2_AWSClusterSpec(in *v1alpha3
 	} else {
 		out.ControlPlaneLoadBalancer = nil
 	}
+	// WARNING: in.ImageLookupFormat requires manual conversion: does not exist in peer-type
 	// WARNING: in.ImageLookupOrg requires manual conversion: does not exist in peer-type
 	// WARNING: in.ImageLookupBaseOS requires manual conversion: does not exist in peer-type
 	// WARNING: in.Bastion requires manual conversion: does not exist in peer-type
@@ -456,7 +457,7 @@ func autoConvert_v1alpha2_AWSClusterStatus_To_v1alpha3_AWSClusterStatus(in *AWSC
 	if err := Convert_v1alpha2_Network_To_v1alpha3_Network(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (./api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
 	out.Ready = in.Ready
 	// WARNING: in.APIEndpoints requires manual conversion: does not exist in peer-type
 	return nil
@@ -468,7 +469,7 @@ func autoConvert_v1alpha3_AWSClusterStatus_To_v1alpha2_AWSClusterStatus(in *v1al
 		return err
 	}
 	// WARNING: in.FailureDomains requires manual conversion: does not exist in peer-type
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs ./api/v1alpha2.Instance)
 	return nil
 }
 
@@ -580,7 +581,7 @@ func autoConvert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachi
 	}
 	// WARNING: in.RootDeviceSize requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*./api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
 	return nil
 }
 
@@ -589,6 +590,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	if err := Convert_v1alpha3_AWSResourceReference_To_v1alpha2_AWSResourceReference(&in.AMI, &out.AMI, s); err != nil {
 		return err
 	}
+	// WARNING: in.ImageLookupFormat requires manual conversion: does not exist in peer-type
 	out.ImageLookupOrg = in.ImageLookupOrg
 	// WARNING: in.ImageLookupBaseOS requires manual conversion: does not exist in peer-type
 	out.InstanceType = in.InstanceType
@@ -604,7 +606,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	// WARNING: in.RootVolume requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	// WARNING: in.UncompressedUserData requires manual conversion: does not exist in peer-type
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *./api/v1alpha2.CloudInit)
 	return nil
 }
 

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -55,7 +55,7 @@ type AWSClusterSpec struct {
 	// ImageLookupFormat is the AMI naming format to look up machine images when
 	// a machine does not specify an AMI. When set, this will be used for all
 	// cluster machines unless a machine specifies a different ImageLookupOrg.
-	// Supports substitutions for ${BASE_OS} and ${K8S_VERSION}.
+	// Supports substitutions for $BASE_OS and $K8S_VERSION.
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -55,11 +55,15 @@ type AWSClusterSpec struct {
 	// ImageLookupFormat is the AMI naming format to look up machine images when
 	// a machine does not specify an AMI. When set, this will be used for all
 	// cluster machines unless a machine specifies a different ImageLookupOrg.
-	// Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} of the base OS
-	// of the AMI and the kubernetes version as defined by the packages produced
-	// by kubernetes/release with or without v as a prefix, for example: 1.13.0,
-	// 1.12.5-mybuild.1, v1.17.3 respectively. See golang templates
-	// https://golang.org/pkg/text/template/.
+	// Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base
+	// OS and kubernetes version, respectively. The BaseOS will be the value in
+	// ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as
+	// defined by the packages produced by kubernetes/release without v as a
+	// prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default
+	// image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up
+	// searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a
+	// Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See
+	// also: https://golang.org/pkg/text/template/
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -52,6 +52,13 @@ type AWSClusterSpec struct {
 	// +optional
 	ControlPlaneLoadBalancer *AWSLoadBalancerSpec `json:"controlPlaneLoadBalancer,omitempty"`
 
+	// ImageLookupFormat is the AMI naming format to look up machine images when
+	// a machine does not specify an AMI. When set, this will be used for all
+	// cluster machines unless a machine specifies a different ImageLookupOrg.
+	// Supports substitutions for ${BASE_OS} and ${K8S_VERSION}.
+	// +optional
+	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
+
 	// ImageLookupOrg is the AWS Organization ID to look up machine images when a
 	// machine does not specify an AMI. When set, this will be used for all
 	// cluster machines unless a machine specifies a different ImageLookupOrg.

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -55,7 +55,11 @@ type AWSClusterSpec struct {
 	// ImageLookupFormat is the AMI naming format to look up machine images when
 	// a machine does not specify an AMI. When set, this will be used for all
 	// cluster machines unless a machine specifies a different ImageLookupOrg.
-	// Supports substitutions for $BASE_OS and $K8S_VERSION.
+	// Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} of the base OS
+	// of the AMI and the kubernetes version as defined by the packages produced
+	// by kubernetes/release with or without v as a prefix, for example: 1.13.0,
+	// 1.12.5-mybuild.1, v1.17.3 respectively. See golang templates
+	// https://golang.org/pkg/text/template/.
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -36,8 +36,14 @@ type AWSMachineSpec struct {
 	// AMI is the reference to the AMI from which to create the machine instance.
 	AMI AWSResourceReference `json:"ami,omitempty"`
 
-	// ImageLookupFormat is the format string used for image lookup if AMI is
-	// not set. Supports substitutions for $BASE_OS and $K8S_VERSION.
+	// ImageLookupFormat is the AMI naming format to look up machine images when
+	// a machine does not specify an AMI. When set, this will be used for all
+	// cluster machines unless a machine specifies a different ImageLookupOrg.
+	// Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} of the base OS
+	// of the AMI and the kubernetes version as defined by the packages produced
+	// by kubernetes/release with or without v as a prefix, for example: 1.13.0,
+	// 1.12.5-mybuild.1, v1.17.3 respectively. See golang templates
+	// https://golang.org/pkg/text/template/.
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -37,7 +37,7 @@ type AWSMachineSpec struct {
 	AMI AWSResourceReference `json:"ami,omitempty"`
 
 	// ImageLookupFormat is the format string used for image lookup if AMI is
-	// not set. Supports substitutions for ${BASE_OS} and ${K8S_VERSION}.
+	// not set. Supports substitutions for $BASE_OS and $K8S_VERSION.
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -38,6 +38,7 @@ type AWSMachineSpec struct {
 
 	// ImageLookupFormat is the format string used for image lookup if AMI is
 	// not set. Supports substitutions for ${BASE_OS} and ${K8S_VERSION}.
+	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
 	// ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -36,6 +36,10 @@ type AWSMachineSpec struct {
 	// AMI is the reference to the AMI from which to create the machine instance.
 	AMI AWSResourceReference `json:"ami,omitempty"`
 
+	// ImageLookupFormat is the format string used for image lookup if AMI is
+	// not set. Supports substitutions for ${BASE_OS} and ${K8S_VERSION}.
+	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
+
 	// ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.
 	ImageLookupOrg string `json:"imageLookupOrg,omitempty"`
 

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -36,14 +36,17 @@ type AWSMachineSpec struct {
 	// AMI is the reference to the AMI from which to create the machine instance.
 	AMI AWSResourceReference `json:"ami,omitempty"`
 
-	// ImageLookupFormat is the AMI naming format to look up machine images when
-	// a machine does not specify an AMI. When set, this will be used for all
-	// cluster machines unless a machine specifies a different ImageLookupOrg.
-	// Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} of the base OS
-	// of the AMI and the kubernetes version as defined by the packages produced
-	// by kubernetes/release with or without v as a prefix, for example: 1.13.0,
-	// 1.12.5-mybuild.1, v1.17.3 respectively. See golang templates
-	// https://golang.org/pkg/text/template/.
+	// ImageLookupFormat is the AMI naming format to look up the image for this
+	// machine It will be ignored if an explicit AMI is set. Supports
+	// substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and
+	// kubernetes version, respectively. The BaseOS will be the value in
+	// ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as
+	// defined by the packages produced by kubernetes/release without v as a
+	// prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default
+	// image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up
+	// searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a
+	// Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See
+	// also: https://golang.org/pkg/text/template/
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -523,10 +523,14 @@ spec:
                   machine images when a machine does not specify an AMI. When set,
                   this will be used for all cluster machines unless a machine specifies
                   a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
-                  and {{.K8sVersion}} of the base OS of the AMI and the kubernetes
-                  version as defined by the packages produced by kubernetes/release
-                  with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1,
-                  v1.17.3 respectively. See golang templates https://golang.org/pkg/text/template/.'
+                  and {{.K8sVersion}} with the base OS and kubernetes version, respectively.
+                  The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the
+                  default), and the kubernetes version as defined by the packages
+                  produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
                 type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to look up

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -522,8 +522,8 @@ spec:
                 description: ImageLookupFormat is the AMI naming format to look up
                   machine images when a machine does not specify an AMI. When set,
                   this will be used for all cluster machines unless a machine specifies
-                  a different ImageLookupOrg. Supports substitutions for ${BASE_OS}
-                  and ${K8S_VERSION}.
+                  a different ImageLookupOrg. Supports substitutions for $BASE_OS
+                  and $K8S_VERSION.
                 type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to look up

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -519,11 +519,14 @@ spec:
                   a machine specifies a different ImageLookupBaseOS.
                 type: string
               imageLookupFormat:
-                description: ImageLookupFormat is the AMI naming format to look up
+                description: 'ImageLookupFormat is the AMI naming format to look up
                   machine images when a machine does not specify an AMI. When set,
                   this will be used for all cluster machines unless a machine specifies
-                  a different ImageLookupOrg. Supports substitutions for $BASE_OS
-                  and $K8S_VERSION.
+                  a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
+                  and {{.K8sVersion}} of the base OS of the AMI and the kubernetes
+                  version as defined by the packages produced by kubernetes/release
+                  with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1,
+                  v1.17.3 respectively. See golang templates https://golang.org/pkg/text/template/.'
                 type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to look up

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -518,6 +518,13 @@ spec:
                   AMI. When set, this will be used for all cluster machines unless
                   a machine specifies a different ImageLookupBaseOS.
                 type: string
+              imageLookupFormat:
+                description: ImageLookupFormat is the AMI naming format to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg. Supports substitutions for ${BASE_OS}
+                  and ${K8S_VERSION}.
+                type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to look up
                   machine images when a machine does not specify an AMI. When set,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -434,6 +434,11 @@ spec:
                 description: ImageLookupBaseOS is the name of the base operating system
                   to use for image lookup the AMI is not set.
                 type: string
+              imageLookupFormat:
+                description: ImageLookupFormat is the format string used for image
+                  lookup if AMI is not set. Supports substitutions for ${BASE_OS}
+                  and ${K8S_VERSION}.
+                type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to use for
                   image lookup if AMI is not set.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -436,8 +436,8 @@ spec:
                 type: string
               imageLookupFormat:
                 description: ImageLookupFormat is the format string used for image
-                  lookup if AMI is not set. Supports substitutions for ${BASE_OS}
-                  and ${K8S_VERSION}.
+                  lookup if AMI is not set. Supports substitutions for $BASE_OS and
+                  $K8S_VERSION.
                 type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to use for

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -436,13 +436,16 @@ spec:
                 type: string
               imageLookupFormat:
                 description: 'ImageLookupFormat is the AMI naming format to look up
-                  machine images when a machine does not specify an AMI. When set,
-                  this will be used for all cluster machines unless a machine specifies
-                  a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
-                  and {{.K8sVersion}} of the base OS of the AMI and the kubernetes
-                  version as defined by the packages produced by kubernetes/release
-                  with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1,
-                  v1.17.3 respectively. See golang templates https://golang.org/pkg/text/template/.'
+                  the image for this machine It will be ignored if an explicit AMI
+                  is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}}
+                  with the base OS and kubernetes version, respectively. The BaseOS
+                  will be the value in ImageLookupBaseOS or ubuntu (the default),
+                  and the kubernetes version as defined by the packages produced by
+                  kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
                 type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to use for

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -435,9 +435,14 @@ spec:
                   to use for image lookup the AMI is not set.
                 type: string
               imageLookupFormat:
-                description: ImageLookupFormat is the format string used for image
-                  lookup if AMI is not set. Supports substitutions for $BASE_OS and
-                  $K8S_VERSION.
+                description: 'ImageLookupFormat is the AMI naming format to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
+                  and {{.K8sVersion}} of the base OS of the AMI and the kubernetes
+                  version as defined by the packages produced by kubernetes/release
+                  with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1,
+                  v1.17.3 respectively. See golang templates https://golang.org/pkg/text/template/.'
                 type: string
               imageLookupOrg:
                 description: ImageLookupOrg is the AWS Organization ID to use for

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -395,14 +395,17 @@ spec:
                         type: string
                       imageLookupFormat:
                         description: 'ImageLookupFormat is the AMI naming format to
-                          look up machine images when a machine does not specify an
-                          AMI. When set, this will be used for all cluster machines
-                          unless a machine specifies a different ImageLookupOrg. Supports
-                          substitutions for {{.BaseOS}} and {{.K8sVersion}} of the
-                          base OS of the AMI and the kubernetes version as defined
-                          by the packages produced by kubernetes/release with or without
-                          v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1, v1.17.3
-                          respectively. See golang templates https://golang.org/pkg/text/template/.'
+                          look up the image for this machine It will be ignored if
+                          an explicit AMI is set. Supports substitutions for {{.BaseOS}}
+                          and {{.K8sVersion}} with the base OS and kubernetes version,
+                          respectively. The BaseOS will be the value in ImageLookupBaseOS
+                          or ubuntu (the default), and the kubernetes version as defined
+                          by the packages produced by kubernetes/release without v
+                          as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example,
+                          the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                          will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                          for a Machine that is targeting kubernetes v1.18.0 and the
+                          ubuntu base OS. See also: https://golang.org/pkg/text/template/'
                         type: string
                       imageLookupOrg:
                         description: ImageLookupOrg is the AWS Organization ID to

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -394,9 +394,15 @@ spec:
                           system to use for image lookup the AMI is not set.
                         type: string
                       imageLookupFormat:
-                        description: ImageLookupFormat is the format string used for
-                          image lookup if AMI is not set. Supports substitutions for
-                          $BASE_OS and $K8S_VERSION.
+                        description: 'ImageLookupFormat is the AMI naming format to
+                          look up machine images when a machine does not specify an
+                          AMI. When set, this will be used for all cluster machines
+                          unless a machine specifies a different ImageLookupOrg. Supports
+                          substitutions for {{.BaseOS}} and {{.K8sVersion}} of the
+                          base OS of the AMI and the kubernetes version as defined
+                          by the packages produced by kubernetes/release with or without
+                          v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1, v1.17.3
+                          respectively. See golang templates https://golang.org/pkg/text/template/.'
                         type: string
                       imageLookupOrg:
                         description: ImageLookupOrg is the AWS Organization ID to

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -393,6 +393,11 @@ spec:
                         description: ImageLookupBaseOS is the name of the base operating
                           system to use for image lookup the AMI is not set.
                         type: string
+                      imageLookupFormat:
+                        description: ImageLookupFormat is the format string used for
+                          image lookup if AMI is not set. Supports substitutions for
+                          ${BASE_OS} and ${K8S_VERSION}.
+                        type: string
                       imageLookupOrg:
                         description: ImageLookupOrg is the AWS Organization ID to
                           use for image lookup if AMI is not set.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -396,7 +396,7 @@ spec:
                       imageLookupFormat:
                         description: ImageLookupFormat is the format string used for
                           image lookup if AMI is not set. Supports substitutions for
-                          ${BASE_OS} and ${K8S_VERSION}.
+                          $BASE_OS and $K8S_VERSION.
                         type: string
                       imageLookupOrg:
                         description: ImageLookupOrg is the AWS Organization ID to

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,7 @@ k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdB
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
+k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apiserver v0.17.2 h1:NssVvPALll6SSeNgo1Wk1h2myU1UHNwmhxV0Oxbcl8Y=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/client-go v0.17.2 h1:ndIfkfXEGrNhLIgkr0+qhRguSD3u6DCmonepn1O6NYc=

--- a/go.sum
+++ b/go.sum
@@ -633,7 +633,6 @@ k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdB
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
-k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apiserver v0.17.2 h1:NssVvPALll6SSeNgo1Wk1h2myU1UHNwmhxV0Oxbcl8Y=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/client-go v0.17.2 h1:ndIfkfXEGrNhLIgkr0+qhRguSD3u6DCmonepn1O6NYc=

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ec2
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -51,7 +50,7 @@ const (
 func amiName(amiNameFormat, baseOS, kubernetesVersion string) string {
 	amiName := strings.ReplaceAll(amiNameFormat,"${BASE_OS}", baseOS)
 	// strip the v (if present) to be able to match images with or without a v prefix
-	amiName = strings.ReplaceAll(amiNameFormat,"${K8S_VERSION}", strings.TrimPrefix(kubernetesVersion, 'v'))
+	amiName = strings.ReplaceAll(amiNameFormat,"${K8S_VERSION}", strings.TrimPrefix(kubernetesVersion, "v"))
 	return amiName
 }
 

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -48,9 +48,9 @@ const (
 )
 
 func amiName(amiNameFormat, baseOS, kubernetesVersion string) string {
-	amiName := strings.ReplaceAll(amiNameFormat,"${BASE_OS}", baseOS)
+	amiName := strings.ReplaceAll(amiNameFormat, "${BASE_OS}", baseOS)
 	// strip the v (if present) to be able to match images with or without a v prefix
-	amiName = strings.ReplaceAll(amiNameFormat,"${K8S_VERSION}", strings.TrimPrefix(kubernetesVersion, "v"))
+	amiName = strings.ReplaceAll(amiName, "${K8S_VERSION}", strings.TrimPrefix(kubernetesVersion, "v"))
 	return amiName
 }
 

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -36,25 +36,30 @@ const (
 	// when looking up machine AMIs
 	defaultMachineAMILookupBaseOS = "ubuntu-18.04"
 
-	// amiNameFormat is defined in the build/ directory of this project.
+	// defaultAmiNameFormat is defined in the build/ directory of this project.
 	// The pattern is:
 	// 1. the string value `capa-ami-`
 	// 2. the baseOS of the AMI, for example: ubuntu-18.04, centos-7, amazon-2
 	// 3. the kubernetes version as defined by the packages produced by kubernetes/release with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1, v1.17.3
 	// 4. a `-` followed by any additional characters
-	amiNameFormat = "capa-ami-%s-?%s-*"
+	defaultAmiNameFormat = "capa-ami-${BASE_OS}-?${K8S_VERSION}-*"
 
 	// Amazon's AMI timestamp format
 	createDateTimestampFormat = "2006-01-02T15:04:05.000Z"
 )
 
-func amiName(baseOS, kubernetesVersion string) string {
+func amiName(amiNameFormat, baseOS, kubernetesVersion string) string {
+	amiName := strings.replaceAll(amiNameFormat,"${BASE_OS}", baseOS)
 	// strip the v (if present) to be able to match images with or without a v prefix
-	return fmt.Sprintf(amiNameFormat, baseOS, strings.TrimPrefix(kubernetesVersion, "v"))
+	amiName = strings.replaceAll(amiNameFormat,"${K8S_VERSION}", .strings.TrimPrefix(kubernetesVersion, 'v'))
+	return amiName
 }
 
 // defaultAMILookup returns the default AMI based on region
-func (s *Service) defaultAMILookup(ownerID, baseOS, kubernetesVersion string) (string, error) {
+func (s *Service) defaultAMILookup(amiNameFormat, ownerID, baseOS, kubernetesVersion string) (string, error) {
+	if amiNameFormat == "" {
+		amiNameFormat = defaultAmiNameFormat
+	}
 	if ownerID == "" {
 		ownerID = defaultMachineAMIOwnerID
 	}
@@ -69,7 +74,7 @@ func (s *Service) defaultAMILookup(ownerID, baseOS, kubernetesVersion string) (s
 			},
 			{
 				Name:   aws.String("name"),
-				Values: []*string{aws.String(amiName(baseOS, kubernetesVersion))},
+				Values: []*string{aws.String(amiName(amiNameFormat, baseOS, kubernetesVersion))},
 			},
 			{
 				Name:   aws.String("architecture"),
@@ -88,10 +93,10 @@ func (s *Service) defaultAMILookup(ownerID, baseOS, kubernetesVersion string) (s
 
 	out, err := s.scope.EC2.DescribeImages(describeImageInput)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to find ami: %q", amiName(baseOS, kubernetesVersion))
+		return "", errors.Wrapf(err, "failed to find ami: %q", amiName(amiNameFormat, baseOS, kubernetesVersion))
 	}
 	if len(out.Images) == 0 {
-		return "", errors.Errorf("found no AMIs with the name: %q", amiName(baseOS, kubernetesVersion))
+		return "", errors.Errorf("found no AMIs with the name: %q", amiName(amiNameFormat, baseOS, kubernetesVersion))
 	}
 	latestImage, err := getLatestImage(out.Images)
 	if err != nil {

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -49,9 +49,9 @@ const (
 )
 
 func amiName(amiNameFormat, baseOS, kubernetesVersion string) string {
-	amiName := strings.replaceAll(amiNameFormat,"${BASE_OS}", baseOS)
+	amiName := strings.ReplaceAll(amiNameFormat,"${BASE_OS}", baseOS)
 	// strip the v (if present) to be able to match images with or without a v prefix
-	amiName = strings.replaceAll(amiNameFormat,"${K8S_VERSION}", .strings.TrimPrefix(kubernetesVersion, 'v'))
+	amiName = strings.ReplaceAll(amiNameFormat,"${K8S_VERSION}", strings.TrimPrefix(kubernetesVersion, 'v'))
 	return amiName
 }
 

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -79,7 +79,7 @@ func TestAMIs(t *testing.T) {
 			tc.expect(ec2Mock.EXPECT())
 
 			s := NewService(scope)
-			id, err := s.defaultAMILookup("", "base os-baseos version", "1.11.1")
+			id, err := s.defaultAMILookup("","", "base os-baseos version", "1.11.1")
 			if err != nil {
 				t.Fatalf("did not expect error calling a mock: %v", err)
 			}
@@ -140,7 +140,7 @@ func TestAMIsWithInvalidCreationDate(t *testing.T) {
 			tc.expect(ec2Mock.EXPECT())
 
 			s := NewService(scope)
-			_, err = s.defaultAMILookup("", "base os-baseos version", "1.11.1")
+			_, err = s.defaultAMILookup("","", "base os-baseos version", "1.11.1")
 			if err == nil {
 				t.Fatalf("expected an error but did not get one")
 			}

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -79,7 +79,7 @@ func TestAMIs(t *testing.T) {
 			tc.expect(ec2Mock.EXPECT())
 
 			s := NewService(scope)
-			id, err := s.defaultAMILookup("","", "base os-baseos version", "1.11.1")
+			id, err := s.defaultAMILookup("", "", "base os-baseos version", "1.11.1")
 			if err != nil {
 				t.Fatalf("did not expect error calling a mock: %v", err)
 			}
@@ -140,7 +140,7 @@ func TestAMIsWithInvalidCreationDate(t *testing.T) {
 			tc.expect(ec2Mock.EXPECT())
 
 			s := NewService(scope)
-			_, err = s.defaultAMILookup("","", "base os-baseos version", "1.11.1")
+			_, err = s.defaultAMILookup("", "", "base os-baseos version", "1.11.1")
 			if err == nil {
 				t.Fatalf("expected an error but did not get one")
 			}

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -136,6 +136,11 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 			return nil, err
 		}
 
+		imageLookupFormat := scope.AWSMachine.Spec.ImageLookupFormat
+		if imageLookupFormat == "" {
+			imageLookupFormat = scope.AWSCluster.Spec.ImageLookupFormat
+		}
+
 		imageLookupOrg := scope.AWSMachine.Spec.ImageLookupOrg
 		if imageLookupOrg == "" {
 			imageLookupOrg = scope.AWSCluster.Spec.ImageLookupOrg
@@ -146,7 +151,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 			imageLookupBaseOS = scope.AWSCluster.Spec.ImageLookupBaseOS
 		}
 
-		input.ImageID, err = s.defaultAMILookup(imageLookupOrg, imageLookupBaseOS, *scope.Machine.Spec.Version)
+		input.ImageID, err = s.defaultAMILookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.Machine.Spec.Version)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -554,7 +554,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*","ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*", "ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -677,7 +677,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*","ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*", "ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -801,7 +801,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*","ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*", "ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -554,7 +554,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*","ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -677,7 +677,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*","ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -801,7 +801,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*","ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -544,6 +544,10 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				amiName, err := amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
+				if err != nil {
+					t.Fatalf("Failed to process ami format: %v", err)
+				}
 				// verify that the ImageLookupOrg is used when finding AMIs
 				m.
 					DescribeImages(gomock.Eq(&ec2.DescribeImagesInput{
@@ -554,7 +558,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName)},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -667,6 +671,10 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				amiName, err := amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
+				if err != nil {
+					t.Fatalf("Failed to process ami format: %v", err)
+				}
 				// verify that the ImageLookupOrg is used when finding AMIs
 				m.
 					DescribeImages(gomock.Eq(&ec2.DescribeImagesInput{
@@ -677,7 +685,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName)},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -791,6 +799,10 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				amiName, err := amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
+				if err != nil {
+					t.Fatalf("Failed to process ami format: %v", err)
+				}
 				// verify that the ImageLookupOrg is used when finding AMIs
 				m.
 					DescribeImages(gomock.Eq(&ec2.DescribeImagesInput{
@@ -801,7 +813,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName)},
 							},
 							{
 								Name:   aws.String("architecture"),

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -554,7 +554,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*", "ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -677,7 +677,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*", "ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),
@@ -801,7 +801,7 @@ func TestCreateInstance(t *testing.T) {
 							},
 							{
 								Name:   aws.String("name"),
-								Values: []*string{aws.String(amiName("capa-ami-${BASE_OS}-?${K8S_VERSION}-*", "ubuntu-18.04", "v1.16.1"))},
+								Values: []*string{aws.String(amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1"))},
 							},
 							{
 								Name:   aws.String("architecture"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow the user to specify a custom format string for AMI lookup based on OS & Kubernetes version inside the AWSMachine and AWSCluster

**Which issue(s) this PR fixes**:
Fixes #1644

