### PR TITLE
PROPOSAL: @richardcase as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,3 +24,5 @@ aliases:
     - vincepri
   cluster-api-aws-reviewers:
     - randomvariable
+  cluster-api-aws-eks-maintainers:
+    - richardcase

--- a/exp/OWNERS
+++ b/exp/OWNERS
@@ -1,22 +1,12 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
 approvers:
   - sig-cluster-lifecycle-leads
   - cluster-api-admins
   - cluster-api-maintainers
   - cluster-api-aws-maintainers
+  - cluster-api-aws-eks-maintainers
 
 reviewers:
   - cluster-api-maintainers
   - cluster-api-aws-maintainers
   - cluster-api-aws-reviewers
   - cluster-api-aws-eks-maintainers
-
-emeritus_approvers:
-  - davidewatson
-  - ingvagabund
-  - enxebre
-
-emeritus_reviewers:
-  - sethp-nr
-  - ashish-amarnath


### PR DESCRIPTION
I would like to propose @richardcase as a reviewer for Cluster API Provider AWS, and a maintainer of the exp directory containing the EKS control plane implementation.

/hold 
for consensus