### PR TITLE
Fix MachineScope GetInstanceState/SetInstanceState comments

### DIFF
--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -143,12 +143,12 @@ func (m *MachineScope) SetProviderID(instanceID, availabilityZone string) {
 	m.AWSMachine.Spec.ProviderID = pointer.StringPtr(providerID)
 }
 
-// GetInstanceID returns the AWSMachine instance state from the status.
+// GetInstanceState returns the AWSMachine instance state from the status.
 func (m *MachineScope) GetInstanceState() *infrav1.InstanceState {
 	return m.AWSMachine.Status.InstanceState
 }
 
-// SetInstanceID sets the AWSMachine instance id.
+// SetInstanceState sets the AWSMachine status instance state.
 func (m *MachineScope) SetInstanceState(v infrav1.InstanceState) {
 	m.AWSMachine.Status.InstanceState = &v
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR fixes incorrect comments of `GetInstanceState` and `SetInstanceState` of MachineScope.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

