### PR TITLE
✨ [cloud/ec2] Support AWSMachineSpec.PublicIP=true

### DIFF
--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller:latest
+      - image: gcr.io/mux-cloud/cluster-api-aws-controller-amd64:0.5.5-mux-0446755647
         name: manager

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/mux-cloud/cluster-api-aws-controller-amd64:0.5.5-mux-0446755647
+      - image: gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller:latest
         name: manager

--- a/pkg/cloud/filter/ec2.go
+++ b/pkg/cloud/filter/ec2.go
@@ -25,11 +25,12 @@ import (
 )
 
 const (
-	filterNameTagKey        = "tag-key"
-	filterNameVpcID         = "vpc-id"
-	filterNameState         = "state"
-	filterNameVpcAttachment = "attachment.vpc-id"
-	filterAvailabilityZone  = "availability-zone"
+	filterNameTagKey              = "tag-key"
+	filterNameVpcID               = "vpc-id"
+	filterNameState               = "state"
+	filterNameVpcAttachment       = "attachment.vpc-id"
+	filterNameMapPublicIPOnLaunch = "map-public-ip-on-launch"
+	filterAvailabilityZone        = "availability-zone"
 )
 
 // EC2 exposes the ec2 sdk related filters.
@@ -147,5 +148,13 @@ func (ec2Filters) AvailabilityZone(zone string) *ec2.Filter {
 	return &ec2.Filter{
 		Name:   aws.String(filterAvailabilityZone),
 		Values: aws.StringSlice([]string{zone}),
+	}
+}
+
+// PublicSubnets returns a filter that matches subnets with auto-assigned public IPs (public subnets).
+func (ec2Filters) PublicSubnets() *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String(filterNameMapPublicIPOnLaunch),
+		Values: aws.StringSlice([]string{"true"}),
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently setting `.publicIP` is ignored when allocating ec2 instance
subnet. Support allocating public subnet when the above field is set (as
already specified in the API definition).

