### PR TITLE
✨ Persists changes early when using default subnets

### DIFF
--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -73,6 +73,10 @@ func (s *Service) reconcileSubnets() error {
 			record.Warnf(s.scope.InfraCluster(), "FailedDefaultSubnets", "Failed getting default subnets: %v", err)
 			return errors.Wrap(err, "failed getting default subnets")
 		}
+		// Persist the new default subnets to AWSCluster
+		if err := s.scope.PatchObject(); err != nil {
+			return err
+		}
 	}
 
 	for _, sub := range subnets {


### PR DESCRIPTION
**What this PR does / why we need it**:
To address a potential issue raised [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1721#discussion_r441821606)

Needed a way to short the rest of the reconciliation after default subnets is determined. I'm not super fond of this implementation where the `requeue` is bubbled up from the ec2 services so open to suggestions. Some other alternatives considered: 
- Patch the AWSCluster like how do for conditions. Calling patch on the spec outside of the controller felt wrong. Conditions was only modifying the status field. 
- Just return after determining the default subnets and continue. This may cause issues further down the line where subnets are expected to have been created. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1906 

