### PR TITLE
🌱 refactor AWSMachine to use scope interfaces

### DIFF
--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/mock_services"
@@ -99,8 +100,8 @@ var _ = Describe("AWSMachineReconciler", func() {
 						},
 					},
 				},
-				AWSCluster: &infrav1.AWSCluster{},
-				AWSMachine: awsMachine,
+				InfraCluster: cs,
+				AWSMachine:   awsMachine,
 			},
 		)
 		Expect(err).To(BeNil())
@@ -113,6 +114,27 @@ var _ = Describe("AWSMachineReconciler", func() {
 		)
 		Expect(err).To(BeNil())
 
+		ms, err = scope.NewMachineScope(
+			scope.MachineScopeParams{
+				Client: fake.NewFakeClient([]runtime.Object{awsMachine, secret}...),
+				Cluster: &clusterv1.Cluster{
+					Status: clusterv1.ClusterStatus{
+						InfrastructureReady: true,
+					},
+				},
+				Machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
+						Bootstrap: clusterv1.Bootstrap{
+							DataSecretName: pointer.StringPtr("bootstrap-data"),
+						},
+					},
+				},
+				InfraCluster: cs,
+				AWSMachine:   awsMachine,
+			},
+		)
+		Expect(err).To(BeNil())
+
 		mockCtrl = gomock.NewController(GinkgoT())
 		ec2Svc = mock_services.NewMockEC2MachineInterface(mockCtrl)
 		secretSvc = mock_services.NewMockSecretsManagerInterface(mockCtrl)
@@ -121,10 +143,10 @@ var _ = Describe("AWSMachineReconciler", func() {
 		recorder = record.NewFakeRecorder(2)
 
 		reconciler = AWSMachineReconciler{
-			ec2ServiceFactory: func(*scope.ClusterScope) services.EC2MachineInterface {
+			ec2ServiceFactory: func(scope.EC2Scope) services.EC2MachineInterface {
 				return ec2Svc
 			},
-			secretsManagerServiceFactory: func(*scope.ClusterScope) services.SecretsManagerInterface {
+			secretsManagerServiceFactory: func(cloud.ClusterScoper) services.SecretsManagerInterface {
 				return secretSvc
 			},
 			Recorder: recorder,
@@ -150,12 +172,12 @@ var _ = Describe("AWSMachineReconciler", func() {
 				buf := new(bytes.Buffer)
 				klog.SetOutput(buf)
 
-				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 				Expect(buf).To(ContainSubstring("Error state detected, skipping reconciliation"))
 			})
 
 			It("should add our finalizer to the machine", func() {
-				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 
 				Expect(ms.AWSMachine.Finalizers).To(ContainElement(infrav1.MachineFinalizer))
 			})
@@ -166,7 +188,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				buf := new(bytes.Buffer)
 				klog.SetOutput(buf)
 
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 				Expect(err).To(BeNil())
 				Expect(buf.String()).To(ContainSubstring("Cluster infrastructure is not ready yet"))
 				expectConditions(ms.AWSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForClusterInfrastructureReason}})
@@ -178,7 +200,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				buf := new(bytes.Buffer)
 				klog.SetOutput(buf)
 
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 
 				Expect(err).To(BeNil())
 				Expect(buf.String()).To(ContainSubstring("Bootstrap data secret reference is not yet available"))
@@ -186,7 +208,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 			})
 
 			It("should return an error when we can't list instances by tags", func() {
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 				Expect(errors.Cause(err)).To(MatchError(expectedErr))
 			})
 		})
@@ -204,7 +226,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				expectedErr := errors.New("no connection available ")
 				ec2Svc.EXPECT().InstanceIfExists(PointsTo("myMachine")).Return(nil, expectedErr)
 
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 				Expect(errors.Cause(err)).To(MatchError(expectedErr))
 			})
 
@@ -214,7 +236,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return("test", int32(1), nil).Times(1)
 				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
 
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 				Expect(errors.Cause(err)).To(MatchError(expectedErr))
 			})
 		})
@@ -238,7 +260,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				})
 
 				It("should set attributes after creating an instance", func() {
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Spec.ProviderID).To(PointTo(Equal("aws:////myMachine")))
 					Expect(ms.AWSMachine.Annotations).To(Equal(map[string]string{"cluster-api-provider-aws": "true"}))
 				})
@@ -253,7 +275,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 					It("should set instance to pending", func() {
 						instance.State = infrav1.InstanceStatePending
-						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 						Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStatePending)))
 						Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
 						Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
@@ -262,7 +284,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 					It("should set instance to running", func() {
 						instance.State = infrav1.InstanceStateRunning
-						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 						Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateRunning)))
 						Expect(ms.AWSMachine.Status.Ready).To(Equal(true))
 						Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
@@ -279,7 +301,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 					klog.SetOutput(buf)
 					instance.State = "NewAWSMachineState"
 					secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state is undefined")))
 					Eventually(recorder.Events).Should(Receive(ContainSubstring("InstanceUnhandledState")))
@@ -304,20 +326,20 @@ var _ = Describe("AWSMachineReconciler", func() {
 					// ms.AWSMachine.Spec.AdditionalSecurityGroups = []infrav1
 					ec2Svc.EXPECT().UpdateInstanceSecurityGroups(instance.ID, []string{"sg-2345"})
 
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					expectConditions(ms.AWSMachine, []conditionAssertion{{conditionType: infrav1.SecurityGroupsReadyCondition, status: corev1.ConditionTrue}})
 				})
 
 				It("should not tag anything if there's not tags", func() {
 					ec2Svc.EXPECT().UpdateInstanceSecurityGroups(gomock.Any(), gomock.Any()).Times(0)
-					if _, err := reconciler.reconcileNormal(context.Background(), ms, cs); err != nil {
+					if _, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs); err != nil {
 						_ = fmt.Errorf("reconcileNormal reutrned an error during test")
 					}
 				})
 
 				It("should tag instances from machine and cluster tags", func() {
 					ms.AWSMachine.Spec.AdditionalTags = infrav1.Tags{"kind": "alicorn"}
-					ms.AWSCluster.Spec.AdditionalTags = infrav1.Tags{"colour": "lavender"}
+					cs.AWSCluster.Spec.AdditionalTags = infrav1.Tags{"colour": "lavender"}
 
 					ec2Svc.EXPECT().UpdateResourceTags(
 						PointsTo("myMachine"),
@@ -328,7 +350,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 						map[string]string{},
 					).Return(nil)
 
-					_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -345,7 +367,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 				It("should set instance to stopping and unready", func() {
 					instance.State = infrav1.InstanceStateStopping
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateStopping)))
 					Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
@@ -354,7 +376,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 				It("should then set instance to stopped and unready", func() {
 					instance.State = infrav1.InstanceStateStopped
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateStopped)))
 					Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
@@ -363,7 +385,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 				It("should then set instance to running and ready once it is restarted", func() {
 					instance.State = infrav1.InstanceStateRunning
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateRunning)))
 					Expect(ms.AWSMachine.Status.Ready).To(Equal(true))
 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
@@ -380,7 +402,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 				It("should warn if an instance is shutting-down", func() {
 					instance.State = infrav1.InstanceStateShuttingDown
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
 					Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
 					Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
@@ -388,7 +410,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 
 				It("should error when the instance is seen as terminated", func() {
 					instance.State = infrav1.InstanceStateTerminated
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
 					Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
 					Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
@@ -417,7 +439,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				ms.AWSMachine.ObjectMeta.Labels = map[string]string{
 					clusterv1.MachineControlPlaneLabelName: "",
 				}
-				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 			})
 		})
 
@@ -446,27 +468,27 @@ var _ = Describe("AWSMachineReconciler", func() {
 					Return(map[string][]string{"eid": {}}, nil).Times(1)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
 				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 			})
 
 			It("should delete the secret if the instance is terminated", func() {
 				instance.State = infrav1.InstanceStateTerminated
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 			})
 
 			It("should delete the secret if the AWSMachine is deleted", func() {
 				instance.State = infrav1.InstanceStateRunning
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-				_, _ = reconciler.reconcileDelete(ms, cs)
+				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs)
 			})
 
 			It("should delete the secret if the AWSMachine is in a failure condition", func() {
 				ms.AWSMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-				_, _ = reconciler.reconcileDelete(ms, cs)
+				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs)
 			})
 		})
 
@@ -488,27 +510,27 @@ var _ = Describe("AWSMachineReconciler", func() {
 					Return(map[string][]string{"eid": {}}, nil).Times(1)
 				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).MaxTimes(0)
-				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 			})
 
 			It("should delete the secret if the instance is terminated", func() {
 				instance.State = infrav1.InstanceStateTerminated
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 			})
 
 			It("should delete the secret if the AWSMachine is deleted", func() {
 				instance.State = infrav1.InstanceStateRunning
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-				_, _ = reconciler.reconcileDelete(ms, cs)
+				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs)
 			})
 
 			It("should delete the secret if the AWSMachine is in a failure condition", func() {
 				ms.AWSMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-				_, _ = reconciler.reconcileDelete(ms, cs)
+				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs)
 			})
 		})
 
@@ -518,7 +540,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 			})
 			It("should error if secret could not be created", func() {
 				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(0), errors.New("connection error")).Times(1)
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring("connection error"))
 				Expect(ms.GetSecretPrefix()).To(Equal(""))
@@ -535,7 +557,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
 				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
 
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 
 				Expect(err).To(BeNil())
 				Expect(ms.GetSecretPrefix()).To(Equal(secretPrefix))
@@ -556,7 +578,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 			expectedErr := errors.New("no connection available ")
 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 
-			_, err := reconciler.reconcileDelete(ms, cs)
+			_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 			Expect(errors.Cause(err)).To(MatchError(expectedErr))
 		})
 
@@ -566,7 +588,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			_, err := reconciler.reconcileDelete(ms, cs)
+			_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 			Expect(err).To(BeNil())
 			Expect(buf.String()).To(ContainSubstring("Unable to locate EC2 instance by ID or tags"))
 			Expect(ms.AWSMachine.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
@@ -581,7 +603,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			_, err := reconciler.reconcileDelete(ms, cs)
+			_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 			Expect(err).To(BeNil())
 			Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
 			Expect(ms.AWSMachine.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
@@ -595,7 +617,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			_, err := reconciler.reconcileDelete(ms, cs)
+			_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 			Expect(err).To(BeNil())
 			Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
 			Expect(ms.AWSMachine.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
@@ -615,7 +637,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 				buf := new(bytes.Buffer)
 				klog.SetOutput(buf)
 
-				_, err := reconciler.reconcileDelete(ms, cs)
+				_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 				Expect(errors.Cause(err)).To(MatchError(expected))
 				Expect(buf.String()).To(ContainSubstring("Terminating EC2 instance"))
 				Eventually(recorder.Events).Should(Receive(ContainSubstring("FailedTerminate")))
@@ -638,7 +660,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 						expected := errors.New("can't reach AWS to list security groups")
 						ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return(nil, expected)
 
-						_, err := reconciler.reconcileDelete(ms, cs)
+						_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 						Expect(errors.Cause(err)).To(MatchError(expected))
 					})
 
@@ -647,7 +669,7 @@ var _ = Describe("AWSMachineReconciler", func() {
 						ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{"sg0", "sg1"}, nil)
 						ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(gomock.Any(), gomock.Any()).Return(expected)
 
-						_, err := reconciler.reconcileDelete(ms, cs)
+						_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 						Expect(errors.Cause(err)).To(MatchError(expected))
 					})
 
@@ -657,13 +679,13 @@ var _ = Describe("AWSMachineReconciler", func() {
 						ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth0").Return(nil)
 						ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth1").Return(nil)
 
-						_, err := reconciler.reconcileDelete(ms, cs)
+						_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 						Expect(err).To(BeNil())
 					})
 				})
 
 				It("should remove security groups", func() {
-					_, err := reconciler.reconcileDelete(ms, cs)
+					_, err := reconciler.reconcileDelete(ms, cs, cs, cs)
 					Expect(err).To(BeNil())
 					Expect(ms.AWSMachine.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
 				})

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -242,3 +242,18 @@ func (s *ClusterScope) SSHKeyName() *string {
 func (s *ClusterScope) ControllerName() string {
 	return s.controllerName
 }
+
+// ImageLookupFormat returns the format string to use when looking up AMIs
+func (s *ClusterScope) ImageLookupFormat() string {
+	return s.AWSCluster.Spec.ImageLookupFormat
+}
+
+// ImageLookupOrg returns the organization name to use when looking up AMIs
+func (s *ClusterScope) ImageLookupOrg() string {
+	return s.AWSCluster.Spec.ImageLookupOrg
+}
+
+// ImageLookupBaseOS returns the base operating system name to use when looking up AMIs
+func (s *ClusterScope) ImageLookupBaseOS() string {
+	return s.AWSCluster.Spec.ImageLookupBaseOS
+}

--- a/pkg/cloud/scope/ec2.go
+++ b/pkg/cloud/scope/ec2.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+)
+
+// Scope is the interface for the scoep to be used with the ec2 service
+type EC2Scope interface {
+	cloud.ClusterScoper
+
+	// VPC returns the cluster VPC.
+	VPC() *infrav1.VPCSpec
+
+	// Subnets returns the cluster subnets.
+	Subnets() infrav1.Subnets
+
+	// Network returns the cluster network object.
+	Network() *infrav1.Network
+
+	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
+	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+
+	// Bastion returns the bastion details for the cluster.
+	Bastion() *infrav1.Bastion
+
+	// SetBastionInstance sets the bastion instance in the status of the cluster.
+	SetBastionInstance(instance *infrav1.Instance)
+
+	// SSHKeyName returns the SSH key name to use for instances.
+	SSHKeyName() *string
+
+	// ImageLookupFormat returns the format string to use when looking up AMIs
+	ImageLookupFormat() string
+
+	// ImageLookupOrg returns the organization name to use when looking up AMIs
+	ImageLookupOrg() string
+
+	// ImageLookupBaseOS returns the base operating system name to use when looking up AMIs
+	ImageLookupBaseOS() string
+}

--- a/pkg/cloud/scope/elb.go
+++ b/pkg/cloud/scope/elb.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+)
+
+// Scope is a scope for use with the ELB reconciling service
+type ELBScope interface {
+	cloud.ClusterScoper
+
+	// Network returns the cluster network object.
+	Network() *infrav1.Network
+
+	// Subnets returns the cluster subnets.
+	Subnets() infrav1.Subnets
+
+	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
+	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+
+	// VPC returns the cluster VPC.
+	VPC() *infrav1.VPCSpec
+
+	// ControlPlaneLoadBalancer returns the AWSLoadBalancerSpec
+	ControlPlaneLoadBalancer() *infrav1.AWSLoadBalancerSpec
+
+	// ControlPlaneLoadBalancerScheme returns the Classic ELB scheme (public or internal facing)
+	ControlPlaneLoadBalancerScheme() infrav1.ClassicELBScheme
+}

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -38,12 +38,12 @@ import (
 
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
 type MachineScopeParams struct {
-	Client     client.Client
-	Logger     logr.Logger
-	Cluster    *clusterv1.Cluster
-	Machine    *clusterv1.Machine
-	AWSCluster *infrav1.AWSCluster
-	AWSMachine *infrav1.AWSMachine
+	Client       client.Client
+	Logger       logr.Logger
+	Cluster      *clusterv1.Cluster
+	Machine      *clusterv1.Machine
+	InfraCluster EC2Scope
+	AWSMachine   *infrav1.AWSMachine
 }
 
 // NewMachineScope creates a new MachineScope from the supplied parameters.
@@ -61,7 +61,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 	if params.AWSMachine == nil {
 		return nil, errors.New("aws machine is required when creating a MachineScope")
 	}
-	if params.AWSCluster == nil {
+	if params.InfraCluster == nil {
 		return nil, errors.New("aws cluster is required when creating a MachineScope")
 	}
 
@@ -78,10 +78,10 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		client:      params.Client,
 		patchHelper: helper,
 
-		Cluster:    params.Cluster,
-		Machine:    params.Machine,
-		AWSCluster: params.AWSCluster,
-		AWSMachine: params.AWSMachine,
+		Cluster:      params.Cluster,
+		Machine:      params.Machine,
+		InfraCluster: params.InfraCluster,
+		AWSMachine:   params.AWSMachine,
 	}, nil
 }
 
@@ -91,10 +91,10 @@ type MachineScope struct {
 	client      client.Client
 	patchHelper *patch.Helper
 
-	Cluster    *clusterv1.Cluster
-	Machine    *clusterv1.Machine
-	AWSCluster *infrav1.AWSCluster
-	AWSMachine *infrav1.AWSMachine
+	Cluster      *clusterv1.Cluster
+	Machine      *clusterv1.Machine
+	InfraCluster EC2Scope
+	AWSMachine   *infrav1.AWSMachine
 }
 
 // Name returns the AWSMachine name.
@@ -281,7 +281,7 @@ func (m *MachineScope) AdditionalTags() infrav1.Tags {
 	tags := make(infrav1.Tags)
 
 	// Start with the cluster-wide tags...
-	tags.Merge(m.AWSCluster.Spec.AdditionalTags)
+	tags.Merge(m.InfraCluster.AdditionalTags())
 	// ... and merge in the Machine's
 	tags.Merge(m.AWSMachine.Spec.AdditionalTags)
 

--- a/pkg/cloud/scope/machine_test.go
+++ b/pkg/cloud/scope/machine_test.go
@@ -125,10 +125,12 @@ func setupMachineScope() (*MachineScope, error) {
 	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
 	return NewMachineScope(
 		MachineScopeParams{
-			Client:     client,
-			Machine:    machine,
-			Cluster:    cluster,
-			AWSCluster: awsCluster,
+			Client:  client,
+			Machine: machine,
+			Cluster: cluster,
+			InfraCluster: &ClusterScope{
+				AWSCluster: awsCluster,
+			},
 			AWSMachine: awsMachine,
 		},
 	)

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -141,17 +141,17 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 
 		imageLookupFormat := scope.AWSMachine.Spec.ImageLookupFormat
 		if imageLookupFormat == "" {
-			imageLookupFormat = scope.AWSCluster.Spec.ImageLookupFormat
+			imageLookupFormat = scope.InfraCluster.ImageLookupFormat()
 		}
 
 		imageLookupOrg := scope.AWSMachine.Spec.ImageLookupOrg
 		if imageLookupOrg == "" {
-			imageLookupOrg = scope.AWSCluster.Spec.ImageLookupOrg
+			imageLookupOrg = scope.InfraCluster.ImageLookupOrg()
 		}
 
 		imageLookupBaseOS := scope.AWSMachine.Spec.ImageLookupBaseOS
 		if imageLookupBaseOS == "" {
-			imageLookupBaseOS = scope.AWSCluster.Spec.ImageLookupBaseOS
+			imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
 		}
 
 		input.ImageID, err = s.defaultAMILookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.Machine.Spec.Version)
@@ -190,8 +190,8 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 	// If a value was not provided in the AWSCluster Spec, then use the defaultSSHKeyName
 	input.SSHKeyName = scope.AWSMachine.Spec.SSHKeyName
 	if input.SSHKeyName == nil {
-		if scope.AWSCluster.Spec.SSHKeyName != nil {
-			input.SSHKeyName = scope.AWSCluster.Spec.SSHKeyName
+		if scope.InfraCluster.SSHKeyName() != nil {
+			input.SSHKeyName = scope.InfraCluster.SSHKeyName()
 		} else {
 			input.SSHKeyName = aws.String(defaultSSHKeyName)
 		}

--- a/pkg/cloud/services/ec2/service.go
+++ b/pkg/cloud/services/ec2/service.go
@@ -19,47 +19,19 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
-
-// Scope is the interface for the scoep to be used with the ec2 service
-type Scope interface {
-	cloud.ClusterScoper
-
-	// VPC returns the cluster VPC.
-	VPC() *infrav1.VPCSpec
-
-	// Subnets returns the cluster subnets.
-	Subnets() infrav1.Subnets
-
-	// Network returns the cluster network object.
-	Network() *infrav1.Network
-
-	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
-	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
-
-	// Bastion returns the bastion details for the cluster.
-	Bastion() *infrav1.Bastion
-
-	// SetBastionInstance sets the bastion instance in the status of the cluster.
-	SetBastionInstance(instance *infrav1.Instance)
-
-	// SSHKeyName returns the SSH key name to use for instances.
-	SSHKeyName() *string
-}
 
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
 // One alternative is to have a large list of functions from the ec2 client.
 type Service struct {
-	scope     Scope
+	scope     scope.EC2Scope
 	EC2Client ec2iface.EC2API
 }
 
 // NewService returns a new service given the ec2 api client.
-func NewService(clusterScope Scope) *Service {
+func NewService(clusterScope scope.EC2Scope) *Service {
 	return &Service{
 		scope:     clusterScope,
 		EC2Client: scope.NewEC2Client(clusterScope, clusterScope, clusterScope.InfraCluster()),

--- a/pkg/cloud/services/elb/service.go
+++ b/pkg/cloud/services/elb/service.go
@@ -20,45 +20,20 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
-
-// Scope is a scope for use with the ELB reconciling service
-type Scope interface {
-	cloud.ClusterScoper
-
-	// Network returns the cluster network object.
-	Network() *infrav1.Network
-
-	// Subnets returns the cluster subnets.
-	Subnets() infrav1.Subnets
-
-	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
-	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
-
-	// VPC returns the cluster VPC.
-	VPC() *infrav1.VPCSpec
-
-	// ControlPlaneLoadBalancer returns the AWSLoadBalancerSpec
-	ControlPlaneLoadBalancer() *infrav1.AWSLoadBalancerSpec
-
-	// ControlPlaneLoadBalancerScheme returns the Classic ELB scheme (public or internal facing)
-	ControlPlaneLoadBalancerScheme() infrav1.ClassicELBScheme
-}
 
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
 // One alternative is to have a large list of functions from the ec2 client.
 type Service struct {
-	scope                 Scope
+	scope                 scope.ELBScope
 	ELBClient             elbiface.ELBAPI
 	ResourceTaggingClient resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 }
 
 // NewService returns a new service given the api clients.
-func NewService(elbScope Scope) *Service {
+func NewService(elbScope scope.ELBScope) *Service {
 	return &Service{
 		scope:                 elbScope,
 		ELBClient:             scope.NewELBClient(elbScope, elbScope, elbScope.InfraCluster()),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Refactors AWSMachine reconciliation to utilize the new scope interfaces. This will make onboarding the AWSManagedControlPlane stuff more simple.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1852 

