### PR TITLE
🌱 Fix error handling for goerr113 linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - gocognit
     - gomnd
     - godot
-    - goerr113
     - gofumpt
   # Run with --fast=false for more extensive checks
   fast: true

--- a/api/v1alpha3/awsmachinetemplate_webhook.go
+++ b/api/v1alpha3/awsmachinetemplate_webhook.go
@@ -17,9 +17,9 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"errors"
 	"reflect"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -60,7 +60,7 @@ func (r *AWSMachineTemplate) ValidateCreate() error {
 func (r *AWSMachineTemplate) ValidateUpdate(old runtime.Object) error {
 	oldAWSMachineTemplate := old.(*AWSMachineTemplate)
 	if !reflect.DeepEqual(r.Spec, oldAWSMachineTemplate.Spec) {
-		return errors.New("awsMachineTemplateSpec is immutable")
+		return apierrors.NewBadRequest("AWSMachineTemplate.Spec is immutable")
 	}
 
 	return nil

--- a/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
@@ -47,13 +47,13 @@ func (t Template) GenerateManagedIAMPolicyDocuments(policyDocDir string) error {
 
 		pds, err := converters.IAMPolicyDocumentToJSON(*pd)
 		if err != nil {
-			return fmt.Errorf("failed to marshal policy document for ManagedIAMPolicy %q: %v", pn, err)
+			return fmt.Errorf("failed to marshal policy document for ManagedIAMPolicy %q: %w", pn, err)
 		}
 
 		fn := path.Join(policyDocDir, fmt.Sprintf("%s.json", pn))
 		err = ioutil.WriteFile(fn, []byte(pds), 0o600)
 		if err != nil {
-			return fmt.Errorf("failed to generate policy document for ManagedIAMPolicy %q: %v", pn, err)
+			return fmt.Errorf("failed to generate policy document for ManagedIAMPolicy %q: %w", pn, err)
 		}
 	}
 	return nil

--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -206,7 +206,7 @@ func generateIAMPolicyDocJSON() *cobra.Command {
 			t := bootstrapTemplateFromCmdLine()
 			err := t.GenerateManagedIAMPolicyDocuments(policyDocDir)
 			if err != nil {
-				return fmt.Errorf("failed to generate PolicyDocument for all ManagedIAMPolicies: %v", err)
+				return fmt.Errorf("failed to generate PolicyDocument for all ManagedIAMPolicies: %w", err)
 			}
 
 			fmt.Printf("PolicyDocument for all ManagedIAMPolicies successfully generated in JSON at %q\n", policyDocDir)

--- a/cmd/clusterawsadm/cmd/bootstrap/credentials/credentials.go
+++ b/cmd/clusterawsadm/cmd/bootstrap/credentials/credentials.go
@@ -76,6 +76,8 @@ const (
 	`
 )
 
+var errInvalidOutputFlag = errors.New("invalid output flag. Expected rawSharedConfig or base64SharedConfig")
+
 // RootCmd is the root of the `alpha bootstrap command`
 func RootCmd() *cobra.Command {
 	newCmd := &cobra.Command{
@@ -103,7 +105,7 @@ func getOutputFlag(cmd *cobra.Command) (string, error) {
 	case rawSharedConfig, base64SharedConfig:
 		return val, nil
 	default:
-		return "", errors.New("invalid output flag. Expected rawSharedConfig or base64SharedConfig")
+		return "", errInvalidOutputFlag
 	}
 }
 

--- a/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
+++ b/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
 
+var errInvalidDocumentName = fmt.Errorf("invalid document name, use one of: %+v", bootstrap.ManagedIAMPolicyNames)
+
 func printPolicyCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "print-policy",
@@ -76,7 +78,7 @@ func printPolicyCmd() *cobra.Command {
 func getDocumentName(cmd *cobra.Command) (bootstrap.PolicyName, error) {
 	val := bootstrap.PolicyName(cmd.Flags().Lookup("document").Value.String())
 	if !val.IsValid() {
-		return "", fmt.Errorf("invalid document name, use one of: %+v", bootstrap.ManagedIAMPolicyNames)
+		return "", errInvalidDocumentName
 	}
 
 	return val, nil

--- a/cmd/clusterawsadm/credentials/credentials.go
+++ b/cmd/clusterawsadm/credentials/credentials.go
@@ -41,6 +41,14 @@ aws_session_token = {{ .SessionToken }}
 
 const AWSDefaultRegion = "us-east-1"
 
+var ErrNoAWSRegionConfigured = errors.New("no AWS region configured. Use --region or set AWS_REGION or DEFAULT_AWS_REGION environment variable")
+
+type ErrEnvironmentVariableNotFound string
+
+func (e ErrEnvironmentVariableNotFound) Error() string {
+	return fmt.Sprintf("environment variable %q not found", string(e))
+}
+
 type AWSCredentials struct {
 	AccessKeyID     string
 	SecretAccessKey string
@@ -78,13 +86,13 @@ func ResolveRegion(explicitRegion string) (string, error) {
 	if err == nil {
 		return region, nil
 	}
-	return "", errors.New("no AWS region configured. Use --region or set AWS_REGION or DEFAULT_AWS_REGION environment variable")
+	return "", ErrNoAWSRegionConfigured
 }
 
 func getEnv(key string) (string, error) {
 	val, ok := os.LookupEnv(key)
 	if !ok {
-		return "", fmt.Errorf("environment variable %q not found", key)
+		return "", ErrEnvironmentVariableNotFound(key)
 	}
 	return val, nil
 }

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -384,7 +384,7 @@ func (r *AWSMachineReconciler) reconcileDelete(machineScope *scope.MachineScope,
 func (r *AWSMachineReconciler) findInstance(scope *scope.MachineScope, ec2svc services.EC2MachineInterface) (*infrav1.Instance, error) {
 	// Parse the ProviderID.
 	pid, err := noderefutil.NewProviderID(scope.GetProviderID())
-	if err != nil && err != noderefutil.ErrEmptyProviderID {
+	if err != nil && !errors.Is(err, noderefutil.ErrEmptyProviderID) {
 		return nil, errors.Wrapf(err, "failed to parse Spec.ProviderID")
 	}
 

--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -63,28 +63,28 @@ func Message(err error) string {
 
 // EC2Error is an error exposed to users of this library.
 type EC2Error struct {
-	err error
+	msg string
 
 	Code int
 }
 
 // Error implements the Error interface.
 func (e *EC2Error) Error() string {
-	return e.err.Error()
+	return e.msg
 }
 
-// NewNotFound returns a new error which indicates that the resource of the kind and the name was not found.
-func NewNotFound(err error) error {
+// NewNotFound returns an error which indicates that the resource of the kind and the name was not found.
+func NewNotFound(msg string) error {
 	return &EC2Error{
-		err:  err,
+		msg:  msg,
 		Code: http.StatusNotFound,
 	}
 }
 
-// NewConflict returns a new error which indicates that the request cannot be processed due to a conflict.
-func NewConflict(err error) error {
+// NewConflict returns an error which indicates that the request cannot be processed due to a conflict.
+func NewConflict(msg string) error {
 	return &EC2Error{
-		err:  err,
+		msg:  msg,
 		Code: http.StatusConflict,
 	}
 }
@@ -96,10 +96,10 @@ func IsResourceExists(err error) bool {
 	return false
 }
 
-// NewFailedDependency returns a new error which indicates that a dependency failure status
-func NewFailedDependency(err error) error {
+// NewFailedDependency returns an error which indicates that a dependency failure status
+func NewFailedDependency(msg string) error {
 	return &EC2Error{
-		err:  err,
+		msg:  msg,
 		Code: http.StatusFailedDependency,
 	}
 }

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -148,7 +148,7 @@ func (s *Service) describeBastionInstance() (*infrav1.Instance, error) {
 		}
 	}
 
-	return nil, awserrors.NewNotFound(errors.New("bastion host not found"))
+	return nil, awserrors.NewNotFound("bastion host not found")
 }
 
 func (s *Service) getDefaultBastion(instanceType string) *infrav1.Instance {

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -54,7 +54,7 @@ func TestInstanceIfExists(t *testing.T) {
 				m.DescribeInstances(gomock.Eq(&ec2.DescribeInstancesInput{
 					InstanceIds: []*string{aws.String("hello")},
 				})).
-					Return(nil, awserrors.NewNotFound(errors.New("not found")))
+					Return(nil, awserrors.NewNotFound("not found"))
 			},
 			check: func(instance *infrav1.Instance, err error) {
 				if err != nil {

--- a/pkg/cloud/services/elb/errors.go
+++ b/pkg/cloud/services/elb/errors.go
@@ -29,28 +29,28 @@ var _ error = &ELBError{}
 
 // ELBError is an error exposed to users of this library.
 type ELBError struct {
-	err error
+	msg string
 
 	Code int
 }
 
 // Error implements the Error interface.
 func (e *ELBError) Error() string {
-	return e.err.Error()
+	return e.msg
 }
 
-// NewNotFound returns a new error which indicates that the resource of the kind and the name was not found.
-func NewNotFound(err error) error {
+// NewNotFound returns an error which indicates that the resource of the kind and the name was not found.
+func NewNotFound(msg string) error {
 	return &ELBError{
-		err:  err,
+		msg:  msg,
 		Code: http.StatusNotFound,
 	}
 }
 
-// NewConflict returns a new error which indicates that the request cannot be processed due to a conflict.
-func NewConflict(err error) error {
+// NewConflict returns an error which indicates that the request cannot be processed due to a conflict.
+func NewConflict(msg string) error {
 	return &ELBError{
-		err:  err,
+		msg:  msg,
 		Code: http.StatusConflict,
 	}
 }

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -523,7 +523,7 @@ func (s *Service) describeClassicELB(name string) (*infrav1.ClassicELB, error) {
 	}
 
 	if out != nil && len(out.LoadBalancerDescriptions) == 0 {
-		return nil, NewNotFound(fmt.Errorf("no classic load balancer found with name %q", name))
+		return nil, NewNotFound(fmt.Sprintf("no classic load balancer found with name %q", name))
 	}
 
 	if s.scope.VPC().ID != "" && s.scope.VPC().ID != *out.LoadBalancerDescriptions[0].VPCId {

--- a/pkg/cloud/services/network/gateways.go
+++ b/pkg/cloud/services/network/gateways.go
@@ -161,7 +161,7 @@ func (s *Service) describeVpcInternetGateways() ([]*ec2.InternetGateway, error) 
 	}
 
 	if len(out.InternetGateways) == 0 {
-		return nil, awserrors.NewNotFound(errors.Errorf("no internet gateways found in vpc %q", s.scope.VPC().ID))
+		return nil, awserrors.NewNotFound(fmt.Sprintf("no internet gateways found in vpc %q", s.scope.VPC().ID))
 	}
 
 	return out.InternetGateways, nil

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -18,7 +18,6 @@ package network
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -26,18 +25,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
-
-func init() {
-	if err := clusterv1.AddToScheme(scheme.Scheme); err != nil {
-		_ = fmt.Errorf("Error adding clusterv1 to scheme")
-	}
-}
 
 const (
 	subnetsVPCID = "vpc-subnets"

--- a/pkg/cloud/services/network/vpc.go
+++ b/pkg/cloud/services/network/vpc.go
@@ -257,15 +257,15 @@ func (s *Service) describeVPC() (*infrav1.VPCSpec, error) {
 	}
 
 	if len(out.Vpcs) == 0 {
-		return nil, awserrors.NewNotFound(errors.Errorf("could not find vpc %q", s.scope.VPC().ID))
+		return nil, awserrors.NewNotFound(fmt.Sprintf("could not find vpc %q", s.scope.VPC().ID))
 	} else if len(out.Vpcs) > 1 {
-		return nil, awserrors.NewConflict(errors.Errorf("found more than one vpc with supplied filters. Please clean up extra VPCs: %s", out.GoString()))
+		return nil, awserrors.NewConflict(fmt.Sprintf("found more than one vpc with supplied filters. Please clean up extra VPCs: %s", out.GoString()))
 	}
 
 	switch *out.Vpcs[0].State {
 	case ec2.VpcStateAvailable, ec2.VpcStatePending:
 	default:
-		return nil, awserrors.NewNotFound(errors.Errorf("could not find available or pending vpc"))
+		return nil, awserrors.NewNotFound("could not find available or pending vpc")
 	}
 
 	return &infrav1.VPCSpec{

--- a/pkg/cloud/services/secretsmanager/helpers_test.go
+++ b/pkg/cloud/services/secretsmanager/helpers_test.go
@@ -37,9 +37,8 @@ func TestSplitBytes(t *testing.T) {
 	t.Run("should call 1 time if it fits", func(t *testing.T) {
 		maxSize := 100
 		input := make([]byte, 100)
-		if _, err := crand.Read(input); err != nil {
-			_ = fmt.Errorf("Could not Read byte input")
-		}
+		_, err := crand.Read(input)
+		g.Expect(err).To(BeNil())
 
 		count := 0
 		splitBytes(input, maxSize, func(split []byte) {
@@ -52,9 +51,8 @@ func TestSplitBytes(t *testing.T) {
 	t.Run("should properly split given random input and maxsize", func(t *testing.T) {
 		maxSize := 1 + rand.Intn(1024)
 		input := make([]byte, rand.Intn(24576))
-		if _, err := crand.Read(input); err != nil {
-			_ = fmt.Errorf(("Could not read byte input"))
-		}
+		_, err := crand.Read(input)
+		g.Expect(err).To(BeNil())
 
 		expected := len(input) / maxSize
 		if math.Mod(float64(len(input)), float64(maxSize)) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Use static errors or wrap them
- Remove redundant error wrapping from the awserrors package

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1800

