### PR TITLE
🌱  Bumps aws-sdk. Creates tags during route table creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api-provider-aws
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.34.10
+	github.com/aws/aws-sdk-go v1.34.16
 	github.com/awslabs/goformation/v4 v4.11.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws/aws-sdk-go v1.34.10 h1:VU78gcf/3wA4HNEDCHidK738l7K0Bals4SJnfnvXOtY=
-github.com/aws/aws-sdk-go v1.34.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.34.16 h1:22jPsMe98UX/van5Ca/5jXnyNsNpJxCJ1rw/wFAlZ+4=
+github.com/aws/aws-sdk-go v1.34.16/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/awslabs/goformation/v4 v4.11.0 h1:dTRaASciMTkaoQrR8CGSDt7e9WfvvsOJXfDbqfiOjkU=
 github.com/awslabs/goformation/v4 v4.11.0/go.mod h1:GcJULxCJfloT+3pbqCluXftdEK2AD/UqpS3hkaaBntg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cloud/services/ec2/mock_ec2iface/ec2api_mock.go
+++ b/pkg/cloud/services/ec2/mock_ec2iface/ec2api_mock.go
@@ -21103,6 +21103,56 @@ func (mr *MockEC2APIMockRecorder) ModifyVpnConnection(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnConnection", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnConnection), arg0)
 }
 
+// ModifyVpnConnectionOptions mocks base method
+func (m *MockEC2API) ModifyVpnConnectionOptions(arg0 *ec2.ModifyVpnConnectionOptionsInput) (*ec2.ModifyVpnConnectionOptionsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyVpnConnectionOptions", arg0)
+	ret0, _ := ret[0].(*ec2.ModifyVpnConnectionOptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyVpnConnectionOptions indicates an expected call of ModifyVpnConnectionOptions
+func (mr *MockEC2APIMockRecorder) ModifyVpnConnectionOptions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnConnectionOptions", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnConnectionOptions), arg0)
+}
+
+// ModifyVpnConnectionOptionsRequest mocks base method
+func (m *MockEC2API) ModifyVpnConnectionOptionsRequest(arg0 *ec2.ModifyVpnConnectionOptionsInput) (*request.Request, *ec2.ModifyVpnConnectionOptionsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyVpnConnectionOptionsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyVpnConnectionOptionsOutput)
+	return ret0, ret1
+}
+
+// ModifyVpnConnectionOptionsRequest indicates an expected call of ModifyVpnConnectionOptionsRequest
+func (mr *MockEC2APIMockRecorder) ModifyVpnConnectionOptionsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnConnectionOptionsRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnConnectionOptionsRequest), arg0)
+}
+
+// ModifyVpnConnectionOptionsWithContext mocks base method
+func (m *MockEC2API) ModifyVpnConnectionOptionsWithContext(arg0 context.Context, arg1 *ec2.ModifyVpnConnectionOptionsInput, arg2 ...request.Option) (*ec2.ModifyVpnConnectionOptionsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyVpnConnectionOptionsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ModifyVpnConnectionOptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyVpnConnectionOptionsWithContext indicates an expected call of ModifyVpnConnectionOptionsWithContext
+func (mr *MockEC2APIMockRecorder) ModifyVpnConnectionOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnConnectionOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnConnectionOptionsWithContext), varargs...)
+}
+
 // ModifyVpnConnectionRequest mocks base method
 func (m *MockEC2API) ModifyVpnConnectionRequest(arg0 *ec2.ModifyVpnConnectionInput) (*request.Request, *ec2.ModifyVpnConnectionOutput) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:
- Utilize the ability to create route tables with tags instead of tagging after creation. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1887 
Fixes #1895
