### PR TITLE
🐛 AWSMachinePool: Remove unused ID field on launch template spec

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -130,9 +130,6 @@ spec:
                   iamInstanceProfile:
                     description: The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.
                     type: string
-                  id:
-                    description: The ID of the launch template.
-                    type: string
                   imageLookupBaseOS:
                     description: ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.
                     type: string

--- a/exp/api/v1alpha3/types.go
+++ b/exp/api/v1alpha3/types.go
@@ -55,9 +55,6 @@ type BlockDeviceMapping struct {
 
 // AwsLaunchTemplate defines the desired state of AWSLaunchTemplate
 type AWSLaunchTemplate struct {
-	// The ID of the launch template.
-	ID string `json:"id,omitempty"`
-
 	// The name of the launch template.
 	Name string `json:"name,omitempty"`
 

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -309,7 +309,8 @@ func (r *AWSMachinePoolReconciler) reconcileDelete(machinePoolScope *scope.Machi
 		}
 	}
 
-	launchTemplate, err := ec2Svc.GetLaunchTemplate(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID)
+	launchTemplateID := machinePoolScope.AWSMachinePool.Status.LaunchTemplateID
+	launchTemplate, err := ec2Svc.GetLaunchTemplate(launchTemplateID)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -322,7 +323,7 @@ func (r *AWSMachinePoolReconciler) reconcileDelete(machinePoolScope *scope.Machi
 	}
 
 	machinePoolScope.Info("deleting launch template", "name", launchTemplate.Name)
-	if err := ec2Svc.DeleteLaunchTemplate(launchTemplate.ID); err != nil {
+	if err := ec2Svc.DeleteLaunchTemplate(launchTemplateID); err != nil {
 		r.Recorder.Eventf(machinePoolScope.AWSMachinePool, corev1.EventTypeWarning, "FailedDelete", "Failed to delete launch template %q: %v", launchTemplate.Name, err)
 		return ctrl.Result{}, errors.Wrap(err, "failed to delete ASG")
 	}

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -214,7 +214,6 @@ func (s *Service) DeleteLaunchTemplate(id string) error {
 func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1.AWSLaunchTemplate, error) {
 	v := d.LaunchTemplateData
 	i := &expinfrav1.AWSLaunchTemplate{
-		ID:   aws.StringValue(d.LaunchTemplateId),
 		Name: aws.StringValue(d.LaunchTemplateName),
 		AMI: infrav1.AWSResourceReference{
 			ID: v.ImageId,

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -124,7 +124,6 @@ func TestService_SDKToLaunchTemplate(t *testing.T) {
 				VersionNumber: aws.Int64(1),
 			},
 			want: &expinfrav1.AWSLaunchTemplate{
-				ID:   "lt-12345",
 				Name: "foo",
 				AMI: infrav1.AWSResourceReference{
 					ID: aws.String("foo-image"),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This field isn't actually respected if set on an `AWSMachinePool`, and in particular a user cannot reference an existing launch template in an `AWSMachinePool`, as far as I can tell. The `ID` field and the `AWSLaunchTemplate` struct are sort of abused internally to hold the results of fetching a launch template based on `status.launchTemplateID` but we don't need to hold the ID.
Ideally this use case would work, but until it does, I think it best to remove this field.