### PR TITLE
🐛 Set Subnets as an optional property

### DIFF
--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -49,6 +49,7 @@ type AWSMachinePoolSpec struct {
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 
 	// Subnets is an array of subnet configurations
+	// +optional
 	Subnets []infrav1.AWSResourceReference `json:"subnets,omitempty"`
 
 	// AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the


### PR DESCRIPTION
**What this PR does / why we need it**:
Marks `subnets` as an optional property on `AWSMachinePool`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/assign @sedefsavas 
