### PR TITLE
🌱 Unmanaged VPCs don't require public subnets

### DIFF
--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -104,14 +104,16 @@ func (s *Service) reconcileSubnets() error {
 		}
 	}
 
-	// Check that we need at least 1 private and 1 public subnet after we have updated the metadata
-	if len(subnets.FilterPrivate()) < 1 {
-		record.Warnf(s.scope.InfraCluster(), "FailedNoPrivateSubnet", "Expected at least 1 private subnet but got 0")
-		return errors.New("expected at least 1 private subnet but got 0")
-	}
-	if len(subnets.FilterPublic()) < 1 {
-		record.Warnf(s.scope.InfraCluster(), "FailedNoPublicSubnet", "Expected at least 1 public subnet but got 0")
-		return errors.New("expected at least 1 public subnet but got 0")
+	if !unmanagedVPC {
+		// Check that we need at least 1 private and 1 public subnet after we have updated the metadata
+		if len(subnets.FilterPrivate()) < 1 {
+			record.Warnf(s.scope.InfraCluster(), "FailedNoPrivateSubnet", "Expected at least 1 private subnet but got 0")
+			return errors.New("expected at least 1 private subnet but got 0")
+		}
+		if len(subnets.FilterPublic()) < 1 {
+			record.Warnf(s.scope.InfraCluster(), "FailedNoPublicSubnet", "Expected at least 1 public subnet but got 0")
+			return errors.New("expected at least 1 public subnet but got 0")
+		}
 	}
 
 	// Proceed to create the rest of the subnets that don't have an ID.


### PR DESCRIPTION
**What this PR does / why we need it**: As a user, I may want to provide CAPA with a VPC that has no associated public subnets or internet gateways. It is unclear whether CAPA would support this today, even with an internal load balancing scheme for the apiserver.

Fixes #1696 

