### PR TITLE
✨ refactor: split security groups from network service

### DIFF
--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -21,6 +21,13 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
 
+const (
+	// TemporaryResourceID is the name used temporarily when creating AWS resources
+	TemporaryResourceID = "temporary-resource-id"
+	// AnyIPv4CidrBlock is the CIDR block to match all IPv4 addresses
+	AnyIPv4CidrBlock = "0.0.0.0/0"
+)
+
 // EC2MachineInterface encapsulates the methods exposed to the machine
 // actuator
 type EC2MachineInterface interface {

--- a/pkg/cloud/services/network/gateways.go
+++ b/pkg/cloud/services/network/gateways.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/filter"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/tags"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
@@ -120,7 +121,7 @@ func (s *Service) deleteInternetGateways() error {
 func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 	ig, err := s.EC2Client.CreateInternetGateway(&ec2.CreateInternetGatewayInput{
 		TagSpecifications: []*ec2.TagSpecification{
-			tags.BuildParamsToTagSpecification(ec2.ResourceTypeInternetGateway, s.getGatewayTagParams(temporaryResourceID)),
+			tags.BuildParamsToTagSpecification(ec2.ResourceTypeInternetGateway, s.getGatewayTagParams(services.TemporaryResourceID)),
 		},
 	})
 	if err != nil {

--- a/pkg/cloud/services/network/natgateways.go
+++ b/pkg/cloud/services/network/natgateways.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/filter"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/tags"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
@@ -228,7 +229,7 @@ func (s *Service) createNatGateway(subnetID, ip string) (*ec2.NatGateway, error)
 		if out, err = s.EC2Client.CreateNatGateway(&ec2.CreateNatGatewayInput{
 			SubnetId:          aws.String(subnetID),
 			AllocationId:      aws.String(ip),
-			TagSpecifications: []*ec2.TagSpecification{tags.BuildParamsToTagSpecification(ec2.ResourceTypeNatgateway, s.getNatGatewayTagParams(temporaryResourceID))},
+			TagSpecifications: []*ec2.TagSpecification{tags.BuildParamsToTagSpecification(ec2.ResourceTypeNatgateway, s.getNatGatewayTagParams(services.TemporaryResourceID))},
 		}); err != nil {
 			return false, err
 		}

--- a/pkg/cloud/services/network/network.go
+++ b/pkg/cloud/services/network/network.go
@@ -58,12 +58,6 @@ func (s *Service) ReconcileNetwork() (err error) {
 		return err
 	}
 
-	// Security groups.
-	if err := s.reconcileSecurityGroups(); err != nil {
-		conditions.MarkFalse(s.scope.InfraCluster(), infrav1.ClusterSecurityGroupsReadyCondition, infrav1.ClusterSecurityGroupReconciliationFailedReason, clusterv1.ConditionSeverityError, err.Error())
-		return err
-	}
-
 	s.scope.V(2).Info("Reconcile network completed successfully")
 	return nil
 }
@@ -82,11 +76,6 @@ func (s *Service) DeleteNetwork() (err error) {
 		return err
 	}
 	vpc.DeepCopyInto(s.scope.VPC())
-
-	// Security groups.
-	if err := s.deleteSecurityGroups(); err != nil {
-		return err
-	}
 
 	// Routing tables.
 	if err := s.deleteRouteTables(); err != nil {

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/filter"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/tags"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
@@ -33,7 +34,6 @@ import (
 )
 
 const (
-	anyIPv4CidrBlock       = "0.0.0.0/0"
 	mainRouteTableInVPCKey = "main"
 )
 
@@ -292,14 +292,14 @@ func (s *Service) associateRouteTable(rt *infrav1.RouteTable, subnetID string) e
 
 func (s *Service) getNatGatewayPrivateRoute(natGatewayID string) *ec2.Route {
 	return &ec2.Route{
-		DestinationCidrBlock: aws.String(anyIPv4CidrBlock),
+		DestinationCidrBlock: aws.String(services.AnyIPv4CidrBlock),
 		NatGatewayId:         aws.String(natGatewayID),
 	}
 }
 
 func (s *Service) getGatewayPublicRoute() *ec2.Route {
 	return &ec2.Route{
-		DestinationCidrBlock: aws.String(anyIPv4CidrBlock),
+		DestinationCidrBlock: aws.String(services.AnyIPv4CidrBlock),
 		GatewayId:            aws.String(*s.scope.VPC().InternetGatewayID),
 	}
 }

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/filter"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/tags"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/internal/cidr"
@@ -291,7 +292,7 @@ func (s *Service) createSubnet(sn *infrav1.SubnetSpec) (*infrav1.SubnetSpec, err
 		TagSpecifications: []*ec2.TagSpecification{
 			tags.BuildParamsToTagSpecification(
 				ec2.ResourceTypeSubnet,
-				s.getSubnetTagParams(temporaryResourceID, sn.IsPublic, sn.AvailabilityZone, sn.Tags),
+				s.getSubnetTagParams(services.TemporaryResourceID, sn.IsPublic, sn.AvailabilityZone, sn.Tags),
 			),
 		},
 	})

--- a/pkg/cloud/services/network/vpc.go
+++ b/pkg/cloud/services/network/vpc.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -176,7 +177,7 @@ func (s *Service) createVPC() (*infrav1.VPCSpec, error) {
 	input := &ec2.CreateVpcInput{
 		CidrBlock: aws.String(s.scope.VPC().CidrBlock),
 		TagSpecifications: []*ec2.TagSpecification{
-			tags.BuildParamsToTagSpecification(ec2.ResourceTypeVpc, s.getVPCTagParams(temporaryResourceID)),
+			tags.BuildParamsToTagSpecification(ec2.ResourceTypeVpc, s.getVPCTagParams(services.TemporaryResourceID)),
 		},
 	}
 

--- a/pkg/cloud/services/securitygroup/securitygroups_test.go
+++ b/pkg/cloud/services/securitygroup/securitygroups_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package network
+package securitygroup
 
 import (
 	"strings"
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
@@ -261,7 +262,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 			s := NewService(scope)
 			s.EC2Client = ec2Mock
 
-			if err := s.reconcileSecurityGroups(); err != nil && tc.err != nil {
+			if err := s.ReconcileSecurityGroups(); err != nil && tc.err != nil {
 				if !strings.Contains(err.Error(), tc.err.Error()) {
 					t.Fatalf("was expecting error to look like '%v', but got '%v'", tc.err, err)
 				}
@@ -290,7 +291,7 @@ func TestControlPlaneSecurityGroupNotOpenToAnyCIDR(t *testing.T) {
 	}
 
 	for _, r := range rules {
-		if sets.NewString(r.CidrBlocks...).Has(anyIPv4CidrBlock) {
+		if sets.NewString(r.CidrBlocks...).Has(services.AnyIPv4CidrBlock) {
 			t.Fatal("Ingress rule allows any CIDR block")
 		}
 	}

--- a/pkg/cloud/services/securitygroup/service.go
+++ b/pkg/cloud/services/securitygroup/service.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package network
+package securitygroup
 
 import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -24,22 +24,21 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
 
-// Scope is scope for use with the network service
+// Scope is a scope for use with the security group reconciling service
 type Scope interface {
 	cloud.ClusterScoper
 
 	// Network returns the cluster network object.
 	Network() *infrav1.Network
-	// VPC returns the cluster VPC.
-	VPC() *infrav1.VPCSpec
-	// Subnets returns the cluster subnets.
-	Subnets() infrav1.Subnets
-	// SetSubnets updates the clusters subnets.
-	SetSubnets(subnets infrav1.Subnets)
-	// CNIIngressRules returns the CNI spec ingress rules.
-	CNIIngressRules() infrav1.CNIIngressRules
+
 	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
 	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+
+	// VPC returns the cluster VPC.
+	VPC() *infrav1.VPCSpec
+
+	// CNIIngressRules returns the CNI spec ingress rules.
+	CNIIngressRules() infrav1.CNIIngressRules
 
 	// Bastion returns the bastion details for the cluster.
 	Bastion() *infrav1.Bastion
@@ -53,10 +52,10 @@ type Service struct {
 	EC2Client ec2iface.EC2API
 }
 
-// NewService returns a new service given the ec2 api client.
-func NewService(networkScope Scope) *Service {
+// NewService returns a new service given the api clients.
+func NewService(sgScope Scope) *Service {
 	return &Service{
-		scope:     networkScope,
-		EC2Client: scope.NewEC2Client(networkScope, networkScope, networkScope.InfraCluster()),
+		scope:     sgScope,
+		EC2Client: scope.NewEC2Client(sgScope, sgScope, sgScope.InfraCluster()),
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The reconciliation of security groups has been split out from the network service. This is to enable the EKS implementation to reconcile the network without the security groups.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1857 

