### PR TITLE
✨ bastion: Make instance type selectable, with new defaults

### DIFF
--- a/api/v1alpha2/awscluster_conversion.go
+++ b/api/v1alpha2/awscluster_conversion.go
@@ -55,6 +55,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.Bastion.AllowedCIDRBlocks = restored.Spec.Bastion.AllowedCIDRBlocks
 	dst.Spec.Bastion.DisableIngressRules = restored.Spec.Bastion.DisableIngressRules
+	dst.Spec.Bastion.InstanceType = restored.Spec.Bastion.InstanceType
 	dst.Spec.ImageLookupFormat = restored.Spec.ImageLookupFormat
 	dst.Spec.ImageLookupOrg = restored.Spec.ImageLookupOrg
 	dst.Spec.ImageLookupBaseOS = restored.Spec.ImageLookupBaseOS

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -99,6 +99,11 @@ type Bastion struct {
 	// They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
 	// +optional
 	AllowedCIDRBlocks []string `json:"allowedCIDRBlocks,omitempty"`
+
+	// InstanceType will use the specified instance type for the bastion. If not specified,
+	// Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro
+	// will be the default.
+	InstanceType string `json:"instanceType,omitempty"`
 }
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -414,6 +414,9 @@ spec:
                   enabled:
                     description: Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.
                     type: boolean
+                  instanceType:
+                    description: InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.
+                    type: string
                 type: object
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
T2 instance type is starting to be removed from Amazon DCs, so update
the default to the most universally available burstable micro instance,
with an exception for us-east-1.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1830 

