### PR TITLE
✨Add copy AMI command to clusterawsadm

### DIFF
--- a/cmd/clusterawsadm/cmd/ami/ami.go
+++ b/cmd/clusterawsadm/cmd/ami/ami.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ami
+
+import (
+	"github.com/spf13/cobra"
+	cp "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/copy"
+)
+
+// RootCmd is the root of the `ami command`
+func RootCmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "ami [command]",
+		Short: "AMI commands",
+		Args:  cobra.NoArgs,
+		Long:  "All AMI related actions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmd.Help(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	newCmd.AddCommand(cp.CopyAMICmd())
+	return newCmd
+}

--- a/cmd/clusterawsadm/cmd/ami/ami.go
+++ b/cmd/clusterawsadm/cmd/ami/ami.go
@@ -19,6 +19,7 @@ package ami
 import (
 	"github.com/spf13/cobra"
 	cp "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/copy"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
 
 // RootCmd is the root of the `ami command`
@@ -27,7 +28,12 @@ func RootCmd() *cobra.Command {
 		Use:   "ami [command]",
 		Short: "AMI commands",
 		Args:  cobra.NoArgs,
-		Long:  "All AMI related actions",
+		Long: cmd.LongDesc(`
+			All AMI related actions such as:
+			# Copy AMIs based on Kubernetes version, OS etc from an AWS account where AMIs are stored
+            to the current AWS account (use case: air-gapped deployments)
+			# (to be implemented) List available AMIs
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmd.Help(); err != nil {
 				return err

--- a/cmd/clusterawsadm/cmd/ami/copy/copy.go
+++ b/cmd/clusterawsadm/cmd/ami/copy/copy.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package copy
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/flags"
+	ec2service "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
+)
+
+func CopyAMICmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "copy",
+		Short: "Copy AMI",
+		Long:  cmd.LongDesc("Copy AMI"),
+		Example: cmd.Examples(`
+		# Copy AMI from the default AWS account where AMIs are stored.
+		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2
+		clusterawsadm ami copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
+
+		# source-account and dry-run flags are optional. region can be set via flag or env
+		clusterawsadm ami copy --os centos-7 --kubernetes-version=1.19.4 --source-account=111111111111 --dry-run
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			region, err := flags.GetRegion(cmd)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Could not resolve AWS region, define it with --region flag or as an environment variable.")
+				return err
+			}
+
+			sess, err := session.NewSessionWithOptions(session.Options{
+				SharedConfigState: session.SharedConfigEnable,
+				Config:            aws.Config{Region: aws.String(region)},
+			})
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return err
+			}
+			ec2Client := ec2.New(sess)
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				fmt.Printf("Failed to parse dry-run value: %v. Defaulting to --dry-run=false\n", err)
+			}
+
+			os := cmd.Flags().Lookup("os").Value.String()
+			if os == "" {
+				return errors.Errorf("missing --os flag")
+			}
+
+			kubernetesVersion := cmd.Flags().Lookup("kubernetes-version").Value.String()
+			if kubernetesVersion == "" {
+				return errors.Errorf("missing --kubernetes-version flag")
+			}
+
+			ownerID := cmd.Flags().Lookup("source-account").Value.String()
+			if ownerID == "" {
+				fmt.Printf("Missing source-account value. Defaulting to %s\n", ec2service.DefaultMachineAMIOwnerID)
+				ownerID = ec2service.DefaultMachineAMIOwnerID
+			}
+
+			image, err := ec2service.DefaultAMILookup(ec2Client, ownerID, os, kubernetesVersion, "")
+			if err != nil {
+				return err
+			}
+			in2 := &ec2.CopyImageInput{
+				ClientToken:   nil,
+				Description:   nil,
+				DryRun:        &dryRun,
+				Name:          image.Name,
+				SourceImageId: image.ImageId,
+				SourceRegion:  &region,
+			}
+			out, err := ec2Client.CopyImage(in2)
+			if err != nil {
+				fmt.Printf("version %q\n", out)
+				return err
+			}
+			return nil
+		},
+	}
+
+	flags.AddRegionFlag(newCmd)
+	addOsFlag(newCmd)
+	addKubernetesVersionFlag(newCmd)
+	addDryRunFlag(newCmd)
+	addSourceAccountFlag(newCmd)
+	return newCmd
+}
+
+func addOsFlag(c *cobra.Command) {
+	c.Flags().String("os", "", "Operating system of the AMI to be copied")
+}
+
+func addKubernetesVersionFlag(c *cobra.Command) {
+	c.Flags().String("kubernetes-version", "", "Kubernetes version of the AMI to be copied")
+}
+
+func addSourceAccountFlag(c *cobra.Command) {
+	c.Flags().String("source-account", "", "The source AWS account ID, where the AMI will be copied from")
+}
+
+func addDryRunFlag(c *cobra.Command) {
+	c.Flags().Bool("dry-run", false, "Check if AMI exists and can be copied")
+}

--- a/cmd/clusterawsadm/cmd/root.go
+++ b/cmd/clusterawsadm/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/alpha"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/bootstrap"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/version"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
@@ -61,6 +62,8 @@ func RootCmd() *cobra.Command {
 	newCmd.AddCommand(alpha.AlphaCmd())
 	newCmd.AddCommand(bootstrap.RootCmd())
 	newCmd.AddCommand(version.VersionCmd(os.Stdout))
+	newCmd.AddCommand(ami.RootCmd())
+
 	return newCmd
 }
 

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -136,8 +136,8 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 	return latestImage, nil
 }
 
-// defaultAMILookup returns the default AMI based on region
-func (s *Service) defaultAMILookup(amiNameFormat, ownerID, baseOS, kubernetesVersion string) (string, error) {
+// defaultAMIIDLookup returns the default AMI based on region
+func (s *Service) defaultAMIIDLookup(amiNameFormat, ownerID, baseOS, kubernetesVersion string) (string, error) {
 	latestImage, err := DefaultAMILookup(s.EC2Client, ownerID, baseOS, kubernetesVersion, amiNameFormat)
 	if err != nil {
 		record.Eventf(s.scope.InfraCluster(), "FailedDescribeImages", "Failed to find ami %q: %v", amiName, err)

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -78,7 +78,7 @@ func TestAMIs(t *testing.T) {
 			s := NewService(scope)
 			s.EC2Client = ec2Mock
 
-			id, err := s.defaultAMILookup("", "", "base os-baseos version", "1.11.1")
+			id, err := s.defaultAMIIDLookup("", "", "base os-baseos version", "1.11.1")
 			if err != nil {
 				t.Fatalf("did not expect error calling a mock: %v", err)
 			}
@@ -138,7 +138,7 @@ func TestAMIsWithInvalidCreationDate(t *testing.T) {
 			s := NewService(scope)
 			s.EC2Client = ec2Mock
 
-			_, err = s.defaultAMILookup("", "", "base os-baseos version", "1.11.1")
+			_, err = s.defaultAMIIDLookup("", "", "base os-baseos version", "1.11.1")
 			if err == nil {
 				t.Fatalf("expected an error but did not get one")
 			}

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -160,7 +160,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 				imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
 			}
 
-			input.ImageID, err = s.defaultAMILookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.Machine.Spec.Version)
+			input.ImageID, err = s.defaultAMIIDLookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.Machine.Spec.Version)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -318,7 +318,7 @@ func (s *Service) DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*str
 			imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
 		}
 
-		lookupAMI, err = s.defaultAMILookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.MachinePool.Spec.Template.Spec.Version)
+		lookupAMI, err = s.defaultAMIIDLookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.MachinePool.Spec.Template.Spec.Version)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `clusterawsadm ami copy` command which can be used to copy a pre-existing AMI to user's AWS account.

Some examples:
```
  clusterawsadm ami copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
  clusterawsadm ami copy --os centos-7 --kubernetes-version=1.19.4 --source-account=111111111111 --dry-run
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2041

