### PR TITLE
📖 Fix link to docs site and move to top of repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ hybrid deployments of Kubernetes. It is built atop the lessons learned from
 previous cluster managers such as [kops][kops] and
 [kubicorn][kubicorn].
 
+## Documentation
+
+Please see our [book](https://cluster-api-aws.sigs.k8s.io) for in-depth documentation.
+
 ## Launching a Kubernetes cluster on AWS
 
 Check out the [Cluster API Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html) for launching a
@@ -105,10 +109,6 @@ Note: These AMIs are not updated for security fixes and it is recommended to alw
 |                          | v1.19.2                 |
 
 ------
-
-## Documentation
-
-Documentation is in the `/docs` directory, and the [index is here](docs/README.md).
 
 ## Getting involved and contributing
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a link to the rendered documentation site and moves the documentation section to the top of the repo readme rather than buried in the middle.

