### PR TITLE
:bug: Fix OpenAPI defaulting for secrets backend and add OpenAPI testing

### DIFF
--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -168,7 +168,6 @@ type CloudInit struct {
 	// Parameter Storage to distribute secrets. By default or with the value of secrets-manager,
 	// will use AWS Secrets Manager instead.
 	// +optional
-	// +kubebuilder:default=secrets-manager
 	// +kubebuilder:validation:Enum=secrets-manager;ssm-parameter-store
 	SecureSecretsBackend SecretBackend `json:"secureSecretsBackend,omitempty"`
 }

--- a/api/v1alpha3/suite_test.go
+++ b/api/v1alpha3/suite_test.go
@@ -14,57 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package v1alpha3
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
+	"strconv"
 	"testing"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	infrav1exp "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var (
-	testEnv *helpers.TestEnvironment
-)
-
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
-}
+var testEnv *helpers.TestEnvironment
 
 func TestMain(m *testing.M) {
 	setup()
-	defer func(){
-		teardown()
-	}()
 	code := m.Run()
+	teardown()
 	os.Exit(code)
 }
 
 func setup() {
-	utilruntime.Must(infrav1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(infrav1exp.AddToScheme(scheme.Scheme))
-	utilruntime.Must(clusterv1exp.AddToScheme(scheme.Scheme))
+	utilruntime.Must(AddToScheme(scheme.Scheme))
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
 		path.Join("config", "crd", "bases"),
 	},
@@ -74,23 +49,17 @@ func setup() {
 	if err != nil {
 		panic(err)
 	}
-	if err := (&infrav1.AWSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&AWSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSCluster webhook: %v", err))
 	}
-	if err := (&infrav1.AWSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&AWSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSMachine webhook: %v", err))
 	}
-	if err := (&infrav1.AWSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&AWSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSMachineTemplate webhook: %v", err))
 	}
-	if err := (&infrav1.AWSMachineList{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&AWSMachineList{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSMachineList webhook: %v", err))
-	}
-	if err := (&infrav1exp.AWSMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Unable to setup AWSMachinePool webhook: %v", err))
-	}
-	if err := (&infrav1exp.AWSManagedMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Unable to setup AWSManagedMachinePool webhook: %v", err))
 	}
 	go func() {
 		fmt.Println("Starting the manager")
@@ -107,3 +76,6 @@ func teardown() {
 	}
 }
 
+func randomName() string {
+	return strconv.FormatInt(rand.Int63(), 10)
+}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -324,7 +324,6 @@ spec:
                     description: SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.
                     type: string
                   secureSecretsBackend:
-                    default: secrets-manager
                     description: SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.
                     enum:
                     - secrets-manager

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -287,7 +287,6 @@ spec:
                             description: SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.
                             type: string
                           secureSecretsBackend:
-                            default: secrets-manager
                             description: SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.
                             enum:
                             - secrets-manager

--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -36,7 +37,7 @@ var _ = Describe("AWSClusterReconciler", func() {
 			ctx := context.Background()
 
 			reconciler := &AWSClusterReconciler{
-				Client: k8sClient,
+				Client: testEnv.Client,
 				Log:    log.Log,
 			}
 
@@ -44,7 +45,7 @@ var _ = Describe("AWSClusterReconciler", func() {
 			instance.Default()
 
 			// Create the AWSCluster object and expect the Reconcile and Deployment to be created
-			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+			Expect(testEnv.Create(ctx, instance)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctrl.Request{
 				NamespacedName: client.ObjectKey{

--- a/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_webhook_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 )
@@ -36,7 +37,13 @@ func TestDefaultingWebhook(t *testing.T) {
 	defaultTestBastion := infrav1.Bastion{
 		AllowedCIDRBlocks: []string{"0.0.0.0/0"},
 	}
+	AZUsageLimit := 3
+	defaultVPCSpec := infrav1.VPCSpec{
+		AvailabilityZoneUsageLimit: &AZUsageLimit,
+		AvailabilityZoneSelection:  &infrav1.AZSelectionSchemeOrdered,
+	}
 	defaultNetworkSpec := infrav1.NetworkSpec{
+		VPC: defaultVPCSpec,
 		CNI: &infrav1.CNISpec{
 			CNIIngressRules: []*infrav1.CNIIngressRule{
 				{
@@ -69,21 +76,21 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec},
+			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator},
 		},
 		{
 			name:         "less than 100 chars, dot in name",
 			resourceName: "team1.cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_team1_cluster1", Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec},
+			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_team1_cluster1", Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator},
 		},
 		{
 			name:         "more than 100 chars",
-			resourceName: "ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE",
+			resourceName: "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde",
 			resourceNS:   "default",
 			expectHash:   true,
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "capi_", Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec},
+			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "capi_", Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator},
 		},
 		{
 			name:         "with patch",
@@ -91,7 +98,7 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceNS:   "default",
 			expectHash:   false,
 			spec:         AWSManagedControlPlaneSpec{Version: &vV1_17_1},
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Version: &vV1_17, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec},
+			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Version: &vV1_17, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator},
 		},
 		{
 			name:         "with allowed ip on bastion",
@@ -99,7 +106,7 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceNS:   "default",
 			expectHash:   false,
 			spec:         AWSManagedControlPlaneSpec{Bastion: infrav1.Bastion{AllowedCIDRBlocks: []string{"100.100.100.100/0"}}},
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Bastion: infrav1.Bastion{AllowedCIDRBlocks: []string{"100.100.100.100/0"}}, NetworkSpec: defaultNetworkSpec},
+			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Bastion: infrav1.Bastion{AllowedCIDRBlocks: []string{"100.100.100.100/0"}}, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator},
 		},
 		{
 			name:         "with CNI on network",
@@ -107,22 +114,28 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceNS:   "default",
 			expectHash:   false,
 			spec:         AWSManagedControlPlaneSpec{NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}}},
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Bastion: defaultTestBastion, NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}}},
+			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Bastion: defaultTestBastion, NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}, VPC: defaultVPCSpec}, TokenMethod: &EKSTokenMethodIAMAuthenticator},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
 			g := NewWithT(t)
 
 			mcp := &AWSManagedControlPlane{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      tc.resourceName,
 					Namespace: tc.resourceNS,
 				},
 			}
 			mcp.Spec = tc.spec
-			mcp.Default()
+
+			g.Expect(testEnv.Create(ctx, mcp)).To(Succeed())
+
+			defer func() {
+				testEnv.Delete(ctx, mcp)
+			}()
 
 			g.Expect(mcp.Spec.EKSClusterName).ToNot(BeEmpty())
 
@@ -136,7 +149,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	}
 }
 
-func TestValidatingWebhookCreate(t *testing.T) {
+func TestWebhookCreate(t *testing.T) {
 	tests := []struct {
 		name           string
 		eksClusterName string
@@ -151,7 +164,7 @@ func TestValidatingWebhookCreate(t *testing.T) {
 		{
 			name:           "ekscluster NOT specified",
 			eksClusterName: "",
-			expectError:    true,
+			expectError:    false,
 		},
 		{
 			name:           "invalid version",
@@ -163,9 +176,14 @@ func TestValidatingWebhookCreate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
 			g := NewWithT(t)
 
 			mcp := &AWSManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "mcp-",
+					Namespace:    "default",
+				},
 				Spec: AWSManagedControlPlaneSpec{
 					EKSClusterName: tc.eksClusterName,
 				},
@@ -173,7 +191,7 @@ func TestValidatingWebhookCreate(t *testing.T) {
 			if tc.eksVersion != "" {
 				mcp.Spec.Version = &tc.eksVersion
 			}
-			err := mcp.ValidateCreate()
+			err := testEnv.Create(ctx, mcp)
 
 			if tc.expectError {
 				g.Expect(err).ToNot(BeNil())
@@ -184,7 +202,7 @@ func TestValidatingWebhookCreate(t *testing.T) {
 	}
 }
 
-func TestValidatingWebhookUpdate(t *testing.T) {
+func TestWebhookUpdate(t *testing.T) {
 	tests := []struct {
 		name           string
 		oldClusterSpec AWSManagedControlPlaneSpec
@@ -266,14 +284,17 @@ func TestValidatingWebhookUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-
-			newMCP := &AWSManagedControlPlane{
-				Spec: tc.newClusterSpec,
-			}
-			oldMCP := &AWSManagedControlPlane{
+			ctx := context.TODO()
+			mcp := &AWSManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "mcp-",
+					Namespace:    "default",
+				},
 				Spec: tc.oldClusterSpec,
 			}
-			err := newMCP.ValidateUpdate(oldMCP)
+			g.Expect(testEnv.Create(ctx, mcp)).To(Succeed())
+			mcp.Spec = tc.newClusterSpec
+			err := testEnv.Update(ctx, mcp)
 
 			if tc.expectError {
 				g.Expect(err).ToNot(BeNil())

--- a/controlplane/eks/api/v1alpha3/suite_test.go
+++ b/controlplane/eks/api/v1alpha3/suite_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
+)
+
+var testEnv *helpers.TestEnvironment
+
+func TestMain(m *testing.M) {
+	setup()
+	code := m.Run()
+	teardown()
+	os.Exit(code)
+}
+
+func setup() {
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
+		path.Join("controlplane", "eks", "config", "crd", "bases"),
+	},
+	).WithWebhookConfiguration("managed", path.Join("controlplane", "eks", "config", "webhook", "manifests.yaml"))
+	var err error
+	testEnv, err = testEnvConfig.Build()
+	if err != nil {
+		panic(err)
+	}
+	if err := (&AWSManagedControlPlane{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup  AWSManagedControlPlane webhook: %v", err))
+	}
+	go func() {
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	testEnv.WaitForWebhooks()
+}
+
+func teardown() {
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
+	}
+}
+
+func randomName() string {
+	return strconv.FormatInt(rand.Int63(), 10)
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	golang.org/x/net v0.0.0-20200930145003-4acb6c075d10
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.17.9
+	k8s.io/apiextensions-apiserver v0.17.9
 	k8s.io/apimachinery v0.17.9
 	k8s.io/client-go v0.17.9
 	k8s.io/component-base v0.17.9

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"io/ioutil"
+	"net"
+	"path"
+	"path/filepath"
+	goruntime "runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/pkg/errors"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/cluster-api-provider-aws/test/helpers/external"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/log"
+	"sigs.k8s.io/cluster-api/util"
+	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	mutatingWebhookKind          = "MutatingWebhookConfiguration"
+	validatingWebhookKind        = "ValidatingWebhookConfiguration"
+	defaultMutatingWebhookName   = "mutating-webhook-configuration"
+	defaultValidatingWebhookName = "validating-webhook-configuration"
+)
+
+var (
+	root string
+)
+
+func init() {
+	klog.InitFlags(nil)
+	logger := klogr.New()
+	// use klog as the internal logger for this envtest environment.
+	log.SetLogger(logger)
+	// additionally force all of the controllers to use the Ginkgo logger.
+	ctrl.SetLogger(logger)
+	// add logger for ginkgo
+	klog.SetOutput(ginkgo.GinkgoWriter)
+
+	// Calculate the scheme.
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(admissionv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
+
+	// Get the root of the current file to use in CRD paths.
+	_, filename, _, _ := goruntime.Caller(0) //nolint
+	root = path.Join(path.Dir(filename), "..", "..")
+
+	// Create the test environment.
+
+}
+
+type webhookConfiguration struct {
+	tag              string
+	relativeFilePath string
+}
+
+// TestEnvironmentConfiguration encapsulates the interim, mutable configuration of the Kubernetes local test environment
+type TestEnvironmentConfiguration struct {
+	env                   *envtest.Environment
+	webhookConfigurations []webhookConfiguration
+}
+
+// TestEnvironment encapsulates a Kubernetes local test environment.
+type TestEnvironment struct {
+	manager.Manager
+	client.Client
+	Config *rest.Config
+
+	doneMgr chan struct{}
+	env     *envtest.Environment
+}
+
+// NewTestEnvironmentConfiguration creates a new test environment configuration for running tests
+func NewTestEnvironmentConfiguration(crdDirectoryPaths []string) *TestEnvironmentConfiguration {
+	resolvedCrdDirectoryPaths := make([]string, len(crdDirectoryPaths))
+
+	for i, p := range crdDirectoryPaths {
+		resolvedCrdDirectoryPaths[i] = path.Join(root, p)
+	}
+
+	return &TestEnvironmentConfiguration{
+		env: &envtest.Environment{
+			ErrorIfCRDPathMissing: true,
+			CRDDirectoryPaths:     resolvedCrdDirectoryPaths,
+			CRDs: []runtime.Object{
+				external.TestClusterCRD.DeepCopy(),
+				external.TestMachineCRD.DeepCopy(),
+			},
+		},
+	}
+
+}
+
+// WithWebhookConfiguration adds the CRD webhook configuration given a named tag and file path for the webhook manifest
+func (t *TestEnvironmentConfiguration) WithWebhookConfiguration(tag string, relativeFilePath string) *TestEnvironmentConfiguration {
+	t.webhookConfigurations = append(t.webhookConfigurations, webhookConfiguration{tag: tag, relativeFilePath: relativeFilePath})
+	return t
+}
+
+// Build creates a new environment spinning up a local api-server.
+// This function should be called only once for each package you're running tests within,
+// usually the environment is initialized in a suite_test.go file within a `BeforeSuite` ginkgo block.
+func (t *TestEnvironmentConfiguration) Build() (*TestEnvironment, error) {
+	mutatingWebhooks := []runtime.Object{}
+	validatingWebhooks := []runtime.Object{}
+	for _, w := range t.webhookConfigurations {
+		m, v, err := buildModifiedWebhook(w.tag, w.relativeFilePath)
+		if err != nil {
+			return nil, err
+		}
+		mutatingWebhooks = append(mutatingWebhooks, m)
+		validatingWebhooks = append(mutatingWebhooks, v)
+	}
+
+	t.env.WebhookInstallOptions = envtest.WebhookInstallOptions{
+		MaxTime:            20 * time.Second,
+		PollInterval:       time.Second,
+		ValidatingWebhooks: validatingWebhooks,
+		MutatingWebhooks:   mutatingWebhooks,
+	}
+
+	if _, err := t.env.Start(); err != nil {
+		panic(err)
+	}
+
+	options := manager.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
+		NewClient:          util.ManagerDelegatingClientFunc,
+		CertDir:            t.env.WebhookInstallOptions.LocalServingCertDir,
+		Port:               t.env.WebhookInstallOptions.LocalServingPort,
+	}
+
+	mgr, err := ctrl.NewManager(t.env.Config, options)
+
+	if err != nil {
+		klog.Fatalf("Failed to start testenv manager: %v", err)
+	}
+
+	return &TestEnvironment{
+		Manager: mgr,
+		Client:  mgr.GetClient(),
+		Config:  mgr.GetConfig(),
+		doneMgr: make(chan struct{}),
+		env:     t.env,
+	}, nil
+
+}
+
+func buildModifiedWebhook(tag string, relativeFilePath string) (runtime.Object, runtime.Object, error) {
+	var mutatingWebhook runtime.Object
+	var validatingWebhook runtime.Object
+	data, err := ioutil.ReadFile(filepath.Join(root, relativeFilePath))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to read webhook configuration file")
+	}
+	objs, err := utilyaml.ToUnstructured(data)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to parse yaml")
+	}
+	for i := range objs {
+		o := objs[i]
+		if o.GetKind() == mutatingWebhookKind {
+			// update the name in metadata
+			if o.GetName() == defaultMutatingWebhookName {
+				o.SetName(strings.Join([]string{defaultMutatingWebhookName, "-", tag}, ""))
+				mutatingWebhook = &o
+			}
+		}
+		if o.GetKind() == validatingWebhookKind {
+			// update the name in metadata
+			if o.GetName() == defaultValidatingWebhookName {
+				o.SetName(strings.Join([]string{defaultValidatingWebhookName, "-", tag}, ""))
+				validatingWebhook = &o
+			}
+		}
+	}
+	return mutatingWebhook, validatingWebhook, nil
+}
+
+// StartManager starts the test controller against the local API server
+func (t *TestEnvironment) StartManager() error {
+	return t.Manager.Start(t.doneMgr)
+}
+
+// WaitForWebhooks will not return until the webhook port is open
+func (t *TestEnvironment) WaitForWebhooks() {
+	port := t.env.WebhookInstallOptions.LocalServingPort
+	klog.V(2).Infof("Waiting for webhook port %d to be open prior to running tests", port)
+	timeout := 1 * time.Second
+	for {
+		time.Sleep(1 * time.Second)
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), timeout)
+		if err != nil {
+			klog.V(2).Infof("Webhook port is not ready, will retry in %v: %s", timeout, err)
+			continue
+		}
+		conn.Close()
+		klog.V(2).Info("Webhook port is now open. Continuing with tests...")
+		return
+	}
+}
+
+// Stop stops the test environment
+func (t *TestEnvironment) Stop() error {
+	t.doneMgr <- struct{}{}
+	return t.env.Stop()
+}

--- a/test/helpers/external/cluster.go
+++ b/test/helpers/external/cluster.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external
+
+import (
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	clusterAPIGroup       = "cluster.x-k8s.io"
+	clusterAPITestVersion = "v1alpha3"
+)
+
+var (
+	TestClusterCRD = generateTestClusterAPICRD("cluster", "clusters")
+	TestMachineCRD = generateTestClusterAPICRD("machine", "machines")
+)
+
+func generateTestClusterAPICRD(kind, pluralKind string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pluralKind + "." + clusterAPIGroup,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cluster.x-k8s.io",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:   strings.Title(kind),
+				Plural: pluralKind,
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    clusterAPITestVersion,
+					Served:  true,
+					Storage: true,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer.BoolPtr(true),
+								},
+								"status": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Also includes fake CRDs for Cluster API clusters and machines<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Creates a multi-package envtest helper, and converts controllers and webhook tests over from fake client to envtest*

Mirrors that of Cluster API where multiple controllers are in the same repo, so webhooks may need to modified so that they can run together.

`* The one exception is awsmachine_controller_test.go, which needs a major refactor to be able to use envtest, as it relies on sequential ordering of test statements. (https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2142)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1999 
Fixes #2064 

