### PR TITLE
Update AMIs for latest Kubernetes patch releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,21 +43,23 @@ cluster on AWS.
 
 This provider's versions are compatible with the following versions of Cluster API:
 
-||Cluster API v1alpha1 (v0.1)|Cluster API v1alpha2 (v0.2)|Cluster API v1alpha3 (v0.3)|
-|-|-|-|-|
-|AWS Provider v1alpha1 (v0.2)|✓|||
-|AWS Provider v1alpha1 (v0.3)|✓|||
-|AWS Provider v1alpha2 (v0.4)||✓||
-|AWS Provider v1alpha3 (v0.5)|||✓|
+|                              | Cluster API v1alpha1 (v0.1) | Cluster API v1alpha2 (v0.2) | Cluster API v1alpha3 (v0.3) |
+| ---------------------------- | --------------------------- | --------------------------- | --------------------------- |
+| AWS Provider v1alpha1 (v0.2) | ✓                           |                             |                             |
+| AWS Provider v1alpha1 (v0.3) | ✓                           |                             |                             |
+| AWS Provider v1alpha2 (v0.4) |                             | ✓                           |                             |
+| AWS Provider v1alpha3 (v0.5) |                             |                             | ✓                           |
+| AWS Provider v1alpha3 (v0.6) |                             |                             | ✓                           |
 
 This provider's versions are able to install and manage the following versions of Kubernetes:
 
-||Kubernetes 1.13|Kubernetes 1.14|Kubernetes 1.15|Kubernetes 1.16|Kubernetes 1.17|Kubernetes 1.18|
-|-|-|-|-|-|-|-|
-|AWS Provider v1alpha1 (v0.2)|✓|✓|✓||||
-|AWS Provider v1alpha1 (v0.3)|✓|✓|✓||||
-|AWS Provider v1alpha2 (v0.4)||✓|✓|✓|✓||
-|AWS Provider v1alpha3 (v0.5)|||✓|✓|✓|✓|
+|                              | Kubernetes 1.13 | Kubernetes 1.14 | Kubernetes 1.15 | Kubernetes 1.16 | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 |
+| ---------------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
+| AWS Provider v1alpha1 (v0.2) | ✓               | ✓               | ✓               |                 |                 |                 |                 |
+| AWS Provider v1alpha1 (v0.3) | ✓               | ✓               | ✓               |                 |                 |                 |                 |
+| AWS Provider v1alpha2 (v0.4) |                 | ✓               | ✓               | ✓               | ✓               |                 |                 |
+| AWS Provider v1alpha3 (v0.5) |                 |                 | ✓               | ✓               | ✓               | ✓               | ✓               |
+| AWS Provider v1alpha3 (v0.6) |                 |                 | ✓               | ✓               | ✓               | ✓               | ✓               |
 
 Each version of Cluster API for AWS will attempt to support two Kubernetes versions; e.g., Cluster API for AWS `v0.2`
 may support Kubernetes 1.13 and Kubernetes 1.14.
@@ -72,7 +74,7 @@ policy may be made to more closely align with other providers in the Cluster API
 Note: These AMIs are not updated for security fixes and it is recommended to always use the latest patch version for the Kubernetes version you wish to run. For production-like environments, it is highly recommended to build and use your own custom images.
 
 | Kubernetes minor version | Kubernetes full version |
-|-|-|
+| ------------------------ | ----------------------- |
 | v1.16                    | v1.16.0                 |
 |                          | v1.16.1                 |
 |                          | v1.16.2                 |
@@ -83,15 +85,19 @@ Note: These AMIs are not updated for security fixes and it is recommended to alw
 |                          | v1.16.7                 |
 |                          | v1.16.8                 |
 |                          | v1.16.9                 |
+|                          | v1.16.14                |
 | v1.17                    | v1.17.0                 |
 |                          | v1.17.1                 |
 |                          | v1.17.2                 |
 |                          | v1.17.3                 |
 |                          | v1.17.4                 |
 |                          | v1.17.5                 |
+|                          | v1.17.11                |
 | v1.18                    | v1.18.0                 |
 |                          | v1.18.1                 |
 |                          | v1.18.2                 |
+|                          | v1.18.8                 |
+| v1.19                    | v1.19.0                 |
 
 ------
 

--- a/docs/amis.md
+++ b/docs/amis.md
@@ -1,206 +1,272 @@
-# Pre-built Kubernetes AMIs  <!-- omit in toc -->
+# Latest pre-built Kubernetes AMIs  <!-- omit in toc -->
 
 <!-- Below is generated using VSCode yzhang.markdown-all-in-one >
 
 <!-- TOC -->
 
-- [Kubernetes Version v1.16.9](#kubernetes-version-v1169)
+- [Kubernetes Version v1.19.0](#kubernetes-version-v1190)
   - [Amazon Linux 2](#amazon-linux-2)
   - [CentOS 7](#centos-7)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic)
-- [Kubernetes Version v1.17.5](#kubernetes-version-v1175)
+- [Kubernetes Version v1.18.8](#kubernetes-version-v1188)
   - [Amazon Linux 2](#amazon-linux-2-1)
   - [CentOS 7](#centos-7-1)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-1)
-- [Kubernetes Version v1.18.2](#kubernetes-version-v1182)
+- [Kubernetes Version v1.17.11](#kubernetes-version-v11711)
   - [Amazon Linux 2](#amazon-linux-2-2)
   - [CentOS 7](#centos-7-2)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-2)
+- [Kubernetes Version v1.16.14](#kubernetes-version-v11614)
+  - [Amazon Linux 2](#amazon-linux-2-3)
+  - [CentOS 7](#centos-7-3)
+  - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-3)
 
 <!-- TOC -->
 
-## Kubernetes Version v1.16.9
+## Kubernetes Version v1.19.0
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0ac75fde02b969179 |
-| ap-northeast-2 | ami-00f56e2873f065aa4 |
-| ap-south-1     | ami-01134f573b77fddce |
-| ap-southeast-1 | ami-08f84986a053c7277 |
-| ap-southeast-2 | ami-08708d627d0127e15 |
-| ca-central-1   | ami-0d673575c203ff559 |
-| eu-central-1   | ami-055927f965d107d72 |
-| eu-west-1      | ami-0d3325b63d1bcb88d |
-| eu-west-2      | ami-0e2d9e1245204987c |
-| eu-west-3      | ami-0162aedac4a4447ba |
-| sa-east-1      | ami-0f26f0c32e969368e |
-| us-east-1      | ami-0309b94f3a52c24ca |
-| us-east-2      | ami-07b5ba1dfc1daa0c0 |
-| us-west-1      | ami-0efdef04247e9a7dc |
-| us-west-2      | ami-030da47b164ad577c |
+| ap-northeast-1 | ami-0e8d84fd00d1fcad7 |
+| ap-northeast-2 | ami-0e58b5d886a1ba7f0 |
+| ap-south-1     | ami-037732d011947bf4c |
+| ap-southeast-1 | ami-035dd31829c500348 |
+| ap-southeast-2 | ami-085e5e5c9534f9af2 |
+| ca-central-1   | ami-05640fd89c03565a0 |
+| eu-central-1   | ami-05e8a1de74ad15111 |
+| eu-west-1      | ami-008be0279452dd310 |
+| eu-west-2      | ami-0d790cfa8f6bc81b5 |
+| eu-west-3      | ami-08faaf3ead8dfade0 |
+| sa-east-1      | ami-09b142ca5b259eed9 |
+| us-east-1      | ami-0e9ae925a5d8f8fa0 |
+| us-east-2      | ami-0439677ca41c1c7db |
+| us-west-1      | ami-01341aa4afbb864ac |
+| us-west-2      | ami-0df16189ecadb1c3a |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0fdbd5d73e8121a8e |
-| ap-northeast-2 | ami-08f7b8920e28bce7b |
-| ap-south-1     | ami-0d1feeabae27c9e32 |
-| ap-southeast-1 | ami-00fef304e46181661 |
-| ap-southeast-2 | ami-07d4661eae147464e |
-| ca-central-1   | ami-0e0a924ffd69d2f39 |
-| eu-central-1   | ami-046bd210f93f179b7 |
-| eu-west-1      | ami-07964453723537396 |
-| eu-west-2      | ami-0250f8eeb4ab3e9e3 |
-| eu-west-3      | ami-08804bc308913005e |
-| sa-east-1      | ami-0c5d0670b9196ceda |
-| us-east-1      | ami-037c5058277ea1ce8 |
-| us-east-2      | ami-00139e43d58e92569 |
-| us-west-1      | ami-05b284a7ff25308a3 |
-| us-west-2      | ami-04b95f58851365597 |
+| ap-northeast-1 | ami-0b9df4503ff170497 |
+| ap-northeast-2 | ami-0696040bf82acf53d |
+| ap-south-1     | ami-0d4257be542933d99 |
+| ap-southeast-1 | ami-00248ba5ead19719e |
+| ap-southeast-2 | ami-0969756fc889a1892 |
+| ca-central-1   | ami-0bcb1d3d9a4072126 |
+| eu-central-1   | ami-08ecd4152eb9aa01e |
+| eu-west-1      | ami-0c9d8f19e284ca357 |
+| eu-west-2      | ami-08d26483187036e60 |
+| eu-west-3      | ami-0c4f3ee669c7f18c4 |
+| sa-east-1      | ami-07c1e22a58f777f2b |
+| us-east-1      | ami-04c9ad318e5da624d |
+| us-east-2      | ami-094965caf5f8cacb5 |
+| us-west-1      | ami-04d55b5ae2bba0d2d |
+| us-west-2      | ami-004523c2ca41fe7f4 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0e6d0cb63669c9fdf |
-| ap-northeast-2 | ami-04a80f83f249564dd |
-| ap-south-1     | ami-0e3a7d3ea01617ef8 |
-| ap-southeast-1 | ami-08205b7ea5ed4bd60 |
-| ap-southeast-2 | ami-03497b28a8ad5fb8d |
-| ca-central-1   | ami-08c96afa343d7b490 |
-| eu-central-1   | ami-0383e999201976f85 |
-| eu-west-1      | ami-041fdff21ed5e21d9 |
-| eu-west-2      | ami-07d12734c470897e6 |
-| eu-west-3      | ami-0b4a0218531471b20 |
-| sa-east-1      | ami-073d1e99548898611 |
-| us-east-1      | ami-006bd4174cc1173dd |
-| us-east-2      | ami-0ed2bbd379c03326e |
-| us-west-1      | ami-0bbd766095e15efe8 |
-| us-west-2      | ami-0dc74165ca2b598e6 |
+| ap-northeast-1 | ami-0cc3ccf2f89fb5b3c |
+| ap-northeast-2 | ami-08e88bc11513eb0ca |
+| ap-south-1     | ami-0dd8b0006f9b753b6 |
+| ap-southeast-1 | ami-0e26f519723bee8d2 |
+| ap-southeast-2 | ami-0fce34d693116ec45 |
+| ca-central-1   | ami-07c4e74e5c8d9c2df |
+| eu-central-1   | ami-09bcf324d00772a11 |
+| eu-west-1      | ami-034aa6e47571b4c1d |
+| eu-west-2      | ami-090060d7ceb48bb9f |
+| eu-west-3      | ami-0f0bb7cccfe23cb10 |
+| sa-east-1      | ami-00d712fa094fc3b3f |
+| us-east-1      | ami-08cd8ad76cae8f5e7 |
+| us-east-2      | ami-0955e78a7116ce622 |
+| us-west-1      | ami-0e8e7583624a9385b |
+| us-west-2      | ami-0511fbc0cc305780b |
 
-## Kubernetes Version v1.17.5
+## Kubernetes Version v1.18.8
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0cdda75c00b770845 |
-| ap-northeast-2 | ami-04474ccde33d4fc02 |
-| ap-south-1     | ami-02cbcda9a255acc98 |
-| ap-southeast-1 | ami-06702d90196666bdf |
-| ap-southeast-2 | ami-0bad2683ba5e02497 |
-| ca-central-1   | ami-058bdac525ebe76d7 |
-| eu-central-1   | ami-0560e9901062bf338 |
-| eu-west-1      | ami-03670f8addaf0b302 |
-| eu-west-2      | ami-0fd6cbf550bd50ec0 |
-| eu-west-3      | ami-075fa196333d2e8c9 |
-| sa-east-1      | ami-056414c59353f3d21 |
-| us-east-1      | ami-00508d307f89f4889 |
-| us-east-2      | ami-0c91831eab4a7e4dd |
-| us-west-1      | ami-0e96eefaeb0b2348d |
-| us-west-2      | ami-0a60f016306dbb40b |
+| ap-northeast-1 | ami-0d50eea76a4cbf3cc |
+| ap-northeast-2 | ami-087769ab73969dd24 |
+| ap-south-1     | ami-0747bf1eed7798ea3 |
+| ap-southeast-1 | ami-04ea3fda882fe61d6 |
+| ap-southeast-2 | ami-06e1390c2fb5dc103 |
+| ca-central-1   | ami-0e88d349df3db7513 |
+| eu-central-1   | ami-040633912271e49d4 |
+| eu-west-1      | ami-05ce1c92d9f549db5 |
+| eu-west-2      | ami-021e77c427dbbb47c |
+| eu-west-3      | ami-04a368d902a43bca7 |
+| sa-east-1      | ami-0cb3a8796bcf76cc7 |
+| us-east-1      | ami-034dbb0b11a3f7a92 |
+| us-east-2      | ami-01cda800fffd0b214 |
+| us-west-1      | ami-056da1120cc4299f6 |
+| us-west-2      | ami-0853be9890380a855 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-08fc96e34d7239fcc |
-| ap-northeast-2 | ami-003d2324309f78447 |
-| ap-south-1     | ami-03555c8236a0e1a31 |
-| ap-southeast-1 | ami-0ad0673ac2a3c8ba8 |
-| ap-southeast-2 | ami-01b4b220081a29079 |
-| ca-central-1   | ami-0420aa66beee55ca6 |
-| eu-central-1   | ami-00452da0e7e1f2434 |
-| eu-west-1      | ami-00152f6212685f2ec |
-| eu-west-2      | ami-085872246c3a2b38d |
-| eu-west-3      | ami-08e1083959446f8fe |
-| sa-east-1      | ami-0939efff9b467230b |
-| us-east-1      | ami-001c54fa7ce71823b |
-| us-east-2      | ami-0755174b542b163bd |
-| us-west-1      | ami-047e839123ddf0788 |
-| us-west-2      | ami-0b0526a8d122bdbe0 |
+| ap-northeast-1 | ami-088446fe9099a8526 |
+| ap-northeast-2 | ami-019f28eb60638654c |
+| ap-south-1     | ami-0e5c1c959cbd0f394 |
+| ap-southeast-1 | ami-0b95a0c4601be3350 |
+| ap-southeast-2 | ami-0ea15bd95eab3d8d8 |
+| ca-central-1   | ami-0a79e612baabcb118 |
+| eu-central-1   | ami-023220dbcade82825 |
+| eu-west-1      | ami-0f5590a61a07952b2 |
+| eu-west-2      | ami-03c590e6cc1486975 |
+| eu-west-3      | ami-09fa3d2a29da5bac6 |
+| sa-east-1      | ami-0fae5ec85ed18a96c |
+| us-east-1      | ami-026c81975c3a1ce5d |
+| us-east-2      | ami-09107464dcc550b89 |
+| us-west-1      | ami-002bd85acf9af58bc |
+| us-west-2      | ami-0af39bd14180617d3 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0bb9d54de16554c38 |
-| ap-northeast-2 | ami-0d0e174d96734e89e |
-| ap-south-1     | ami-0a9edbec5839885d6 |
-| ap-southeast-1 | ami-0f347d28c8b5c4c43 |
-| ap-southeast-2 | ami-00e2154128638e540 |
-| ca-central-1   | ami-0138799afef404a26 |
-| eu-central-1   | ami-005a1f75dce1d7414 |
-| eu-west-1      | ami-07cfb3fb10ad477ee |
-| eu-west-2      | ami-04876ecaa9dbe43e4 |
-| eu-west-3      | ami-0891448600957aac3 |
-| sa-east-1      | ami-02bb59962de22231c |
-| us-east-1      | ami-0ddf1e42629f45bf1 |
-| us-east-2      | ami-01f484cf13f498f7b |
-| us-west-1      | ami-0288de2cd06d482c7 |
-| us-west-2      | ami-05a2b5532f1df54ca |
+| ap-northeast-1 | ami-052caee3e4b10082e |
+| ap-northeast-2 | ami-0766b8473594c7ae2 |
+| ap-south-1     | ami-079b69775f9522b11 |
+| ap-southeast-1 | ami-07f905903734754be |
+| ap-southeast-2 | ami-001e6d7bfe144d0fc |
+| ca-central-1   | ami-0d5272848142d913a |
+| eu-central-1   | ami-0619da04800b1bde1 |
+| eu-west-1      | ami-0bda0a4b993339fa7 |
+| eu-west-2      | ami-03c1c9d70c8e480a5 |
+| eu-west-3      | ami-01a627c97ad278a8d |
+| sa-east-1      | ami-0d2f89b7ca4869da4 |
+| us-east-1      | ami-0338998e57c111717 |
+| us-east-2      | ami-014dc2dbdc63e8e47 |
+| us-west-1      | ami-04f9a8a9b9c069b7e |
+| us-west-2      | ami-0444f6ea72cf74c4d |
 
-## Kubernetes Version v1.18.2
+## Kubernetes Version v1.17.11
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-0be42f99377128778 |
-| ap-northeast-2 | ami-0d1c8d4d08956d7b5 |
-| ap-south-1     | ami-09bd574ba1d67a0c0 |
-| ap-southeast-1 | ami-07b03dae22d418088 |
-| ap-southeast-2 | ami-0e2c980febda7d42c |
-| ca-central-1   | ami-098485a2e479cc864 |
-| eu-central-1   | ami-011f99842c4a62927 |
-| eu-west-1      | ami-0894ddf24c7be059f |
-| eu-west-2      | ami-0b085419fbfad1b3d |
-| eu-west-3      | ami-0e9d80f149c3dfea4 |
-| sa-east-1      | ami-05fcb299181fac18b |
-| us-east-1      | ami-06d4d33e16dcfdedf |
-| us-east-2      | ami-07e7eaa9bab6088b6 |
-| us-west-1      | ami-00098e1135c041e8a |
-| us-west-2      | ami-0ef27d9aa3ac8b0d0 |
+| ap-northeast-1 | ami-04701a81bdbb0f20e |
+| ap-northeast-2 | ami-09e66209b632f0e27 |
+| ap-south-1     | ami-05c04f1d582bb7265 |
+| ap-southeast-1 | ami-022616f333479f060 |
+| ap-southeast-2 | ami-02dc13904265f3dc1 |
+| ca-central-1   | ami-0487aaf5c5bbe1bc4 |
+| eu-central-1   | ami-0891a307202ad90c6 |
+| eu-west-1      | ami-097f6641fa5aac5e2 |
+| eu-west-2      | ami-02decb4d40d4dd0f9 |
+| eu-west-3      | ami-09be768427f36ae23 |
+| sa-east-1      | ami-023d1b16c3fe74c89 |
+| us-east-1      | ami-010a2c7be6f573667 |
+| us-east-2      | ami-0cbcee9a25fd98a54 |
+| us-west-1      | ami-0da43321d0a1a084a |
+| us-west-2      | ami-0c3e3e2b4f1a86fae |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-093a43fb1a4f001b1 |
-| ap-northeast-2 | ami-00a9cfc4d17c952cc |
-| ap-south-1     | ami-0fdb591fb70892e94 |
-| ap-southeast-1 | ami-0d4b956f427110dda |
-| ap-southeast-2 | ami-0204d947468ea1c7f |
-| ca-central-1   | ami-0e3caa7682e653812 |
-| eu-central-1   | ami-0d4f64f4bfd565fd2 |
-| eu-west-1      | ami-0f3c06e2d1e4f16fd |
-| eu-west-2      | ami-01aad99ab2c200c5e |
-| eu-west-3      | ami-0e9fe178e6325a383 |
-| sa-east-1      | ami-07b15ec1c0f1407b7 |
-| us-east-1      | ami-036279de3877bef57 |
-| us-east-2      | ami-0be7e189cef75f282 |
-| us-west-1      | ami-022f6221325c45e45 |
-| us-west-2      | ami-08d2407207fd7bdb8 |
+| ap-northeast-1 | ami-0523c85106561b710 |
+| ap-northeast-2 | ami-0c4726bfa40d4881e |
+| ap-south-1     | ami-0fc219306e1029a8f |
+| ap-southeast-1 | ami-011078691aa10c036 |
+| ap-southeast-2 | ami-0987cec97ba539a7f |
+| ca-central-1   | ami-0df5fc937478ca544 |
+| eu-central-1   | ami-0e6bc4c6ee9626083 |
+| eu-west-1      | ami-099e6e156ee3320c8 |
+| eu-west-2      | ami-05e1a9b8d5ec74bb6 |
+| eu-west-3      | ami-03c3ccb14f0878568 |
+| sa-east-1      | ami-04ff828eb97d08c7d |
+| us-east-1      | ami-090b875ae79d90db6 |
+| us-east-2      | ami-0e5f89aca409bc675 |
+| us-west-1      | ami-0883d0141087cf523 |
+| us-west-2      | ami-0ddea88b73e853ee6 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 | -------------- | --------------------- |
-| ap-northeast-1 | ami-00365b48b0a26c11a |
-| ap-northeast-2 | ami-0eff0d7f4eb06ac5e |
-| ap-south-1     | ami-0b145dff4c001d22e |
-| ap-southeast-1 | ami-09135ae607b94e091 |
-| ap-southeast-2 | ami-0a480800abf836999 |
-| ca-central-1   | ami-0e977ba648a8eff40 |
-| eu-central-1   | ami-0d07eee4ef7dedee1 |
-| eu-west-1      | ami-0bbcae229110fd172 |
-| eu-west-2      | ami-02d5a4238b2b78220 |
-| eu-west-3      | ami-0f51cd5679fb64b50 |
-| sa-east-1      | ami-0f0f890292647cb86 |
-| us-east-1      | ami-04d57e17c284ca940 |
-| us-east-2      | ami-0288fa05d2ca8b5c7 |
-| us-west-1      | ami-038bc7a989423bd46 |
-| us-west-2      | ami-053b7f6f651b56de8 |
+| ap-northeast-1 | ami-0c3ac9289d443548c |
+| ap-northeast-2 | ami-0eac8903a83d049af |
+| ap-south-1     | ami-04b59b7395fdda96f |
+| ap-southeast-1 | ami-095e348d93bdf2173 |
+| ap-southeast-2 | ami-0cacf1961f8199459 |
+| ca-central-1   | ami-06a32deff912b001f |
+| eu-central-1   | ami-005aaeb549958f5d9 |
+| eu-west-1      | ami-0f5d320911c292645 |
+| eu-west-2      | ami-0b4ad58a3aa0f779c |
+| eu-west-3      | ami-00b7a407a70adfafd |
+| sa-east-1      | ami-0ea784c1728ea5756 |
+| us-east-1      | ami-0568b0d4f980bf33b |
+| us-east-2      | ami-0833c2cbab3d66033 |
+| us-west-1      | ami-094d3532bb1e08c33 |
+| us-west-2      | ami-0167336744bce671d |
+
+## Kubernetes Version v1.16.14
+
+### Amazon Linux 2
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-0903d9a6bdbaf60cb |
+| ap-northeast-2 | ami-0926c4fa9e12f58be |
+| ap-south-1     | ami-056176fb0c6b86e81 |
+| ap-southeast-1 | ami-009b4637bdef87deb |
+| ap-southeast-2 | ami-016eb7e3fcf525c76 |
+| ca-central-1   | ami-0e070543677632423 |
+| eu-central-1   | ami-0d0eb46af9af4e2aa |
+| eu-west-1      | ami-0957ed8ffdadb6556 |
+| eu-west-2      | ami-05f20e7d943469130 |
+| eu-west-3      | ami-09115cbc64caa8516 |
+| sa-east-1      | ami-0d59266047739188c |
+| us-east-1      | ami-01bd7910e7eaf3b2c |
+| us-east-2      | ami-0156ec3135c4e59f1 |
+| us-west-1      | ami-04cf54c3861fb40ea |
+| us-west-2      | ami-066a793a26f023946 |
+
+### CentOS 7
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-08b93b2d4385c326a |
+| ap-northeast-2 | ami-047c51f2fee6b6d06 |
+| ap-south-1     | ami-02a17b172538c7011 |
+| ap-southeast-1 | ami-036ec94c1b0523405 |
+| ap-southeast-2 | ami-0764c2f8cbd59b76d |
+| ca-central-1   | ami-0138bfdcbd846a00c |
+| eu-central-1   | ami-0a9fb0e7416186a7e |
+| eu-west-1      | ami-0b16e31c8efff52fe |
+| eu-west-2      | ami-0b6617e9e9da2627e |
+| eu-west-3      | ami-0aa710f6462030db4 |
+| sa-east-1      | ami-0a4a879c3c0c2e9cc |
+| us-east-1      | ami-09dc5befd75c185a3 |
+| us-east-2      | ami-0fd1c8327540ccd56 |
+| us-west-1      | ami-0304bccd5d22d8176 |
+| us-west-2      | ami-02f4d0afd3ec1ae32 |
+
+### Ubuntu 18.04 (Bionic)
+
+| Region         | AMI                   |
+| -------------- | --------------------- |
+| ap-northeast-1 | ami-0f070a36a8eefd954 |
+| ap-northeast-2 | ami-0df2423b7dcb47e89 |
+| ap-south-1     | ami-02601261da666bf1d |
+| ap-southeast-1 | ami-0967ce84ae7fee0d6 |
+| ap-southeast-2 | ami-0f2074550d6adb5f9 |
+| ca-central-1   | ami-022871d3497afc42f |
+| eu-central-1   | ami-029284088df804fc0 |
+| eu-west-1      | ami-0b29555f32dd3d9ac |
+| eu-west-2      | ami-0eae493c3277f3f4c |
+| eu-west-3      | ami-0b6297a8459a5e3ae |
+| sa-east-1      | ami-0ec807d85be0b2ef7 |
+| us-east-1      | ami-0d0e5cd6f685d4529 |
+| us-east-2      | ami-0b3eaa6343a1e5e1a |
+| us-west-1      | ami-0786620aaccf74612 |
+| us-west-2      | ami-07e2e80448546b8da |


### PR DESCRIPTION
EOW 28/08/2020

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1892 
Fixes #1847 

