### PR TITLE
:book: Update consuming-existing-aws-infrastructure.md to provide context to where networkSpec belongs

### DIFF
--- a/docs/book/src/topics/consuming-existing-aws-infrastructure.md
+++ b/docs/book/src/topics/consuming-existing-aws-infrastructure.md
@@ -34,6 +34,10 @@ Finally, if the controller manager isn't started with the `--configure-cloud-rou
 Specifying existing infrastructure for Cluster API to use takes place in the specification for the AWSCluster object. Specifically, you will need to add an entry with the VPC ID and the IDs of all applicable subnets into the `networkSpec` field. Here is an example:
 
 ```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: AWSManagedControlPlane
+metadata:
+  name: managed-test-control-plane
 spec:
   networkSpec:
     vpc:

--- a/docs/book/src/topics/consuming-existing-aws-infrastructure.md
+++ b/docs/book/src/topics/consuming-existing-aws-infrastructure.md
@@ -33,11 +33,18 @@ Finally, if the controller manager isn't started with the `--configure-cloud-rou
 
 Specifying existing infrastructure for Cluster API to use takes place in the specification for the AWSCluster object. Specifically, you will need to add an entry with the VPC ID and the IDs of all applicable subnets into the `networkSpec` field. Here is an example:
 
+For EC2
+```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: AWSCluster
+```
+For EKS
 ```yaml
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: AWSManagedControlPlane
-metadata:
-  name: managed-test-control-plane
+```
+
+```yaml
 spec:
   networkSpec:
     vpc:


### PR DESCRIPTION
Provide context as to where the `networkSpec` is to be updated inside the `kind: AWSManagedControlPlane`


