### PR TITLE
🐛 Add externalManagedControlPlane Status to fix node drain under EKS

### DIFF
--- a/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
@@ -166,6 +166,10 @@ type AWSManagedControlPlaneStatus struct {
 	// uploaded kubernetes config-map.
 	// +optional
 	Initialized bool `json:"initialized"`
+	// ExternalManagedControlPlane indicates to cluster-api that the control plane
+	// is managed by an external service such as AKS, EKS, GKE, etc.
+	// +kubebuilder:default=true
+	ExternalManagedControlPlane bool `json:"externalManagedControlPlane"`
 	// Ready denotes that the AWSManagedControlPlane API Server is ready to
 	// receive requests and that the VPC infra is ready.
 	// +kubebuilder:default=false

--- a/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -460,6 +460,10 @@ spec:
                   - type
                   type: object
                 type: array
+              externalManagedControlPlane:
+                default: true
+                description: ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.
+                type: boolean
               failureDomains:
                 additionalProperties:
                   description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
@@ -638,6 +642,7 @@ spec:
                 description: Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.
                 type: boolean
             required:
+            - externalManagedControlPlane
             - ready
             type: object
         type: object


### PR DESCRIPTION
**What this PR does / why we need it**: When using the AWSManagedControlPlane, if you delete a Machine resource it does not gracefully cordon and drain the associated Node. The fix for this in CAPI is to have the managed control plane provider set the `externalManagedControlPlane: true` value in its status to signal to cluster-api that the control plane Nodes are not visible in the cluster.

Related to: https://github.com/kubernetes-sigs/cluster-api/issues/3631


