### PR TITLE
:bug: Add capi exp schema and fix manager args and rbac

### DIFF
--- a/bootstrap/eks/config/manager/kustomization.yaml
+++ b/bootstrap/eks/config/manager/kustomization.yaml
@@ -5,3 +5,4 @@ patchesStrategicMerge:
 - manager_image_patch.yaml
 - manager_pull_policy.yaml
 - manager_auth_proxy_patch.yaml
+- manager_manager_args_patch.yaml

--- a/bootstrap/eks/config/manager/manager_manager_args_patch.yaml
+++ b/bootstrap/eks/config/manager/manager_manager_args_patch.yaml
@@ -9,13 +9,8 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+      - name: manager
         args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
+        - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"

--- a/bootstrap/eks/config/rbac/role.yaml
+++ b/bootstrap/eks/config/rbac/role.yaml
@@ -48,17 +48,17 @@ rules:
   - list
   - watch
 - apiGroups:
-  - infrastructure.cluster.x-k8s.io
+  - exp.cluster.x-k8s.io
   resources:
-  - awsmanagedcontrolplanes
+  - machinepools
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - exp.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
   resources:
-  - machinepools
+  - awsmanagedcontrolplanes
   verbs:
   - get
   - list

--- a/bootstrap/eks/config/rbac/role.yaml
+++ b/bootstrap/eks/config/rbac/role.yaml
@@ -55,3 +55,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - exp.cluster.x-k8s.io
+  resources:
+  - machinepools
+  verbs:
+  - get
+  - list
+  - watch

--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -59,6 +59,7 @@ type EKSConfigReconciler struct {
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=eksconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmanagedcontrolplanes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machinepools;clusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=exp.cluster.x-k8s.io,resources=machinepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;
 
 func (r *EKSConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rerr error) {

--- a/bootstrap/eks/main.go
+++ b/bootstrap/eks/main.go
@@ -39,6 +39,7 @@ import (
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/version"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -54,6 +55,7 @@ func init() {
 	_ = clusterv1.AddToScheme(scheme)
 	_ = bootstrapv1.AddToScheme(scheme)
 	_ = expinfrav1.AddToScheme(scheme)
+	_ = expclusterv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
* eks-bootstrap doesn't know about the CRD `machinepools.exp.cluster.x-k8s.io` and `User "system:serviceaccount:capa-eks-bootstrap-system:default" cannot list resource "machinepools" in API group "exp.cluster.x-k8s.io"`
* I want to be able to use `"EXP_MACHINE_POOL": "true"` like in the capi-controller-manager and capa-controller-manager

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This needs to be merged so that awsmachinepools can connect to an eks controlplane
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1860

