### PR TITLE
✨Add ability to specify instance tenancy

### DIFF
--- a/api/v1alpha2/awsmachine_conversion.go
+++ b/api/v1alpha2/awsmachine_conversion.go
@@ -70,6 +70,8 @@ func restoreAWSMachineSpec(restored, dst *infrav1alpha3.AWSMachineSpec) {
 			dst.NonRootVolumes = append(dst.NonRootVolumes, volume.DeepCopy())
 		}
 	}
+
+	dst.Tenancy = restored.Tenancy
 }
 
 // ConvertFrom converts from the Hub version (v1alpha3) to this version.

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -611,6 +611,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	// WARNING: in.UncompressedUserData requires manual conversion: does not exist in peer-type
 	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
 	// WARNING: in.SpotMarketOptions requires manual conversion: does not exist in peer-type
+	// WARNING: in.Tenancy requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -1017,6 +1018,7 @@ func autoConvert_v1alpha3_Instance_To_v1alpha2_Instance(in *v1alpha3.Instance, o
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	// WARNING: in.AvailabilityZone requires manual conversion: does not exist in peer-type
 	// WARNING: in.SpotMarketOptions requires manual conversion: does not exist in peer-type
+	// WARNING: in.Tenancy requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -127,6 +127,11 @@ type AWSMachineSpec struct {
 	// SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.
 	// +optional
 	SpotMarketOptions *SpotMarketOptions `json:"spotMarketOptions,omitempty"`
+
+	// Tenancy indicates if instance should run on shared or single-tenant hardware.
+	// +optional
+	// +kubebuilder:validation:Enum:=default;dedicated;host
+	Tenancy string `json:"tenancy,omitempty"`
 }
 
 // CloudInit defines options related to the bootstrapping systems where

--- a/api/v1alpha3/awsmachinetemplate_webhook.go
+++ b/api/v1alpha3/awsmachinetemplate_webhook.go
@@ -34,7 +34,9 @@ func (r *AWSMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-awsmachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=awsmachinetemplates,versions=v1alpha3,name=validation.awsmachinetemplate.infrastructure.x-k8s.io,sideEffects=None
 
-var _ webhook.Validator = &AWSMachineTemplate{}
+var (
+	_ webhook.Validator = &AWSMachineTemplate{}
+)
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *AWSMachineTemplate) ValidateCreate() error {

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -646,6 +646,10 @@ type Instance struct {
 
 	// SpotMarketOptions option for configuring instances to be run using AWS Spot instances.
 	SpotMarketOptions *SpotMarketOptions `json:"spotMarketOptions,omitempty"`
+
+	// Tenancy indicates if instance should run on shared or single-tenant hardware.
+	// +optional
+	Tenancy string `json:"tenancy,omitempty"`
 }
 
 // Volume encapsulates the configuration options for the root volume

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -685,6 +685,9 @@ spec:
                       type: string
                     description: The tags associated with the instance.
                     type: object
+                  tenancy:
+                    description: Tenancy indicates if instance should run on shared or single-tenant hardware.
+                    type: string
                   type:
                     description: The instance type.
                     type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -449,6 +449,13 @@ spec:
                     description: ID of resource
                     type: string
                 type: object
+              tenancy:
+                description: Tenancy indicates if instance should run on shared or single-tenant hardware.
+                enum:
+                - default
+                - dedicated
+                - host
+                type: string
               uncompressedUserData:
                 description: UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.
                 type: boolean

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -412,6 +412,13 @@ spec:
                             description: ID of resource
                             type: string
                         type: object
+                      tenancy:
+                        description: Tenancy indicates if instance should run on shared or single-tenant hardware.
+                        enum:
+                        - default
+                        - dedicated
+                        - host
+                        type: string
                       uncompressedUserData:
                         description: UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.
                         type: boolean

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -419,6 +419,9 @@ spec:
                       type: string
                     description: The tags associated with the instance.
                     type: object
+                  tenancy:
+                    description: Tenancy indicates if instance should run on shared or single-tenant hardware.
+                    type: string
                   type:
                     description: The instance type.
                     type: string

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -208,6 +208,8 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 
 	input.SpotMarketOptions = scope.AWSMachine.Spec.SpotMarketOptions
 
+	input.Tenancy = scope.AWSMachine.Spec.Tenancy
+
 	s.scope.V(2).Info("Running instance", "machine-role", scope.Role())
 	out, err := s.runInstance(scope.Role(), input)
 	if err != nil {
@@ -501,6 +503,12 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 	}
 
 	input.InstanceMarketOptions = getInstanceMarketOptionsRequest(i.SpotMarketOptions)
+
+	if i.Tenancy != "" {
+		input.Placement = &ec2.Placement{
+			Tenancy: &i.Tenancy,
+		}
+	}
 
 	out, err := s.EC2Client.RunInstances(input)
 	if err != nil {

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ec2
 
 import (
+	"encoding/base64"
 	"reflect"
 	"testing"
 
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/filter"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -268,6 +270,14 @@ func TestCreateInstance(t *testing.T) {
 	}
 
 	az := "test-zone-1a"
+	tenancy := "dedicated"
+
+	data := []byte("userData")
+
+	userData, err := userdata.GzipBytes(data)
+	if err != nil {
+		t.Fatal("Failed to gzip test user data")
+	}
 
 	testcases := []struct {
 		name          string
@@ -1110,6 +1120,143 @@ func TestCreateInstance(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "with dedicated tenancy",
+			machine: clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"set": "node"},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: pointer.StringPtr("bootstrap-data"),
+					},
+				},
+			},
+			machineConfig: &infrav1.AWSMachineSpec{
+				AMI: infrav1.AWSResourceReference{
+					ID: aws.String("abc"),
+				},
+				InstanceType: "m5.large",
+				Tenancy:      "dedicated",
+			},
+			awsCluster: &infrav1.AWSCluster{
+				Spec: infrav1.AWSClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
+							&infrav1.SubnetSpec{
+								ID:       "subnet-1",
+								IsPublic: false,
+							},
+							&infrav1.SubnetSpec{
+								IsPublic: false,
+							},
+						},
+					},
+				},
+				Status: infrav1.AWSClusterStatus{
+					Network: infrav1.Network{
+						SecurityGroups: map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+							infrav1.SecurityGroupControlPlane: {
+								ID: "1",
+							},
+							infrav1.SecurityGroupNode: {
+								ID: "2",
+							},
+							infrav1.SecurityGroupLB: {
+								ID: "3",
+							},
+						},
+						APIServerELB: infrav1.ClassicELB{
+							DNSName: "test-apiserver.us-east-1.aws",
+						},
+					},
+				},
+			},
+			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+				m.
+					DescribeImages(gomock.Any()).
+					Return(&ec2.DescribeImagesOutput{
+						Images: []*ec2.Image{
+							{
+								Name: aws.String("ami-1"),
+							},
+						},
+					}, nil)
+				m. // TODO: Restore these parameters, but with the tags as well
+					RunInstances(gomock.Eq(&ec2.RunInstancesInput{
+						ImageId:      aws.String("abc"),
+						InstanceType: aws.String("m5.large"),
+						KeyName:      aws.String("default"),
+						MaxCount:     aws.Int64(1),
+						MinCount:     aws.Int64(1),
+						Placement: &ec2.Placement{
+							Tenancy: &tenancy,
+						},
+						SecurityGroupIds: []*string{aws.String("2"), aws.String("3")},
+						SubnetId:         aws.String("subnet-1"),
+						TagSpecifications: []*ec2.TagSpecification{
+							{
+								ResourceType: aws.String("instance"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+								},
+							},
+						},
+						UserData: aws.String(base64.StdEncoding.EncodeToString(userData)),
+					})).
+					Return(&ec2.Reservation{
+						Instances: []*ec2.Instance{
+							{
+								State: &ec2.InstanceState{
+									Name: aws.String(ec2.InstanceStateNamePending),
+								},
+								IamInstanceProfile: &ec2.IamInstanceProfile{
+									Arn: aws.String("arn:aws:iam::123456789012:instance-profile/foo"),
+								},
+								InstanceId:     aws.String("two"),
+								InstanceType:   aws.String("m5.large"),
+								SubnetId:       aws.String("subnet-1"),
+								ImageId:        aws.String("ami-1"),
+								RootDeviceName: aws.String("device-1"),
+								BlockDeviceMappings: []*ec2.InstanceBlockDeviceMapping{
+									{
+										DeviceName: aws.String("device-1"),
+										Ebs: &ec2.EbsInstanceBlockDevice{
+											VolumeId: aws.String("volume-1"),
+										},
+									},
+								},
+								Placement: &ec2.Placement{
+									AvailabilityZone: &az,
+									Tenancy:          &tenancy,
+								},
+							},
+						},
+					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+			},
+			check: func(instance *infrav1.Instance, err error) {
+				if err != nil {
+					t.Fatalf("did not expect error: %v", err)
+				}
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -1181,7 +1328,7 @@ func TestCreateInstance(t *testing.T) {
 			s := NewService(clusterScope)
 			s.EC2Client = ec2Mock
 
-			instance, err := s.CreateInstance(machineScope, []byte("userData"))
+			instance, err := s.CreateInstance(machineScope, data)
 			tc.check(instance, err)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to specify instance tenancy and makes possible running dedicated instances.
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
