### PR TITLE
🐛 fix: add required iam permission for managed node groups

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -230,9 +230,15 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 					"eks:DeleteCluster",
 					"eks:UpdateClusterConfig",
 					"eks:UntagResource",
+					"eks:UpdateNodegroupVersion",
+					"eks:DescribeNodegroup",
+					"eks:DeleteNodegroup",
+					"eks:UpdateNodegroupConfig",
+					"eks:CreateNodegroup",
 				},
 				Resource: iamv1.Resources{
 					"arn:aws:eks:*:*:cluster/*",
+					"arn:aws:eks:*:*:nodegroup/*/*/*",
 				},
 				Effect: iamv1.EffectAllow,
 			}, {

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -247,9 +247,15 @@ Resources:
           - eks:DeleteCluster
           - eks:UpdateClusterConfig
           - eks:UntagResource
+          - eks:UpdateNodegroupVersion
+          - eks:DescribeNodegroup
+          - eks:DeleteNodegroup
+          - eks:UpdateNodegroupConfig
+          - eks:CreateNodegroup
           Effect: Allow
           Resource:
           - arn:aws:eks:*:*:cluster/*
+          - arn:aws:eks:*:*:nodegroup/*/*/*
         - Action:
           - iam:PassRole
           Condition:
@@ -313,6 +319,7 @@ Resources:
           Effect: Allow
           Principal:
             Service:
+            - ec2.amazonaws.com
             - eks.amazonaws.com
         Version: 2012-10-17
       ManagedPolicyArns:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
@@ -247,9 +247,15 @@ Resources:
           - eks:DeleteCluster
           - eks:UpdateClusterConfig
           - eks:UntagResource
+          - eks:UpdateNodegroupVersion
+          - eks:DescribeNodegroup
+          - eks:DeleteNodegroup
+          - eks:UpdateNodegroupConfig
+          - eks:CreateNodegroup
           Effect: Allow
           Resource:
           - arn:aws:eks:*:*:cluster/*
+          - arn:aws:eks:*:*:nodegroup/*/*/*
         - Action:
           - iam:PassRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/managed_control_plane.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/managed_control_plane.go
@@ -31,5 +31,5 @@ func (t Template) eksControlPlanePolicies() []string {
 }
 
 func eksAssumeRolePolicy() *iamv1.PolicyDocument {
-	return assumeRolePolicy("eks.amazonaws.com")
+	return assumeRolePolicy([]string{"eks.amazonaws.com"})
 }

--- a/cmd/clusterawsadm/cloudformation/bootstrap/managed_control_plane.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/managed_control_plane.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package bootstrap
 
-import iamv1 "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/api/iam/v1alpha1"
-
 func (t Template) eksControlPlanePolicies() []string {
 	policies := []string{EKSClusterPolicy}
 	if t.Spec.EKS.DefaultControlPlaneRole.ExtraPolicyAttachments != nil {
@@ -28,8 +26,4 @@ func (t Template) eksControlPlanePolicies() []string {
 	}
 
 	return policies
-}
-
-func eksAssumeRolePolicy() *iamv1.PolicyDocument {
-	return assumeRolePolicy([]string{"eks.amazonaws.com"})
 }

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template.go
@@ -163,7 +163,7 @@ func (t Template) RenderCloudFormation() *cloudformation.Template {
 	if !t.Spec.EKS.DefaultControlPlaneRole.Disable {
 		template.Resources[AWSIAMRoleEKSControlPlane] = &cfn_iam.Role{
 			RoleName:                 ekscontrolplanev1.DefaultEKSControlPlaneRole,
-			AssumeRolePolicyDocument: eksAssumeRolePolicy(),
+			AssumeRolePolicyDocument: assumeRolePolicy([]string{"eks.amazonaws.com"}),
 			ManagedPolicyArns:        t.eksControlPlanePolicies(),
 			Tags:                     converters.MapToCloudFormationTags(t.Spec.EKS.DefaultControlPlaneRole.Tags),
 		}

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template.go
@@ -172,7 +172,7 @@ func (t Template) RenderCloudFormation() *cloudformation.Template {
 	if !t.Spec.EKS.ManagedMachinePool.Disable {
 		template.Resources[AWSIAMRoleEKSNodegroup] = &cfn_iam.Role{
 			RoleName:                 infrav1exp.DefaultEKSNodegroupRole,
-			AssumeRolePolicyDocument: eksAssumeRolePolicy(),
+			AssumeRolePolicyDocument: assumeRolePolicy([]string{"ec2.amazonaws.com", "eks.amazonaws.com"}),
 			ManagedPolicyArns:        t.eksMachinePoolPolicies(),
 			Tags:                     converters.MapToCloudFormationTags(t.Spec.EKS.ManagedMachinePool.Tags),
 		}
@@ -182,16 +182,16 @@ func (t Template) RenderCloudFormation() *cloudformation.Template {
 }
 
 func ec2AssumeRolePolicy() *iamv1.PolicyDocument {
-	return assumeRolePolicy("ec2.amazonaws.com")
+	return assumeRolePolicy([]string{"ec2.amazonaws.com"})
 }
 
-func assumeRolePolicy(principalID string) *iamv1.PolicyDocument {
+func assumeRolePolicy(principalIDs []string) *iamv1.PolicyDocument {
 	return &iamv1.PolicyDocument{
 		Version: iamv1.CurrentVersion,
 		Statement: []iamv1.StatementEntry{
 			{
 				Effect:    iamv1.EffectAllow,
-				Principal: iamv1.Principals{iamv1.PrincipalService: iamv1.PrincipalID{principalID}},
+				Principal: iamv1.Principals{iamv1.PrincipalService: principalIDs},
 				Action:    iamv1.Actions{"sts:AssumeRole"},
 			},
 		},

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -37,6 +37,7 @@ import (
 func (s *NodegroupService) describeNodegroup() (*eks.Nodegroup, error) {
 	eksClusterName := s.scope.KubernetesClusterName()
 	nodegroupName := s.scope.NodegroupName()
+	s.scope.V(2).Info("describing eks node group", "cluster", eksClusterName, "nodegroup", nodegroupName)
 	input := &eks.DescribeNodegroupInput{
 		ClusterName:   aws.String(eksClusterName),
 		NodegroupName: aws.String(nodegroupName),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When creating the bootstrap stack the permissions required for managed machine pools (a.k.a EKS managed machine node groups) aren't added.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2042 

