### PR TITLE
🐛 Fix AWSMachinePool panic when MixedInstancesPolicy is not set

### DIFF
--- a/exp/api/v1alpha3/types.go
+++ b/exp/api/v1alpha3/types.go
@@ -135,9 +135,9 @@ var (
 	// your instances across the number of Spot pools that you specify
 	SpotAllocationStrategyLowestPrice = SpotAllocationStrategy("lowest-price")
 
-	// SpotAllocationStrategyCapacityOtimized will make the Auto Scaling group launche
+	// SpotAllocationStrategyCapacityOptimized will make the Auto Scaling group launch
 	// instances using Spot pools that are optimally chosen based on the available Spot capacity
-	SpotAllocationStrategyCapacityOtimized = SpotAllocationStrategy("capacity-optimized")
+	SpotAllocationStrategyCapacityOptimized = SpotAllocationStrategy("capacity-optimized")
 )
 
 // InstancesDistribution to configure distribution of On-Demand Instances and Spot Instances.

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -53,18 +53,18 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 		for _, override := range v.MixedInstancesPolicy.LaunchTemplate.Overrides {
 			i.MixedInstancesPolicy.Overrides = append(i.MixedInstancesPolicy.Overrides, expinfrav1.Overrides{InstanceType: aws.StringValue(override.InstanceType)})
 		}
-	}
 
-	onDemandAllocationStrategy := aws.StringValue(v.MixedInstancesPolicy.InstancesDistribution.OnDemandAllocationStrategy)
-	if onDemandAllocationStrategy == string(expinfrav1.OnDemandAllocationStrategyPrioritized) {
-		i.MixedInstancesPolicy.InstancesDistribution.OnDemandAllocationStrategy = expinfrav1.OnDemandAllocationStrategyPrioritized
-	}
+		onDemandAllocationStrategy := aws.StringValue(v.MixedInstancesPolicy.InstancesDistribution.OnDemandAllocationStrategy)
+		if onDemandAllocationStrategy == string(expinfrav1.OnDemandAllocationStrategyPrioritized) {
+			i.MixedInstancesPolicy.InstancesDistribution.OnDemandAllocationStrategy = expinfrav1.OnDemandAllocationStrategyPrioritized
+		}
 
-	spotAllocationStrategy := aws.StringValue(v.MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy)
-	if spotAllocationStrategy == string(expinfrav1.SpotAllocationStrategyLowestPrice) {
-		i.MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy = expinfrav1.SpotAllocationStrategyLowestPrice
-	} else {
-		i.MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy = expinfrav1.SpotAllocationStrategyCapacityOtimized
+		spotAllocationStrategy := aws.StringValue(v.MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy)
+		if spotAllocationStrategy == string(expinfrav1.SpotAllocationStrategyLowestPrice) {
+			i.MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy = expinfrav1.SpotAllocationStrategyLowestPrice
+		} else {
+			i.MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy = expinfrav1.SpotAllocationStrategyCapacityOptimized
+		}
 	}
 
 	if v.Status != nil {

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -173,6 +173,26 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "valid input - without mixedInstancesPolicy",
+			input: &autoscaling.Group{
+				AutoScalingGroupARN:  aws.String("test-id"),
+				AutoScalingGroupName: aws.String("test-name"),
+				DesiredCapacity:      aws.Int64(1234),
+				MaxSize:              aws.Int64(1234),
+				MinSize:              aws.Int64(1234),
+				MixedInstancesPolicy: nil,
+			},
+			want: &expinfrav1.AutoScalingGroup{
+				ID:                   "test-id",
+				Name:                 "test-name",
+				DesiredCapacity:      aws.Int32(1234),
+				MaxSize:              int32(1234),
+				MinSize:              int32(1234),
+				MixedInstancesPolicy: nil,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**: While testing the AWSMachinePools implementation, I noticed that if the optional field mixedInstancesPolicy is not set, the controller panics due to a nil pointer reference at line 58. 


