### PR TITLE
🌱 Improve AWSManagedMachinePool remote access support

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -89,7 +89,7 @@ spec:
                       type: string
                     type: array
                   sshKeyName:
-                    description: SSHKeyName specifies which EC2 SSH key can be used to access machines
+                    description: SSHKeyName specifies which EC2 SSH key can be used to access machines. If left empty, the key from the control plane is used.
                     type: string
                 type: object
               roleName:

--- a/exp/api/v1alpha3/awsmanagedmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmanagedmachinepool_types.go
@@ -124,7 +124,8 @@ type ManagedMachinePoolScaling struct {
 
 // ManagedRemoteAccess specifies remote access settings for EC2 instances
 type ManagedRemoteAccess struct {
-	// SSHKeyName specifies which EC2 SSH key can be used to access machines
+	// SSHKeyName specifies which EC2 SSH key can be used to access machines.
+	// If left empty, the key from the control plane is used.
 	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// SourceSecurityGroups specifies which security groups are allowed access

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -108,6 +108,37 @@ func ngTags(key string, additionalTags infrav1.Tags) map[string]string {
 	return tags
 }
 
+func (s *NodegroupService) remoteAccess() (*eks.RemoteAccessConfig, error) {
+	pool := s.scope.ManagedMachinePool.Spec
+	if pool.RemoteAccess == nil {
+		return nil, nil
+	}
+
+	controlPlane := s.scope.ControlPlane
+	sSGs := pool.RemoteAccess.SourceSecurityGroups
+
+	if controlPlane.Spec.Bastion.Enabled {
+		additionalSG, ok := controlPlane.Status.Network.SecurityGroups[infrav1.SecurityGroupEKSNodeAdditional]
+		if !ok {
+			return nil, errors.Errorf("%s security group not found on control plane", infrav1.SecurityGroupEKSNodeAdditional)
+		}
+		sSGs = append(
+			sSGs,
+			additionalSG.ID,
+		)
+	}
+
+	sshKeyName := pool.RemoteAccess.SSHKeyName
+	if sshKeyName == nil {
+		sshKeyName = controlPlane.Spec.SSHKeyName
+	}
+
+	return &eks.RemoteAccessConfig{
+		SourceSecurityGroups: aws.StringSlice(sSGs),
+		Ec2SshKey:            sshKeyName,
+	}, nil
+}
+
 func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 	eksClusterName := s.scope.KubernetesClusterName()
 	nodegroupName := s.scope.NodegroupName()
@@ -118,6 +149,12 @@ func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 	}
 	managedPool := s.scope.ManagedMachinePool.Spec
 	tags := ngTags(s.scope.Name(), additionalTags)
+
+	remoteAccess, err := s.remoteAccess()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create remote access configuration")
+	}
+
 	input := &eks.CreateNodegroupInput{
 		ScalingConfig: s.scalingConfig(),
 		ClusterName:   aws.String(eksClusterName),
@@ -126,6 +163,7 @@ func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 		NodeRole:      roleArn,
 		Labels:        aws.StringMap(managedPool.Labels),
 		Tags:          aws.StringMap(tags),
+		RemoteAccess:  remoteAccess,
 	}
 	if managedPool.AMIType != nil {
 		input.AmiType = aws.String(string(*managedPool.AMIType))
@@ -135,12 +173,6 @@ func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 	}
 	if managedPool.InstanceType != nil {
 		input.InstanceTypes = []*string{managedPool.InstanceType}
-	}
-	if managedPool.RemoteAccess != nil {
-		input.RemoteAccess = &eks.RemoteAccessConfig{
-			Ec2SshKey:            managedPool.RemoteAccess.SSHKeyName,
-			SourceSecurityGroups: aws.StringSlice(managedPool.RemoteAccess.SourceSecurityGroups),
-		}
 	}
 	if err := input.Validate(); err != nil {
 		return nil, errors.Wrap(err, "created invalid CreateNodegroupInput")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Addresses part of #1990, making it less cumbersome to set up remote access for AWSManagedMachinePool

