### PR TITLE
:bug: Ignore "not found" errors when deregistering ELB instances

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -246,6 +246,17 @@ func (s *Service) DeregisterInstanceFromAPIServerELB(i *infrav1.Instance) error 
 	}
 
 	_, err = s.scope.ELB.DeregisterInstancesFromLoadBalancer(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case elb.ErrCodeAccessPointNotFoundException, elb.ErrCodeInvalidEndPointException:
+				// Ignoring LoadBalancerNotFound and InvalidInstance when deregistering
+				return nil
+			default:
+				return err
+			}
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When de-registering instances from an ELB, we ignore errors relating to "instance not found" or "loadbalancer not found". This avoids issues when the controller got interrupted **after** deleting the ELB but **before** deregistering the instances.
Also should handle the case where a controller is interrupted between the instance deregistration and the instance delete.

**Which issue(s) this PR fixes**
Fixes #1736 

