### PR TITLE
🐛 externalManagedControlPlane status field should have been optional

### DIFF
--- a/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
@@ -162,14 +162,14 @@ type AWSManagedControlPlaneStatus struct {
 	// Bastion holds details of the instance that is used as a bastion jump box
 	// +optional
 	Bastion *infrav1.Instance `json:"bastion,omitempty"`
+	// ExternalManagedControlPlane indicates to cluster-api that the control plane
+	// is managed by an external service such as AKS, EKS, GKE, etc.
+	// +kubebuilder:default=true
+	ExternalManagedControlPlane *bool `json:"externalManagedControlPlane,omitempty"`
 	// Initialized denotes whether or not the control plane has the
 	// uploaded kubernetes config-map.
 	// +optional
 	Initialized bool `json:"initialized"`
-	// ExternalManagedControlPlane indicates to cluster-api that the control plane
-	// is managed by an external service such as AKS, EKS, GKE, etc.
-	// +kubebuilder:default=true
-	ExternalManagedControlPlane bool `json:"externalManagedControlPlane"`
 	// Ready denotes that the AWSManagedControlPlane API Server is ready to
 	// receive requests and that the VPC infra is ready.
 	// +kubebuilder:default=false

--- a/controlplane/eks/api/v1alpha3/zz_generated.deepcopy.go
+++ b/controlplane/eks/api/v1alpha3/zz_generated.deepcopy.go
@@ -166,6 +166,11 @@ func (in *AWSManagedControlPlaneStatus) DeepCopyInto(out *AWSManagedControlPlane
 		*out = new(apiv1alpha3.Instance)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExternalManagedControlPlane != nil {
+		in, out := &in.ExternalManagedControlPlane, &out.ExternalManagedControlPlane
+		*out = new(bool)
+		**out = **in
+	}
 	if in.FailureMessage != nil {
 		in, out := &in.FailureMessage, &out.FailureMessage
 		*out = new(string)

--- a/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -642,7 +642,6 @@ spec:
                 description: Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.
                 type: boolean
             required:
-            - externalManagedControlPlane
             - ready
             type: object
         type: object


### PR DESCRIPTION
**What this PR does / why we need it**: The recently added `externalManagedControlPlane` in #1992 should have been optional, not required to be eligible for release in a minor version.





