### PR TITLE
e2e: Output service quotas for debugging and move conformance template generation into go from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ E2E_DATA_DIR ?= $(REPO_ROOT)/test/e2e_new/data
 E2E_CONF_PATH  ?= $(E2E_DATA_DIR)/e2e_conf.yaml
 KUBETEST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance.yaml)
 KUBETEST_FAST_CONF_PATH ?= $(abspath $(REPO_ROOT)/test/e2e_new/data/kubetest/conformance-fast.yaml)
-CONFORMANCE_CI_TEMPLATE := $(ARTIFACTS)/templates/cluster-template-conformance-ci-artifacts.yaml
+CONFORMANCE_CI_TEMPLATE := _artifacts/templates/cluster-template-conformance-ci-artifacts.yaml
+CONFORMANCE_CI_TEMPLATE_ARTIFACT := $(ARTIFACTS)/templates/cluster-template-conformance-ci-artifacts.yaml
 
 # Binaries.
 CLUSTERCTL := $(BIN_DIR)/clusterctl
@@ -147,7 +148,11 @@ $(OVERLAY_DIR)/cluster-template.yaml: $(OVERLAY_DIR)
 	cp -f templates/cluster-template.yaml $@
 
 $(CONFORMANCE_CI_TEMPLATE): $(OVERLAY_DIR)/cluster-template.yaml $(ARTIFACTS)/templates $(KUSTOMIZE) $(OVERLAY_DIR)/kustomization.yaml $(OVERLAY_DIR)/kustomizeversions.yaml
-		$(KUSTOMIZE) build $(OVERLAY_DIR) > $@
+	mkdir -p $(dir $(CONFORMANCE_CI_TEMPLATE))
+	$(KUSTOMIZE) build $(OVERLAY_DIR) > $@
+
+$(CONFORMANCE_CI_TEMPLATE_ARTIFACT): $(CONFORMANCE_CI_TEMPLATE) $(ARTIFACTS)/templates
+	-cp -R $(CONFORMANCE_CI_TEMPLATE) $@
 
 .PHONY: test-e2e
 test-e2e: $(GINKGO) $(KIND) ## Run e2e tests

--- a/test/e2e_new/e2e_suite_test.go
+++ b/test/e2e_new/e2e_suite_test.go
@@ -152,6 +152,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	e2eConfig = loadE2EConfig(configPath)
 
 	awsSession = newAWSSession()
+	if err := dumpServiceQuotas(context.TODO(), artifactFolder); err != nil {
+		// Non-lethal error
+		fmt.Fprintln(GinkgoWriter, "Error dumping service quotas: err=%s", err)
+	}
 	createCloudFormationStack(awsSession, getBootstrapTemplate())
 	ensureNoServiceLinkedRoles(awsSession)
 	ensureSSHKeyPair(awsSession, defaultSSHKeyPairName)


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Output service quotas to help with debugging

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

