### PR TITLE
test/e2e_new: Use ci/latest version marker for retrieving cross builds

### DIFF
--- a/test/e2e_new/kubetest/setup.go
+++ b/test/e2e_new/kubetest/setup.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 const (
-	ciVersionURL = "https://dl.k8s.io/ci/k8s-master.txt"
+	ciVersionURL = "https://dl.k8s.io/ci/latest.txt"
 )
 
 // Configuration creates a new kubetest configuration


### PR DESCRIPTION
**What this PR does / why we need it**:

(Follow-up to https://github.com/kubernetes/test-infra/pull/18290.)

[Now](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1288265272272097280) that the `ci/latest` version marker again represents a cross build of `kubernetes/kubernetes@master`, we should stop using the `ci/k8s-master` generic version marker.

ref: https://github.com/kubernetes/test-infra/blob/master/docs/kubernetes-versions.md, https://github.com/kubernetes/sig-release/issues/850

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

