### PR TITLE
:seedling: instances: Sort tag keys so unit tests can succeed

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -492,10 +493,16 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 
 	if len(i.Tags) > 0 {
 		spec := &ec2.TagSpecification{ResourceType: aws.String(ec2.ResourceTypeInstance)}
-		for key, value := range i.Tags {
+		// We need to sort keys for tests to work
+		keys := make([]string, 0, len(i.Tags))
+		for k := range i.Tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
 			spec.Tags = append(spec.Tags, &ec2.Tag{
 				Key:   aws.String(key),
-				Value: aws.String(value),
+				Value: aws.String(i.Tags[key]),
 			})
 		}
 

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -1199,6 +1199,10 @@ func TestCreateInstance(t *testing.T) {
 								ResourceType: aws.String("instance"),
 								Tags: []*ec2.Tag{
 									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
 										Key:   aws.String("kubernetes.io/cluster/test1"),
 										Value: aws.String("owned"),
 									},
@@ -1209,10 +1213,6 @@ func TestCreateInstance(t *testing.T) {
 									{
 										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
 										Value: aws.String("node"),
-									},
-									{
-										Key:   aws.String("Name"),
-										Value: aws.String("aws-test1"),
 									},
 								},
 							},


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

