### PR TITLE
✨ Support custom AMI lookup with EKS

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -139,27 +139,27 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 			return nil, err
 		}
 
-		if scope.IsEKSManaged() {
+		imageLookupFormat := scope.AWSMachine.Spec.ImageLookupFormat
+		if imageLookupFormat == "" {
+			imageLookupFormat = scope.InfraCluster.ImageLookupFormat()
+		}
+
+		imageLookupOrg := scope.AWSMachine.Spec.ImageLookupOrg
+		if imageLookupOrg == "" {
+			imageLookupOrg = scope.InfraCluster.ImageLookupOrg()
+		}
+
+		imageLookupBaseOS := scope.AWSMachine.Spec.ImageLookupBaseOS
+		if imageLookupBaseOS == "" {
+			imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
+		}
+
+		if scope.IsEKSManaged() && imageLookupFormat == "" && imageLookupOrg == "" && imageLookupBaseOS == "" {
 			input.ImageID, err = s.eksAMILookup(*scope.Machine.Spec.Version)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			imageLookupFormat := scope.AWSMachine.Spec.ImageLookupFormat
-			if imageLookupFormat == "" {
-				imageLookupFormat = scope.InfraCluster.ImageLookupFormat()
-			}
-
-			imageLookupOrg := scope.AWSMachine.Spec.ImageLookupOrg
-			if imageLookupOrg == "" {
-				imageLookupOrg = scope.InfraCluster.ImageLookupOrg()
-			}
-
-			imageLookupBaseOS := scope.AWSMachine.Spec.ImageLookupBaseOS
-			if imageLookupBaseOS == "" {
-				imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
-			}
-
 			input.ImageID, err = s.defaultAMIIDLookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.Machine.Spec.Version)
 			if err != nil {
 				return nil, err

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -295,28 +295,27 @@ func (s *Service) DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*str
 	var lookupAMI string
 	var err error
 
-	if scope.IsEKSManaged() { // nolint:nestif
+	imageLookupFormat := lt.ImageLookupFormat
+	if imageLookupFormat == "" {
+		imageLookupFormat = scope.InfraCluster.ImageLookupFormat()
+	}
+
+	imageLookupOrg := lt.ImageLookupOrg
+	if imageLookupOrg == "" {
+		imageLookupOrg = scope.InfraCluster.ImageLookupOrg()
+	}
+
+	imageLookupBaseOS := lt.ImageLookupBaseOS
+	if imageLookupBaseOS == "" {
+		imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
+	}
+
+	if scope.IsEKSManaged() && imageLookupFormat == "" && imageLookupOrg == "" && imageLookupBaseOS == "" {
 		lookupAMI, err = s.eksAMILookup(*scope.MachinePool.Spec.Template.Spec.Version)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-
-		imageLookupFormat := lt.ImageLookupFormat
-		if imageLookupFormat == "" {
-			imageLookupFormat = scope.InfraCluster.ImageLookupFormat()
-		}
-
-		imageLookupOrg := lt.ImageLookupOrg
-		if imageLookupOrg == "" {
-			imageLookupOrg = scope.InfraCluster.ImageLookupOrg()
-		}
-
-		imageLookupBaseOS := lt.ImageLookupBaseOS
-		if imageLookupBaseOS == "" {
-			imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
-		}
-
 		lookupAMI, err = s.defaultAMIIDLookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.MachinePool.Spec.Template.Spec.Version)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
(This applies to both `AWSMachinePools` and `AWSMachines`)

Allows specifying AMI lookup details when using AWSManagedControlPlane (EKS), allowing the use of custom AMIs with EKS.

The logic takes the following steps:
1. If AMI ID is provided, use that
2. Check if any of the image lookup values are provided on the AWSMachinePool or AWSMachine (if any of these are empty then the AWSManagedControlPlane is checked), if found use those to search for an AMI
4. Lookup the AWS-provided AMIs based on the Kubernetes version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2056

