### PR TITLE
🐛 Restricts AZ limit to 1 in e2e tests

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.31.6
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/gophercloud/gophercloud v0.2.0
 	github.com/onsi/ginkgo v1.12.2
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
**What this PR does / why we need it**:
The e2e tests have been failing for a while: https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-cluster-api-provider-aws#periodic-e2e-v1alpha3&width=20
They all seem to hit the 20 minute timeout while waiting for the cluster to reach `InfrastructureReady`. One of the recent changes that increased the time needed for an AWScluster to reach ready is the subnet defaulting logic #1721 

These changes restrict the number of AZs to provision infrastructure to 1. While testing locally, this made an improvement from 12 minutes down to 5 minutes. 
Note: We still have a test case that specifies subnets in multiple AZs and validates machines are created appropriately but there is now a gap in e2e testing the defaulting logic. 
