### PR TITLE
Fix roundtrip conversions between v1alpha2 and v1alpha3

### DIFF
--- a/api/v1alpha2/awsmachine_conversion.go
+++ b/api/v1alpha2/awsmachine_conversion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"reflect"
+
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/utils/pointer"
 	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
@@ -37,13 +39,14 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
 		return err
 	}
-	restoreAWSMachineSpec(&restored.Spec, &dst.Spec)
+	restoreAWSMachineSpec(&restored.Spec, &dst.Spec, &src.Spec)
+
 	// Manual conversion for conditions
 	dst.SetConditions(restored.GetConditions())
 	return nil
 }
 
-func restoreAWSMachineSpec(restored, dst *infrav1alpha3.AWSMachineSpec) {
+func restoreAWSMachineSpec(restored, dst *infrav1alpha3.AWSMachineSpec, src *AWSMachineSpec) {
 	dst.ImageLookupFormat = restored.ImageLookupFormat
 	dst.ImageLookupBaseOS = restored.ImageLookupBaseOS
 
@@ -70,9 +73,23 @@ func restoreAWSMachineSpec(restored, dst *infrav1alpha3.AWSMachineSpec) {
 			dst.NonRootVolumes = append(dst.NonRootVolumes, volume.DeepCopy())
 		}
 	}
+	if src.RootDeviceSize != 0 {
+		if dst.RootVolume == nil {
+			dst.RootVolume = &infrav1alpha3.Volume{
+				Size: src.RootDeviceSize,
+			}
+		} else {
+			dst.RootVolume.Size = src.RootDeviceSize
+		}
+	}
 
 	dst.Tenancy = restored.Tenancy
-	dst.CloudInit.SecureSecretsBackend = restored.CloudInit.SecureSecretsBackend
+
+	if restored.CloudInit.SecureSecretsBackend != "" {
+		if src.CloudInit != nil {
+			dst.CloudInit.SecureSecretsBackend = restored.CloudInit.SecureSecretsBackend
+		}
+	}
 }
 
 // ConvertFrom converts from the Hub version (v1alpha3) to this version.
@@ -115,10 +132,10 @@ func Convert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachineSp
 	// Manually convert SSHKeyName
 	out.SSHKeyName = pointer.StringPtr(in.SSHKeyName)
 
-	if in.CloudInit == nil {
-		out.CloudInit.InsecureSkipSecretsManager = true
-	} else if err := Convert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(in.CloudInit, &out.CloudInit, s); err != nil {
-		return err
+	if in.CloudInit != nil {
+		if err := Convert_v1alpha2_CloudInit_To_v1alpha3_CloudInit(in.CloudInit, &out.CloudInit, s); err != nil {
+			return err
+		}
 	}
 
 	// Manually convert RootDeviceSize. This may be overridden by restoring / upconverting from annotation.
@@ -145,9 +162,12 @@ func Convert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *infrav1alpha
 	if in.SSHKeyName != nil {
 		out.SSHKeyName = *in.SSHKeyName
 	}
-	out.CloudInit = &CloudInit{}
-	if err := Convert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(&in.CloudInit, out.CloudInit, s); err != nil {
-		return err
+
+	if !reflect.DeepEqual(in.CloudInit, infrav1alpha3.CloudInit{}) {
+		out.CloudInit = &CloudInit{}
+		if err := Convert_v1alpha3_CloudInit_To_v1alpha2_CloudInit(&in.CloudInit, out.CloudInit, s); err != nil {
+			return err
+		}
 	}
 
 	if in.RootVolume != nil {
@@ -191,7 +211,7 @@ func Convert_v1alpha2_Instance_To_v1alpha3_Instance(in *Instance, out *infrav1al
 		return err
 	}
 
-	// Manually convert RootDeviceSize.
+	// Manually convert RootDeviceSize. This may be overridden by restoring / upconverting from annotation.
 	if in.RootDeviceSize != 0 {
 		out.RootVolume = &infrav1alpha3.Volume{
 			Size: in.RootDeviceSize,

--- a/api/v1alpha2/awsmachinetemplate_conversion.go
+++ b/api/v1alpha2/awsmachinetemplate_conversion.go
@@ -34,7 +34,7 @@ func (src *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
 		return err
 	}
-	restoreAWSMachineSpec(&restored.Spec.Template.Spec, &dst.Spec.Template.Spec)
+	restoreAWSMachineSpec(&restored.Spec.Template.Spec, &dst.Spec.Template.Spec, &src.Spec.Template.Spec)
 
 	return nil
 }

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -105,6 +105,8 @@ providers:
         targetName: "cluster-template-limit-az.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template-spot-instances.yaml"
         targetName: "cluster-template-spot-instances.yaml"
+      - sourcePath: "../../../_artifacts/templates/cluster-template-conformance-ci-artifacts.yaml"
+        targetName: "cluster-template-conformance-ci-artifacts.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.19.1"

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -105,8 +105,6 @@ providers:
         targetName: "cluster-template-limit-az.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template-spot-instances.yaml"
         targetName: "cluster-template-spot-instances.yaml"
-      - sourcePath: "../../../_artifacts/templates/cluster-template-conformance-ci-artifacts.yaml"
-        targetName: "cluster-template-conformance-ci-artifacts.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.19.1"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR prevents overriding ControlPlaneLoadBalancer and Bastion changes.
It also avoids creating `CloudInit` during the conversion if it is empty, because if we create an empty `CloudInit` during conversion,
`out.EnableSecureSecretsManager = !in.InsecureSkipSecretsManager` sets a field that should not be there.
``

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2059

