### PR TITLE
🌱 fix: incorrect capitalization for eks field

### DIFF
--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
@@ -101,7 +101,7 @@ type EKSConfig struct {
 	// the EKS control plane. This is the default role that will be used if
 	// no role is included in the spec and automatic creation of the role
 	// isn't enabled
-	DefaultControlPlaneRole AWSIAMRoleSpec `json:"DefaultControlPlaneRole,omitempty"`
+	DefaultControlPlaneRole AWSIAMRoleSpec `json:"defaultControlPlaneRole,omitempty"`
 }
 
 // ClusterAPIControllers controls the configuration of the AWS IAM role for


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Noticed a very minor capitaliztion issue related to the bootstrap template for EKS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #1997 

