### PR TITLE
Sshkey regex workaround

### DIFF
--- a/api/v1alpha3/webhooks.go
+++ b/api/v1alpha3/webhooks.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"regexp"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"regexp"
 )
 
 func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorList) error {
@@ -38,7 +39,7 @@ func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorLis
 func isValidSSHKey(sshKey *string) field.ErrorList {
 	var allErrs field.ErrorList
 	if sshKey != nil {
-		reg, err := regexp.Compile("[^-A-Za-z0-9-]+")
+		reg, err := regexp.Compile("[^-A-Za-z0-9-_]+")
 		if err != nil {
 			return append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "SSHKey contains invalid character"))
 		}

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -451,7 +451,7 @@ func (r *AWSMachinePoolReconciler) reconcileTags(machinePoolScope *scope.Machine
 
 // asgNeedsUpdates compares incoming AWSMachinePool and compares against existing ASG
 func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *infrav1exp.AutoScalingGroup) bool {
-	if machinePoolScope.MachinePool.Spec.Replicas != nil && machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity {
+	if machinePoolScope.MachinePool.Spec.Replicas != nil && *machinePoolScope.MachinePool.Spec.Replicas != 1 && machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity {
 		return true
 	}
 

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -275,7 +275,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 		VPCZoneIdentifier:    aws.String(strings.Join(subnetIDs, ", ")),
 	}
 
-	if scope.MachinePool.Spec.Replicas != nil {
+	if scope.MachinePool.Spec.Replicas != nil && *scope.MachinePool.Spec.Replicas != 1 {
 		input.DesiredCapacity = aws.Int64(int64(*scope.MachinePool.Spec.Replicas))
 	}
 

--- a/pkg/cloud/services/eks/config.go
+++ b/pkg/cloud/services/eks/config.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha3"
-	infrav1exp "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
 )
 
@@ -108,7 +107,7 @@ func (s *Service) reconcileAdditionalKubeconfigs(ctx context.Context, cluster *e
 }
 
 func (s *Service) createCAPIKubeconfigSecret(ctx context.Context, cluster *eks.Cluster, clusterRef *types.NamespacedName) error {
-	controllerOwnerRef := *metav1.NewControllerRef(s.scope.ControlPlane, infrav1exp.GroupVersion.WithKind("AWSManagedControlPlane"))
+	controllerOwnerRef := *metav1.NewControllerRef(s.scope.ControlPlane, ekscontrolplanev1.GroupVersion.WithKind("AWSManagedControlPlane"))
 
 	clusterName := s.scope.KubernetesClusterName()
 	userName := s.getKubeConfigUserName(clusterName, false)
@@ -180,7 +179,7 @@ func (s *Service) updateCAPIKubeconfigSecret(ctx context.Context, configSecret *
 }
 
 func (s *Service) createUserKubeconfigSecret(ctx context.Context, cluster *eks.Cluster, clusterRef *types.NamespacedName) error {
-	controllerOwnerRef := *metav1.NewControllerRef(s.scope.ControlPlane, infrav1exp.GroupVersion.WithKind("AWSManagedControlPlane"))
+	controllerOwnerRef := *metav1.NewControllerRef(s.scope.ControlPlane, ekscontrolplanev1.GroupVersion.WithKind("AWSManagedControlPlane"))
 
 	clusterName := s.scope.KubernetesClusterName()
 	userName := s.getKubeConfigUserName(clusterName, true)


### PR DESCRIPTION
error 
```
\"validation.awsmachine.infrastructure.cluster.x-k8s.io\" denied the request: AWSMachine.infrastructure.cluster.x-k8s.io \"mn2a-general-nodes-subnet-06f76e12b5fde40e5-pff9r\" is invalid: sshKey: Invalid value: \"confab_development\": SSHKey contains invalid character" "controller"="machineset" "name"="mn2a-general-nodes-subnet-06f76e12b5fde40e5-6b6859586b" "namespace"="mn2a"
```