### PR TITLE
🐛 Fix issue with NAT gateway failing due to EIP already been assigned

### DIFF
--- a/pkg/cloud/services/ec2/natgateways_test.go
+++ b/pkg/cloud/services/ec2/natgateways_test.go
@@ -140,6 +140,7 @@ func TestReconcileNatGateways(t *testing.T) {
 				).Return(&ec2.CreateNatGatewayOutput{
 					NatGateway: &ec2.NatGateway{
 						NatGatewayId: aws.String("natgateway"),
+						SubnetId:     aws.String("subnet-1"),
 					},
 				}, nil)
 
@@ -228,6 +229,7 @@ func TestReconcileNatGateways(t *testing.T) {
 				}).Return(&ec2.CreateNatGatewayOutput{
 					NatGateway: &ec2.NatGateway{
 						NatGatewayId: aws.String("natgateway"),
+						SubnetId:     aws.String("subnet-3"),
 					},
 				}, nil)
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Until the code is refactored in #1792 , this PR fixes the NAT gateway issue where creation fails because it assigned an EIP that is already bound to a different NAT gateway. The PR tries to keep the exact same workflow and steps but just batch creates the EIPs before creating the NAT gateways.

Changes/Additions:

Created a `createNatGateways` function that batch creates all the NAT gateways while keeping the createNatGateway function intact as much as possible
Changed `getOrAllocateAddress` to `getOrAllocateAddresses` to batch find/create all the EIPs before the NAT gateways are created

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1752 

Note I need to test this tomorrow because I had to resolve a merge conflict with the recent NAT gateway status condition code change.
