### PR TITLE
🐛fix: ensure env var enables AWSMachinePool webhooks

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - args:
         - --enable-leader-election
-        - "--feature-gates=EKS=${EXP_EKS:=false},EKSEnableIAM=${EXP_EKS_IAM:=false},EKSAllowAddRoles=${EXP_EKS_ADD_ROLES:=false}"
+        - "--feature-gates=EKS=${EXP_EKS:=false},EKSEnableIAM=${EXP_EKS_IAM:=false},EKSAllowAddRoles=${EXP_EKS_ADD_ROLES:=false},MachinePool=${EXP_MACHINE_POOL:=false}"
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/config/webhook/manager_webhook_patch.yaml
+++ b/config/webhook/manager_webhook_patch.yaml
@@ -11,7 +11,7 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
-        - "--feature-gates=EKS=${EXP_EKS:=false}"
+        - "--feature-gates=EKS=${EXP_EKS:=false},MachinePool=${EXP_MACHINE_POOL:=false}"
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 	// Initialize event recorder.
 	record.InitFromRecorder(mgr.GetEventRecorderFor("aws-controller"))
 
-	setupLog.V(1).Info(fmt.Sprintf("%+v\n", feature.Gates))
+	setupLog.V(1).Info(fmt.Sprintf("feature gates: %+v\n", feature.Gates))
 
 	// Parse service endpoints.
 	AWSServiceEndpoints, err := endpoints.ParseFlag(serviceEndpoints)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The `EXP_MACHINE_POOL` environment variable isn't being propagated to the the webhook manager and therefore the webhooks for AWSMachinePool aren't registsred

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2045 

