### PR TITLE
chore: wire up EKS bootstrapper and AWSMachine controller for AWSManagedControlPlane

### DIFF
--- a/bootstrap/eks/config/rbac/role.yaml
+++ b/bootstrap/eks/config/rbac/role.yaml
@@ -47,3 +47,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmanagedcontrolplanes
+  verbs:
+  - get
+  - list
+  - watch

--- a/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
+++ b/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
@@ -75,6 +75,13 @@ func newCluster(name string) *clusterv1.Cluster {
 			Namespace: "default",
 			Name:      name,
 		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				Name:      name,
+				Kind:      "AWSManagedControlPlane",
+				Namespace: "default",
+			},
+		},
 	}
 }
 

--- a/bootstrap/eks/main.go
+++ b/bootstrap/eks/main.go
@@ -34,9 +34,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
-	eksbootstrapv1alpha3 "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/api/v1alpha3"
-	eksbootstrapcontrollers "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/controllers"
+	bootstrapv1 "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/api/v1alpha3"
+	bootstrapv1controllers "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/controllers"
 	"sigs.k8s.io/cluster-api-provider-aws/version"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )
@@ -51,7 +52,8 @@ func init() {
 
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
-	_ = eksbootstrapv1alpha3.AddToScheme(scheme)
+	_ = bootstrapv1.AddToScheme(scheme)
+	_ = expinfrav1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -151,7 +153,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 		return
 	}
 
-	if err := (&eksbootstrapcontrollers.EKSConfigReconciler{
+	if err := (&bootstrapv1controllers.EKSConfigReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("EKSConfig"),
 	}).SetupWithManager(mgr, concurrency(eksConfigConcurrency)); err != nil {

--- a/bootstrap/eks/main.go
+++ b/bootstrap/eks/main.go
@@ -36,8 +36,8 @@ import (
 
 	bootstrapv1 "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/api/v1alpha3"
 	bootstrapv1controllers "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/controllers"
-	"sigs.k8s.io/cluster-api-provider-aws/version"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/version"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
@@ -121,29 +122,66 @@ func (r *AWSMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 
 	logger = logger.WithValues("cluster", cluster.Name)
 
-	infraClusterName := client.ObjectKey{
-		Namespace: awsMachine.Namespace,
-		Name:      cluster.Spec.InfrastructureRef.Name,
+	var clusterScope *scope.ClusterScope
+	var managedControlPlaneScope *scope.ManagedControlPlaneScope
+
+	if cluster.Spec.ControlPlaneRef != nil && cluster.Spec.ControlPlaneRef.Kind == "AWSManagedControlPlane" {
+		controlPlane := &expinfrav1.AWSManagedControlPlane{}
+		controlPlaneName := client.ObjectKey{
+			Namespace: awsMachine.Namespace,
+			Name:      cluster.Spec.ControlPlaneRef.Name,
+		}
+
+		if err := r.Get(ctx, controlPlaneName, controlPlane); err != nil {
+			logger.Info("AWSManagedControlPlane is not available yet")
+			return ctrl.Result{}, nil
+		}
+
+		logger = logger.WithValues("AWSManagedControlPlane", controlPlane.Name)
+
+		managedControlPlaneScope, err = scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
+			Client:         r.Client,
+			Logger:         logger,
+			Cluster:        cluster,
+			ControlPlane:   controlPlane,
+			ControllerName: "awsManagedControlPlane",
+		})
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		awsCluster := &infrav1.AWSCluster{}
+
+		infraClusterName := client.ObjectKey{
+			Namespace: awsMachine.Namespace,
+			Name:      cluster.Spec.InfrastructureRef.Name,
+		}
+
+		if err := r.Client.Get(ctx, infraClusterName, awsCluster); err != nil {
+			logger.Info("AWSCluster is not available yet")
+			return ctrl.Result{}, nil
+		}
+
+		logger = logger.WithValues("awsCluster", awsCluster.Name)
+
+		// Create the cluster scope
+		clusterScope, err = scope.NewClusterScope(scope.ClusterScopeParams{
+			Client:         r.Client,
+			Logger:         logger,
+			Cluster:        cluster,
+			AWSCluster:     awsCluster,
+			ControllerName: "awsmachine",
+		})
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
-	awsCluster := &infrav1.AWSCluster{}
-	if err := r.Client.Get(ctx, infraClusterName, awsCluster); err != nil {
-		logger.Info("AWSCluster is not available yet")
-		return ctrl.Result{}, nil
-	}
-
-	logger = logger.WithValues("awsCluster", awsCluster.Name)
-
-	// Create the cluster scope
-	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
-		Client:         r.Client,
-		Logger:         logger,
-		Cluster:        cluster,
-		AWSCluster:     awsCluster,
-		ControllerName: "awsmachine",
-	})
-	if err != nil {
-		return ctrl.Result{}, err
+	var infraCluster scope.EC2Scope
+	if managedControlPlaneScope != nil {
+		infraCluster = managedControlPlaneScope
+	} else {
+		infraCluster = clusterScope
 	}
 
 	// Create the machine scope
@@ -152,7 +190,7 @@ func (r *AWSMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 		Client:       r.Client,
 		Cluster:      cluster,
 		Machine:      machine,
-		InfraCluster: clusterScope,
+		InfraCluster: infraCluster,
 		AWSMachine:   awsMachine,
 	})
 	if err != nil {
@@ -194,7 +232,15 @@ func (r *AWSMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 	}()
 
 	if !awsMachine.ObjectMeta.DeletionTimestamp.IsZero() {
+		if managedControlPlaneScope != nil {
+			return r.reconcileDelete(machineScope, managedControlPlaneScope, managedControlPlaneScope, nil)
+		}
+
 		return r.reconcileDelete(machineScope, clusterScope, clusterScope, clusterScope)
+	}
+
+	if managedControlPlaneScope != nil {
+		return r.reconcileNormal(ctx, machineScope, managedControlPlaneScope, managedControlPlaneScope, nil)
 	}
 
 	return r.reconcileNormal(ctx, machineScope, clusterScope, clusterScope, clusterScope)

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -310,3 +310,7 @@ func (m *MachineScope) InstanceIsInKnownState() bool {
 func (m *MachineScope) AWSMachineIsDeleted() bool {
 	return !m.AWSMachine.ObjectMeta.DeletionTimestamp.IsZero()
 }
+
+func (m *MachineScope) IsEKSManaged() bool {
+	return m.InfraCluster.InfraCluster().GetObjectKind().GroupVersionKind().Kind == "AWSManagedControlPlane"
+}

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -225,6 +225,7 @@ func (s *Service) eksAMILookup(kubernetesVersion string) (string, error) {
 	out, err := s.SSMClient.GetParameter(input)
 	if err != nil {
 		record.Eventf(s.scope.InfraCluster(), "FailedGetParameter", "Failed to get ami SSM parameter %q: %v", paramName, err)
+
 		return "", errors.Wrapf(err, "failed to get ami SSM parameter: %q", paramName)
 	}
 
@@ -232,7 +233,10 @@ func (s *Service) eksAMILookup(kubernetesVersion string) (string, error) {
 		return "", errors.Errorf("SSM parameter returned with nil value: %q", paramName)
 	}
 
-	return aws.StringValue(out.Parameter.Value), nil
+	id := aws.StringValue(out.Parameter.Value)
+	s.scope.Info("found AMI", "id", id, "version", formattedVersion)
+
+	return id, nil
 }
 
 func formatVersionForEKS(version string) (string, error) {

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -140,7 +140,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 			return nil, err
 		}
 
-		if s.shouldUseEksAMI() {
+		if scope.IsEKSManaged() {
 			input.ImageID, err = s.eksAMILookup(*scope.Machine.Spec.Version)
 			if err != nil {
 				return nil, err
@@ -174,7 +174,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 	}
 	input.SubnetID = subnetID
 
-	if scope.InfraCluster.ControllerName() == "awsCluster" && s.scope.Network().APIServerELB.DNSName == "" {
+	if !scope.IsEKSManaged() && s.scope.Network().APIServerELB.DNSName == "" {
 		record.Eventf(s.scope.InfraCluster(), "FailedCreateInstance", "Failed to run controlplane, APIServer ELB not available")
 
 		return nil, awserrors.NewFailedDependency("failed to run controlplane, APIServer ELB not available")
@@ -311,8 +311,12 @@ func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, er
 	// These are common across both controlplane and node machines
 	sgRoles := []infrav1.SecurityGroupRole{
 		infrav1.SecurityGroupNode,
-		infrav1.SecurityGroupLB,
 	}
+
+	if !scope.IsEKSManaged() {
+		sgRoles = append(sgRoles, infrav1.SecurityGroupLB)
+	}
+
 	switch scope.Role() {
 	case "node":
 		// Just the common security groups above
@@ -818,12 +822,6 @@ func (s *Service) DetachSecurityGroupsFromNetworkInterface(groups []string, inte
 		return errors.Wrapf(err, "failed to modify interface %q", interfaceID)
 	}
 	return nil
-}
-
-func (s *Service) shouldUseEksAMI() bool {
-	gvk := s.scope.InfraCluster().GetObjectKind().GroupVersionKind()
-
-	return gvk.Kind == "AWSManagedControlPlane"
 }
 
 // filterGroups filters a list for a string.

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -174,8 +174,9 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 	}
 	input.SubnetID = subnetID
 
-	if s.scope.Network().APIServerELB.DNSName == "" {
+	if scope.InfraCluster.ControllerName() == "awsCluster" && s.scope.Network().APIServerELB.DNSName == "" {
 		record.Eventf(s.scope.InfraCluster(), "FailedCreateInstance", "Failed to run controlplane, APIServer ELB not available")
+
 		return nil, awserrors.NewFailedDependency("failed to run controlplane, APIServer ELB not available")
 	}
 	if !scope.UserDataIsUncompressed() {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Wires up AWSMachine controller to join AWSManagedControlPlanes. Also checks for EKSClusterName in the EKS bootstrap provider.

With this PR, I was able to fully join a MachineDeployment to the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1897 

