### PR TITLE
🐛Validate that additional security groups can not have filters

### DIFF
--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -53,6 +53,7 @@ func (r *AWSMachine) ValidateCreate() error {
 	allErrs = append(allErrs, r.validateRootVolume()...)
 	allErrs = append(allErrs, r.validateNonRootVolumes()...)
 	allErrs = append(allErrs, isValidSSHKey(r.Spec.SSHKeyName)...)
+	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
@@ -182,4 +183,15 @@ func (r *AWSMachine) Default() {
 	if r.Spec.CloudInit.SecureSecretsBackend == "" {
 		r.Spec.CloudInit.SecureSecretsBackend = SecretBackendSecretsManager
 	}
+}
+
+func (r *AWSMachine) validateAdditionalSecurityGroups() field.ErrorList {
+	var allErrs field.ErrorList
+
+	for _, additionalSecurityGroups := range r.Spec.AdditionalSecurityGroups {
+		if len(additionalSecurityGroups.Filters) > 0 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.additionalSecurityGroups"), "filters are not implemented for security groups and will be removed in a future release"))
+		}
+	}
+	return allErrs
 }

--- a/api/v1alpha3/awsmachine_webhook_test.go
+++ b/api/v1alpha3/awsmachine_webhook_test.go
@@ -137,6 +137,24 @@ func TestAWSMachine_ValidateCreate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "additional security groups should not have filters",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					AdditionalSecurityGroups: []AWSResourceReference{
+						{
+							Filters: []Filter{
+								{
+									Name:   "example-name",
+									Values: []string{"example-value"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds validation in webhook to validate that filter can not be there in additional security groups
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1723

Note to reviewer: Will have a separate PR(#2032) to refactor the error handling

