### PR TITLE
📖 docs: fix a broken link to prerequisites

### DIFF
--- a/docs/book/src/topics/eks.md
+++ b/docs/book/src/topics/eks.md
@@ -18,7 +18,7 @@ And a new template is available in the templates folder for creating a managed w
 
 ## Prerequisites
 
-To use EKS you must give the controller the required permissions. The easiest way to do this is by using `clusterawasadm`. For instructions on how to do this see the [prerequisites](./topics/using-clusterawsadm-to-fulfill-prerequisites.md).
+To use EKS you must give the controller the required permissions. The easiest way to do this is by using `clusterawasadm`. For instructions on how to do this see the [prerequisites](./using-clusterawsadm-to-fulfill-prerequisites.md).
 
 When using `clusterawsadm` and enabling EKS support a new IAM role will be created for you called **eks-controlplane.cluster-api-provider-aws.sigs.k8s.io**. This role is the IAM role that will be used for the EKS control plane if you don't specify your own role and if **EKSEnableIAM** isn't enabled.
 


### PR DESCRIPTION
https://cluster-api-aws.sigs.k8s.io/topics/eks.html has a broken link to the prerequisites page.

It should actually point to https://cluster-api-aws.sigs.k8s.io/topics/using-clusterawsadm-to-fulfill-prerequisites.html .