### PR TITLE
🐛: handle all subnets properties for AWSMachinePool

### DIFF
--- a/pkg/cloud/services/autoscaling/service.go
+++ b/pkg/cloud/services/autoscaling/service.go
@@ -18,6 +18,7 @@ package asg
 
 import (
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
@@ -29,6 +30,9 @@ import (
 type Service struct {
 	scope     cloud.ClusterScoper
 	ASGClient autoscalingiface.AutoScalingAPI
+
+	// Used to lookup Subnets
+	EC2Client ec2iface.EC2API
 }
 
 // NewService returns a new service given the asg api client.
@@ -36,5 +40,6 @@ func NewService(clusterScope cloud.ClusterScoper) *Service {
 	return &Service{
 		scope:     clusterScope,
 		ASGClient: scope.NewASGClient(clusterScope, clusterScope, clusterScope.InfraCluster()),
+		EC2Client: scope.NewEC2Client(clusterScope, clusterScope, clusterScope.InfraCluster()),
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Ensures all properties provided for `Subnets` on the `AWSMachinePool` resource are handled. If none are provided it falls back to the control-plane subnets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2047 

