### PR TITLE
🐛 Fix AWSManagedMachinePool NPE with scalingConfig

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -68,6 +68,9 @@ func (s *NodegroupService) scalingConfig() *eks.NodegroupScalingConfig {
 		DesiredSize: aws.Int64(int64(replicas)),
 	}
 	scaling := s.scope.ManagedMachinePool.Spec.Scaling
+	if scaling == nil {
+		return &cfg
+	}
 	if scaling.MaxSize != nil {
 		cfg.MaxSize = aws.Int64(int64(*scaling.MaxSize))
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Nil pointer panic when creating the ScalingConfig for the CreateNodegroup call.
