### PR TITLE
🐛Make the regex less restrictive to allow underscore etc. for ssh key file name

### DIFF
--- a/api/v1alpha3/awsmachine_webhook_test.go
+++ b/api/v1alpha3/awsmachine_webhook_test.go
@@ -119,6 +119,24 @@ func TestAWSMachine_ValidateCreate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "SSH key with underscore is valid",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					SSHKeyName: aws.String("test_key"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "SSH key with dash is valid",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					SSHKeyName: aws.String(`test-key`),
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/v1alpha3/webhooks.go
+++ b/api/v1alpha3/webhooks.go
@@ -23,6 +23,10 @@ import (
 	"regexp"
 )
 
+var (
+	sshKeyValidNameRegex = regexp.MustCompile(`^[[:graph:]]+([[:print:]]*[[:graph:]]+)*$`)
+)
+
 func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorList) error {
 	if len(allErrs) == 0 {
 		return nil
@@ -38,15 +42,9 @@ func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorLis
 func isValidSSHKey(sshKey *string) field.ErrorList {
 	var allErrs field.ErrorList
 	if sshKey != nil {
-		reg, err := regexp.Compile("[^-A-Za-z0-9-]+")
-		if err != nil {
-			return append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "SSHKey contains invalid character"))
+		if sshKey != nil && !sshKeyValidNameRegex.Match([]byte(*sshKey)) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
 		}
-		processedString := reg.ReplaceAllString(*sshKey, "")
-		if *sshKey == processedString {
-			return nil
-		}
-		allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "SSHKey contains invalid character"))
 	}
 
 	return allErrs


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Make the regex less restrictive to allows underscore etc. for ssh key file name
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2060

