### PR TITLE
:running: Switch to using CAPI's MachineAddress instead of corev1.NodeAddress types

### DIFF
--- a/api/v1alpha2/awsmachine_types.go
+++ b/api/v1alpha2/awsmachine_types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha2
 
 import (
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -122,7 +122,7 @@ type AWSMachineStatus struct {
 	Ready bool `json:"ready"`
 
 	// Addresses contains the AWS instance associated addresses.
-	Addresses []v1.NodeAddress `json:"addresses,omitempty"`
+	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// InstanceState is the state of the AWS instance for this machine.
 	// +optional

--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 )
 
 // AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
@@ -505,7 +505,7 @@ type Instance struct {
 	IAMProfile string `json:"iamProfile,omitempty"`
 
 	// Addresses contains the AWS instance associated addresses.
-	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
+	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// The private IPv4 address assigned to the instance.
 	PrivateIP *string `json:"privateIp,omitempty"`

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -24,11 +24,12 @@ import (
 	time "time"
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	v1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 func init() {
@@ -612,7 +613,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 
 func autoConvert_v1alpha2_AWSMachineStatus_To_v1alpha3_AWSMachineStatus(in *AWSMachineStatus, out *v1alpha3.AWSMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]apiv1alpha3.MachineAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*v1alpha3.InstanceState)(unsafe.Pointer(in.InstanceState))
 	// WARNING: in.ErrorReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.ErrorMessage requires manual conversion: does not exist in peer-type
@@ -621,7 +622,7 @@ func autoConvert_v1alpha2_AWSMachineStatus_To_v1alpha3_AWSMachineStatus(in *AWSM
 
 func autoConvert_v1alpha3_AWSMachineStatus_To_v1alpha2_AWSMachineStatus(in *v1alpha3.AWSMachineStatus, out *AWSMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]apiv1alpha2.MachineAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*InstanceState)(unsafe.Pointer(in.InstanceState))
 	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureMessage requires manual conversion: does not exist in peer-type
@@ -980,7 +981,7 @@ func autoConvert_v1alpha2_Instance_To_v1alpha3_Instance(in *Instance, out *v1alp
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
 	out.UserData = (*string)(unsafe.Pointer(in.UserData))
 	out.IAMProfile = in.IAMProfile
-	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]apiv1alpha3.MachineAddress)(unsafe.Pointer(&in.Addresses))
 	out.PrivateIP = (*string)(unsafe.Pointer(in.PrivateIP))
 	out.PublicIP = (*string)(unsafe.Pointer(in.PublicIP))
 	out.ENASupport = (*bool)(unsafe.Pointer(in.ENASupport))
@@ -1001,7 +1002,7 @@ func autoConvert_v1alpha3_Instance_To_v1alpha2_Instance(in *v1alpha3.Instance, o
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
 	out.UserData = (*string)(unsafe.Pointer(in.UserData))
 	out.IAMProfile = in.IAMProfile
-	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]apiv1alpha2.MachineAddress)(unsafe.Pointer(&in.Addresses))
 	out.PrivateIP = (*string)(unsafe.Pointer(in.PrivateIP))
 	out.PublicIP = (*string)(unsafe.Pointer(in.PublicIP))
 	out.ENASupport = (*bool)(unsafe.Pointer(in.ENASupport))

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -294,7 +294,7 @@ func (in *AWSMachineStatus) DeepCopyInto(out *AWSMachineStatus) {
 	*out = *in
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
-		*out = make([]v1.NodeAddress, len(*in))
+		*out = make([]apiv1alpha2.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.InstanceState != nil {
@@ -677,7 +677,7 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 	}
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
-		*out = make([]v1.NodeAddress, len(*in))
+		*out = make([]apiv1alpha2.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.PrivateIP != nil {

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha3
 
 import (
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -148,7 +148,7 @@ type AWSMachineStatus struct {
 	Ready bool `json:"ready"`
 
 	// Addresses contains the AWS instance associated addresses.
-	Addresses []v1.NodeAddress `json:"addresses,omitempty"`
+	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// InstanceState is the state of the AWS instance for this machine.
 	// +optional

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -21,8 +21,8 @@ import (
 	"sort"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 // AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
@@ -531,7 +531,7 @@ type Instance struct {
 	IAMProfile string `json:"iamProfile,omitempty"`
 
 	// Addresses contains the AWS instance associated addresses.
-	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
+	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// The private IPv4 address assigned to the instance.
 	PrivateIP *string `json:"privateIp,omitempty"`

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
@@ -304,7 +303,7 @@ func (in *AWSMachineStatus) DeepCopyInto(out *AWSMachineStatus) {
 	*out = *in
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
-		*out = make([]v1.NodeAddress, len(*in))
+		*out = make([]apiv1alpha3.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.InstanceState != nil {
@@ -707,7 +706,7 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 	}
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
-		*out = make([]v1.NodeAddress, len(*in))
+		*out = make([]apiv1alpha3.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.PrivateIP != nil {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -159,14 +159,14 @@ spec:
                   addresses:
                     description: Addresses contains the AWS instance associated addresses.
                     items:
-                      description: NodeAddress contains information for the node's
+                      description: MachineAddress contains information for the node's
                         address.
                       properties:
                         address:
-                          description: The node address.
+                          description: The machine address.
                           type: string
                         type:
-                          description: Node address type, one of Hostname, ExternalIP
+                          description: Machine address type, one of Hostname, ExternalIP
                             or InternalIP.
                           type: string
                       required:
@@ -623,14 +623,14 @@ spec:
                   addresses:
                     description: Addresses contains the AWS instance associated addresses.
                     items:
-                      description: NodeAddress contains information for the node's
+                      description: MachineAddress contains information for the node's
                         address.
                       properties:
                         address:
-                          description: The node address.
+                          description: The machine address.
                           type: string
                         type:
-                          description: Node address type, one of Hostname, ExternalIP
+                          description: Machine address type, one of Hostname, ExternalIP
                             or InternalIP.
                           type: string
                       required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -219,13 +219,14 @@ spec:
               addresses:
                 description: Addresses contains the AWS instance associated addresses.
                 items:
-                  description: NodeAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
-                      description: The node address.
+                      description: The machine address.
                       type: string
                     type:
-                      description: Node address type, one of Hostname, ExternalIP
+                      description: Machine address type, one of Hostname, ExternalIP
                         or InternalIP.
                       type: string
                   required:
@@ -554,13 +555,14 @@ spec:
               addresses:
                 description: Addresses contains the AWS instance associated addresses.
                 items:
-                  description: NodeAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
-                      description: The node address.
+                      description: The machine address.
                       type: string
                     type:
-                      description: Node address type, one of Hostname, ExternalIP
+                      description: Machine address type, one of Hostname, ExternalIP
                         or InternalIP.
                       type: string
                   required:

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -223,7 +223,7 @@ func (m *MachineScope) SetSecretCount(i int32) {
 }
 
 // SetAddresses sets the AWSMachine address status.
-func (m *MachineScope) SetAddresses(addrs []corev1.NodeAddress) {
+func (m *MachineScope) SetAddresses(addrs []clusterv1.MachineAddress) {
 	m.AWSMachine.Status.Addresses = addrs
 }
 

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
@@ -36,6 +35,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
@@ -627,27 +627,27 @@ func (s *Service) SDKToInstance(v *ec2.Instance) (*infrav1.Instance, error) {
 	return i, nil
 }
 
-func (s *Service) getInstanceAddresses(instance *ec2.Instance) []corev1.NodeAddress {
-	addresses := []corev1.NodeAddress{}
+func (s *Service) getInstanceAddresses(instance *ec2.Instance) []clusterv1.MachineAddress {
+	addresses := []clusterv1.MachineAddress{}
 	for _, eni := range instance.NetworkInterfaces {
-		privateDNSAddress := corev1.NodeAddress{
-			Type:    corev1.NodeInternalDNS,
+		privateDNSAddress := clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalDNS,
 			Address: aws.StringValue(eni.PrivateDnsName),
 		}
-		privateIPAddress := corev1.NodeAddress{
-			Type:    corev1.NodeInternalIP,
+		privateIPAddress := clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalIP,
 			Address: aws.StringValue(eni.PrivateIpAddress),
 		}
 		addresses = append(addresses, privateDNSAddress, privateIPAddress)
 
 		// An elastic IP is attached if association is non nil pointer
 		if eni.Association != nil {
-			publicDNSAddress := corev1.NodeAddress{
-				Type:    corev1.NodeExternalDNS,
+			publicDNSAddress := clusterv1.MachineAddress{
+				Type:    clusterv1.MachineExternalDNS,
 				Address: aws.StringValue(eni.Association.PublicDnsName),
 			}
-			publicIPAddress := corev1.NodeAddress{
-				Type:    corev1.NodeExternalIP,
+			publicIPAddress := clusterv1.MachineAddress{
+				Type:    clusterv1.MachineExternalIP,
 				Address: aws.StringValue(eni.Association.PublicIp),
 			}
 			addresses = append(addresses, publicDNSAddress, publicIPAddress)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
[KEP-1664](https://github.com/kubernetes/enhancements/pull/1665) is proposing to deprecate and replace Node.Status.Address, so probably best to avoid
using those types. We have a copy of these types in CAPI, so this PR switches them over.

This doesn't really change the CRD API types other than changing the field
descriptions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

