### PR TITLE
:bug: Include stopped bastion instances when describing

### DIFF
--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -113,7 +113,12 @@ func (s *Service) describeBastionInstance() (*infrav1.Instance, error) {
 		Filters: []*ec2.Filter{
 			filter.EC2.ProviderRole(infrav1.BastionRoleTagValue),
 			filter.EC2.Cluster(s.scope.Name()),
-			filter.EC2.InstanceStates(ec2.InstanceStateNamePending, ec2.InstanceStateNameRunning),
+			filter.EC2.InstanceStates(
+				ec2.InstanceStateNamePending,
+				ec2.InstanceStateNameRunning,
+				ec2.InstanceStateNameStopping,
+				ec2.InstanceStateNameStopped,
+			),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR allows `describeBastionInstance` method to return instances also in stopping or stopped state, avoiding to create a new machine when users stop machines outside of Cluster API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1704 

/milestone v0.5.4
/assign @detiber @ashoksekar07 
