### PR TITLE
✨  Use filters to select subnet for machines

### DIFF
--- a/pkg/cloud/filter/ec2.go
+++ b/pkg/cloud/filter/ec2.go
@@ -29,6 +29,7 @@ const (
 	filterNameVpcID         = "vpc-id"
 	filterNameState         = "state"
 	filterNameVpcAttachment = "attachment.vpc-id"
+	filterAvailabilityZone  = "availability-zone"
 )
 
 // EC2 exposes the ec2 sdk related filters.
@@ -139,5 +140,12 @@ func (ec2Filters) SubnetStates(states ...string) *ec2.Filter {
 	return &ec2.Filter{
 		Name:   aws.String("state"),
 		Values: aws.StringSlice(states),
+	}
+}
+
+func (ec2Filters) AvailabilityZone(zone string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String(filterAvailabilityZone),
+		Values: aws.StringSlice([]string{zone}),
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the only way to specify a subnet to be used by a machine is by using the subnetID. It's restrictive as the user may not always have the subnet provisioned beforehand or have access to the subnetID. These changes allow the user to specify AWS filters to be used to select a subnet for a given machine template. 

It looks for subnet to use in the following order: 
- subnetID specified in template
- subnet filters specified in template (will add availability-zone filter if failureDomain is also specified)
- filter available private subnets by failureDomain if specified
- select first available private subnet

**If multiple subnets are returned by the filter parameters, the first one is used.** 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1776 

