### PR TITLE
Update controlplane OWNERS file to include EKS maintainers

### DIFF
--- a/controlplane/OWNERS
+++ b/controlplane/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - sig-cluster-lifecycle-leads
+  - cluster-api-admins
+  - cluster-api-maintainers
+  - cluster-api-aws-maintainers
+  - cluster-api-aws-eks-maintainers
+
+reviewers:
+  - cluster-api-maintainers
+  - cluster-api-aws-maintainers
+  - cluster-api-aws-reviewers
+  - cluster-api-aws-eks-maintainers


### PR DESCRIPTION
Equalises owners across controlplane and exp dirs, i.e. allow @richardcase to be an owner.
