### PR TITLE
:seedling: ci: disable gofumpt linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - gomnd
     - godot
     - goerr113
+    - gofumpt
   # Run with --fast=false for more extensive checks
   fast: true
 issues:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Disables `gofumpt` linter. This linter has slightly stricter requirements than `gofmt` which could perhaps be useful, but `gofumpt` itself isn't compatible with `gopls` at this time.


