### PR TITLE
🌱 Fix volume description to remove 'root' since it's also used for non-root volume

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -660,18 +660,18 @@ type Instance struct {
 	Tenancy string `json:"tenancy,omitempty"`
 }
 
-// Volume encapsulates the configuration options for the root volume
+// Volume encapsulates the configuration options for the storage device
 type Volume struct {
 	// Device name
 	// +optional
 	DeviceName string `json:"deviceName,omitempty"`
 
-	// Size specifies size (in Gi) of the root storage device.
-	// Must be greater than the image root snapshot size or 8 (whichever is greater).
+	// Size specifies size (in Gi) of the storage device.
+	// Must be greater than the image snapshot size or 8 (whichever is greater).
 	// +kubebuilder:validation:Minimum=8
 	Size int64 `json:"size"`
 
-	// Type is the type of the root volume (e.g. gp2, io1, etc...).
+	// Type is the type of the volume (e.g. gp2, io1, etc...).
 	// +optional
 	Type string `json:"type,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -607,7 +607,7 @@ spec:
                   nonRootVolumes:
                     description: Configuration options for the non root storage volumes.
                     items:
-                      description: Volume encapsulates the configuration options for the root volume
+                      description: Volume encapsulates the configuration options for the storage device
                       properties:
                         deviceName:
                           description: Device name
@@ -623,12 +623,12 @@ spec:
                           format: int64
                           type: integer
                         size:
-                          description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                          description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                           format: int64
                           minimum: 8
                           type: integer
                         type:
-                          description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                          description: Type is the type of the volume (e.g. gp2, io1, etc...).
                           type: string
                       required:
                       - size
@@ -657,12 +657,12 @@ spec:
                         format: int64
                         type: integer
                       size:
-                        description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                        description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                         format: int64
                         minimum: 8
                         type: integer
                       type:
-                        description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                        description: Type is the type of the volume (e.g. gp2, io1, etc...).
                         type: string
                     required:
                     - size

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -165,12 +165,12 @@ spec:
                         format: int64
                         type: integer
                       size:
-                        description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                        description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                         format: int64
                         minimum: 8
                         type: integer
                       type:
-                        description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                        description: Type is the type of the volume (e.g. gp2, io1, etc...).
                         type: string
                     required:
                     - size

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -351,7 +351,7 @@ spec:
               nonRootVolumes:
                 description: Configuration options for the non root storage volumes.
                 items:
-                  description: Volume encapsulates the configuration options for the root volume
+                  description: Volume encapsulates the configuration options for the storage device
                   properties:
                     deviceName:
                       description: Device name
@@ -367,12 +367,12 @@ spec:
                       format: int64
                       type: integer
                     size:
-                      description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                      description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                       format: int64
                       minimum: 8
                       type: integer
                     type:
-                      description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                      description: Type is the type of the volume (e.g. gp2, io1, etc...).
                       type: string
                   required:
                   - size
@@ -401,12 +401,12 @@ spec:
                     format: int64
                     type: integer
                   size:
-                    description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                    description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                     format: int64
                     minimum: 8
                     type: integer
                   type:
-                    description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                    description: Type is the type of the volume (e.g. gp2, io1, etc...).
                     type: string
                 required:
                 - size

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -314,7 +314,7 @@ spec:
                       nonRootVolumes:
                         description: Configuration options for the non root storage volumes.
                         items:
-                          description: Volume encapsulates the configuration options for the root volume
+                          description: Volume encapsulates the configuration options for the storage device
                           properties:
                             deviceName:
                               description: Device name
@@ -330,12 +330,12 @@ spec:
                               format: int64
                               type: integer
                             size:
-                              description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                              description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                               format: int64
                               minimum: 8
                               type: integer
                             type:
-                              description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                              description: Type is the type of the volume (e.g. gp2, io1, etc...).
                               type: string
                           required:
                           - size
@@ -364,12 +364,12 @@ spec:
                             format: int64
                             type: integer
                           size:
-                            description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                            description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                             format: int64
                             minimum: 8
                             type: integer
                           type:
-                            description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                            description: Type is the type of the volume (e.g. gp2, io1, etc...).
                             type: string
                         required:
                         - size

--- a/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -386,7 +386,7 @@ spec:
                   nonRootVolumes:
                     description: Configuration options for the non root storage volumes.
                     items:
-                      description: Volume encapsulates the configuration options for the root volume
+                      description: Volume encapsulates the configuration options for the storage device
                       properties:
                         deviceName:
                           description: Device name
@@ -402,12 +402,12 @@ spec:
                           format: int64
                           type: integer
                         size:
-                          description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                          description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                           format: int64
                           minimum: 8
                           type: integer
                         type:
-                          description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                          description: Type is the type of the volume (e.g. gp2, io1, etc...).
                           type: string
                       required:
                       - size
@@ -436,12 +436,12 @@ spec:
                         format: int64
                         type: integer
                       size:
-                        description: Size specifies size (in Gi) of the root storage device. Must be greater than the image root snapshot size or 8 (whichever is greater).
+                        description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
                         format: int64
                         minimum: 8
                         type: integer
                       type:
-                        description: Type is the type of the root volume (e.g. gp2, io1, etc...).
+                        description: Type is the type of the volume (e.g. gp2, io1, etc...).
                         type: string
                     required:
                     - size


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that we have support for non-root volume, we should remove the 'root' keyword in description for Volume.

Fixes #

