### PR TITLE
clusterawsadm: Enable use of shared configuration file

### DIFF
--- a/cmd/clusterawsadm/credentials/credentials.go
+++ b/cmd/clusterawsadm/credentials/credentials.go
@@ -25,7 +25,7 @@ import (
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 // AWSCredentialsTemplate generates an AWS credentials file that can
@@ -60,12 +60,17 @@ func NewAWSCredentialFromDefaultChain(region string) (*AWSCredentials, error) {
 	creds := AWSCredentials{}
 	conf := aws.NewConfig()
 	conf.CredentialsChainVerboseErrors = aws.Bool(true)
-	chain := defaults.CredChain(conf, defaults.Handlers())
-	chainCreds, err := chain.Get()
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config:            *conf,
+	})
 	if err != nil {
 		return nil, err
 	}
-
+	chainCreds, err := sess.Config.Credentials.Get()
+	if err != nil {
+		return nil, err
+	}
 	creds.Region = region
 	creds.AccessKeyID = chainCreds.AccessKeyID
 	creds.SecretAccessKey = chainCreds.SecretAccessKey


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

When using clusterawsadm to encode credentials, allow the use of the shared configuration file to resolve them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

