### PR TITLE
🌱 Ignores local zones when fetching AZs

### DIFF
--- a/pkg/cloud/filter/ec2.go
+++ b/pkg/cloud/filter/ec2.go
@@ -149,3 +149,10 @@ func (ec2Filters) AvailabilityZone(zone string) *ec2.Filter {
 		Values: aws.StringSlice([]string{zone}),
 	}
 }
+
+func (ec2Filters) IgnoreLocalZones() *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String("opt-in-status"),
+		Values: aws.StringSlice([]string{"opt-in-not-required"}),
+	}
+}

--- a/pkg/cloud/services/network/account.go
+++ b/pkg/cloud/services/network/account.go
@@ -27,7 +27,10 @@ import (
 
 func (s *Service) getAvailableZones() ([]string, error) {
 	out, err := s.EC2Client.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{
-		Filters: []*ec2.Filter{filter.EC2.Available()},
+		Filters: []*ec2.Filter{
+			filter.EC2.Available(),
+			filter.EC2.IgnoreLocalZones(),
+		},
 	})
 	if err != nil {
 		record.Eventf(s.scope.InfraCluster(), "FailedDescribeAvailableZone", "Failed getting available zones: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Local zones don't currently work with CAPA. If a user has opted into the Local Zone feature, this change will skip that zone during reconciliation. Regions that need to be opted into like eu-south-1 will not be affected by these changes. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1799 

