### PR TITLE
🐛  Updates AWSMachine CloudInit defaulting logic

### DIFF
--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -177,9 +177,9 @@ func (r *AWSMachine) ValidateDelete() error {
 }
 
 // Default implements webhook.Defaulter such that an empty CloudInit will be defined with a default
-// SecureSecretsBackend as SecretBackendSecretsManager
+// SecureSecretsBackend as SecretBackendSecretsManager iff InsecureSkipSecretsManager is unset
 func (r *AWSMachine) Default() {
-	if r.Spec.CloudInit.SecureSecretsBackend == "" {
+	if !r.Spec.CloudInit.InsecureSkipSecretsManager && r.Spec.CloudInit.SecureSecretsBackend == "" {
 		r.Spec.CloudInit.SecureSecretsBackend = SecretBackendSecretsManager
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch checks for the presence of the `spec.cloudInit.insecureSkipSecretsManager` before setting the default value for the `spec.cloudInit.secureSecretsBackend`.

**Which issue(s) this PR fixes**:
Fixes #2064 

