### PR TITLE
Add more condition in WithEventFiltering-UpdateFunc

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"net"
 	"reflect"
-	"sigs.k8s.io/cluster-api/util/conditions"
 	"time"
+
+	"sigs.k8s.io/cluster-api/util/conditions"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -244,6 +245,9 @@ func (r *AWSClusterReconciler) SetupWithManager(mgr ctrl.Manager, options contro
 
 					oldCluster.Status = infrav1.AWSClusterStatus{}
 					newCluster.Status = infrav1.AWSClusterStatus{}
+
+					oldCluster.ObjectMeta.ResourceVersion = ""
+					newCluster.ObjectMeta.ResourceVersion = ""
 
 					return !reflect.DeepEqual(oldCluster, newCluster)
 				},

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -230,6 +230,9 @@ func (r *AWSMachineReconciler) SetupWithManager(mgr ctrl.Manager, options contro
 					oldMachine.Status = infrav1.AWSMachineStatus{}
 					newMachine.Status = infrav1.AWSMachineStatus{}
 
+					oldMachine.ObjectMeta.ResourceVersion = ""
+					newMachine.ObjectMeta.ResourceVersion = ""
+
 					return !reflect.DeepEqual(oldMachine, newMachine)
 				},
 			},


### PR DESCRIPTION
🐛 Add more condition to filter status properly in WithEventFilter-predicate.Funcs-UpdateFunc

**What this PR does / why we need it**:
awscluster/awsmachine controller's code has "SetupWithManager-WithEventFilter-predicate.Funcs-UpdateFunc" to prevent incremental status updates. that code is written by

oldMachine := e.ObjectOld.(*infrav1.AWSMachine).DeepCopy()
newMachine := e.ObjectNew.(*infrav1.AWSMachine).DeepCopy()

oldMachine.Status = infrav1.AWSMachineStatus{}
newMachine.Status = infrav1.AWSMachineStatus{}

But if status updates, so does resourceVersion in metadata.
Therefore, even if the status is updated, the reconciler is called.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2025

