### PR TITLE
📖 Updates docs to upload existing keypair to AWS

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -81,7 +81,7 @@ aws ssm put-parameter --name "/sigs.k8s.io/cluster-api-provider-aws/ssh-key" \
 # Replace with your own public key
 aws ec2 import-key-pair \
   --key-name default \
-  --public-key-material "$(cat ~/.ssh/id_rsa.pub)"
+  --public-key-material "$(base64 -i ~/.ssh/id_rsa.pub)"
 ```
 
 > **NB**: Only RSA keys are supported by AWS.


### PR DESCRIPTION
**What this PR does / why we need it**:
The `aws ec2 import-key-pair` requires the input for the `--public-key-material` flag to be base64 encoded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

