### PR TITLE
🐛 Error if a loadbalancer exist with the same name in the same region with a different scheme

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -22,14 +22,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/ec2"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	rgapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
@@ -110,19 +110,6 @@ func (s *Service) ReconcileLoadbalancers() error {
 
 	s.scope.V(2).Info("Reconcile load balancers completed successfully")
 	return nil
-}
-
-// GetAPIServerDNSName returns the DNS name endpoint for the API server
-func (s *Service) GetAPIServerDNSName() (string, error) {
-	elbName, err := GenerateELBName(s.scope.Name())
-	if err != nil {
-		return "", err
-	}
-	apiELB, err := s.describeClassicELB(elbName)
-	if err != nil {
-		return "", err
-	}
-	return apiELB.DNSName, nil
 }
 
 // DeleteLoadbalancers deletes the load balancers for the given cluster.
@@ -594,6 +581,12 @@ func (s *Service) describeClassicELB(name string) (*infrav1.ClassicELB, error) {
 		return nil, errors.Errorf(
 			"ELB names must be unique within a region: %q ELB already exists in this region in VPC %q",
 			name, *out.LoadBalancerDescriptions[0].VPCId)
+	}
+
+	if s.scope.ControlPlaneLoadBalancer().Scheme != nil && pointer.StringPtr(string(*s.scope.ControlPlaneLoadBalancer().Scheme)) != out.LoadBalancerDescriptions[0].Scheme {
+		return nil, errors.Errorf(
+			"ELB names must be unique within a region: %q ELB already exists in this region with a different scheme %q",
+			name, *out.LoadBalancerDescriptions[0].Scheme)
 	}
 
 	outAtt, err := s.ELBClient.DescribeLoadBalancerAttributes(&elb.DescribeLoadBalancerAttributesInput{


### PR DESCRIPTION

**What this PR does / why we need it**:
In clusters that uses existing VPCs, if there is an existing LB with matching name but with different scheme, LB returns error saying the load balancer scheme is different.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2008

