### PR TITLE
✨ Look up official EKS AMI when appropriate

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -151,6 +151,16 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 			"iam:GetRole",
 			"iam:ListAttachedRolePolicies",
 		}
+		statement = append(statement, iamv1.StatementEntry{
+			Effect: iamv1.EffectAllow,
+			Resource: iamv1.Resources{
+				"arn:aws:ssm:*:*:parameter/aws/service/eks/optimized-ami/*",
+			},
+			Action: iamv1.Actions{
+				"ssm:GetParameter",
+			},
+		})
+
 		if t.Spec.ClusterAPIControllers.EKS.IAMRoleCreation {
 			allowedIAMActions = append(allowedIAMActions, iamv1.Actions{
 				"iam:DetachRolePolicy",
@@ -206,6 +216,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 			},
 		}...)
 	}
+
 	return &iamv1.PolicyDocument{
 		Version:   iamv1.CurrentVersion,
 		Statement: statement,

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
@@ -215,6 +215,11 @@ Resources:
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
         - Action:
+          - ssm:GetParameter
+          Effect: Allow
+          Resource:
+          - arn:aws:ssm:*:*:parameter/aws/service/eks/optimized-ami/*
+        - Action:
           - iam:GetRole
           - iam:ListAttachedRolePolicies
           Effect: Allow

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.34.10
 	github.com/awslabs/goformation/v4 v4.11.0
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/golang/mock v1.4.3
 	github.com/google/goexpect v0.0.0-20200703111054-623d5ca06f56

--- a/pkg/cloud/services/ec2/service.go
+++ b/pkg/cloud/services/ec2/service.go
@@ -18,6 +18,7 @@ package ec2
 
 import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
@@ -28,6 +29,9 @@ import (
 type Service struct {
 	scope     scope.EC2Scope
 	EC2Client ec2iface.EC2API
+
+	// SSMClient is used to look up the official EKS AMI ID
+	SSMClient ssmiface.SSMAPI
 }
 
 // NewService returns a new service given the ec2 api client.
@@ -35,5 +39,6 @@ func NewService(clusterScope scope.EC2Scope) *Service {
 	return &Service{
 		scope:     clusterScope,
 		EC2Client: scope.NewEC2Client(clusterScope, clusterScope, clusterScope.InfraCluster()),
+		SSMClient: scope.NewSSMClient(clusterScope, clusterScope, clusterScope.InfraCluster()),
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This adds a lookup for the official EKS AMI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1778 

This is WIP until #1724 goes in. Will be using those types to determine if using the EKS AMI is appropriate. I'll also need some additional changes when #1810 goes in. 

Also still working on finding the right IAM updates. I'm having an obnoxiously difficult time getting a policy statement that is properly scoped. Wildcards are not appropriate at all for SSM Parameter Store.