### PR TITLE
[WIP] refactor: split network from cluster scope/service

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -28,6 +28,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/network"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/elb"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
@@ -118,6 +119,7 @@ func reconcileDelete(clusterScope *scope.ClusterScope) (reconcile.Result, error)
 
 	ec2svc := ec2.NewService(clusterScope)
 	elbsvc := elb.NewService(clusterScope)
+	networkSvc := network.NewService(clusterScope.NetworkScope)
 	awsCluster := clusterScope.AWSCluster
 
 	if err := elbsvc.DeleteLoadbalancers(); err != nil {
@@ -128,7 +130,7 @@ func reconcileDelete(clusterScope *scope.ClusterScope) (reconcile.Result, error)
 		return reconcile.Result{}, errors.Wrapf(err, "error deleting bastion for AWSCluster %s/%s", awsCluster.Namespace, awsCluster.Name)
 	}
 
-	if err := ec2svc.DeleteNetwork(); err != nil {
+	if err := networkSvc.DeleteNetwork(); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "error deleting network for AWSCluster %s/%s", awsCluster.Namespace, awsCluster.Name)
 	}
 
@@ -153,8 +155,9 @@ func reconcileNormal(clusterScope *scope.ClusterScope) (reconcile.Result, error)
 
 	ec2Service := ec2.NewService(clusterScope)
 	elbService := elb.NewService(clusterScope)
+	networkSvc := network.NewService(clusterScope.NetworkScope)
 
-	if err := ec2Service.ReconcileNetwork(); err != nil {
+	if err := networkSvc.ReconcileNetwork(); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile network for AWSCluster %s/%s", awsCluster.Namespace, awsCluster.Name)
 	}
 

--- a/pkg/cloud/scope/clusternetwork.go
+++ b/pkg/cloud/scope/clusternetwork.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/klogr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/version"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ClusterNetworkScopeParams defines the input parameters used to create a new Scope.
+type ClusterNetworkScopeParams struct {
+	AWSClients
+	Client  client.Client
+	Logger  logr.Logger
+	Cluster *clusterv1.Cluster
+	Target  runtime.Object
+
+	Region         string
+	NetworkSpec    *infrav1.NetworkSpec
+	NetworkStatus  *infrav1.Network
+	AdditionalTags infrav1.Tags
+	APIServerPort  *int32
+}
+
+// NewClusterNetworkScope creates a new Scope from the supplied parameters.
+// This is meant to be called for each reconcile iteration.
+func NewClusterNetworkScope(params ClusterNetworkScopeParams) (*ClusterNetworkScope, error) {
+	if params.Cluster == nil {
+		return nil, errors.New("failed to generate new scope from nil Cluster")
+	}
+	if params.Target == nil {
+		return nil, errors.New("failed to generate new scope from nil Target")
+	}
+
+	if params.Logger == nil {
+		params.Logger = klogr.New()
+	}
+
+	session, err := sessionForRegion(params.Region)
+	if err != nil {
+		return nil, errors.Errorf("failed to create aws session: %v", err)
+	}
+
+	userAgentHandler := request.NamedHandler{
+		Name: "capa/user-agent",
+		Fn:   request.MakeAddToUserAgentHandler("aws.cluster.x-k8s.io", version.Get().String()),
+	}
+
+	if params.AWSClients.EC2 == nil {
+		ec2Client := ec2.New(session)
+		ec2Client.Handlers.Build.PushFrontNamed(userAgentHandler)
+		ec2Client.Handlers.Complete.PushBack(recordAWSPermissionsIssue(params.Target))
+		params.AWSClients.EC2 = ec2Client
+	}
+
+	if params.AWSClients.ELB == nil {
+		elbClient := elb.New(session)
+		elbClient.Handlers.Build.PushFrontNamed(userAgentHandler)
+		elbClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(params.Target))
+		params.AWSClients.ELB = elbClient
+	}
+
+	if params.AWSClients.ResourceTagging == nil {
+		resourceTagging := resourcegroupstaggingapi.New(session)
+		resourceTagging.Handlers.Build.PushFrontNamed(userAgentHandler)
+		resourceTagging.Handlers.Complete.PushBack(recordAWSPermissionsIssue(params.Target))
+		params.AWSClients.ResourceTagging = resourceTagging
+	}
+
+	if params.AWSClients.SecretsManager == nil {
+		sClient := secretsmanager.New(session)
+		sClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(params.Target))
+		params.AWSClients.SecretsManager = sClient
+	}
+
+	helper, err := patch.NewHelper(params.Target, params.Client)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to init patch helper")
+	}
+	return &ClusterNetworkScope{
+		Logger:      params.Logger,
+		client:      params.Client,
+		AWSClients:  params.AWSClients,
+		Cluster:     params.Cluster,
+		Target:      params.Target,
+		patchHelper: helper,
+
+		region:        params.Region,
+		NetworkSpec:   params.NetworkSpec,
+		networkStatus: params.NetworkStatus,
+		apiServerPort: params.APIServerPort,
+		tags:          params.AdditionalTags,
+	}, nil
+}
+
+// ClusterNetworkScope defines the basic context for an actuator to operate upon.
+type ClusterNetworkScope struct {
+	logr.Logger
+	client      client.Client
+	patchHelper *patch.Helper
+
+	AWSClients
+	Cluster *clusterv1.Cluster
+	Target  runtime.Object
+
+	region string
+
+	NetworkSpec   *infrav1.NetworkSpec
+	networkStatus *infrav1.Network
+
+	apiServerPort *int32
+	tags          infrav1.Tags
+}
+
+// Network returns the cluster network object.
+func (s *ClusterNetworkScope) Network() *infrav1.Network {
+	return s.networkStatus
+}
+
+// VPC returns the cluster VPC.
+func (s *ClusterNetworkScope) VPC() *infrav1.VPCSpec {
+	return &s.NetworkSpec.VPC
+}
+
+// Subnets returns the cluster subnets.
+func (s *ClusterNetworkScope) Subnets() infrav1.Subnets {
+	return s.NetworkSpec.Subnets
+}
+
+// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
+func (s *ClusterNetworkScope) SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup {
+	return s.networkStatus.SecurityGroups
+}
+
+// Name returns the cluster name.
+func (s *ClusterNetworkScope) Name() string {
+	return s.Cluster.Name
+}
+
+// Namespace returns the cluster namespace.
+func (s *ClusterNetworkScope) Namespace() string {
+	return s.Cluster.Namespace
+}
+
+// Region returns the cluster region.
+func (s *ClusterNetworkScope) Region() string {
+	return s.region
+}
+
+// PatchObject persists the cluster configuration and status.
+func (s *ClusterNetworkScope) PatchObject() error {
+	return s.patchHelper.Patch(context.TODO(), s.Target)
+}
+
+// Close closes the current scope persisting the cluster configuration and status.
+func (s *ClusterNetworkScope) Close() error {
+	return s.PatchObject()
+}
+
+// AdditionalTags returns AdditionalTags from the scope's AWSCluster. The returned value will never be nil.
+func (s *ClusterNetworkScope) AdditionalTags() infrav1.Tags {
+	if s.tags == nil {
+		s.tags = infrav1.Tags{}
+	}
+
+	return s.tags.DeepCopy()
+}
+
+// APIServerPort returns the APIServerPort to use when creating the load balancer.
+func (s *ClusterNetworkScope) APIServerPort() int32 {
+	if s.apiServerPort != nil {
+		return *s.apiServerPort
+	}
+	return 6443
+}

--- a/pkg/cloud/services/ec2/network/account.go
+++ b/pkg/cloud/services/ec2/network/account.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"sort"

--- a/pkg/cloud/services/ec2/network/eips.go
+++ b/pkg/cloud/services/ec2/network/eips.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"fmt"
@@ -52,7 +52,7 @@ func (s *Service) allocateAddress(role string) (string, error) {
 	})
 
 	if err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedAllocateEIP", "Failed to allocate Elastic IP for %q: %v", role, err)
+		record.Warnf(s.scope.Target, "FailedAllocateEIP", "Failed to allocate Elastic IP for %q: %v", role, err)
 		return "", errors.Wrap(err, "failed to allocate Elastic IP")
 	}
 
@@ -103,7 +103,7 @@ func (s *Service) disassociateAddress(ip *ec2.Address) error {
 		return true, nil
 	}, awserrors.AuthFailure)
 	if err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedDisassociateEIP", "Failed to disassociate Elastic IP %q: %v", *ip.AllocationId, err)
+		record.Warnf(s.scope.Target, "FailedDisassociateEIP", "Failed to disassociate Elastic IP %q: %v", *ip.AllocationId, err)
 		return errors.Wrapf(err, "failed to disassociate Elastic IP %q", *ip.AllocationId)
 	}
 	return nil
@@ -125,7 +125,7 @@ func (s *Service) releaseAddresses() error {
 				AssociationId: ip.AssociationId,
 			})
 			if err != nil {
-				record.Warnf(s.scope.AWSCluster, "FailedDisassociateEIP", "Failed to disassociate Elastic IP %q: %v", *ip.AllocationId, err)
+				record.Warnf(s.scope.Target, "FailedDisassociateEIP", "Failed to disassociate Elastic IP %q: %v", *ip.AllocationId, err)
 				return errors.Errorf("failed to disassociate Elastic IP %q with allocation ID %q: Still associated with association ID %q", *ip.PublicIp, *ip.AllocationId, *ip.AssociationId)
 			}
 		}
@@ -144,7 +144,7 @@ func (s *Service) releaseAddresses() error {
 			return true, nil
 		}, awserrors.AuthFailure, awserrors.InUseIPAddress)
 		if err != nil {
-			record.Warnf(s.scope.AWSCluster, "FailedReleaseEIP", "Failed to disassociate Elastic IP %q: %v", *ip.AllocationId, err)
+			record.Warnf(s.scope.Target, "FailedReleaseEIP", "Failed to disassociate Elastic IP %q: %v", *ip.AllocationId, err)
 			return errors.Wrapf(err, "failed to release ElasticIP %q", *ip.AllocationId)
 		}
 

--- a/pkg/cloud/services/ec2/network/gateways.go
+++ b/pkg/cloud/services/ec2/network/gateways.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"fmt"
@@ -67,7 +67,7 @@ func (s *Service) reconcileInternetGateways() error {
 		}
 		return true, nil
 	}, awserrors.InternetGatewayNotFound); err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", gateway.InternetGatewayId, err)
+		record.Warnf(s.scope.Target, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", gateway.InternetGatewayId, err)
 		return errors.Wrapf(err, "failed to tag internet gateway %q", *gateway.InternetGatewayId)
 	}
 
@@ -94,11 +94,11 @@ func (s *Service) deleteInternetGateways() error {
 		}
 
 		if _, err := s.scope.EC2.DetachInternetGateway(detachReq); err != nil {
-			record.Warnf(s.scope.AWSCluster, "FailedDetachInternetGateway", "Failed to detach Internet Gateway %q from VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
+			record.Warnf(s.scope.Target, "FailedDetachInternetGateway", "Failed to detach Internet Gateway %q from VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
 			return errors.Wrapf(err, "failed to detach internet gateway %q", *ig.InternetGatewayId)
 		}
 
-		record.Eventf(s.scope.AWSCluster, "SuccessfulDetachInternetGateway", "Detached Internet Gateway %q from VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
+		record.Eventf(s.scope.Target, "SuccessfulDetachInternetGateway", "Detached Internet Gateway %q from VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
 		s.scope.Info("Detached internet gateway from VPC", "internet-gateway-id", *ig.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 
 		deleteReq := &ec2.DeleteInternetGatewayInput{
@@ -106,11 +106,11 @@ func (s *Service) deleteInternetGateways() error {
 		}
 
 		if _, err = s.scope.EC2.DeleteInternetGateway(deleteReq); err != nil {
-			record.Warnf(s.scope.AWSCluster, "FailedDeleteInternetGateway", "Failed to delete Internet Gateway %q previously attached to VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
+			record.Warnf(s.scope.Target, "FailedDeleteInternetGateway", "Failed to delete Internet Gateway %q previously attached to VPC %q: %v", *ig.InternetGatewayId, s.scope.VPC().ID, err)
 			return errors.Wrapf(err, "failed to delete internet gateway %q", *ig.InternetGatewayId)
 		}
 
-		record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteInternetGateway", "Deleted Internet Gateway %q previously attached to VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
+		record.Eventf(s.scope.Target, "SuccessfulDeleteInternetGateway", "Deleted Internet Gateway %q previously attached to VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
 		s.scope.Info("Deleted internet gateway in VPC", "internet-gateway-id", *ig.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 	}
 
@@ -120,10 +120,10 @@ func (s *Service) deleteInternetGateways() error {
 func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 	ig, err := s.scope.EC2.CreateInternetGateway(&ec2.CreateInternetGatewayInput{})
 	if err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedCreateInternetGateway", "Failed to create new managed Internet Gateway: %v", err)
+		record.Warnf(s.scope.Target, "FailedCreateInternetGateway", "Failed to create new managed Internet Gateway: %v", err)
 		return nil, errors.Wrap(err, "failed to create internet gateway")
 	}
-	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateInternetGateway", "Created new managed Internet Gateway %q", *ig.InternetGateway.InternetGatewayId)
+	record.Eventf(s.scope.Target, "SuccessfulCreateInternetGateway", "Created new managed Internet Gateway %q", *ig.InternetGateway.InternetGatewayId)
 	s.scope.Info("Created internet gateway for VPC", "vpc-id", s.scope.VPC().ID)
 
 	tagParams := s.getGatewayTagParams(*ig.InternetGateway.InternetGatewayId)
@@ -136,7 +136,7 @@ func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 		}
 		return true, nil
 	}, awserrors.InternetGatewayNotFound); err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", *ig.InternetGateway.InternetGatewayId, err)
+		record.Warnf(s.scope.Target, "FailedTagInternetGateway", "Failed to tag managed Internet Gateway %q: %v", *ig.InternetGateway.InternetGatewayId, err)
 		return nil, errors.Wrapf(err, "failed to tag internet gateway %q", *ig.InternetGateway.InternetGatewayId)
 	}
 
@@ -152,10 +152,10 @@ func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 		}
 		return true, nil
 	}, awserrors.InternetGatewayNotFound); err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedAttachInternetGateway", "Failed to attach managed Internet Gateway %q to vpc %q: %v", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID, err)
+		record.Warnf(s.scope.Target, "FailedAttachInternetGateway", "Failed to attach managed Internet Gateway %q to vpc %q: %v", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID, err)
 		return nil, errors.Wrapf(err, "failed to attach internet gateway %q to vpc %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
 	}
-	record.Eventf(s.scope.AWSCluster, "SuccessfulAttachInternetGateway", "Internet Gateway %q attached to VPC %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
+	record.Eventf(s.scope.Target, "SuccessfulAttachInternetGateway", "Internet Gateway %q attached to VPC %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
 	s.scope.Info("attached internet gateway to VPC", "internet-gateway-id", *ig.InternetGateway.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 
 	return ig.InternetGateway, nil

--- a/pkg/cloud/services/ec2/network/gateways_test.go
+++ b/pkg/cloud/services/ec2/network/gateways_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"testing"
@@ -127,7 +127,7 @@ func TestReconcileInternetGateways(t *testing.T) {
 
 			tc.expect(ec2Mock.EXPECT())
 
-			s := NewService(scope)
+			s := NewService(scope.NetworkScope)
 			if err := s.reconcileInternetGateways(); err != nil {
 				t.Fatalf("got an unexpected error: %v", err)
 			}

--- a/pkg/cloud/services/ec2/network/natgateways_test.go
+++ b/pkg/cloud/services/ec2/network/natgateways_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"testing"
@@ -288,7 +288,7 @@ func TestReconcileNatGateways(t *testing.T) {
 			ec2Mock := mock_ec2iface.NewMockEC2API(mockCtrl)
 			elbMock := mock_elbiface.NewMockELBAPI(mockCtrl)
 
-			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+			scope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 				},
@@ -316,7 +316,7 @@ func TestReconcileNatGateways(t *testing.T) {
 
 			tc.expect(ec2Mock.EXPECT())
 
-			s := NewService(clusterScope)
+			s := NewService(scope.NetworkScope)
 			if err := s.reconcileNatGateways(); err != nil {
 				t.Fatalf("got an unexpected error: %v", err)
 			}

--- a/pkg/cloud/services/ec2/network/network.go
+++ b/pkg/cloud/services/ec2/network/network.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"

--- a/pkg/cloud/services/ec2/network/routetables_test.go
+++ b/pkg/cloud/services/ec2/network/routetables_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"strings"
@@ -267,7 +267,7 @@ func TestReconcileRouteTables(t *testing.T) {
 
 			tc.expect(ec2Mock.EXPECT())
 
-			s := NewService(scope)
+			s := NewService(scope.NetworkScope)
 			if err := s.reconcileRouteTables(); err != nil && tc.err != nil {
 				if !strings.Contains(err.Error(), tc.err.Error()) {
 					t.Fatalf("was expecting error to look like '%v', but got '%v'", tc.err, err)

--- a/pkg/cloud/services/ec2/network/securitygroups_test.go
+++ b/pkg/cloud/services/ec2/network/securitygroups_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"fmt"
@@ -269,7 +269,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 
 			tc.expect(ec2Mock.EXPECT())
 
-			s := NewService(scope)
+			s := NewService(scope.NetworkScope)
 			if err := s.reconcileSecurityGroups(); err != nil && tc.err != nil {
 				if !strings.Contains(err.Error(), tc.err.Error()) {
 					t.Fatalf("was expecting error to look like '%v', but got '%v'", tc.err, err)
@@ -292,7 +292,7 @@ func TestControlPlaneSecurityGroupNotOpenToAnyCIDR(t *testing.T) {
 		t.Fatalf("Failed to create test context: %v", err)
 	}
 
-	s := NewService(scope)
+	s := NewService(scope.NetworkScope)
 	rules, err := s.getSecurityGroupIngressRules(infrav1.SecurityGroupControlPlane)
 	if err != nil {
 		t.Fatalf("Failed to lookup controlplane security group ingress rules: %v", err)

--- a/pkg/cloud/services/ec2/network/service.go
+++ b/pkg/cloud/services/ec2/network/service.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+)
+
+// Service holds a collection of interfaces.
+// The interfaces are broken down like this to group functions together.
+// One alternative is to have a large list of functions from the ec2 client.
+type Service struct {
+	scope *scope.ClusterNetworkScope
+}
+
+// NewService returns a new service given the ec2 network api client.
+func NewService(scope *scope.ClusterNetworkScope) *Service {
+	return &Service{
+		scope: scope,
+	}
+}

--- a/pkg/cloud/services/ec2/network/subnets.go
+++ b/pkg/cloud/services/ec2/network/subnets.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"strings"
@@ -45,7 +45,7 @@ func (s *Service) reconcileSubnets() error {
 
 	subnets := s.scope.Subnets()
 	defer func() {
-		s.scope.AWSCluster.Spec.NetworkSpec.Subnets = subnets
+		s.scope.NetworkSpec.Subnets = subnets
 	}()
 
 	// Describe subnets in the vpc.
@@ -112,7 +112,7 @@ LoopExisting:
 					}
 					return true, nil
 				}, awserrors.SubnetNotFound); err != nil {
-					record.Warnf(s.scope.AWSCluster, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", exsn.ID, err)
+					record.Warnf(s.scope.Target, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", exsn.ID, err)
 					return errors.Wrapf(err, "failed to ensure tags on subnet %q", exsn.ID)
 				}
 
@@ -244,11 +244,11 @@ func (s *Service) createSubnet(sn *infrav1.SubnetSpec) (*infrav1.SubnetSpec, err
 	})
 
 	if err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedCreateSubnet", "Failed creating new managed Subnet %v", err)
+		record.Warnf(s.scope.Target, "FailedCreateSubnet", "Failed creating new managed Subnet %v", err)
 		return nil, errors.Wrap(err, "failed to create subnet")
 	}
 
-	record.Eventf(s.scope.AWSCluster, "SuccessfulCreateSubnet", "Created new managed Subnet %q", *out.Subnet.SubnetId)
+	record.Eventf(s.scope.Target, "SuccessfulCreateSubnet", "Created new managed Subnet %q", *out.Subnet.SubnetId)
 
 	wReq := &ec2.DescribeSubnetsInput{SubnetIds: []*string{out.Subnet.SubnetId}}
 	if err := s.scope.EC2.WaitUntilSubnetAvailable(wReq); err != nil {
@@ -264,11 +264,11 @@ func (s *Service) createSubnet(sn *infrav1.SubnetSpec) (*infrav1.SubnetSpec, err
 		}
 		return true, nil
 	}, awserrors.SubnetNotFound); err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", *out.Subnet.SubnetId, err)
+		record.Warnf(s.scope.Target, "FailedTagSubnet", "Failed tagging managed Subnet %q: %v", *out.Subnet.SubnetId, err)
 		return nil, errors.Wrapf(err, "failed to tag subnet %q", *out.Subnet.SubnetId)
 	}
 
-	record.Eventf(s.scope.AWSCluster, "SuccessfulTagSubnet", "Tagged managed Subnet %q", *out.Subnet.SubnetId)
+	record.Eventf(s.scope.Target, "SuccessfulTagSubnet", "Tagged managed Subnet %q", *out.Subnet.SubnetId)
 
 	if sn.IsPublic {
 		attReq := &ec2.ModifySubnetAttributeInput{
@@ -284,10 +284,10 @@ func (s *Service) createSubnet(sn *infrav1.SubnetSpec) (*infrav1.SubnetSpec, err
 			}
 			return true, nil
 		}, awserrors.SubnetNotFound); err != nil {
-			record.Warnf(s.scope.AWSCluster, "FailedModifySubnetAttributes", "Failed modifying managed Subnet %q attributes: %v", *out.Subnet.SubnetId, err)
+			record.Warnf(s.scope.Target, "FailedModifySubnetAttributes", "Failed modifying managed Subnet %q attributes: %v", *out.Subnet.SubnetId, err)
 			return nil, errors.Wrapf(err, "failed to set subnet %q attributes", *out.Subnet.SubnetId)
 		}
-		record.Eventf(s.scope.AWSCluster, "SuccessfulModifySubnetAttributes", "Modified managed Subnet %q attributes", *out.Subnet.SubnetId)
+		record.Eventf(s.scope.Target, "SuccessfulModifySubnetAttributes", "Modified managed Subnet %q attributes", *out.Subnet.SubnetId)
 	}
 
 	s.scope.V(2).Info("Created new subnet in VPC with cidr and availability zone ",
@@ -310,12 +310,12 @@ func (s *Service) deleteSubnet(id string) error {
 	})
 
 	if err != nil {
-		record.Warnf(s.scope.AWSCluster, "FailedDeleteSubnet", "Failed to delete managed Subnet %q: %v", id, err)
+		record.Warnf(s.scope.Target, "FailedDeleteSubnet", "Failed to delete managed Subnet %q: %v", id, err)
 		return errors.Wrapf(err, "failed to delete subnet %q", id)
 	}
 
 	s.scope.V(2).Info("Deleted subnet in vpc", "subnet-id", id, "vpc-id", s.scope.VPC().ID)
-	record.Eventf(s.scope.AWSCluster, "SuccessfulDeleteSubnet", "Deleted managed Subnet %q", id)
+	record.Eventf(s.scope.Target, "SuccessfulDeleteSubnet", "Deleted managed Subnet %q", id)
 	return nil
 }
 

--- a/pkg/cloud/services/ec2/network/subnets_test.go
+++ b/pkg/cloud/services/ec2/network/subnets_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"encoding/json"
@@ -531,7 +531,7 @@ func TestReconcileSubnets(t *testing.T) {
 
 			tc.expect(ec2Mock.EXPECT())
 
-			s := NewService(scope)
+			s := NewService(scope.NetworkScope)
 			if err := s.reconcileSubnets(); err != nil {
 				t.Fatalf("got an unexpected error: %v", err)
 			}
@@ -699,12 +699,12 @@ func TestDiscoverSubnets(t *testing.T) {
 
 			tc.mocks(ec2Mock.EXPECT())
 
-			s := NewService(scope)
+			s := NewService(scope.NetworkScope)
 			if err := s.reconcileSubnets(); err != nil {
 				t.Fatalf("got an unexpected error: %v", err)
 			}
 
-			subnets := s.scope.AWSCluster.Spec.NetworkSpec.Subnets
+			subnets := s.scope.Subnets()
 			out := make(map[string]*infrav1.SubnetSpec)
 			for _, sn := range subnets {
 				out[sn.ID] = sn

--- a/pkg/cloud/services/ec2/network/vpc_test.go
+++ b/pkg/cloud/services/ec2/network/vpc_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ec2
+package network
 
 import (
 	"reflect"
@@ -183,7 +183,7 @@ func TestReconcileVPC(t *testing.T) {
 
 			tc.expect(ec2Mock.EXPECT())
 
-			s := NewService(scope)
+			s := NewService(scope.NetworkScope)
 			if err := s.reconcileVPC(); err != nil {
 				t.Fatalf("got an unexpected error: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

A minor refactor to separate the networking side of the ec2 service so that it can be used with a `managed cluster` in the future. A new scope has been introduced called `clusternetwork` and this scope is accessible from the `cluster` scope.

**Which issue(s) this PR fixes** :
Relates To #1534 

