### PR TITLE
✨ Custom Bastion AMI

### DIFF
--- a/api/v1alpha2/awscluster_conversion.go
+++ b/api/v1alpha2/awscluster_conversion.go
@@ -54,6 +54,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.Spec.Bastion.AllowedCIDRBlocks = restored.Spec.Bastion.AllowedCIDRBlocks
+	dst.Spec.Bastion.AMI = restored.Spec.Bastion.AMI
 	dst.Spec.Bastion.DisableIngressRules = restored.Spec.Bastion.DisableIngressRules
 	dst.Spec.Bastion.InstanceType = restored.Spec.Bastion.InstanceType
 	dst.Spec.ImageLookupFormat = restored.Spec.ImageLookupFormat

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -104,6 +104,11 @@ type Bastion struct {
 	// Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro
 	// will be the default.
 	InstanceType string `json:"instanceType,omitempty"`
+
+	// InstanceImage will use a specified AMI to boot the bastion. If not specified,
+	// the image will default to one picked out in public space.
+	// +optional
+	AMI string `json:"ami,omitempty"`
 }
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -408,6 +408,9 @@ spec:
                     items:
                       type: string
                     type: array
+                  ami:
+                    description: InstanceImage will use a specified AMI to boot the bastion. If not specified, the image will default to one picked out in public space.
+                    type: string
                   disableIngressRules:
                     description: DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.
                     type: boolean

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -71,6 +71,9 @@ spec:
                     items:
                       type: string
                     type: array
+                  ami:
+                    description: InstanceImage will use a specified AMI to boot the bastion. If not specified, the image will default to one picked out in public space.
+                    type: string
                   disableIngressRules:
                     description: DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.
                     type: boolean


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows us to specify a custom bastion AMI image. Useful for private partitions in AWS.

**Which issue(s) this PR fixes**:
Fixes #1441 

