### PR TITLE
🐛 test: investigate and fix eks e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run e2e test
 
 .PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
 test-e2e-eks: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests
-	time $(GINKGO) -trace -progress -v -tags=e2e $(GINKGO_ARGS) ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" --source-template="eks/cluster-template-eks-control-plane-only.yaml" --skip-eks-upgrade-tests $(E2E_ARGS)
+	time $(GINKGO) -trace -progress -v -tags=e2e $(GINKGO_ARGS) ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" --source-template="eks/cluster-template-eks-control-plane-only.yaml" $(E2E_ARGS)
 
 .PHONY: e2e-image
 e2e-image:

--- a/controlplane/eks/config/manager/manager_args_patch.yaml
+++ b/controlplane/eks/config/manager/manager_args_patch.yaml
@@ -14,3 +14,4 @@ spec:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
         - "--feature-gates=EKSEnableIAM=${EXP_EKS_IAM:=false},EKSAllowAddRoles=${EXP_EKS_ADD_ROLES:=false},MachinePool=${EXP_MACHINE_POOL:=false}"
+        - "--v=${EKS_CP_LOGLEVEL:=4}"

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -119,7 +119,7 @@ intervals:
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-controllers: ["3m", "10s"]
-  default/wait-delete-cluster: ["20m", "10s"]
+  default/wait-delete-cluster: ["30m", "10s"]
   default/wait-delete-machine: ["10m", "10s"]
   default/wait-delete-machine-deployment: ["10m", "10s"]
   default/wait-delete-machine-pool: ["20m", "10s"]

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -200,6 +200,7 @@ func Node1AfterSuite(e2eCtx *E2EContext) {
 	}
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
 	defer cancel()
+	DumpEKSClusters(ctx, e2eCtx)
 	for k := range e2eCtx.Environment.Namespaces {
 		DumpSpecResourcesAndCleanup(ctx, "", k, e2eCtx)
 		DumpMachines(ctx, e2eCtx, k)

--- a/test/e2e/suites/managed/eks_test.go
+++ b/test/e2e/suites/managed/eks_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 // General EKS e2e test
-var _ = Describe("EKS Cluster node types test", func() {
+var _ = Describe("EKS cluster tests", func() {
 	var (
 		namespace   *corev1.Namespace
 		ctx         context.Context
@@ -95,6 +95,16 @@ var _ = Describe("EKS Cluster node types test", func() {
 				ClusterName:           clusterName,
 				IncludeScaling:        true,
 				Cleanup:               true,
+			}
+		})
+
+		shared.Byf("should delete cluster %s", clusterName)
+		DeleteClusterSpec(ctx, func() DeleteClusterSpecInput {
+			return DeleteClusterSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ClusterName:           clusterName,
+				Namespace:             namespace,
 			}
 		})
 	})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The EKS e2e tests have stopped working on connection to the remote cluster (with a connection timeout).

This is PR to enable investigation and testing of the failure.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2179 

