### PR TITLE
🌱Add CAPI E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ LDFLAGS := $(shell source ./hack/version.sh; version::ldflags)
 E2E_UNMANAGED_FOCUS ?= "functional tests - unmanaged"
 # Instead, you can run a quick smoke test, it should run fast (9 minutes)...
 # E2E_UNMANAGED_FOCUS := "Create cluster with name having"
+# For running CAPI e2e tests: E2E_UNMANAGED_FOCUS := "Cluster API E2E tests"
+USE_EXISTING_CLUSTER ?= "false"
 
 GINKGO_NODES ?= 2
 GINKGO_ARGS ?=

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test: ## Run tests
 
 .PHONY: test-e2e ## Run e2e tests using clusterctl
 test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run e2e tests
-	time $(GINKGO) -trace -progress -v -tags=e2e -focus=$(E2E_UNMANAGED_FOCUS) $(GINKGO_ARGS) ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" $(E2E_ARGS)
+	time $(GINKGO) -trace -progress -v -tags=e2e -focus=$(E2E_UNMANAGED_FOCUS) $(GINKGO_ARGS) ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" $(E2E_ARGS) -use-existing-cluster=$(USE_EXISTING_CLUSTER)
 
 .PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
 test-e2e-eks: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -120,6 +120,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 				"elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
 				"elasticloadbalancing:RemoveTags",
 				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeInstanceRefreshes",
 				"ec2:CreateLaunchTemplate",
 				"ec2:CreateLaunchTemplateVersion",
 				"ec2:DescribeLaunchTemplates",
@@ -138,9 +139,20 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 				"autoscaling:UpdateAutoScalingGroup",
 				"autoscaling:CreateOrUpdateTags",
 				"autoscaling:StartInstanceRefresh",
-				"autoscaling:UpdateAutoScalingGroup",
 				"autoscaling:DeleteAutoScalingGroup",
 				"autoscaling:DeleteTags",
+			},
+		},
+		{
+			Effect: iamv1.EffectAllow,
+			Resource: iamv1.Resources{
+				"arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+			},
+			Action: iamv1.Actions{
+				"iam:CreateServiceLinkedRole",
+			},
+			Condition: iamv1.Conditions{
+				iamv1.StringLike: map[string]string{"iam:AWSServiceName": "autoscaling.amazonaws.com"},
 			},
 		},
 		{

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -137,6 +137,8 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 				"autoscaling:CreateAutoScalingGroup",
 				"autoscaling:UpdateAutoScalingGroup",
 				"autoscaling:CreateOrUpdateTags",
+				"autoscaling:StartInstanceRefresh",
+				"autoscaling:UpdateAutoScalingGroup",
 				"autoscaling:DeleteAutoScalingGroup",
 				"autoscaling:DeleteTags",
 			},

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -192,6 +192,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -205,11 +206,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -192,6 +192,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -205,11 +206,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -198,6 +198,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -211,11 +212,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -197,6 +197,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -210,11 +211,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -192,6 +192,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -205,11 +206,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -192,6 +192,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -205,11 +206,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
@@ -192,6 +192,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -205,11 +206,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -192,6 +192,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -205,11 +206,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -192,6 +192,7 @@ Resources:
           - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
           - elasticloadbalancing:RemoveTags
           - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
           - ec2:CreateLaunchTemplate
           - ec2:CreateLaunchTemplateVersion
           - ec2:DescribeLaunchTemplates
@@ -205,11 +206,20 @@ Resources:
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:UpdateAutoScalingGroup
           - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
           - autoscaling:DeleteAutoScalingGroup
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
           - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -105,26 +105,36 @@ providers:
         targetName: "cluster-template-limit-az.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template-spot-instances.yaml"
         targetName: "cluster-template-spot-instances.yaml"
-
+      - sourcePath: "./infrastructure-aws/cluster-template-mhc.yaml"
+        targetName: "cluster-template-mhc.yaml"
+      - sourcePath: "./infrastructure-aws/cluster-template-machine-pool.yaml"
+        targetName: "cluster-template-machine-pool.yaml"
 variables:
-  KUBERNETES_VERSION: "v1.19.4"
+  KUBERNETES_VERSION: "v1.20.1"
   CNI: "../../data/cni/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   AWS_CONTROL_PLANE_MACHINE_TYPE: t3.large
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.19.4"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.20.1"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
+  EXP_MACHINE_POOL: "true"
+  ETCD_VERSION_UPGRADE_TO: "3.4.13-0"
+  COREDNS_VERSION_UPGRADE_TO: "1.7.1"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.20.1"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.19.6"
 
 intervals:
-  default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["10m", "10s"]
-  default/wait-worker-nodes: ["10m", "10s"]
-  conformance/wait-control-plane: ["30m", "10s"]
-  conformance/wait-worker-nodes: ["30m", "10s"]
-  default/wait-controllers: ["3m", "10s"]
-  default/wait-delete-cluster: ["20m", "10s"]
-  default/wait-machine-upgrade: ["20m", "10s"]
-  default/wait-machine-status: ["20m", "10s"]
+  default/wait-cluster: ["30m", "10s"]
+  default/wait-control-plane: ["40m", "10s"]
+  default/wait-worker-nodes: ["40m", "10s"]
+  conformance/wait-control-plane: ["40m", "10s"]
+  conformance/wait-worker-nodes: ["40m", "10s"]
+  default/wait-controllers: ["40m", "10s"]
+  default/wait-delete-cluster: ["40m", "10s"]
+  default/wait-machine-upgrade: ["40m", "10s"]
+  default/wait-machine-status: ["40m", "10s"]
   default/wait-infra-subnets: ["5m", "30s"]
+  default/wait-machine-pool-nodes: ["40m", "10s"]
+  default/wait-machine-pool-upgrade: [ "40m", "10s" ]

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -137,4 +137,4 @@ intervals:
   default/wait-machine-status: ["40m", "10s"]
   default/wait-infra-subnets: ["5m", "30s"]
   default/wait-machine-pool-nodes: ["40m", "10s"]
-  default/wait-machine-pool-upgrade: [ "40m", "10s" ]
+  default/wait-machine-pool-upgrade: [ "50m", "10s" ]

--- a/test/e2e/data/infrastructure-aws/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template-machine-pool.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-0"
+spec:
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: AWSCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  region: "${AWS_REGION}"
+  sshKeyName: "${AWS_SSH_KEY_NAME}"
+  networkSpec:
+    vpc:
+      availabilityZoneUsageLimit: 1
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  infrastructureTemplate:
+    kind: AWSMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname }}'
+        kubeletExtraArgs:
+          cloud-provider: aws
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: aws
+      controllerManager:
+        extraArgs:
+          cloud-provider: aws
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname }}'
+        kubeletExtraArgs:
+          cloud-provider: aws
+  version: "${KUBERNETES_VERSION}"
+---
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"
+      iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+      sshKeyName: "${AWS_SSH_KEY_NAME}"
+---
+apiVersion: exp.cluster.x-k8s.io/v1alpha3
+kind: MachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfig
+          name: ${CLUSTER_NAME}-mp-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AWSMachinePool
+        name: ${CLUSTER_NAME}-mp-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+spec:
+  minSize: 1
+  maxSize: 4
+  awsLaunchTemplate:
+    instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"
+    iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
+    sshKeyName: "${AWS_SSH_KEY_NAME}"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: KubeadmConfig
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+  namespace: default
+spec:
+  joinConfiguration:
+    nodeRegistration:
+      name: '{{ ds.meta_data.local_hostname }}'
+      kubeletExtraArgs:
+        cloud-provider: aws
+---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-0"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name:  "${CLUSTER_NAME}-crs-0"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-0"
+  resources:
+    - name: "cni-${CLUSTER_NAME}-crs-0"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-aws/cluster-template-mhc.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template-mhc.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-0"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: AWSCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  region: "${AWS_REGION}"
+  sshKeyName: "${AWS_SSH_KEY_NAME}"
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  infrastructureTemplate:
+    kind: AWSMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname }}'
+        kubeletExtraArgs:
+          cloud-provider: aws
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: aws
+      controllerManager:
+        extraArgs:
+          cloud-provider: aws
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname }}'
+        kubeletExtraArgs:
+          cloud-provider: aws
+  version: "${KUBERNETES_VERSION}"
+---
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"
+      iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+      sshKeyName: "${AWS_SSH_KEY_NAME}"
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    metadata:
+      labels:
+        nodepool: pool1
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AWSMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      instanceType: "${AWS_NODE_MACHINE_TYPE}"
+      iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
+      sshKeyName: "${AWS_SSH_KEY_NAME}"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: '{{ ds.meta_data.local_hostname }}'
+          kubeletExtraArgs:
+            cloud-provider: aws
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-0"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name:  "${CLUSTER_NAME}-crs-0"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-0"
+  resources:
+    - name: "cni-${CLUSTER_NAME}-crs-0"
+      kind: ConfigMap
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      nodepool: "pool1"
+  unhealthyConditions:
+    - type: E2ENodeUnhealthy
+      status: "True"
+      timeout: 30s

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -1,0 +1,113 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unmanaged
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+var _ = Describe("Cluster API E2E tests - unmanaged", func() {
+	var (
+		namespace *corev1.Namespace
+		ctx       context.Context
+		specName  = "capi-tests"
+	)
+
+	BeforeEach(func() {
+		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
+		ctx = context.TODO()
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
+	})
+
+	SetDefaultEventuallyTimeout(20 * time.Minute)
+	SetDefaultEventuallyPollingInterval(10 * time.Second)
+	Context("Running the quick-start spec", func() {
+		capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
+			return capi_e2e.QuickStartSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			}
+		})
+	})
+	Context("Running the KCP upgrade spec", func() {
+		capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
+			return capi_e2e.KCPUpgradeSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			}
+		})
+	})
+	Context("Running the MachineDeployment upgrade spec", func() {
+		capi_e2e.MachineDeploymentUpgradesSpec(context.TODO(), func() capi_e2e.MachineDeploymentUpgradesSpecInput {
+			return capi_e2e.MachineDeploymentUpgradesSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			}
+		})
+	})
+	Context("Running the MachineRemediation spec", func() {
+		capi_e2e.MachineRemediationSpec(context.TODO(), func() capi_e2e.MachineRemediationSpecInput {
+			return capi_e2e.MachineRemediationSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			}
+		})
+	})
+
+	Context("Running the Machine pool spec", func() {
+		capi_e2e.MachinePoolSpec(context.TODO(), func() capi_e2e.MachinePoolInput {
+			return capi_e2e.MachinePoolInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			}
+		})
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+	})
+})

--- a/test/e2e/suites/unmanaged/unmanaged_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_test.go
@@ -50,6 +50,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/test/e2e/suites/unmanaged/unmanaged_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_test.go
@@ -47,7 +47,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
-	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
@@ -85,67 +84,6 @@ var _ = Describe("functional tests - unmanaged", func() {
 		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
 		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
-	})
-
-	Describe("Running the Cluster API E2E tests", func() {
-		SetDefaultEventuallyTimeout(20 * time.Minute)
-		SetDefaultEventuallyPollingInterval(10 * time.Second)
-		Context("Running the quick-start spec", func() {
-			capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
-				return capi_e2e.QuickStartSpecInput{
-					E2EConfig:             e2eCtx.E2EConfig,
-					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
-					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
-				}
-			})
-		})
-		Context("Running the KCP upgrade spec", func() {
-			capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
-				return capi_e2e.KCPUpgradeSpecInput{
-					E2EConfig:             e2eCtx.E2EConfig,
-					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
-					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
-				}
-			})
-		})
-		Context("Running the MachineDeployment upgrade spec", func() {
-			capi_e2e.MachineDeploymentUpgradesSpec(context.TODO(), func() capi_e2e.MachineDeploymentUpgradesSpecInput {
-				return capi_e2e.MachineDeploymentUpgradesSpecInput{
-					E2EConfig:             e2eCtx.E2EConfig,
-					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
-					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
-				}
-			})
-		})
-		Context("Running the MachineRemediation spec", func() {
-			capi_e2e.MachineRemediationSpec(context.TODO(), func() capi_e2e.MachineRemediationSpecInput {
-				return capi_e2e.MachineRemediationSpecInput{
-					E2EConfig:             e2eCtx.E2EConfig,
-					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
-					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
-				}
-			})
-		})
-
-		Context("Running the Machine pool spec", func() {
-			capi_e2e.MachinePoolSpec(context.TODO(), func() capi_e2e.MachinePoolInput {
-				return capi_e2e.MachinePoolInput{
-					E2EConfig:             e2eCtx.E2EConfig,
-					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
-					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
-				}
-			})
-		})
 	})
 
 	Describe("Workload cluster with AWS SSM Parameter as the Secret Backend", func() {

--- a/test/e2e/suites/unmanaged/unmanaged_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_test.go
@@ -43,15 +43,14 @@ import (
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-	"sigs.k8s.io/cluster-api/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
 )
 
 type statefulSetInfo struct {
@@ -85,6 +84,67 @@ var _ = Describe("functional tests - unmanaged", func() {
 		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
 		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
+	})
+
+	Describe("Running the Cluster API E2E tests", func() {
+		SetDefaultEventuallyTimeout(20 * time.Minute)
+		SetDefaultEventuallyPollingInterval(10 * time.Second)
+		Context("Running the quick-start spec", func() {
+			capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
+				return capi_e2e.QuickStartSpecInput{
+					E2EConfig:             e2eCtx.E2EConfig,
+					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+				}
+			})
+		})
+		Context("Running the KCP upgrade spec", func() {
+			capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
+				return capi_e2e.KCPUpgradeSpecInput{
+					E2EConfig:             e2eCtx.E2EConfig,
+					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+				}
+			})
+		})
+		Context("Running the MachineDeployment upgrade spec", func() {
+			capi_e2e.MachineDeploymentUpgradesSpec(context.TODO(), func() capi_e2e.MachineDeploymentUpgradesSpecInput {
+				return capi_e2e.MachineDeploymentUpgradesSpecInput{
+					E2EConfig:             e2eCtx.E2EConfig,
+					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+				}
+			})
+		})
+		Context("Running the MachineRemediation spec", func() {
+			capi_e2e.MachineRemediationSpec(context.TODO(), func() capi_e2e.MachineRemediationSpecInput {
+				return capi_e2e.MachineRemediationSpecInput{
+					E2EConfig:             e2eCtx.E2EConfig,
+					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+				}
+			})
+		})
+
+		Context("Running the Machine pool spec", func() {
+			capi_e2e.MachinePoolSpec(context.TODO(), func() capi_e2e.MachinePoolInput {
+				return capi_e2e.MachinePoolInput{
+					E2EConfig:             e2eCtx.E2EConfig,
+					ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+					ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
+					SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+				}
+			})
+		})
 	})
 
 	Describe("Workload cluster with AWS SSM Parameter as the Secret Backend", func() {
@@ -310,7 +370,7 @@ var _ = Describe("functional tests - unmanaged", func() {
 		})
 	})
 
-	Describe("multiple workload clusters", func() {
+	Describe("Multiple workload clusters", func() {
 		Context("in different namespaces with machine failures", func() {
 			It("should setup namespaces correctly for the two clusters", func() {
 				By("Creating first cluster with single control plane")


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding CAPI tests except KCP adoption.
MachinePool test will be uncommented once https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2137 is done.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2132
