### PR TITLE
New AMIs for Kubernetes versions 1.17.16, 1.18.14, 1.19.6, 1.20.1

### DIFF
--- a/docs/amis.md
+++ b/docs/amis.md
@@ -1,336 +1,356 @@
 # Latest pre-built Kubernetes AMIs  <!-- omit in toc -->
 
-<!-- Below is generated using VSCode yzhang.markdown-all-in-one >
+<!-- Below is generated using VSCode yzhang.markdown-all-in-one -->
 
 <!-- TOC -->
 
-- [Kubernetes Version v1.19.4](#kubernetes-version-v1192)
+- [Kubernetes Version v1.20.1](#kubernetes-version-v1201)
   - [Amazon Linux 2](#amazon-linux-2)
   - [CentOS 7](#centos-7)
   - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic)
-- [Kubernetes Version v1.18.12](#kubernetes-version-v1189)
+- [Kubernetes Version v1.19.6](#kubernetes-version-v1196)
   - [Amazon Linux 2](#amazon-linux-2-1)
   - [CentOS 7](#centos-7-1)
   - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal-1)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-1)
-- [Kubernetes Version v1.17.14](#kubernetes-version-v11712)
+- [Kubernetes Version v1.18.14](#kubernetes-version-v11814)
   - [Amazon Linux 2](#amazon-linux-2-2)
   - [CentOS 7](#centos-7-2)
   - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal-2)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-2)
-- [Kubernetes Version v1.16.15](#kubernetes-version-v11615)
+- [Kubernetes Version v1.17.16](#kubernetes-version-v11716)
   - [Amazon Linux 2](#amazon-linux-2-3)
   - [CentOS 7](#centos-7-3)
+  - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal-3)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-3)
 
 <!-- TOC -->
 
-## Kubernetes Version v1.19.5
+## Kubernetes Version v1.20.1
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-031b515d183c98b6f |
-| ap-northeast-2 | ami-0d7b8bda6f0abf0d1 |
-| ap-south-1     | ami-07760c2ff57fdf150 |
-| ap-southeast-1 | ami-08eb4a903faad593a |
-| ap-southeast-2 | ami-025c3d025ca83ab80 |
-| ca-central-1   | ami-017d7d5a6cd083da3 |
-| eu-central-1   | ami-045b112568e0ade89 |
-| eu-west-1      | ami-074845be12115a7b9 |
-| eu-west-2      | ami-0c7049e0f1ba28035 |
-| eu-west-3      | ami-021c20a8afa8a5ee7 |
-| sa-east-1      | ami-0809b54bf614c8856 |
-| us-east-1      | ami-01d7cf7b029ad674d |
-| us-east-2      | ami-0283bc0d1a27ea39b |
-| us-west-1      | ami-0a82730bf12bc9191 |
-| us-west-2      | ami-039107717d906453a |
+| ap-northeast-1 | ami-07fb84d3d80d1585d |
+| ap-northeast-2 | ami-012eb7f3c00ac6601 |
+| ap-south-1     | ami-0b74cad9c11d1f743 |
+| ap-southeast-1 | ami-0124349ad69c52cd3 |
+| ap-southeast-2 | ami-0a175fe7e620e5696 |
+| ca-central-1   | ami-0cd7051925fc44131 |
+| eu-central-1   | ami-030a4623040119ced |
+| eu-west-1      | ami-0c68fd2a22af9f6eb |
+| eu-west-2      | ami-09577c6b3e4dfc64d |
+| eu-west-3      | ami-0769fb3c9c92cef71 |
+| sa-east-1      | ami-0c75cec4e02d0a8cd |
+| us-east-1      | ami-0fceb871bd214883d |
+| us-east-2      | ami-071d40b0ac16ecfc9 |
+| us-west-1      | ami-00876401317dfe2db |
+| us-west-2      | ami-0603e17bb4ab18840 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0614018821fb70481 |
-| ap-northeast-2 | ami-039d0f24da0a4e200 |
-| ap-south-1     | ami-0daf3e7dd0f55f4df |
-| ap-southeast-1 | ami-01bb067fc1084e4c9 |
-| ap-southeast-2 | ami-0c4df88584bee6f67 |
-| ca-central-1   | ami-044d5accd69837495 |
-| eu-central-1   | ami-068b7e14ac5d86774 |
-| eu-west-1      | ami-045f86415c03fcc70 |
-| eu-west-2      | ami-0592ae09336dce4c4 |
-| eu-west-3      | ami-0c9e1676806431ed6 |
-| sa-east-1      | ami-0784e438a9eaca9d8 |
-| us-east-1      | ami-03773826045bf4c48 |
-| us-east-2      | ami-0db47ae41553615dc |
-| us-west-1      | ami-06ad834c0e90071b2 |
-| us-west-2      | ami-0a2435162128ff598 |
+| ap-northeast-1 | ami-02d9d8569fff5531c |
+| ap-northeast-2 | ami-0d7ca389e767eb158 |
+| ap-south-1     | ami-085bf1ad515b3fa7f |
+| ap-southeast-1 | ami-0489ff46038cfc888 |
+| ap-southeast-2 | ami-0ca97b4b579fe0d55 |
+| ca-central-1   | ami-07938452f16d30228 |
+| eu-central-1   | ami-0d1d35e425738f68f |
+| eu-west-1      | ami-0a0428a225dc131dc |
+| eu-west-2      | ami-09e6866d0f392dbf4 |
+| eu-west-3      | ami-0fb1c1545658220e3 |
+| sa-east-1      | ami-0bef2c84e10e005fd |
+| us-east-1      | ami-08fceaee5e09922f0 |
+| us-east-2      | ami-0d33b13fa243222ae |
+| us-west-1      | ami-03b77d4a167abb48f |
+| us-west-2      | ami-0ee7bf6c3acbc5190 |
 
 ### Ubuntu 20.04 (Focal)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0cfdf2b1dfe841b6f |
-| ap-northeast-2 | ami-0925ae81c566825e5 |
-| ap-south-1     | ami-09adfdb4981593ec0 |
-| ap-southeast-1 | ami-055aa3d9cb7c02cba |
-| ap-southeast-2 | ami-00752caa405eaf772 |
-| ca-central-1   | ami-0a3901139c9563f72 |
-| eu-central-1   | ami-06f6cf3431c796f8d |
-| eu-west-1      | ami-0745e450aae9931c3 |
-| eu-west-2      | ami-01f9a93c7fffca3cf |
-| eu-west-3      | ami-0fc7b571d5b8394d6 |
-| sa-east-1      | ami-0b414cde36b1b3bc2 |
-| us-east-1      | ami-06a19b7374e66c806 |
-| us-east-2      | ami-01ff7af4031e8e810 |
-| us-west-1      | ami-056afeae771e47266 |
-| us-west-2      | ami-09a478454c2d76fe0 |
+| ap-northeast-1 | ami-0080481ec34e771e7 |
+| ap-northeast-2 | ami-05c147dc4d7ac1eb1 |
+| ap-south-1     | ami-0f5567ea4774095e2 |
+| ap-southeast-1 | ami-0483151d09672625b |
+| ap-southeast-2 | ami-002b7748b42c7baf2 |
+| ca-central-1   | ami-0489190a3a3871280 |
+| eu-central-1   | ami-05aff95c3e3e14192 |
+| eu-west-1      | ami-01e4062a81e647523 |
+| eu-west-2      | ami-0f39b602298b01a72 |
+| eu-west-3      | ami-09c8c9a8f437da3d9 |
+| sa-east-1      | ami-0d3c25e4f36dd8cc8 |
+| us-east-1      | ami-0cc6c0e728a9eadd1 |
+| us-east-2      | ami-0f554c86b79e018d6 |
+| us-west-1      | ami-01850c058657cb1ed |
+| us-west-2      | ami-0fc18749aef0207fb |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0ad16e067790d552d |
-| ap-northeast-2 | ami-01b11229fe3415bc8 |
-| ap-south-1     | ami-0a8505d1cb61cb92c |
-| ap-southeast-1 | ami-07599f51af8aca855 |
-| ap-southeast-2 | ami-0df64621de3bc6902 |
-| ca-central-1   | ami-0b8605513ac2c299a |
-| eu-central-1   | ami-08c91834a5d4bc279 |
-| eu-west-1      | ami-052edde77d3c27158 |
-| eu-west-2      | ami-0e1dbcc60c6d38894 |
-| eu-west-3      | ami-02c320cfce511d761 |
-| sa-east-1      | ami-04377183e17434b8f |
-| us-east-1      | ami-08eabc82f7a59e111 |
-| us-east-2      | ami-04f1ae74adcbb7d4b |
-| us-west-1      | ami-0fafada1061c3c3e0 |
-| us-west-2      | ami-06e4300f26abde5c0 |
+| ap-northeast-1 | ami-0946af1df95a48f3c |
+| ap-northeast-2 | ami-0a2ba642ea163e983 |
+| ap-south-1     | ami-0bad82a7f2b375885 |
+| ap-southeast-1 | ami-08bf438e539f97939 |
+| ap-southeast-2 | ami-0fd49725559bcf5d0 |
+| ca-central-1   | ami-0cdc6e4828bcb5f52 |
+| eu-central-1   | ami-06e458bfb2fb6be50 |
+| eu-west-1      | ami-00279a3a2f1dc12b2 |
+| eu-west-2      | ami-0b8e5c54dcad6d28a |
+| eu-west-3      | ami-05423a4a0d6e1d88f |
+| sa-east-1      | ami-00dad5d3dfc293883 |
+| us-east-1      | ami-0de349d67d6a28cd1 |
+| us-east-2      | ami-00eb0d34ab1dfefed |
+| us-west-1      | ami-0ea093e8916dc0a51 |
+| us-west-2      | ami-09bc9bf339b3b90e8 |
 
-## Kubernetes Version v1.18.13
+## Kubernetes Version v1.19.6
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-09f05eb5b9cfa23ec |
-| ap-northeast-2 | ami-09b489192afb8a8c7 |
-| ap-south-1     | ami-03e5122616f898198 |
-| ap-southeast-1 | ami-0e212faa51ee92b65 |
-| ap-southeast-2 | ami-0452151566604740c |
-| ca-central-1   | ami-0db033cb873e3a670 |
-| eu-central-1   | ami-0f43482489fe75d25 |
-| eu-west-1      | ami-00d94635aec121ace |
-| eu-west-2      | ami-05706d623b7584146 |
-| eu-west-3      | ami-0d2741f7dcb885a57 |
-| sa-east-1      | ami-028aaaefcd14e350e |
-| us-east-1      | ami-006de2bbf73593aa6 |
-| us-east-2      | ami-01906a446c7628e62 |
-| us-west-1      | ami-0558a2bd68c183cd9 |
-| us-west-2      | ami-0d03ce0c1c93330d8 |
+| ap-northeast-1 | ami-0e01d45e33c9f0eee |
+| ap-northeast-2 | ami-0c2294c73518b16a0 |
+| ap-south-1     | ami-0a727586e308d9ac7 |
+| ap-southeast-1 | ami-0ef38f62de472c0c4 |
+| ap-southeast-2 | ami-07a90a3635e1ba001 |
+| ca-central-1   | ami-0f374d3ec69a5e31c |
+| eu-central-1   | ami-0cb0b5dfde3faf88f |
+| eu-west-1      | ami-0189ad5b9e5b914ab |
+| eu-west-2      | ami-03b1914dc08c781cb |
+| eu-west-3      | ami-0f13151c449cbdff3 |
+| sa-east-1      | ami-0123eabd62eb55d1d |
+| us-east-1      | ami-08015819901cb1012 |
+| us-east-2      | ami-086986043358db462 |
+| us-west-1      | ami-0f3b1127adcb777e2 |
+| us-west-2      | ami-00c1b8dc8eb2a18ec |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0f06098155be1fdbb |
-| ap-northeast-2 | ami-079b004e5c73e17f9 |
-| ap-south-1     | ami-037c09c3a570c7ce4 |
-| ap-southeast-1 | ami-065f2a56647da48f2 |
-| ap-southeast-2 | ami-0a481d04d8014b495 |
-| ca-central-1   | ami-0e2ce50490393fc72 |
-| eu-central-1   | ami-0a0199af3f44f608a |
-| eu-west-1      | ami-001f48482dea25766 |
-| eu-west-2      | ami-04fe670d0244e6a2b |
-| eu-west-3      | ami-0456dca6f84d0110d |
-| sa-east-1      | ami-0dc948b9961fda4f4 |
-| us-east-1      | ami-02ff11c6d45d88076 |
-| us-east-2      | ami-0e849de415df7f17c |
-| us-west-1      | ami-01f1796ecbc987314 |
-| us-west-2      | ami-0bc13e8c2752f4a32 |
+| ap-northeast-1 | ami-01c6f00448f816dc6 |
+| ap-northeast-2 | ami-08f7387dcc360c081 |
+| ap-south-1     | ami-081eab72f9d612bce |
+| ap-southeast-1 | ami-0d75c600d579a06a6 |
+| ap-southeast-2 | ami-05e0e9178841df73d |
+| ca-central-1   | ami-03f0df844e3feba04 |
+| eu-central-1   | ami-01df9e70292801c95 |
+| eu-west-1      | ami-0f39127f0e94dc8a5 |
+| eu-west-2      | ami-049025933438d09df |
+| eu-west-3      | ami-0e6422ae1884afebb |
+| sa-east-1      | ami-06b79a4a3284698b2 |
+| us-east-1      | ami-00f69ffae68884fe9 |
+| us-east-2      | ami-0430ed6e6a515fac8 |
+| us-west-1      | ami-05e2b8c914006aa92 |
+| us-west-2      | ami-0eab08cc890904102 |
 
 ### Ubuntu 20.04 (Focal)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-04b40a01a72906575 |
-| ap-northeast-2 | ami-0b6f15a5572b89a03 |
-| ap-south-1     | ami-0c75b3580a21c38f1 |
-| ap-southeast-1 | ami-07cf5420e1a90bbf2 |
-| ap-southeast-2 | ami-0e2eaf2ee6ab29e3e |
-| ca-central-1   | ami-0ef3853377695b69b |
-| eu-central-1   | ami-0c75d2483c358b56c |
-| eu-west-1      | ami-0d85c0d0910181d10 |
-| eu-west-2      | ami-0b3f3dc67fabef979 |
-| eu-west-3      | ami-0e06f2c7b8c833a8b |
-| sa-east-1      | ami-096692ec48d630a52 |
-| us-east-1      | ami-097af9ec0ea0f6076 |
-| us-east-2      | ami-01bd305e1c423022b |
-| us-west-1      | ami-0be12d231928905ff |
-| us-west-2      | ami-080d29a31d1647c8b |
+| ap-northeast-1 | ami-04756cd609e1163fe |
+| ap-northeast-2 | ami-08e5477a5a1634bee |
+| ap-south-1     | ami-01cabea6b5fae7409 |
+| ap-southeast-1 | ami-0e789a1237c6403e5 |
+| ap-southeast-2 | ami-07c228160373ea8a7 |
+| ca-central-1   | ami-0d0ff1dbb9ac00e4f |
+| eu-central-1   | ami-0c19243256810a906 |
+| eu-west-1      | ami-02638eb44439050f9 |
+| eu-west-2      | ami-0ef5068755e088df4 |
+| eu-west-3      | ami-02d3560795db16bca |
+| sa-east-1      | ami-031d00e7fc3fbba7d |
+| us-east-1      | ami-0a4e98cebed946aa2 |
+| us-east-2      | ami-055af13990fd4ffa2 |
+| us-west-1      | ami-0fb41e8b53ff0b35d |
+| us-west-2      | ami-01ce34e352f8017ae |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0a4c5d82c208b7f24 |
-| ap-northeast-2 | ami-0ca90ecb1025bba0b |
-| ap-south-1     | ami-062b04abccee04d6a |
-| ap-southeast-1 | ami-0d18f5ddc7d57fcbc |
-| ap-southeast-2 | ami-0bfeeecbaf952c3d2 |
-| ca-central-1   | ami-07c502d6b6e2ced38 |
-| eu-central-1   | ami-0db7334ad536ff082 |
-| eu-west-1      | ami-0c29b9b337ff5a898 |
-| eu-west-2      | ami-00e3c7cd6691ad3e6 |
-| eu-west-3      | ami-029e4fb57c6f183ea |
-| sa-east-1      | ami-08500eedfe3e27ae9 |
-| us-east-1      | ami-02f4e8e60c7781515 |
-| us-east-2      | ami-0ea56e1618425c1a6 |
-| us-west-1      | ami-0a51011f2382ae9de |
-| us-west-2      | ami-055fd561c2e2a4060 |
+| ap-northeast-1 | ami-01657bd1fcc450b0e |
+| ap-northeast-2 | ami-090e7b4cf9e3a6e5a |
+| ap-south-1     | ami-0551fc90a57fe0d51 |
+| ap-southeast-1 | ami-053877b1114dbfe6e |
+| ap-southeast-2 | ami-022f0921198a5055d |
+| ca-central-1   | ami-0c76fdf87b931be14 |
+| eu-central-1   | ami-0d3f896be378fab0b |
+| eu-west-1      | ami-0d43c7b06b524040d |
+| eu-west-2      | ami-0b871863b654c6ae0 |
+| eu-west-3      | ami-0affd3647fac7942f |
+| sa-east-1      | ami-029b1a32de70021b5 |
+| us-east-1      | ami-0f0ce06dbe9c2f20d |
+| us-east-2      | ami-0567dee6692fd9178 |
+| us-west-1      | ami-0bffaf3c133fcdb71 |
+| us-west-2      | ami-080df543220e3b580 |
 
-## Kubernetes Version v1.17.15
+## Kubernetes Version v1.18.14
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-093fb0c65415600c2 |
-| ap-northeast-2 | ami-06690df0ac06838da |
-| ap-south-1     | ami-094305859a5db319e |
-| ap-southeast-1 | ami-0fc6a6e4a12a8bf14 |
-| ap-southeast-2 | ami-05fecfc1a495f101e |
-| ca-central-1   | ami-0acd5a85045642b6d |
-| eu-central-1   | ami-0310a0e5b4761e8af |
-| eu-west-1      | ami-08aeac63c26378b1f |
-| eu-west-2      | ami-053f59dbaaf179450 |
-| eu-west-3      | ami-00c1b17e36a19b98f |
-| sa-east-1      | ami-06c276479bf0ed3c6 |
-| us-east-1      | ami-07d7b1eb76ef00f04 |
-| us-east-2      | ami-09893111280f6f93d |
-| us-west-1      | ami-0edc1f798a86ff8ac |
-| us-west-2      | ami-061f4bc311ca1c75b |
+| ap-northeast-1 | ami-0037ab6bbb0c90053 |
+| ap-northeast-2 | ami-09589b9a51e389a07 |
+| ap-south-1     | ami-00d594d0e1acab96d |
+| ap-southeast-1 | ami-0ec5e312a648ef695 |
+| ap-southeast-2 | ami-060c2a260d9768b92 |
+| ca-central-1   | ami-0232761c128f7c35b |
+| eu-central-1   | ami-03fc434a200580945 |
+| eu-west-1      | ami-0af646d36ad352e25 |
+| eu-west-2      | ami-0263fde08f4bba7ea |
+| eu-west-3      | ami-06ae90bc5b8f323c2 |
+| sa-east-1      | ami-02916e3caaaa34f76 |
+| us-east-1      | ami-0e1bccd0524342c2a |
+| us-east-2      | ami-00c878354407f84c6 |
+| us-west-1      | ami-018afd52bad192543 |
+| us-west-2      | ami-08dbcc3651d93c121 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0daf5146fa8e96f97 |
-| ap-northeast-2 | ami-0ae4fa7fe4866b855 |
-| ap-south-1     | ami-0d93d62a7dc1433df |
-| ap-southeast-1 | ami-0bfadfcca22e8a48f |
-| ap-southeast-2 | ami-041083a72b454792e |
-| ca-central-1   | ami-09a79a8cced4f0786 |
-| eu-central-1   | ami-01d6f9cc54957024e |
-| eu-west-1      | ami-0dfd2b69cb3c14e6d |
-| eu-west-2      | ami-018c3a23b55dd1a28 |
-| eu-west-3      | ami-0c86943ef8924c0f4 |
-| sa-east-1      | ami-018c1edd5c5d1695d |
-| us-east-1      | ami-03b703d5c6a0860a5 |
-| us-east-2      | ami-0dfb82b6f2938137f |
-| us-west-1      | ami-04a46156923aff301 |
-| us-west-2      | ami-09ce15bed3fe0a411 |
+| ap-northeast-1 | ami-0e6547e137b5b81c9 |
+| ap-northeast-2 | ami-047c9f80833fc5854 |
+| ap-south-1     | ami-09548a43cf815353c |
+| ap-southeast-1 | ami-087efb4fc89ffe3d7 |
+| ap-southeast-2 | ami-08d5d50237afbedf5 |
+| ca-central-1   | ami-0d6ce42936df81204 |
+| eu-central-1   | ami-00bed183af7d642aa |
+| eu-west-1      | ami-0f4803f2a6a89ff79 |
+| eu-west-2      | ami-0eb3997e1cd341d51 |
+| eu-west-3      | ami-0fdb103c42d1ca70a |
+| sa-east-1      | ami-05faa45f4f2725b4d |
+| us-east-1      | ami-07bfbc1788aa41bd7 |
+| us-east-2      | ami-08ad362a229915a24 |
+| us-west-1      | ami-05a71c9ba5df9df4e |
+| us-west-2      | ami-0687f479bff707c88 |
 
 ### Ubuntu 20.04 (Focal)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0308c3f333cc558c8 |
-| ap-northeast-2 | ami-072ab756cbedccdb5 |
-| ap-south-1     | ami-0ea18b330a5d881a9 |
-| ap-southeast-1 | ami-0632422905b006e4d |
-| ap-southeast-2 | ami-0b65861463b91b35c |
-| ca-central-1   | ami-089a43466b9f55c0a |
-| eu-central-1   | ami-03514535c760ccddf |
-| eu-west-1      | ami-005192403d4992b9d |
-| eu-west-2      | ami-0c7df31281513396c |
-| eu-west-3      | ami-041b1e5d2241c7597 |
-| sa-east-1      | ami-0e2616fc1fa09dce5 |
-| us-east-1      | ami-04d7ebc7f790d6a5c |
-| us-east-2      | ami-05a8eeba265235068 |
-| us-west-1      | ami-0a35287c847fe517b |
-| us-west-2      | ami-0fefed5604b4e517d |
+| ap-northeast-1 | ami-056a0f8aad5da8916 |
+| ap-northeast-2 | ami-01990c256a4d94da7 |
+| ap-south-1     | ami-0b1d43ff089102d20 |
+| ap-southeast-1 | ami-02093b6d7f5fb3c7b |
+| ap-southeast-2 | ami-0873b5a6e3782bd6b |
+| ca-central-1   | ami-08fd9a1d9350211a0 |
+| eu-central-1   | ami-025dade402786f5bb |
+| eu-west-1      | ami-0d55c81ac995d65c9 |
+| eu-west-2      | ami-03cd6d47c752ac682 |
+| eu-west-3      | ami-055c12a90f80e792b |
+| sa-east-1      | ami-0e1141320c838b14c |
+| us-east-1      | ami-0e558d1264acf1981 |
+| us-east-2      | ami-0b277fbc24c16ecf2 |
+| us-west-1      | ami-033686f19b97ab65e |
+| us-west-2      | ami-01a808bf9b5bd0748 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-05b82297d5fa86042 |
-| ap-northeast-2 | ami-03c7fede7f489da83 |
-| ap-south-1     | ami-0360c5de6d45a87e7 |
-| ap-southeast-1 | ami-0f3f219b072290931 |
-| ap-southeast-2 | ami-0d479221029d0aef6 |
-| ca-central-1   | ami-07fdd4882e661c985 |
-| eu-central-1   | ami-0217f721032c2a1f7 |
-| eu-west-1      | ami-099db154690a77f44 |
-| eu-west-2      | ami-0062e16214770eb22 |
-| eu-west-3      | ami-0c65def7e3448c85c |
-| sa-east-1      | ami-042b5bbae4f446d44 |
-| us-east-1      | ami-0f502e99a290372e7 |
-| us-east-2      | ami-079f96320fd43be89 |
-| us-west-1      | ami-07a8f0f0855874737 |
-| us-west-2      | ami-0597a16677c49b2e8 |
+| ap-northeast-1 | ami-01d19d1fc9bf37aed |
+| ap-northeast-2 | ami-0041756144d972ce3 |
+| ap-south-1     | ami-0246b59b79c485a36 |
+| ap-southeast-1 | ami-08425843f070a52e6 |
+| ap-southeast-2 | ami-06b0cf6a7a7ad9890 |
+| ca-central-1   | ami-0e7575fb8870bb245 |
+| eu-central-1   | ami-0455b35f66a867418 |
+| eu-west-1      | ami-029943a49cf9c65fd |
+| eu-west-2      | ami-0df2beea8d16fa396 |
+| eu-west-3      | ami-049aaee3409504082 |
+| sa-east-1      | ami-05588892e5dbe6f06 |
+| us-east-1      | ami-04097592f09bdd904 |
+| us-east-2      | ami-03fe97cdd4c083cbd |
+| us-west-1      | ami-0d3f3b7d7a760725f |
+| us-west-2      | ami-012df423af9e3cf4a |
 
-## Kubernetes Version v1.16.15
+## Kubernetes Version v1.17.16
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
-| -------------- | --------------------- |
-| ap-northeast-1 | ami-07d7f122e39e0d659 |
-| ap-northeast-2 | ami-0481ea57dfa758d51 |
-| ap-south-1     | ami-0c5eda038666fb420 |
-| ap-southeast-1 | ami-0f7e2deb05c6d57f3 |
-| ap-southeast-2 | ami-076124b3ad1726696 |
-| ca-central-1   | ami-04541468b59c41bdc |
-| eu-central-1   | ami-0e5f802d4525429b6 |
-| eu-west-1      | ami-0b6ddde65046661da |
-| eu-west-2      | ami-0e7babfcb39b88e10 |
-| eu-west-3      | ami-0244d27208dcb37ea |
-| sa-east-1      | ami-04a5c179a3ab90aea |
-| us-east-1      | ami-0e9152d6c14040f7a |
-| us-east-2      | ami-0473d3f15c2eaeb8f |
-| us-west-1      | ami-06357681d35da50e2 |
-| us-west-2      | ami-06575bde05fbb98f0 |
-
+|----------------|-----------------------|
+| ap-northeast-1 | ami-0151c94334b4ade3c |
+| ap-northeast-2 | ami-0f69526fd32301b89 |
+| ap-south-1     | ami-03bb5d00709a4c4b2 |
+| ap-southeast-1 | ami-0490f7ad0f2bd2791 |
+| ap-southeast-2 | ami-0d3333fe1018560f4 |
+| ca-central-1   | ami-035aa3b93ac4d8146 |
+| eu-central-1   | ami-0a7cf92a0f279f72b |
+| eu-west-1      | ami-01a4f001c3f57754b |
+| eu-west-2      | ami-0f1968f77bb9b316f |
+| eu-west-3      | ami-0cd11641c2ab7adac |
+| sa-east-1      | ami-0652075d2b221785d |
+| us-east-1      | ami-09e7d21f9bc00da4b |
+| us-east-2      | ami-0b8b8d79035eda813 |
+| us-west-1      | ami-08e99eca3ee123712 |
+| us-west-2      | ami-05e32bb894fc8d5c7 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
-| -------------- | --------------------- |
-| ap-northeast-1 | ami-04f4e87ff8b29e2e7 |
-| ap-northeast-2 | ami-066ed4b7eed2dc4e1 |
-| ap-south-1     | ami-04c538740b8de05be |
-| ap-southeast-1 | ami-0719afecc276ca4c9 |
-| ap-southeast-2 | ami-001032c42bba4a812 |
-| ca-central-1   | ami-09155719f41b52db7 |
-| eu-central-1   | ami-068bcbb464d44fd22 |
-| eu-west-1      | ami-04e1769e36402dc9c |
-| eu-west-2      | ami-0f1bd070582bf7abc |
-| eu-west-3      | ami-0db64677189ca2376 |
-| sa-east-1      | ami-0daa73780d22722e6 |
-| us-east-1      | ami-00c6cc15ff4e735c6 |
-| us-east-2      | ami-0ddb8b6fb58bc7f63 |
-| us-west-1      | ami-0f24bd8d74e2cb6dc |
-| us-west-2      | ami-008b251034c1b02b7 |
+|----------------|-----------------------|
+| ap-northeast-1 | ami-0b343426a3a004c0e |
+| ap-northeast-2 | ami-005fcc2ddecc76716 |
+| ap-south-1     | ami-0032cf2e680e9ecd3 |
+| ap-southeast-1 | ami-0992464cce7f6ba44 |
+| ap-southeast-2 | ami-0a5ef7bbc0ab3f2a5 |
+| ca-central-1   | ami-0100fc28c8751ed32 |
+| eu-central-1   | ami-021f81a1e75ad97e0 |
+| eu-west-1      | ami-04fcb053c75a4bf5a |
+| eu-west-2      | ami-0718cc54836f73dea |
+| eu-west-3      | ami-09833a2bd916f7865 |
+| sa-east-1      | ami-0880cf60f5c4b2fcb |
+| us-east-1      | ami-0b97fbf3881269034 |
+| us-east-2      | ami-02c7e1da5cd3b79bf |
+| us-west-1      | ami-05641c7ee6e29f24c |
+| us-west-2      | ami-05b8bac8a54b4eedf |
+
+### Ubuntu 20.04 (Focal)
+
+| Region         | AMI                   |
+|----------------|-----------------------|
+| ap-northeast-1 | ami-0ba86f52e38d43e11 |
+| ap-northeast-2 | ami-0eeb2e8442c55fff2 |
+| ap-south-1     | ami-09b746555e8a4a57f |
+| ap-southeast-1 | ami-061ded98ce1ed7f4d |
+| ap-southeast-2 | ami-0223a1450581d85ec |
+| ca-central-1   | ami-0230caab35f4d9c7d |
+| eu-central-1   | ami-00ca5335ed110a01e |
+| eu-west-1      | ami-0dd1546c60b046fe7 |
+| eu-west-2      | ami-0836852a851bacf96 |
+| eu-west-3      | ami-0f59205b2f0db96b9 |
+| sa-east-1      | ami-0a0343368107d9e92 |
+| us-east-1      | ami-070786693c4ebcea3 |
+| us-east-2      | ami-08b768f129510a647 |
+| us-west-1      | ami-0107dd5e31f4c79a9 |
+| us-west-2      | ami-081e0f604341ed3b1 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
-| -------------- | --------------------- |
-| ap-northeast-1 | ami-0ee601075e6dfc130 |
-| ap-northeast-2 | ami-0c57172adf32ce110 |
-| ap-south-1     | ami-09d61b7e7a2e21d68 |
-| ap-southeast-1 | ami-0dfc9c034901e79ff |
-| ap-southeast-2 | ami-040ec1427b2a6e240 |
-| ca-central-1   | ami-0287e54249ae5f915 |
-| eu-central-1   | ami-0a7f7be76a09818a9 |
-| eu-west-1      | ami-0e241b24b5938395f |
-| eu-west-2      | ami-0b811deccfc4fc339 |
-| eu-west-3      | ami-01f8a9a70afde3b3f |
-| sa-east-1      | ami-08557f37ad5af8caa |
-| us-east-1      | ami-0e7946a5e49799988 |
-| us-east-2      | ami-068f28225f778c989 |
-| us-west-1      | ami-05eb589d7ff69796a |
-| us-west-2      | ami-02544569e9fd7ed59 |
+|----------------|-----------------------|
+| ap-northeast-1 | ami-0acbefbeeca8403b5 |
+| ap-northeast-2 | ami-00b63a9347f62d85c |
+| ap-south-1     | ami-0c829e5b0f95c5a71 |
+| ap-southeast-1 | ami-02a5e11261c873172 |
+| ap-southeast-2 | ami-0a65a66bfa63af62f |
+| ca-central-1   | ami-022513e320cebffc0 |
+| eu-central-1   | ami-057df83fc6353e961 |
+| eu-west-1      | ami-09c3eb3753dafd5b0 |
+| eu-west-2      | ami-0c862a33925709571 |
+| eu-west-3      | ami-08ed0f6e37c94448a |
+| sa-east-1      | ami-023220c3cd9c47857 |
+| us-east-1      | ami-086257cfa05f77b5d |
+| us-east-2      | ami-05a4bb76a4710e783 |
+| us-west-1      | ami-0b35ac5d7f19255e6 |
+| us-west-2      | ami-05aea9d24e22cd74a |


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2174

