### PR TITLE
🌱Upgrade e2e Kubernetes version to 1.19.4

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -107,13 +107,13 @@ providers:
         targetName: "cluster-template-spot-instances.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.19.2"
+  KUBERNETES_VERSION: "v1.19.4"
   CNI: "../../data/cni/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   AWS_CONTROL_PLANE_MACHINE_TYPE: t3.large
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.19.2"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.19.4"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

/hold
until https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2102 is merged.
