### PR TITLE
:sparkles: clusterawsadm: Allow CLI to take a configuration file to print IAM policy documents

### DIFF
--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
@@ -93,7 +93,7 @@ type AWSIAMRoleSpec struct {
 // EKSConfig represents the EKS related configuration config
 type EKSConfig struct {
 	// Enable controls whether EKS-related permissions are granted
-	Enable bool `json:"enable,omitempty"`
+	Enable bool `json:"enable"`
 	// AllowIAMRoleCreation controls whether the EKS controllers have permissions for creating IAM
 	// roles per cluster
 	AllowIAMRoleCreation bool `json:"iamRoleCreation,omitempty"`

--- a/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
+++ b/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
@@ -39,6 +39,9 @@ func printPolicyCmd() *cobra.Command {
 		# Print out the IAM policy for the Kubernetes Cluster API Provider AWS Controller.
 		clusterawsadm bootstrap iam print-policy --document AWSIAMManagedPolicyControllers
 
+		# Print out the IAM policy for the Kubernetes Cluster API Provider AWS Controller using a given configuration file.
+		clusterawsadm bootstrap iam print-policy --document AWSIAMManagedPolicyControllers --config bootstrap_config.yaml		
+
 		# Print out the IAM policy for the Kubernetes AWS Cloud Provider for the control plane.
 		clusterawsadm bootstrap iam print-policy --document AWSIAMManagedPolicyCloudProviderControlPlane
 
@@ -70,7 +73,7 @@ func printPolicyCmd() *cobra.Command {
 			return nil
 		},
 	}
-
+	addConfigFlag(newCmd)
 	newCmd.Flags().String("document", "", fmt.Sprintf("which document to show: %+v", bootstrap.ManagedIAMPolicyNames))
 	return newCmd
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Allow CLI to take a configuration file to print IAM policy documents.
Additionally, show that EKS is disabled by default in the configuration.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

