### PR TITLE
loadbalancer: Fix NPE when comparing load balancers

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -29,7 +29,6 @@ import (
 	rgapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
@@ -583,7 +582,9 @@ func (s *Service) describeClassicELB(name string) (*infrav1.ClassicELB, error) {
 			name, *out.LoadBalancerDescriptions[0].VPCId)
 	}
 
-	if s.scope.ControlPlaneLoadBalancer().Scheme != nil && pointer.StringPtr(string(*s.scope.ControlPlaneLoadBalancer().Scheme)) != out.LoadBalancerDescriptions[0].Scheme {
+	if s.scope.ControlPlaneLoadBalancer() != nil &&
+		s.scope.ControlPlaneLoadBalancer().Scheme != nil &&
+		string(*s.scope.ControlPlaneLoadBalancer().Scheme) != aws.StringValue(out.LoadBalancerDescriptions[0].Scheme) {
 		return nil, errors.Errorf(
 			"ELB names must be unique within a region: %q ELB already exists in this region with a different scheme %q",
 			name, *out.LoadBalancerDescriptions[0].Scheme)


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

For addressing the following

```
E1210 19:57:59.133730       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 350 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1f3db60, 0x39e1490)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1f3db60, 0x39e1490)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/elb.(*Service).describeClassicELB(0xc00120cfc0, 0xc000eb0de0, 0x18, 0x0, 0x0, 0x0)
	/workspace/pkg/cloud/services/elb/loadbalancer.go:586 +0x29c
sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/elb.(*Service).ReconcileLoadbalancers(0xc00120cfc0, 0x0, 0x0)
	/workspace/pkg/cloud/services/elb/loadbalancer.go:58 +0xe4
sigs.k8s.io/cluster-api-provider-aws/controllers.reconcileNormal(0xc000f6e720, 0xc0006b7590, 0x274cf20, 0xc00072b3e0, 0xc00083b1e0)
	/workspace/controllers/awscluster_controller.go:195 +0x233
sigs.k8s.io/cluster-api-provider-aws/controllers.(*AWSClusterReconciler).Reconcile(0xc0000b4ff0, 0xc000766760, 0x17, 0xc0008001b0, 0xe, 0xc0005d8200, 0x0, 0x0, 0x0)
	/workspace/controllers/awscluster_controller.go:122 +0x6d6
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001d6840, 0x1ff7b40, 0xc0008f52a0, 0x0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:255 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0001d6840, 0xc0004aef00)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:231 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0001d6840)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:210 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000314630)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000314630, 0x3b9aca00, 0x0, 0x1, 0xc0003f6ba0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000314630, 0x3b9aca00, 0xc0003f6ba0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:192 +0x468
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1bbdd6c]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

