### PR TITLE
clusterawsadm: Add bootstrap user back to deprecated alpha command

### DIFF
--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -65,6 +65,7 @@ func RootCmd() *cobra.Command {
 
 func bootstrapTemplateFromCmdLine() cfnBootstrap.Template {
 	conf := bootstrapv1.NewAWSIAMConfiguration()
+	conf.Spec.BootstrapUser.Enable = true
 	conf.Spec.ControlPlane.ExtraPolicyAttachments = extraControlPlanePolicies
 	conf.Spec.Nodes.ExtraPolicyAttachments = extraNodePolicies
 	return cfnBootstrap.Template{


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fixes a reported regression with the old deprecated commands. Default in new commands remains that the bootstrap user is not enabled.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

