### PR TITLE
create a bastion host if it's enabled in the spec, regardless of managed or unmanaged VPC

### DIFF
--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -36,12 +36,9 @@ const (
 
 // ReconcileBastion ensures a bastion is created for the cluster
 func (s *Service) ReconcileBastion() error {
-	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping bastion reconcile in unmanaged mode")
-		return nil
-	}
 
 	if !s.scope.AWSCluster.Spec.Bastion.Enabled {
+		s.scope.V(4).Info("Skipping bastion reconcile")
 		_, err := s.describeBastionInstance()
 		if err != nil {
 			if awserrors.IsNotFound(err) {


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Presently if you are using an unmanaged (bring your own) VPC, we do not create or reconcile a bastion host, but we do reconcile the security group for the bastion.Now  we could create a bastion host if it's enabled in the spec, regardless of managed or unmanaged VPC.

**Which issue(s) this PR fixes** 
Fixes #1748 

