### PR TITLE
🌱 Support using custom endpoints for AWS services

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -52,8 +52,9 @@ import (
 // AWSClusterReconciler reconciles a AwsCluster object
 type AWSClusterReconciler struct {
 	client.Client
-	Recorder record.EventRecorder
-	Log      logr.Logger
+	Recorder  record.EventRecorder
+	Log       logr.Logger
+	Endpoints []scope.ServiceEndpoint
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusters,verbs=get;list;watch;create;update;patch;delete
@@ -99,6 +100,7 @@ func (r *AWSClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 		Cluster:        cluster,
 		AWSCluster:     awsCluster,
 		ControllerName: "awscluster",
+		Endpoints:      r.Endpoints,
 	})
 	if err != nil {
 		return reconcile.Result{}, errors.Errorf("failed to create scope: %+v", err)

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -53,8 +53,9 @@ import (
 // AWSManagedControlPlaneReconciler reconciles a AWSManagedControlPlane object
 type AWSManagedControlPlaneReconciler struct {
 	client.Client
-	Log      logr.Logger
-	Recorder record.EventRecorder
+	Log       logr.Logger
+	Recorder  record.EventRecorder
+	Endpoints []scope.ServiceEndpoint
 
 	EnableIAM            bool
 	AllowAdditionalRoles bool
@@ -139,6 +140,7 @@ func (r *AWSManagedControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl
 		ControllerName:       "awsmanagedcontrolplane",
 		EnableIAM:            r.EnableIAM,
 		AllowAdditionalRoles: r.AllowAdditionalRoles,
+		Endpoints:            r.Endpoints,
 	})
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)

--- a/pkg/cloud/endpoints/endpoints.go
+++ b/pkg/cloud/endpoints/endpoints.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+)
+
+var (
+	errServiceEndpointFormat             = errors.New("must be formatted as ${ServiceID}=${URL}")
+	errServiceEndpointSigningRegion      = errors.New("must be formatted as ${SigningRegion}:${ServiceID1}=${URL1},${ServiceID2}=${URL2...}")
+	errServiceEndpointURL                = errors.New("must use a valid URL as a service-endpoint")
+	errServiceEndpointServiceID          = errors.New("must use a valid serviceID from the AWS GO SDK")
+	errServiceEndpointDuplicateServiceID = errors.New("same serviceID defined twice for signing region")
+)
+
+func serviceEnum() []string {
+	var serviceIDs = []string{}
+	resolver := endpoints.DefaultResolver()
+	partitions := resolver.(endpoints.EnumPartitions).Partitions()
+	for _, p := range partitions {
+		for id := range p.Services() {
+			var add bool = true
+			for _, s := range serviceIDs {
+				if id == s {
+					add = false
+				}
+			}
+			if add {
+				serviceIDs = append(serviceIDs, id)
+			}
+		}
+	}
+
+	return serviceIDs
+}
+
+// ParseFlag parses the command line flag of service endponts in the format ${SigningRegion1}:${ServiceID1}=${URL1},${ServiceID2}=${URL2}...;${SigningRegion2}...
+// returning a set of ServiceEndpoints
+func ParseFlag(serviceEndpoints string) ([]scope.ServiceEndpoint, error) {
+	if serviceEndpoints == "" {
+
+		return nil, nil
+	}
+	serviceIDs := serviceEnum()
+	signingRegionConfigs := strings.Split(serviceEndpoints, ";")
+	endpoints := []scope.ServiceEndpoint{}
+	for _, regionConfig := range signingRegionConfigs {
+		components := strings.SplitN(regionConfig, ":", 2)
+		if len(components) != 2 {
+
+			return nil, errServiceEndpointSigningRegion
+		}
+		signingRegion := components[0]
+		servicePairs := strings.Split(components[1], ",")
+		seenServices := []string{}
+		for _, servicePair := range servicePairs {
+			kv := strings.Split(servicePair, "=")
+			if len(kv) != 2 {
+
+				return nil, errServiceEndpointFormat
+			}
+			var serviceID string = ""
+			for _, id := range serviceIDs {
+				if kv[0] == id {
+					serviceID = kv[0]
+
+					break
+				}
+			}
+			if serviceID == "" {
+				return nil, errServiceEndpointServiceID
+			}
+			if containsString(seenServices, serviceID) {
+				return nil, errServiceEndpointDuplicateServiceID
+			}
+			seenServices = append(seenServices, serviceID)
+			URL, err := url.ParseRequestURI(kv[1])
+			if err != nil {
+
+				return nil, errServiceEndpointURL
+			}
+			endpoints = append(endpoints, scope.ServiceEndpoint{
+				ServiceID:     serviceID,
+				URL:           URL.String(),
+				SigningRegion: signingRegion,
+			})
+		}
+	}
+
+	return endpoints, nil
+}
+
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/cloud/endpoints/endpoints_test.go
+++ b/pkg/cloud/endpoints/endpoints_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"errors"
+	"testing"
+
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+)
+
+func TestParseFlags(t *testing.T) {
+
+	testCases := []struct {
+		name           string
+		flagToParse    string
+		expectedOutput []scope.ServiceEndpoint
+		expectedError  error
+	}{
+		{
+			name:           "no configuration",
+			flagToParse:    "",
+			expectedOutput: nil,
+			expectedError:  nil,
+		},
+		{
+			name:        "single region, single service",
+			flagToParse: "us-iso:ec2=https://localhost:8080",
+			expectedOutput: []scope.ServiceEndpoint{
+				{
+					ServiceID:     "ec2",
+					URL:           "https://localhost:8080",
+					SigningRegion: "us-iso",
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:        "single region, multiple services",
+			flagToParse: "us-iso:ec2=https://localhost:8080,sts=https://elbhost:8080",
+			expectedOutput: []scope.ServiceEndpoint{
+				{
+					ServiceID:     "ec2",
+					URL:           "https://localhost:8080",
+					SigningRegion: "us-iso",
+				},
+				{
+					ServiceID:     "sts",
+					URL:           "https://elbhost:8080",
+					SigningRegion: "us-iso",
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:           "single region, duplicate service",
+			flagToParse:    "us-iso:ec2=https://localhost:8080,ec2=https://elbhost:8080",
+			expectedOutput: nil,
+			expectedError:  errServiceEndpointDuplicateServiceID,
+		},
+		{
+			name:           "single region, non-valid URI",
+			flagToParse:    "us-iso:ec2=fdsfs",
+			expectedOutput: nil,
+			expectedError:  errServiceEndpointURL,
+		},
+		{
+			name:        "multiples regions",
+			flagToParse: "us-iso:ec2=https://localhost:8080,sts=https://elbhost:8080;gb-iso:ec2=https://localhost:8080,sts=https://elbhost:8080",
+			expectedOutput: []scope.ServiceEndpoint{
+				{
+					ServiceID:     "ec2",
+					URL:           "https://localhost:8080",
+					SigningRegion: "us-iso",
+				},
+				{
+					ServiceID:     "sts",
+					URL:           "https://elbhost:8080",
+					SigningRegion: "us-iso",
+				},
+				{
+					ServiceID:     "ec2",
+					URL:           "https://localhost:8080",
+					SigningRegion: "gb-iso",
+				},
+				{
+					ServiceID:     "sts",
+					URL:           "https://elbhost:8080",
+					SigningRegion: "gb-iso",
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:           "invalid config",
+			flagToParse:    "us-isoec2=localhost",
+			expectedOutput: nil,
+			expectedError:  errServiceEndpointSigningRegion,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ParseFlag(tc.flagToParse)
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Fatalf("did not expect correct error: got %v, expected %v", err, tc.expectedError)
+			}
+
+			if !endpointsEqual(out, tc.expectedOutput) {
+				t.Fatalf("did not expect correct output: got %v, expected %v", out, tc.expectedOutput)
+			}
+		})
+	}
+}
+
+func endpointsEqual(a, b []scope.ServiceEndpoint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -39,6 +39,7 @@ type ClusterScopeParams struct {
 	Cluster        *clusterv1.Cluster
 	AWSCluster     *infrav1.AWSCluster
 	ControllerName string
+	Endpoints      []ServiceEndpoint
 	Session        awsclient.ConfigProvider
 }
 
@@ -56,7 +57,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		params.Logger = klogr.New()
 	}
 
-	session, err := sessionForRegion(params.AWSCluster.Spec.Region)
+	session, err := sessionForRegion(params.AWSCluster.Spec.Region, params.Endpoints)
 	if err != nil {
 		return nil, errors.Errorf("failed to create aws session: %v", err)
 	}

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -40,6 +40,7 @@ type ManagedControlPlaneScopeParams struct {
 	Cluster        *clusterv1.Cluster
 	ControlPlane   *controlplanev1.AWSManagedControlPlane
 	ControllerName string
+	Endpoints      []ServiceEndpoint
 	Session        awsclient.ConfigProvider
 
 	EnableIAM            bool
@@ -59,7 +60,7 @@ func NewManagedControlPlaneScope(params ManagedControlPlaneScopeParams) (*Manage
 		params.Logger = klogr.New()
 	}
 
-	session, err := sessionForRegion(params.ControlPlane.Spec.Region)
+	session, err := sessionForRegion(params.ControlPlane.Spec.Region, params.Endpoints)
 	if err != nil {
 		return nil, errors.Errorf("failed to create aws session: %v", err)
 	}

--- a/pkg/cloud/scope/session.go
+++ b/pkg/cloud/scope/session.go
@@ -20,18 +20,40 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+// ServiceEndpoint defines a tuple containing AWS Service resolution information
+type ServiceEndpoint struct {
+	ServiceID     string
+	URL           string
+	SigningRegion string
+}
+
 var sessionCache sync.Map
 
-func sessionForRegion(region string) (*session.Session, error) {
+func sessionForRegion(region string, endpoint []ServiceEndpoint) (*session.Session, error) {
 	s, ok := sessionCache.Load(region)
 	if ok {
 		return s.(*session.Session), nil
 	}
 
-	ns, err := session.NewSession(aws.NewConfig().WithRegion(region))
+	resolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+		for _, s := range endpoint {
+			if service == s.ServiceID {
+				return endpoints.ResolvedEndpoint{
+					URL:           s.URL,
+					SigningRegion: s.SigningRegion,
+				}, nil
+			}
+		}
+		return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
+	}
+	ns, err := session.NewSession(&aws.Config{
+		Region:           aws.String(region),
+		EndpointResolver: endpoints.ResolverFunc(resolver),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/secretsmanager/cloudinit.go
+++ b/pkg/cloud/services/secretsmanager/cloudinit.go
@@ -51,12 +51,13 @@ type scriptVariables struct {
 	SecretPrefix string
 	Chunks       int32
 	Region       string
+	Endpoint     string
 }
 
 // GenerateCloudInitMIMEDocument creates a multi-part MIME document including a script boothook to
 // download userdata from AWS Secrets Manager and then restart cloud-init, and an include part
 // specifying the on disk location of the new userdata
-func GenerateCloudInitMIMEDocument(secretPrefix string, chunks int32, region string) ([]byte, error) {
+func GenerateCloudInitMIMEDocument(secretPrefix string, chunks int32, region string, endpoint string) ([]byte, error) {
 	var buf bytes.Buffer
 	mpWriter := multipart.NewWriter(&buf)
 	buf.WriteString(fmt.Sprintf(multipartHeader, mpWriter.Boundary()))
@@ -69,6 +70,7 @@ func GenerateCloudInitMIMEDocument(secretPrefix string, chunks int32, region str
 		SecretPrefix: secretPrefix,
 		Chunks:       chunks,
 		Region:       region,
+		Endpoint:     endpoint,
 	}
 
 	var scriptBuf bytes.Buffer

--- a/pkg/cloud/services/secretsmanager/cloudinit_test.go
+++ b/pkg/cloud/services/secretsmanager/cloudinit_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestGenerateCloudInitMIMEDocument(t *testing.T) {
 	secretARN := "secretARN"
-	doc, _ := GenerateCloudInitMIMEDocument(secretARN, 1, "eu-west-1")
+	doc, _ := GenerateCloudInitMIMEDocument(secretARN, 1, "eu-west-1", "")
 
 	_, err := mail.ReadMessage(bytes.NewBuffer(doc))
 	if err != nil {

--- a/pkg/cloud/services/secretsmanager/secret_fetch_script.go
+++ b/pkg/cloud/services/secretsmanager/secret_fetch_script.go
@@ -41,6 +41,9 @@ set -o pipefail
 umask 006
 
 REGION="{{.Region}}"
+if [ "{{.Endpoint}}" != "" ]; then
+  ENDPOINT="--endpoint-url {{.Endpoint}}"
+fi
 SECRET_PREFIX="{{.SecretPrefix}}"
 CHUNKS="{{.Chunks}}"
 FILE="/etc/secret-userdata.txt"
@@ -120,7 +123,7 @@ delete_secret_value() {
   set +o nounset
   set +o pipefail
   out=$(
-    aws secretsmanager --region ${REGION} delete-secret --force-delete-without-recovery --secret-id "${id}" 2>&1
+    aws secretsmanager ${ENDPOINT} --region ${REGION} delete-secret --force-delete-without-recovery --secret-id "${id}" 2>&1
   )
   local delete_return=$?
   set -o errexit


### PR DESCRIPTION
**What this PR does / why we need it**: Allows custom endpoints for aws services to be specified for the aws provider. Not only would this allow for local stack testing but would pave the road for Cluster API into AWS IC partitions which require FIPS named endpoints.

**Which issue(s) this PR fixes**:
Fixes #1855

