### PR TITLE
:sparkles: Hacky patch to enable VXLAN for Antrea

### DIFF
--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -416,6 +416,16 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 				},
 			},
 			{
+				Description: "vxlan (antrea)",
+				Protocol:    infrav1.SecurityGroupProtocolUDP,
+				FromPort:    4789,
+				ToPort:      4789,
+				SourceSecurityGroupIDs: []string{
+					s.scope.SecurityGroups()[infrav1.SecurityGroupControlPlane].ID,
+					s.scope.SecurityGroups()[infrav1.SecurityGroupNode].ID,
+				},
+			},
+			{
 				Description: "IP-in-IP (calico)",
 				Protocol:    infrav1.SecurityGroupProtocolIPinIP,
 				FromPort:    -1,


### PR DESCRIPTION
Just as a way to start the conversation.

**What this PR does / why we need it**:

Enable Antrea so its at parity with calico in terms of working out of the box.

**Which issue(s) this PR fixes** 

partially fixes  #1588  and https://github.com/vmware-tanzu/antrea/issues/802  , allowing us to test OVS based CNIs, i.e. antrea