### PR TITLE
 📖 docs: eks docs update for managed machine pools

### DIFF
--- a/docs/book/src/topics/machinepools.md
+++ b/docs/book/src/topics/machinepools.md
@@ -33,6 +33,8 @@ Cluster API Provider AWS (CAPA) has experimental support for [EKS Managed Node G
 
 The AWSManagedMachinePool controller creates and manages an EKS managed node group with in turn manages an AWS AutoScaling Group of managed EC2 instance types.
 
+To use the managed machine pools certain IAM permissions are needed. The easiest way to ensure the required IAM permissions are in place is to use `clusterawsadm` to create them. To do this, follow the EKS instructions in [using clusterawsadm to fulfill prerequisites](using-clusterawsadm-to-fulfill-prerequisites.md).
+
 ### Using `clusterctl` to deploy
 
 To deploy an EKS managed node group using AWSManagedMachinePool via `clusterctl config` you can use a [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#flavors).

--- a/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
+++ b/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
@@ -82,6 +82,8 @@ spec:
     iamRoleCreation: false # Set to true if you plan to use the EKSEnableIAM feature flag to enable automatic creation of IAM roles
     defaultControlPlaneRole:
       disable: false # Set to false to enable creation of the default control plane role
+    managedMachinePool:
+      disable: false # Set to false to enable creation of the default node role for managed machine pools
 ```
 
 and then use that configuration file:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
A small update to the EKS docs to show home to enable the role creation for the managed machine pools

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

