### PR TITLE
📖  Correct Ubuntu 20.04 AMI of the Kubernetes Version v1.19.2 on us-west-2

### DIFF
--- a/docs/amis.md
+++ b/docs/amis.md
@@ -86,7 +86,7 @@
 | us-east-1      | ami-00ceb2c6df9565544 |
 | us-east-2      | ami-03fdb3a5e47320a15 |
 | us-west-1      | ami-01186e9687c392ec4 |
-| us-west-2      | ami-054006e5fedebab3  |
+| us-west-2      | ami-054006e5fedebab32 |
 
 
 ### Ubuntu 18.04 (Bionic)


### PR DESCRIPTION
**What this PR does / why we need it**:

The Ubuntu 20.04 AMI(`ami-054006e5fedebab3`) for K8S v1.19.2 on us-west-2  which does not exist. Using it will cause the incorrect ami error from capa, and bootstrapping would get stuck.

This fix updates the AMI to be `ami-054006e5fedebab32`:

```
AMI ID: ami-054006e5fedebab32
AMI Name: capa-ami-ubuntu-20.04-1.19.2-00-1602498041
Owner: 258751437250
Source: 258751437250/capa-ami-ubuntu-20.04-1.19.2-00-1602498041
Architecture: x86_64
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

