### PR TITLE
🐛  Fixes cluster creation with names starting with 'sg-'

### DIFF
--- a/pkg/cloud/services/ec2/securitygroups.go
+++ b/pkg/cloud/services/ec2/securitygroups.go
@@ -18,6 +18,7 @@ package ec2
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -452,7 +453,11 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 }
 
 func (s *Service) getSecurityGroupName(clusterName string, role infrav1.SecurityGroupRole) string {
-	return fmt.Sprintf("%s-%v", clusterName, role)
+	groupPrefix := clusterName
+	if strings.HasPrefix(clusterName, "sg-") {
+		groupPrefix = "@" + clusterName
+	}
+	return fmt.Sprintf("%s-%v", groupPrefix, role)
 }
 
 func (s *Service) getDefaultSecurityGroup(role infrav1.SecurityGroupRole) *ec2.SecurityGroup {

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -528,6 +528,20 @@ var _ = Describe("functional tests", func() {
 			By("PASSED!")
 		})
 	})
+
+	Describe("Create cluster with name starting with 'sg-'", func() {
+		It("Cluster should be provisioned and deleted", func() {
+			setup, cancelFunc := setup1()
+			defer cancelFunc()
+			By("Creating a workload cluster with single control plane")
+			setup.clusterName = "sg-" + util.RandomString(6)
+			makeSingleControlPlaneCluster(setup)
+
+			By("Deleting the Cluster")
+			deleteCluster(setup.namespace, setup.clusterName)
+			By("PASSED!")
+		})
+	})
 })
 
 func watchEvents(ctx context.Context, namespace string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes security group failures when attempting to create a cluster that has a name starting with 'sg-'

Fixes #1725 

