### PR TITLE
:bug: ELB should now not register subnets in the same AZ more than once

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -291,12 +291,13 @@ func (s *Service) getAPIServerClassicELBSpec() (*infrav1.ClassicELB, error) {
 		subnets = s.scope.Subnets().FilterPublic()
 	}
 
+subnetLoop:
 	for _, sn := range subnets {
 		for _, az := range res.AvailabilityZones {
 			if sn.AvailabilityZone == az {
 				// If we already attached another subnet in the same AZ, there is no need to
 				// add this subnet to the list of the ELB's subnets.
-				continue
+				continue subnetLoop
 			}
 		}
 		res.AvailabilityZones = append(res.AvailabilityZones, sn.AvailabilityZone)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes an issue with the subnet loop when the ELB is created or reconciled, it allowed to attach more than one subnet to the ELB in the same Availability Zone.

