### PR TITLE
🏃Reconcile ELB attached machines when a Machine is being deleted

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -476,13 +476,20 @@ var (
 	// that has been stopped and can be restarted
 	InstanceStateStopped = InstanceState("stopped")
 
-	// InstanceOperationalStates defines the set of states in which an EC2 instance is
-	// or can return to running, and supports all EC2 operations
-	InstanceOperationalStates = sets.NewString(
+	// InstanceRunningStates defines the set of states in which an EC2 instance is
+	// running or going to be running soon
+	InstanceRunningStates = sets.NewString(
 		string(InstanceStatePending),
 		string(InstanceStateRunning),
-		string(InstanceStateStopping),
-		string(InstanceStateStopped),
+	)
+
+	// InstanceOperationalStates defines the set of states in which an EC2 instance is
+	// or can return to running, and supports all EC2 operations
+	InstanceOperationalStates = InstanceRunningStates.Union(
+		sets.NewString(
+			string(InstanceStateStopping),
+			string(InstanceStateStopped),
+		),
 	)
 
 	// InstanceKnownStates represents all known EC2 instance states

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -283,6 +283,11 @@ func (m *MachineScope) HasFailed() bool {
 	return m.AWSMachine.Status.FailureReason != nil || m.AWSMachine.Status.FailureMessage != nil
 }
 
+func (m *MachineScope) InstanceIsRunning() bool {
+	state := m.GetInstanceState()
+	return state != nil && infrav1.InstanceRunningStates.Has(string(*state))
+}
+
 func (m *MachineScope) InstanceIsOperational() bool {
 	state := m.GetInstanceState()
 	return state != nil && infrav1.InstanceOperationalStates.Has(string(*state))

--- a/pkg/cloud/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/services/cloudformation/bootstrap.go
@@ -204,6 +204,7 @@ func controllersPolicy(accountID, partition string) *iam.PolicyDocument {
 					"elasticloadbalancing:DescribeTags",
 					"elasticloadbalancing:ModifyLoadBalancerAttributes",
 					"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+					"elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
 					"elasticloadbalancing:RemoveTags",
 				},
 			},

--- a/pkg/cloud/services/elb/errors.go
+++ b/pkg/cloud/services/elb/errors.go
@@ -68,6 +68,16 @@ func IsNotFound(err error) bool {
 	return false
 }
 
+// IsAccessDenied returns true if the error is AccessDenied.
+func IsAccessDenied(err error) bool {
+	if code, ok := awserrors.Code(errors.Cause(err)); ok {
+		if code == "AccessDenied" {
+			return true
+		}
+	}
+	return false
+}
+
 // IsConflict returns true if the error was created by NewConflict.
 func IsConflict(err error) bool {
 	return ReasonForError(err) == http.StatusConflict

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -201,11 +201,23 @@ func (s *Service) RegisterInstanceWithAPIServerELB(i *infrav1.Instance) error {
 	}
 
 	_, err = s.scope.ELB.RegisterInstancesWithLoadBalancer(input)
+	return err
+}
+
+// DeregisterInstanceFromAPIServerELB de-registers an instance from a classic ELB
+func (s *Service) DeregisterInstanceFromAPIServerELB(i *infrav1.Instance) error {
+	name, err := GenerateELBName(s.scope.Name())
 	if err != nil {
 		return err
 	}
 
-	return nil
+	input := &elb.DeregisterInstancesFromLoadBalancerInput{
+		Instances:        []*elb.Instance{{InstanceId: aws.String(i.ID)}},
+		LoadBalancerName: aws.String(name),
+	}
+
+	_, err = s.scope.ELB.DeregisterInstancesFromLoadBalancer(input)
+	return err
 }
 
 // GenerateELBName generates a formatted ELB name via either


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes CAPA remove control plane machine attached to ELB as soon as the machine is deleted or detected in some not running states, so the ELB immediately stops to forward requests without waiting for the health check timeouts

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1705

```release-note
⚠️ Action Required
The IAM policy for the controllers requires new permissions:

elasticloadbalancing:DeregisterInstancesFromLoadBalancer
```
