### PR TITLE
🌱  Remove unused v1alpha2-specific annotation on Machine

### DIFF
--- a/controllers/awsmachine_annotations.go
+++ b/controllers/awsmachine_annotations.go
@@ -43,7 +43,9 @@ func (r *AWSMachineReconciler) updateMachineAnnotation(machine *infrav1.AWSMachi
 	annotations := machine.GetAnnotations()
 
 	// Set our annotation to the given content.
-	annotations[annotation] = content
+	if annotations != nil {
+		annotations[annotation] = content
+	}
 
 	// Update the machine object with these annotations
 	machine.SetAnnotations(annotations)

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -479,9 +479,6 @@ func (r *AWSMachineReconciler) reconcileNormal(_ context.Context, machineScope *
 		machineScope.Info("EC2 instance state changed", "state", instance.State, "instance-id", *machineScope.GetInstanceID())
 	}
 
-	// TODO(vincepri): Remove this annotation when clusterctl is no longer relevant.
-	machineScope.SetAnnotation("cluster-api-provider-aws", "true")
-
 	switch instance.State {
 	case infrav1.InstanceStatePending:
 		machineScope.SetNotReady()

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -262,7 +262,6 @@ var _ = Describe("AWSMachineReconciler", func() {
 				It("should set attributes after creating an instance", func() {
 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
 					Expect(ms.AWSMachine.Spec.ProviderID).To(PointTo(Equal("aws:////myMachine")))
-					Expect(ms.AWSMachine.Annotations).To(Equal(map[string]string{"cluster-api-provider-aws": "true"}))
 				})
 
 				Context("with captured logging", func() {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- according to this [thread in slack](https://kubernetes.slack.com/archives/C8TSNPY4T/p1597858577173900) this setting of  the annotation `"cluster-api-provider-aws" = "true"` on the machine is left over from the old `clusterctl` and should be removed
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

