### PR TITLE
⚠️: change AWSMachinePool subnets to an optional list of IDs

### DIFF
--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -48,8 +48,9 @@ type AWSMachinePoolSpec struct {
 	// AvailabilityZones is an array of availability zones instances can run in
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 
-	// Subnets is an array of subnet configurations
-	Subnets []infrav1.AWSResourceReference `json:"subnets,omitempty"`
+	// Subnets is an array of subnet IDs
+	// +optional
+	Subnets []string `json:"subnets,omitempty"`
 
 	// AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the
 	// AWS provider.

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -140,14 +140,12 @@ func (s *Service) GetASGByName(scope *scope.MachinePoolScope) (*expinfrav1.AutoS
 
 // CreateASG runs an autoscaling group.
 func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error) {
-	subnetIDs := make([]string, len(scope.AWSMachinePool.Spec.Subnets))
-	for i, v := range scope.AWSMachinePool.Spec.Subnets {
-		subnetIDs[i] = aws.StringValue(v.ID)
+	subnetIDs := scope.AWSMachinePool.Spec.Subnets
+	if len(subnetIDs) == 0 {
+		for _, subnet := range scope.InfraCluster.Subnets() {
+			subnetIDs = append(subnetIDs, subnet.ID)
+		}
 	}
-	// subnetIDs := []string{}
-	// for _, v := range scope.AWSMachinePool.Spec.Subnets {
-	// 	subnetIDs = append(subnetIDs, aws.StringValue(v.ID))
-	// }
 
 	input := &expinfrav1.AutoScalingGroup{
 		Name:                 scope.Name(),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Change the `Subnets` field on `AWSMachinePool` to be an optional string slice containing subnet IDs rather than `AWSResourceReference` as only the IDs are currently being used. If none are provided it falls back to the subnets associated with `InfraCluster`

See also: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2048 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2047 

