### PR TITLE
🐛Fix clusterawsadm policy mix up

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
@@ -61,8 +61,8 @@ func (t Template) GenerateManagedIAMPolicyDocuments(policyDocDir string) error {
 
 func (t Template) policyFunctionMap() map[PolicyName]func() *iamv1.PolicyDocument {
 	return map[PolicyName]func() *iamv1.PolicyDocument{
-		ControlPlanePolicy: t.controllersPolicy,
-		ControllersPolicy:  t.cloudProviderControlPlaneAwsPolicy,
+		ControlPlanePolicy: t.cloudProviderControlPlaneAwsPolicy,
+		ControllersPolicy:  t.controllersPolicy,
 		NodePolicy:         t.cloudProviderNodeAwsPolicy,
 		CSIPolicy:          t.csiControllerPolicy,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a minor mix up happens during printing IAM policies with clusterawsadm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1921

