### PR TITLE
:running: Makefile: Build clean binaries on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,11 +306,12 @@ release: clean-release  ## Builds and push container images using the latest git
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
 	git checkout "${RELEASE_TAG}"
+	# Build binaries prior to marking the git tree as dirty
+	$(MAKE) release-binaries
 	# Set the manifest image to the production bucket.
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(PROD_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG)
 	$(MAKE) set-manifest-pull-policy PULL_POLICY=IfNotPresent
 	$(MAKE) release-manifests
-	$(MAKE) release-binaries
 
 .PHONY: release-manifests
 release-manifests: $(RELEASE_DIR) ## Builds the manifests to publish with a release


### PR DESCRIPTION
Small fix to the release process so we don't end up publishing binaries that appear to be built from a non-tagged git tree.