### PR TITLE
🐛 AWSManagedMachinePool: Fix cloud provider key usage and nodegroup IAM role name

### DIFF
--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -143,6 +143,7 @@ func (r *AWSManagedMachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Re
 		Logger:             logger,
 		Client:             r.Client,
 		ControllerName:     "awsmanagedmachinepool",
+		Cluster:            cluster,
 		ControlPlane:       controlPlane,
 		MachinePool:        machinePool,
 		ManagedMachinePool: awsPool,

--- a/pkg/cloud/scope/managednodegroup.go
+++ b/pkg/cloud/scope/managednodegroup.go
@@ -40,6 +40,7 @@ import (
 type ManagedMachinePoolScopeParams struct {
 	Client             client.Client
 	Logger             logr.Logger
+	Cluster            *clusterv1.Cluster
 	ControlPlane       *controlplanev1exp.AWSManagedControlPlane
 	ManagedMachinePool *infrav1exp.AWSManagedMachinePool
 	MachinePool        *clusterv1exp.MachinePool
@@ -76,6 +77,7 @@ func NewManagedMachinePoolScope(params ManagedMachinePoolScopeParams) (*ManagedM
 	return &ManagedMachinePoolScope{
 		Logger:             params.Logger,
 		Client:             params.Client,
+		Cluster:            params.Cluster,
 		ControlPlane:       params.ControlPlane,
 		ManagedMachinePool: params.ManagedMachinePool,
 		MachinePool:        params.MachinePool,
@@ -92,6 +94,7 @@ type ManagedMachinePoolScope struct {
 	Client      client.Client
 	patchHelper *patch.Helper
 
+	Cluster            *clusterv1.Cluster
 	ControlPlane       *controlplanev1exp.AWSManagedControlPlane
 	ManagedMachinePool *infrav1exp.AWSManagedMachinePool
 	MachinePool        *clusterv1exp.MachinePool
@@ -102,9 +105,14 @@ type ManagedMachinePoolScope struct {
 	enableIAM bool
 }
 
-// Name returns the machine pool name.
-func (s *ManagedMachinePoolScope) Name() string {
+// ManagedPoolName returns the managed machine pool name.
+func (s *ManagedMachinePoolScope) ManagedPoolName() string {
 	return s.ManagedMachinePool.Name
+}
+
+// ClusterName returns the cluster name.
+func (s *ManagedMachinePoolScope) ClusterName() string {
+	return s.Cluster.Name
 }
 
 // EnableIAM indicates that reconciliation should create IAM roles

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -152,7 +152,7 @@ func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 		return nil, err
 	}
 	managedPool := s.scope.ManagedMachinePool.Spec
-	tags := ngTags(s.scope.Name(), additionalTags)
+	tags := ngTags(s.scope.ClusterName(), additionalTags)
 
 	remoteAccess, err := s.remoteAccess()
 	if err != nil {
@@ -370,10 +370,10 @@ func (s *NodegroupService) reconcileNodegroup() error {
 		}
 		s.scope.Info("Created EKS nodegroup in AWS", "cluster-name", eksClusterName, "nodegroup-name", eksNodegroupName)
 	} else {
-		tagKey := infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name())
+		tagKey := infrav1.ClusterAWSCloudProviderTagKey(s.scope.ClusterName())
 		ownedTag := ng.Tags[tagKey]
 		if ownedTag == nil {
-			return errors.Wrapf(err, "owner of %s mismatch: %s", eksNodegroupName, s.scope.Name())
+			return errors.Wrapf(err, "owner of %s mismatch: %s", eksNodegroupName, s.scope.ClusterName())
 		}
 		s.scope.V(2).Info("Found owned EKS nodegroup in AWS", "cluster-name", eksClusterName, "nodegroup-name", eksNodegroupName)
 	}

--- a/pkg/cloud/services/eks/roles.go
+++ b/pkg/cloud/services/eks/roles.go
@@ -149,7 +149,7 @@ func (s *NodegroupService) reconcileNodegroupIAMRole() error {
 			roleName = infrav1exp.DefaultEKSNodegroupRole
 		} else {
 			s.scope.Info("no EKS nodegroup role specified, using role based on nodegroup name")
-			roleName = fmt.Sprintf("%s-nodegroup-iam-service-role", s.scope.NodegroupName())
+			roleName = fmt.Sprintf("%s-%s-nodegroup-iam-service-role", s.scope.KubernetesClusterName(), s.scope.NodegroupName())
 		}
 		s.scope.ManagedMachinePool.Spec.RoleName = roleName
 	}

--- a/pkg/cloud/services/eks/tags.go
+++ b/pkg/cloud/services/eks/tags.go
@@ -68,7 +68,7 @@ func getTagUpdates(currentTags map[string]string, tags map[string]string) (untag
 }
 
 func (s *NodegroupService) reconcileTags(ng *eks.Nodegroup) error {
-	tags := ngTags(s.scope.Name(), s.scope.AdditionalTags())
+	tags := ngTags(s.scope.ClusterName(), s.scope.AdditionalTags())
 
 	untagKeys, newTags := getTagUpdates(aws.StringValueMap(ng.Tags), tags)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes incorrectly using the nodegroup name for tagging resources instead of cluster name.
Fixes potential nodegroup IAM role name collisions.
