### PR TITLE
[WIP]🐛 Add conformance template sourcePath to e2e-conf

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -105,6 +105,8 @@ providers:
         targetName: "cluster-template-limit-az.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template-spot-instances.yaml"
         targetName: "cluster-template-spot-instances.yaml"
+      - sourcePath: "../../../_artifacts/templates/cluster-template-conformance-ci-artifacts.yaml"
+        targetName: "cluster-template-conformance-ci-artifacts.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.19.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
The generated conformance template is added to the e2e_conf so that clusterctl can find it.
`cluster-template-conformance-ci-artifacts.yaml` is generated during the beginning of the e2e tests, and uses `ARTIFACTS` variable set in `Makefile` as the part of the path.

We should probably find a better way to pass this location.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2061

