### PR TITLE
🐛 fix: bastion reconcilation and connection error when using `eks` flavor

### DIFF
--- a/api/v1alpha3/awscluster_webhook_test.go
+++ b/api/v1alpha3/awscluster_webhook_test.go
@@ -300,7 +300,7 @@ func TestAWSCluster_ValidateAllowedCIDRBlocks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.awsc.validateAllowedCIDRBlocks(); (err != nil) != tt.wantErr {
+			if err := tt.awsc.Spec.Bastion.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateAllowedCIDRBlocks() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/api/v1alpha3/defaults.go
+++ b/api/v1alpha3/defaults.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+// TODO (richardcase): get this working with defaulter-gen
+
+// SetDefaults_Bastion is used by defaulter-gen
+func SetDefaults_Bastion(obj *Bastion) { //nolint:golint,stylecheck
+	// Default to allow open access to the bastion host if no CIDR Blocks have been set
+	if len(obj.AllowedCIDRBlocks) == 0 && !obj.DisableIngressRules {
+		obj.AllowedCIDRBlocks = []string{"0.0.0.0/0"}
+	}
+}
+
+// SetDefaults_NetworkSpec is used by defaulter-gen
+func SetDefaults_NetworkSpec(obj *NetworkSpec) { //nolint:golint,stylecheck
+	// Default to Calico ingress rules if no rules have been set
+	if obj.CNI == nil {
+		obj.CNI = &CNISpec{
+			CNIIngressRules: CNIIngressRules{
+				{
+					Description: "bgp (calico)",
+					Protocol:    SecurityGroupProtocolTCP,
+					FromPort:    179,
+					ToPort:      179,
+				},
+				{
+					Description: "IP-in-IP (calico)",
+					Protocol:    SecurityGroupProtocolIPinIP,
+					FromPort:    -1,
+					ToPort:      65535,
+				},
+			},
+		}
+	}
+}

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -394,6 +394,9 @@ var (
 	// SecurityGroupNode defines a Kubernetes workload node role
 	SecurityGroupNode = SecurityGroupRole("node")
 
+	// SecurityGroupEKSNodeAdditional defines an extra node group from eks nodes
+	SecurityGroupEKSNodeAdditional = SecurityGroupRole("node-eks-additional")
+
 	// SecurityGroupControlPlane defines a Kubernetes control plane node role
 	SecurityGroupControlPlane = SecurityGroupRole("controlplane")
 

--- a/api/v1alpha3/validate.go
+++ b/api/v1alpha3/validate.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"net"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Validate will validate the bastion fields
+func (b *Bastion) Validate() []*field.Error {
+	var errs field.ErrorList
+
+	if b.DisableIngressRules && len(b.AllowedCIDRBlocks) > 0 {
+		errs = append(errs,
+			field.Forbidden(field.NewPath("spec", "bastion", "allowedCIDRBlocks"), "cannot be set if spec.bastion.disableIngressRules is true"),
+		)
+		return errs
+	}
+
+	for i, cidr := range b.AllowedCIDRBlocks {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			errs = append(errs,
+				field.Invalid(field.NewPath("spec", "bastion", fmt.Sprintf("allowedCIDRBlocks[%d]", i)), cidr, "must be a valid CIDR block"),
+			)
+		}
+	}
+	return errs
+}

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -203,14 +203,14 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile network for AWSManagedControlPlane %s/%s: %w", awsManagedControlPlane.Namespace, awsManagedControlPlane.Name, err)
 	}
 
-	if err := ec2Service.ReconcileBastion(); err != nil {
-		conditions.MarkFalse(awsManagedControlPlane, infrav1.BastionHostReadyCondition, infrav1.BastionHostFailedReason, clusterv1.ConditionSeverityError, err.Error())
-		return reconcile.Result{}, fmt.Errorf("failed to reconcile bastion host for AWSManagedControlPlane %s/%s: %w", awsManagedControlPlane.Namespace, awsManagedControlPlane.Name, err)
-	}
-
 	if err := sgService.ReconcileSecurityGroups(); err != nil {
 		conditions.MarkFalse(awsManagedControlPlane, infrav1.ClusterSecurityGroupsReadyCondition, infrav1.ClusterSecurityGroupReconciliationFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile general security groups for AWSManagedControlPlane %s/%s", awsManagedControlPlane.Namespace, awsManagedControlPlane.Name)
+	}
+
+	if err := ec2Service.ReconcileBastion(); err != nil {
+		conditions.MarkFalse(awsManagedControlPlane, infrav1.BastionHostReadyCondition, infrav1.BastionHostFailedReason, clusterv1.ConditionSeverityError, err.Error())
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile bastion host for AWSManagedControlPlane %s/%s: %w", awsManagedControlPlane.Namespace, awsManagedControlPlane.Name, err)
 	}
 
 	if err := ekssvc.ReconcileControlPlane(ctx); err != nil {
@@ -240,12 +240,12 @@ func (r *AWSManagedControlPlaneReconciler) reconcileDelete(_ context.Context, ma
 		return reconcile.Result{}, fmt.Errorf("error deleting EKS cluster for EKS control plane %s/%s: %w", controlPlane.Namespace, controlPlane.Name, err)
 	}
 
-	if err := sgService.DeleteSecurityGroups(); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error deleting general security groups for AWSManagedControlPlane %s/%s: %w", controlPlane.Namespace, controlPlane.Name, err) //nolint:goerr113
-	}
-
 	if err := ec2svc.DeleteBastion(); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error deleting bastion for AWSManagedControlPlane %s/%s: %w", controlPlane.Namespace, controlPlane.Name, err)
+	}
+
+	if err := sgService.DeleteSecurityGroups(); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error deleting general security groups for AWSManagedControlPlane %s/%s: %w", controlPlane.Namespace, controlPlane.Name, err) //nolint:goerr113
 	}
 
 	if err := networkSvc.DeleteNetwork(); err != nil {

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -192,6 +192,7 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 
 	sgRoles := []infrav1.SecurityGroupRole{
 		infrav1.SecurityGroupBastion,
+		infrav1.SecurityGroupEKSNodeAdditional,
 	}
 
 	ec2Service := ec2.NewService(managedScope)

--- a/docs/accessing-instances.md
+++ b/docs/accessing-instances.md
@@ -72,12 +72,20 @@ case, the values returned are `10.0.0.16` and `10.0.0.68`.
 
 ### Connecting to the nodes via SSH
 
-To access one of the nodes (either a control plane node or a worker node) via the SSH bastion host, use this command:
+To access one of the nodes (either a control plane node or a worker node) via the SSH bastion host, use this command if you are using a non-EKS cluster:
 
 ```bash
 ssh -i ${CLUSTER_SSH_KEY} ubuntu@<NODE_IP> \
 	-o "ProxyCommand ssh -W %h:%p -i ${CLUSTER_SSH_KEY} ubuntu@${BASTION_HOST}"
 ```
+
+And use this command if you are using a EKS based cluster:
+
+```bash
+ssh -i ${CLUSTER_SSH_KEY} ec2-user@<NODE_IP> \
+	-o "ProxyCommand ssh -W %h:%p -i ${CLUSTER_SSH_KEY} ubuntu@${BASTION_HOST}"
+```
+
 
 If the whole document is followed, the value of `<NODE_IP>` will be either
 10.0.0.16 or 10.0.0.68.

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -336,6 +336,9 @@ func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, er
 	switch scope.Role() {
 	case "node":
 		// Just the common security groups above
+		if scope.IsEKSManaged() {
+			sgRoles = append(sgRoles, infrav1.SecurityGroupEKSNodeAdditional)
+		}
 	case "control-plane":
 		sgRoles = append(sgRoles, infrav1.SecurityGroupControlPlane)
 	default:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The bastion was being reconciled before the security groups and this based the bastion reconciliation to fail. The reconciliation order has been updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1956
Fixes #1958  

