### PR TITLE
Add externalInfraCluster

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -26,7 +27,18 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/elb"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/secretsmanager"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ssm"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
@@ -39,17 +51,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha3"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/elb"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/secretsmanager"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ssm"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 )
 
 // AWSMachineReconciler reconciles a AwsMachine object
@@ -65,7 +66,8 @@ type AWSMachineReconciler struct {
 
 const (
 	// AWSManagedControlPlaneRefKind is the string value indicating that a cluster is AWS managed
-	AWSManagedControlPlaneRefKind = "AWSManagedControlPlane"
+	AWSManagedControlPlaneRefKind   = "AWSManagedControlPlane"
+	AWSClusterInfrastructureRefKind = "AWSCluster"
 )
 
 func (r *AWSMachineReconciler) getEC2Service(scope scope.EC2Scope) services.EC2MachineInterface {
@@ -190,7 +192,10 @@ func (r *AWSMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 
 		return r.reconcileNormal(ctx, machineScope, infraScope, infraScope, infraScope)
 	default:
-		return ctrl.Result{}, errors.New("infraCluster has unknown type")
+		if !awsMachine.ObjectMeta.DeletionTimestamp.IsZero() {
+			return r.reconcileDelete(machineScope, infraScope, infraScope, nil)
+		}
+		return r.reconcileNormal(ctx, machineScope, infraScope, infraScope, nil)
 	}
 }
 
@@ -794,6 +799,31 @@ func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log logr.Log
 		}
 
 		return managedControlPlaneScope, nil
+	}
+
+	if cluster.Spec.InfrastructureRef != nil &&
+		cluster.Spec.InfrastructureRef.Kind != AWSClusterInfrastructureRefKind {
+		externalInfraCluster, err := external.Get(ctx, r.Client, cluster.Spec.InfrastructureRef, cluster.Spec.InfrastructureRef.Namespace)
+		if err != nil {
+			log.Error(err, "error fetching externalInfraCluster")
+			return nil, fmt.Errorf("error fetching externalInfraCluster: %w", err)
+		}
+
+		// Create the cluster scope
+		extenalInfraClusterScope, err := scope.NewExternalInfraClusterScope(scope.ExternalInfraClusterScopeParams{
+			Client:               r.Client,
+			Logger:               log,
+			Cluster:              cluster,
+			ExternalInfraCluster: externalInfraCluster,
+			ControllerName:       "externalInfraCluster",
+		})
+		if err != nil {
+			log.Error(err, "unable to create external cluster scope")
+			return nil, fmt.Errorf("unable to create external cluster scope: %w", err)
+		}
+
+		r.Log.Info("Using externalInfraCluster")
+		return extenalInfraClusterScope, nil
 	}
 
 	awsCluster := &infrav1.AWSCluster{}

--- a/pkg/cloud/scope/externalinfracluster.go
+++ b/pkg/cloud/scope/externalinfracluster.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"fmt"
+
+	awsclient "github.com/aws/aws-sdk-go/aws/client"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/klogr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ExternalInfraClusterScopeParams defines the input parameters used to create a new Scope.
+type ExternalInfraClusterScopeParams struct {
+	Client               client.Client
+	Logger               logr.Logger
+	Cluster              *clusterv1.Cluster
+	ExternalInfraCluster *unstructured.Unstructured
+	ControllerName       string
+	Endpoints            []ServiceEndpoint
+	Session              awsclient.ConfigProvider
+}
+
+// NewExternalInfraClusterScope creates a new Scope from the supplied parameters.
+// This is meant to be called for each reconcile iteration.
+func NewExternalInfraClusterScope(params ExternalInfraClusterScopeParams) (*ExternalInfraClusterScope, error) {
+	if params.Cluster == nil {
+		return nil, errors.New("failed to generate new scope from nil Cluster")
+	}
+	if params.ExternalInfraCluster == nil {
+		return nil, errors.New("failed to generate new scope from nil ExternalInfraCluster")
+	}
+
+	if params.Logger == nil {
+		params.Logger = klogr.New()
+	}
+
+	region, found, err := unstructured.NestedString(params.ExternalInfraCluster.Object, "spec", "region")
+	if err != nil || !found {
+		return nil, fmt.Errorf("error getting region: %w", err)
+	}
+	session, err := sessionForRegion(region, params.Endpoints)
+	if err != nil {
+		return nil, errors.Errorf("failed to create aws session: %v", err)
+	}
+
+	helper, err := patch.NewHelper(params.ExternalInfraCluster, params.Client)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to init patch helper")
+	}
+	return &ExternalInfraClusterScope{
+		Logger:               params.Logger,
+		client:               params.Client,
+		Cluster:              params.Cluster,
+		ExternalInfraCluster: &ExternalInfraClusterObject{params.ExternalInfraCluster},
+		patchHelper:          helper,
+		session:              session,
+		controllerName:       params.ControllerName,
+	}, nil
+}
+
+// ExternalInfraClusterScope defines the basic context for an actuator to operate upon.
+type ExternalInfraClusterScope struct {
+	logr.Logger
+	client      client.Client
+	patchHelper *patch.Helper
+
+	Cluster              *clusterv1.Cluster
+	ExternalInfraCluster *ExternalInfraClusterObject
+
+	session        awsclient.ConfigProvider
+	controllerName string
+}
+
+// Network returns the cluster network object.
+func (s *ExternalInfraClusterScope) Network() *infrav1.Network {
+	return nil
+}
+
+// VPC returns the cluster VPC.
+func (s *ExternalInfraClusterScope) VPC() *infrav1.VPCSpec {
+	return &infrav1.VPCSpec{}
+}
+
+// Subnets returns the cluster subnets.
+func (s *ExternalInfraClusterScope) Subnets() infrav1.Subnets {
+	return nil
+}
+
+// SetSubnets updates the clusters subnets.
+func (s *ExternalInfraClusterScope) SetSubnets(subnets infrav1.Subnets) {
+}
+
+// CNIIngressRules returns the CNI spec ingress rules.
+func (s *ExternalInfraClusterScope) CNIIngressRules() infrav1.CNIIngressRules {
+	return infrav1.CNIIngressRules{}
+}
+
+// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
+func (s *ExternalInfraClusterScope) SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup {
+	return nil
+}
+
+// Name returns the CAPI cluster name.
+func (s *ExternalInfraClusterScope) Name() string {
+	return s.Cluster.Name
+}
+
+// Namespace returns the cluster namespace.
+func (s *ExternalInfraClusterScope) Namespace() string {
+	return s.Cluster.Namespace
+}
+
+// Region returns the cluster region.
+func (s *ExternalInfraClusterScope) Region() string {
+	region, found, err := unstructured.NestedString(s.ExternalInfraCluster.Object, "spec", "region")
+	if err != nil || !found {
+		s.Error(err, "error getting region")
+		return ""
+	}
+	return region
+}
+
+// KubernetesClusterName is the name of the Kubernetes cluster. For the cluster
+// scope this is the same as the CAPI cluster name
+func (s *ExternalInfraClusterScope) KubernetesClusterName() string {
+	return s.Cluster.Name
+}
+
+// ControlPlaneLoadBalancer returns the AWSLoadBalancerSpec
+func (s *ExternalInfraClusterScope) ControlPlaneLoadBalancer() *infrav1.AWSLoadBalancerSpec {
+	return nil
+}
+
+// ControlPlaneLoadBalancerScheme returns the Classic ELB scheme (public or internal facing)
+func (s *ExternalInfraClusterScope) ControlPlaneLoadBalancerScheme() infrav1.ClassicELBScheme {
+	if s.ControlPlaneLoadBalancer() != nil && s.ControlPlaneLoadBalancer().Scheme != nil {
+		return *s.ControlPlaneLoadBalancer().Scheme
+	}
+	return infrav1.ClassicELBSchemeInternetFacing
+}
+
+// ControlPlaneConfigMapName returns the name of the ConfigMap used to
+// coordinate the bootstrapping of control plane nodes.
+func (s *ExternalInfraClusterScope) ControlPlaneConfigMapName() string {
+	return fmt.Sprintf("%s-controlplane", s.Cluster.UID)
+}
+
+// ListOptionsLabelSelector returns a ListOptions with a label selector for clusterName.
+func (s *ExternalInfraClusterScope) ListOptionsLabelSelector() client.ListOption {
+	return client.MatchingLabels(map[string]string{
+		clusterv1.ClusterLabelName: s.Cluster.Name,
+	})
+}
+
+// PatchObject persists the cluster configuration and status.
+func (s *ExternalInfraClusterScope) PatchObject() error {
+	return nil
+}
+
+// Close closes the current scope persisting the cluster configuration and status.
+func (s *ExternalInfraClusterScope) Close() error {
+	return s.PatchObject()
+}
+
+// AdditionalTags returns AdditionalTags from the scope's ExternalInfraCluster. The returned value will never be nil.
+func (s *ExternalInfraClusterScope) AdditionalTags() infrav1.Tags {
+	return nil
+}
+
+// APIServerPort returns the APIServerPort to use when creating the load balancer.
+func (s *ExternalInfraClusterScope) APIServerPort() int32 {
+	if s.Cluster.Spec.ClusterNetwork != nil && s.Cluster.Spec.ClusterNetwork.APIServerPort != nil {
+		return *s.Cluster.Spec.ClusterNetwork.APIServerPort
+	}
+	return 6443
+}
+
+// SetFailureDomain sets the infrastructure provider failure domain key to the spec given as input.
+func (s *ExternalInfraClusterScope) SetFailureDomain(id string, spec clusterv1.FailureDomainSpec) {
+}
+
+type ExternalInfraClusterObject struct {
+	*unstructured.Unstructured
+}
+
+// InfraCluster returns the AWS infrastructure cluster or control plane object.
+func (s *ExternalInfraClusterScope) InfraCluster() cloud.ClusterObject {
+	return s.ExternalInfraCluster
+}
+
+func (r *ExternalInfraClusterObject) GetConditions() clusterv1.Conditions {
+	return nil
+}
+
+func (r *ExternalInfraClusterObject) SetConditions(conditions clusterv1.Conditions) {
+}
+
+// Session returns the AWS SDK session. Used for creating clients
+func (s *ExternalInfraClusterScope) Session() awsclient.ConfigProvider {
+	return s.session
+}
+
+// Bastion returns the bastion details.
+func (s *ExternalInfraClusterScope) Bastion() *infrav1.Bastion {
+	return nil
+}
+
+// SetBastionInstance sets the bastion instance in the status of the cluster.
+func (s *ExternalInfraClusterScope) SetBastionInstance(instance *infrav1.Instance) {
+}
+
+// SSHKeyName returns the SSH key name to use for instances.
+func (s *ExternalInfraClusterScope) SSHKeyName() *string {
+	return nil
+}
+
+// ControllerName returns the name of the controller that
+// created the ExternalInfraClusterScope.
+func (s *ExternalInfraClusterScope) ControllerName() string {
+	return s.controllerName
+}
+
+// ImageLookupFormat returns the format string to use when looking up AMIs
+func (s *ExternalInfraClusterScope) ImageLookupFormat() string {
+	return ""
+}
+
+// ImageLookupOrg returns the organization name to use when looking up AMIs
+func (s *ExternalInfraClusterScope) ImageLookupOrg() string {
+	return ""
+}
+
+// ImageLookupBaseOS returns the base operating system name to use when looking up AMIs
+func (s *ExternalInfraClusterScope) ImageLookupBaseOS() string {
+	return ""
+}

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -344,3 +344,7 @@ func (m *MachineScope) SetInterruptible() {
 		m.AWSMachine.Status.Interruptible = true
 	}
 }
+
+func (m *MachineScope) IsExternalInfraCluster() bool {
+	return m.InfraCluster.InfraCluster().GetObjectKind().GroupVersionKind().Kind == "ExternalInfraCluster"
+}

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -173,7 +173,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 	}
 	input.SubnetID = subnetID
 
-	if !scope.IsEKSManaged() && s.scope.Network().APIServerELB.DNSName == "" {
+	if !scope.IsExternalInfraCluster() && !scope.IsEKSManaged() && s.scope.Network().APIServerELB.DNSName == "" {
 		record.Eventf(s.scope.InfraCluster(), "FailedCreateInstance", "Failed to run controlplane, APIServer ELB not available")
 
 		return nil, awserrors.NewFailedDependency("failed to run controlplane, APIServer ELB not available")
@@ -188,11 +188,13 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 	input.UserData = pointer.StringPtr(base64.StdEncoding.EncodeToString(userData))
 
 	// Set security groups.
-	ids, err := s.GetCoreSecurityGroups(scope)
-	if err != nil {
-		return nil, err
+	if !scope.IsExternalInfraCluster() {
+		ids, err := s.GetCoreSecurityGroups(scope)
+		if err != nil {
+			return nil, err
+		}
+		input.SecurityGroupIDs = append(input.SecurityGroupIDs, ids...)
 	}
-	input.SecurityGroupIDs = append(input.SecurityGroupIDs, ids...)
 
 	// If SSHKeyName WAS NOT provided in the AWSMachine Spec, fallback to the value provided in the AWSCluster Spec.
 	// If a value was not provided in the AWSCluster Spec, then use the defaultSSHKeyName
@@ -210,7 +212,9 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 		// fallback to AWSCluster.Spec.SSHKeyName if it is defined
 		prioritizedSSHKeyName = *scope.InfraCluster.SSHKeyName()
 	default:
-		prioritizedSSHKeyName = defaultSSHKeyName
+		if !scope.IsExternalInfraCluster() {
+			prioritizedSSHKeyName = defaultSSHKeyName
+		}
 	}
 
 	// Only set input.SSHKeyName if the user did not explicitly request no ssh key be set (explicitly setting "" on either the Machine or related Cluster)
@@ -291,8 +295,11 @@ func (s *Service) findSubnet(scope *scope.MachineScope) (string, error) {
 	case scope.AWSMachine.Spec.Subnet != nil && scope.AWSMachine.Spec.Subnet.Filters != nil:
 		criteria := []*ec2.Filter{
 			filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-			filter.EC2.VPC(s.scope.VPC().ID),
 		}
+		if !scope.IsExternalInfraCluster() {
+			criteria = append(criteria, filter.EC2.VPC(s.scope.VPC().ID))
+		}
+
 		if failureDomain != nil {
 			criteria = append(criteria, filter.EC2.AvailabilityZone(*failureDomain))
 		}
@@ -355,6 +362,10 @@ func (s *Service) getFilteredSubnets(criteria ...*ec2.Filter) ([]*ec2.Subnet, er
 // GetCoreSecurityGroups looks up the security group IDs managed by this actuator
 // They are considered "core" to its proper functioning
 func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, error) {
+	if scope.IsExternalInfraCluster() {
+		return nil, nil
+	}
+
 	// These are common across both controlplane and node machines
 	sgRoles := []infrav1.SecurityGroupRole{
 		infrav1.SecurityGroupNode,


### PR DESCRIPTION
This decouples the machine controller from the Infrastructure resource.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2125

