### PR TITLE
.dockerignore: Add cmd package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,6 @@ tilt-provider.json
 test/
 _artifacts
 .tiltbuild
-cmd/
 Makefile
 *.md
 .gitignore


### PR DESCRIPTION
Fixes broken docker builds