### PR TITLE
✨ feat: added ability to enable EKS via env vars

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
       - args:
         - --enable-leader-election
+        - "--feature-gates=EKS=${EXP_EKS:=false},EKSEnableIAM=${EXP_EKS_IAM:=false},EKSAllowAddRoles=${EXP_EKS_ADD_ROLES:=false}"
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -23,3 +23,4 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
+        - "--feature-gates=EKS=${EXP_EKS:=false},EKSEnableIAM=${EXP_EKS_IAM:=false},EKSAllowAddRoles=${EXP_EKS_ADD_ROLES:=false}"

--- a/config/webhook/manager_webhook_patch.yaml
+++ b/config/webhook/manager_webhook_patch.yaml
@@ -11,6 +11,7 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
+        - "--feature-gates=EKS=${EXP_EKS:=false}"
         ports:
         - containerPort: 9443
           name: webhook-server


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The manager config has been updated so that you van enabled the EKS features flags by using envsubst. This is to provide the user with an easy way to enable the functionality.

**NOTE: the version of envsubst must be: https://github.com/a8m/envsubst as this allows defaults**

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

