### PR TITLE
🐛 Leader election role binding uses default service account

### DIFF
--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system


### PR DESCRIPTION
**What this PR does / why we need it**:

After the changes in https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2100, we need to use capa-controller-manager serviceAccount in the leader-rolebinding as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

