### PR TITLE
:seedling: cloudbuild: Increase timeout, use newer Docker image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,10 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 2100s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+  # 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud@sha256:e9d6b4ff5ef9f7d89fa3dac20b6493ae7cdd1ad44b7c08a762aa7c228d17751c'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
builds have been failing of late. measured in a local cloudbuild run, and it takes about 28 minutes, so bump the timeout to 35 minutes.

Whilst I was here, I also bumped the docker build image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

