### PR TITLE
:bug: Workaround for https://bugs.launchpad.net/cloud-init/+bug/1888822

### DIFF
--- a/pkg/cloud/services/secretsmanager/secret_fetch_script.go
+++ b/pkg/cloud/services/secretsmanager/secret_fetch_script.go
@@ -17,7 +17,8 @@ limitations under the License.
 package secretsmanager
 
 // nolint
-const secretFetchScript = `#!/bin/bash
+const secretFetchScript = `#cloud-boothook
+#!/bin/bash
 
 # Copyright 2020 The Kubernetes Authors.
 #


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As per @oddbloke's suggestion, adding a #cloud-boothook line to the boothook script allows cloud-init v20.2 to correctly interpret the boothook.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1839

