### PR TITLE
🌱 add Interruptible field to AWSMachine status

### DIFF
--- a/api/v1alpha2/awsmachine_conversion.go
+++ b/api/v1alpha2/awsmachine_conversion.go
@@ -40,6 +40,7 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	restoreAWSMachineSpec(&restored.Spec, &dst.Spec, &src.Spec)
+	restoreAWSMachineStatus(&restored.Status, &dst.Status)
 
 	// Manual conversion for conditions
 	dst.SetConditions(restored.GetConditions())
@@ -90,6 +91,10 @@ func restoreAWSMachineSpec(restored, dst *infrav1alpha3.AWSMachineSpec, src *AWS
 			dst.CloudInit.SecureSecretsBackend = restored.CloudInit.SecureSecretsBackend
 		}
 	}
+}
+
+func restoreAWSMachineStatus(restored, dst *infrav1alpha3.AWSMachineStatus) {
+	dst.Interruptible = restored.Interruptible
 }
 
 // ConvertFrom converts from the Hub version (v1alpha3) to this version.

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -458,7 +458,7 @@ func autoConvert_v1alpha2_AWSClusterStatus_To_v1alpha3_AWSClusterStatus(in *AWSC
 	if err := Convert_v1alpha2_Network_To_v1alpha3_Network(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (./api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
 	out.Ready = in.Ready
 	// WARNING: in.APIEndpoints requires manual conversion: does not exist in peer-type
 	return nil
@@ -470,7 +470,7 @@ func autoConvert_v1alpha3_AWSClusterStatus_To_v1alpha2_AWSClusterStatus(in *v1al
 		return err
 	}
 	// WARNING: in.FailureDomains requires manual conversion: does not exist in peer-type
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs ./api/v1alpha2.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance)
 	// WARNING: in.Conditions requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -584,7 +584,7 @@ func autoConvert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachi
 	}
 	// WARNING: in.RootDeviceSize requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*./api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
 	return nil
 }
 
@@ -610,7 +610,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	// WARNING: in.NonRootVolumes requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	// WARNING: in.UncompressedUserData requires manual conversion: does not exist in peer-type
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *./api/v1alpha2.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
 	// WARNING: in.SpotMarketOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.Tenancy requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -458,7 +458,7 @@ func autoConvert_v1alpha2_AWSClusterStatus_To_v1alpha3_AWSClusterStatus(in *AWSC
 	if err := Convert_v1alpha2_Network_To_v1alpha3_Network(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (./api/v1alpha2.Instance vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance)
 	out.Ready = in.Ready
 	// WARNING: in.APIEndpoints requires manual conversion: does not exist in peer-type
 	return nil
@@ -470,7 +470,7 @@ func autoConvert_v1alpha3_AWSClusterStatus_To_v1alpha2_AWSClusterStatus(in *v1al
 		return err
 	}
 	// WARNING: in.FailureDomains requires manual conversion: does not exist in peer-type
-	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.Instance)
+	// WARNING: in.Bastion requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.Instance vs ./api/v1alpha2.Instance)
 	// WARNING: in.Conditions requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -584,7 +584,7 @@ func autoConvert_v1alpha2_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *AWSMachi
 	}
 	// WARNING: in.RootDeviceSize requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (*./api/v1alpha2.CloudInit vs sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit)
 	return nil
 }
 
@@ -610,7 +610,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha2_AWSMachineSpec(in *v1alpha3
 	// WARNING: in.NonRootVolumes requires manual conversion: does not exist in peer-type
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	// WARNING: in.UncompressedUserData requires manual conversion: does not exist in peer-type
-	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2.CloudInit)
+	// WARNING: in.CloudInit requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3.CloudInit vs *./api/v1alpha2.CloudInit)
 	// WARNING: in.SpotMarketOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.Tenancy requires manual conversion: does not exist in peer-type
 	return nil
@@ -627,6 +627,7 @@ func autoConvert_v1alpha2_AWSMachineStatus_To_v1alpha3_AWSMachineStatus(in *AWSM
 
 func autoConvert_v1alpha3_AWSMachineStatus_To_v1alpha2_AWSMachineStatus(in *v1alpha3.AWSMachineStatus, out *AWSMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
+	// WARNING: in.Interruptible requires manual conversion: does not exist in peer-type
 	out.Addresses = *(*[]apiv1alpha2.MachineAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*InstanceState)(unsafe.Pointer(in.InstanceState))
 	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -179,7 +179,8 @@ type AWSMachineStatus struct {
 	// +optional
 	Ready bool `json:"ready"`
 
-	// Interruptible is true when SpotMarketOptions is non-nil in AWS machine spec that is, the instances are configured to be run using AWS Spot instances.
+	// Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS.
+	// This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).
 	// +optional
 	Interruptible bool `json:"interruptible,omitempty"`
 

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -179,6 +179,10 @@ type AWSMachineStatus struct {
 	// +optional
 	Ready bool `json:"ready"`
 
+	// Interruptible is true when SpotMarketOptions is non-nil in AWS machine spec that is, the instances are configured to be run using AWS Spot instances.
+	// +optional
+	Interruptible bool `json:"interruptible,omitempty"`
+
 	// Addresses contains the AWS instance associated addresses.
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -524,6 +524,9 @@ spec:
               instanceState:
                 description: InstanceState is the state of the AWS instance for this machine.
                 type: string
+              interruptible:
+                description: Interruptible is true when SpotMarketOptions is non-nil in AWS machine spec that is, the instances are configured to be run using AWS Spot instances.
+                type: boolean
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -525,7 +525,7 @@ spec:
                 description: InstanceState is the state of the AWS instance for this machine.
                 type: string
               interruptible:
-                description: Interruptible is true when SpotMarketOptions is non-nil in AWS machine spec that is, the instances are configured to be run using AWS Spot instances.
+                description: Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS. This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).
                 type: boolean
               ready:
                 description: Ready is true when the provider resource is ready.

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -495,6 +495,9 @@ func (r *AWSMachineReconciler) reconcileNormal(_ context.Context, machineScope *
 
 	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html
 
+	// Sets the AWSMachine status Interruptible, when the SpotMarketOptions is enabled for AWSMachine, Interruptible is set as true.
+	machineScope.SetInterruptible()
+
 	existingInstanceState := machineScope.GetInstanceState()
 	machineScope.SetInstanceState(instance.State)
 

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -337,3 +337,10 @@ func (m *MachineScope) AWSMachineIsDeleted() bool {
 func (m *MachineScope) IsEKSManaged() bool {
 	return m.InfraCluster.InfraCluster().GetObjectKind().GroupVersionKind().Kind == "AWSManagedControlPlane"
 }
+
+// SetInterruptible sets the AWSMachine status Interruptible
+func (m *MachineScope) SetInterruptible() {
+	if m.AWSMachine.Spec.SpotMarketOptions != nil {
+		m.AWSMachine.Status.Interruptible = true
+	}
+}


### PR DESCRIPTION
set Interruptible as true when SpotMarketOptions for AWSMachine is non-nil
fixes issue 1899

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**Which issue(s) this PR fixes** *
Fixes #1899 

