### PR TITLE
📖 fix emoji display on contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,5 @@ Kubernetes projects require that you sign a Contributor License Agreement (CLA) 
 1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
 1. Fork the desired repo, develop and test your code changes.
 1. Submit a pull request.
-  1. All code PR must be labeled with
-    ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
+  1. All code PR titles must be prefixed with:
+    ⚠️ (`:warning:`, major or breaking changes), ✨ (`:sparkles:`, minor or feature additions), 🐛 (`:bug:`, patch and bugfixes), 📖 (`:book:`, documentation or proposals), or 🌱 (`:seedling:`, minor or other)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fixed the display of the emoji codewords so they dont render as emojis and updated wording to indicate they should be used at the start of PR titles.

