### PR TITLE
🐛Create Session with Options

### DIFF
--- a/pkg/cloud/scope/session.go
+++ b/pkg/cloud/scope/session.go
@@ -33,7 +33,13 @@ func sessionForRegion(region string) (*session.Session, error) {
 		return s.(*session.Session), nil
 	}
 
-	ns, err := session.NewSession(aws.NewConfig().WithRegion(region))
+	ns, err := session.NewSessionWithOptions(session.Options{
+		// Provide SDK Config options, such as Region.
+		Config: aws.Config{
+			Region: aws.String(region),
+		},
+	})
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:
Previously, a new session with a new config gets created every time. This overrides any other options the user may provide using the go-aws-sdk. This fix creates a session using the ambient config rather. 

Fixes # N/A

