### PR TITLE
📖 Update prerequisites.md to add IAM section header

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -7,6 +7,7 @@
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 - [jq](https://stedolan.github.io/jq/download/)
 
+## IAM resources
 ### With `clusterawsadm`
 
 Get the latest [clusterawsadm](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases)


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this section header, the reader can assume that the SSH Key Pair header is under the **Without clusterawsadm** section and incorrectly setup the prerequisites. This explicit header makes sure that the two headings stand visually apart from each other.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

