### PR TITLE
🐛 Add CNI defaulting to the controller

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -177,6 +177,11 @@ func reconcileNormal(clusterScope *scope.ClusterScope) (reconcile.Result, error)
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile network for AWSCluster %s/%s", awsCluster.Namespace, awsCluster.Name)
 	}
 
+	// CNI related security groups gets deleted from the AWSClusters created prior to networkSpec.cni defaulting (5.5) after upgrading controllers.
+	// https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2084
+	// TODO: Remove this after v1aplha4
+	clusterScope.AWSCluster.Default()
+
 	if err := sgService.ReconcileSecurityGroups(); err != nil {
 		conditions.MarkFalse(awsCluster, infrav1.ClusterSecurityGroupsReadyCondition, infrav1.ClusterSecurityGroupReconciliationFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile security groups for AWSCluster %s/%s", awsCluster.Namespace, awsCluster.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds defaulting to the AWSCluster controller to prevent deletion of CNI related security groups from the AWSClusters that are created before v0.5.5.

Starting from v0.5.5, CNI-related security groups are added to spec by defaulting and ReconcileSecurityGroups() uses networkSpec.cni to add CNI-related security groups. Controllers < v0.5.5, they were added by the ReconcileSecurityGroups(). CNI related security groups from AWSClusters (created before v0.5.5) that is not defaulted, were being deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2084

