### PR TITLE
e2e: Fixups for conformance template generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ junit.*.xml
 
 # test results
 _artifacts
+awsiamconfiguration.yaml
+cloudformation.yaml

--- a/test/e2e_new/data/e2e_conf.yaml
+++ b/test/e2e_new/data/e2e_conf.yaml
@@ -89,7 +89,6 @@ providers:
     files:
       # Add a cluster template
       - sourcePath: "../../../templates/cluster-template.yaml"
-      - sourcePath: "../../../_artifacts/templates/cluster-template-conformance-ci-artifacts.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.18.2"
@@ -100,11 +99,6 @@ variables:
   CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.18.2"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
-  # include hacks for a typical conformance bootstrap script
-  GSUTIL: '${GSUTIL}'
-  PACKAGE_VERSION: '${PACKAGE_VERSION}'
-  SUDO: '${SUDO}'
-  VERSION_REGEX: '${VERSION_REGEX}'
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e_new/data/kubetest/kustomization/kustomizeversions.yaml
+++ b/test/e2e_new/data/kubetest/kustomization/kustomizeversions.yaml
@@ -6,7 +6,7 @@ spec:
   kubeadmConfigSpec:
     useExperimentalRetryJoin: true
     clusterConfiguration:
-      kubernetesVersion: "ci/${CI_VERSION}"
+      kubernetesVersion: "ci/${KUBERNETES_VERSION}"
     preKubeadmCommands:
       - bash -c /tmp/kubeadm-bootstrap.sh
     files:
@@ -21,58 +21,58 @@ spec:
           set -o errexit
           [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
           GSUTIL=gsutil
-          if ! command -v ${GSUTIL} > /dev/null; then
+          if ! command -v $${GSUTIL} > /dev/null; then
             curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
             GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
             # For faster downloads
             pip install --no-cache-dir -U crcmod
           fi
-          ${GSUTIL} version
+          $${GSUTIL} version
           # This test installs release packages or binaries that are a result of the CI and release builds.
           # It runs '... --version' commands to verify that the binaries are correctly installed
           # and finally uninstalls the packages.
           # For the release packages it tests all versions in the support skew.
           LINE_SEPARATOR="*************************************************"
-          echo "$LINE_SEPARATOR"
-          CI_VERSION=${CI_VERSION}
-          if [[ "${CI_VERSION}" != "" ]]; then
+          echo "$$LINE_SEPARATOR"
+          KUBERNETES_VERSION=${KUBERNETES_VERSION}
+          if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
             CI_DIR=/tmp/k8s-ci
-            mkdir -p $CI_DIR
+            mkdir -p $$CI_DIR
             declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
             declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
             CONTAINER_EXT="tar"
-            echo "* testing CI version $CI_VERSION"
+            echo "* testing CI version $$KUBERNETES_VERSION"
             # Check for semver
-            if [[ "${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
-              VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
+            if [[ "$${KUBERNETES_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              CI_URL="gs://kubernetes-release/release/$$KUBERNETES_VERSION/bin/linux/amd64"
+              VERSION_WITHOUT_PREFIX="${KUBERNETES_VERSION#v}"
               DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
               curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
               echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
               apt-get update
               # replace . with \.
               VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
-              PACKAGE_VERSION="$(apt-cache madison kubelet|grep ${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
-              for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
-                echo "* installing package: $CI_PACKAGE ${PACKAGE_VERSION}"
-                DEBIAN_FRONTEND=noninteractive apt-get install -y $CI_PACKAGE=$PACKAGE_VERSION
+              PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+              for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+                echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
+                DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
               done
             else
-              CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-              for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
-                echo "* downloading binary: $CI_URL/$CI_PACKAGE"
-                ${GSUTIL} cp "$CI_URL/$CI_PACKAGE" "$CI_DIR/$CI_PACKAGE"
-                chmod +x "$CI_DIR/$CI_PACKAGE"
-                mv "$CI_DIR/$CI_PACKAGE" "/usr/bin/$CI_PACKAGE"
+              CI_URL="gs://kubernetes-release-dev/ci/$$KUBERNETES_VERSION-bazel/bin/linux/amd64"
+              for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+                echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
+                $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"
+                chmod +x "$$CI_DIR/$$CI_PACKAGE"
+                mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
               done
               systemctl restart kubelet
             fi
-            for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
-              echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-              ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
-              ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
-              ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
-              ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"
+            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+              echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
+              $${GSUTIL} cp "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
+              $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
+              $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${KUBERNETES_VERSION//+/_}" k8s.gcr.io/$$CI_CONTAINER:"$${KUBERNETES_VERSION//+/_}"
+              $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${KUBERNETES_VERSION//+/_}" gcr.io/kubernetes-ci-images/$$CI_CONTAINER:"$${KUBERNETES_VERSION//+/_}"
             done
           fi
           echo "* checking binary versions"
@@ -80,7 +80,7 @@ spec:
           echo "kubeadm version: " $(kubeadm version -o=short)
           echo "kubectl version: " $(kubectl version --client=true --short=true)
           echo "kubelet version: " $(kubelet --version)
-          echo "$LINE_SEPARATOR"
+          echo "$$LINE_SEPARATOR"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
@@ -113,58 +113,58 @@ spec:
             set -o errexit
             [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
             GSUTIL=gsutil
-            if ! command -v ${GSUTIL} > /dev/null; then
+            if ! command -v $${GSUTIL} > /dev/null; then
               curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
               GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
               # For faster downloads
               pip install --no-cache-dir -U crcmod
             fi
-            ${GSUTIL} version
+            $${GSUTIL} version
             # This test installs release packages or binaries that are a result of the CI and release builds.
             # It runs '... --version' commands to verify that the binaries are correctly installed
             # and finally uninstalls the packages.
             # For the release packages it tests all versions in the support skew.
             LINE_SEPARATOR="*************************************************"
-            echo "$LINE_SEPARATOR"
-            CI_VERSION=${CI_VERSION}
-            if [[ "${CI_VERSION}" != "" ]]; then
+            echo "$$LINE_SEPARATOR"
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
               CI_DIR=/tmp/k8s-ci
-              mkdir -p $CI_DIR
+              mkdir -p $$CI_DIR
               declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
               declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
               CONTAINER_EXT="tar"
-              echo "* testing CI version $CI_VERSION"
+              echo "* testing CI version $$KUBERNETES_VERSION"
               # Check for semver
-              if [[ "${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                CI_URL="gs://kubernetes-release/release/$CI_VERSION/bin/linux/amd64"
-                VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
+              if [[ "$${KUBERNETES_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                CI_URL="gs://kubernetes-release/release/$$KUBERNETES_VERSION/bin/linux/amd64"
+                VERSION_WITHOUT_PREFIX="${KUBERNETES_VERSION#v}"
                 DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
                 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
                 echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
                 apt-get update
                 # replace . with \.
                 VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
-                PACKAGE_VERSION="$(apt-cache madison kubelet|grep ${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
-                for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
-                  echo "* installing package: $CI_PACKAGE ${PACKAGE_VERSION}"
-                  DEBIAN_FRONTEND=noninteractive apt-get install -y $CI_PACKAGE=$PACKAGE_VERSION
+                PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+                for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+                  echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
+                  DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
                 done
               else
-                CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-                for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
-                  echo "* downloading binary: $CI_URL/$CI_PACKAGE"
-                  ${GSUTIL} cp "$CI_URL/$CI_PACKAGE" "$CI_DIR/$CI_PACKAGE"
-                  chmod +x "$CI_DIR/$CI_PACKAGE"
-                  mv "$CI_DIR/$CI_PACKAGE" "/usr/bin/$CI_PACKAGE"
+                CI_URL="gs://kubernetes-release-dev/ci/$$KUBERNETES_VERSION-bazel/bin/linux/amd64"
+                for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+                  echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
+                  $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"
+                  chmod +x "$$CI_DIR/$$CI_PACKAGE"
+                  mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
                 done
                 systemctl restart kubelet
               fi
-              for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
-                echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-                ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
-                ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
-                ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
-                ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"
+              for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+                echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
+                $${GSUTIL} cp "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
+                $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
+                $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${KUBERNETES_VERSION//+/_}" k8s.gcr.io/$$CI_CONTAINER:"$${KUBERNETES_VERSION//+/_}"
+                $${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$$CI_CONTAINER-amd64:"$${KUBERNETES_VERSION//+/_}" gcr.io/kubernetes-ci-images/$$CI_CONTAINER:"$${KUBERNETES_VERSION//+/_}"
               done
             fi
             echo "* checking binary versions"
@@ -172,7 +172,7 @@ spec:
             echo "kubeadm version: " $(kubeadm version -o=short)
             echo "kubectl version: " $(kubectl version --client=true --short=true)
             echo "kubelet version: " $(kubelet --version)
-            echo "$LINE_SEPARATOR"
+            echo "$$LINE_SEPARATOR"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
@@ -183,12 +183,3 @@ spec:
     spec:
       ami:
         id: ${IMAGE_ID}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSCluster
-metadata:
-  name: "${CLUSTER_NAME}"
-spec:
-  networkSpec:
-    vpc:
-      availabilityZoneUsageLimit: 1

--- a/test/e2e_new/e2e_suite_test.go
+++ b/test/e2e_new/e2e_suite_test.go
@@ -145,12 +145,12 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+	flag.Parse()
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. configPath should be an existing file.")
 	Expect(os.MkdirAll(artifactFolder, 0o750)).To(Succeed(), "Invalid test suite argument. Can't create artifacts-folder %q", artifactFolder)
-
 	Byf("Loading the e2e test configuration from %q", configPath)
 	e2eConfig = loadE2EConfig(configPath)
-
+	Expect(prepConformanceConfig(artifactFolder, e2eConfig)).To(Succeed())
 	awsSession = newAWSSession()
 	createCloudFormationStack(awsSession, getBootstrapTemplate())
 	ensureNoServiceLinkedRoles(awsSession)

--- a/test/e2e_new/kubetest/setup.go
+++ b/test/e2e_new/kubetest/setup.go
@@ -81,7 +81,6 @@ func NewConfiguration(e2eConfig *clusterctl.E2EConfig, artifactsDirectory string
 	if c.UseCIArtifacts {
 		newVersion := fetchKubernetesCIVersion()
 		c.E2EConfig.Variables["KUBERNETES_VERSION"] = newVersion
-		c.E2EConfig.Variables["CI_VERSION"] = newVersion
 	}
 	c.DumpE2EConfig()
 	return &c


### PR DESCRIPTION
Resolves a CI difference where _artifacts is not the same as the ARTIFACTS directory, by moving the logic from GNU Make to go

