### PR TITLE
🌱 New AMIs for Kubernetes versions 1.20.2, 1.19.6, 1.18.15, 1.17.17

### DIFF
--- a/docs/amis.md
+++ b/docs/amis.md
@@ -4,22 +4,22 @@
 
 <!-- TOC -->
 
-- [Kubernetes Version v1.20.1](#kubernetes-version-v1201)
+- [Kubernetes Version v1.20.2](#kubernetes-version-v1202)
   - [Amazon Linux 2](#amazon-linux-2)
   - [CentOS 7](#centos-7)
   - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic)
-- [Kubernetes Version v1.19.6](#kubernetes-version-v1196)
+- [Kubernetes Version v1.19.7](#kubernetes-version-v1197)
   - [Amazon Linux 2](#amazon-linux-2-1)
   - [CentOS 7](#centos-7-1)
   - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal-1)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-1)
-- [Kubernetes Version v1.18.14](#kubernetes-version-v11814)
+- [Kubernetes Version v1.18.15](#kubernetes-version-v11815)
   - [Amazon Linux 2](#amazon-linux-2-2)
   - [CentOS 7](#centos-7-2)
   - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal-2)
   - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-bionic-2)
-- [Kubernetes Version v1.17.16](#kubernetes-version-v11716)
+- [Kubernetes Version v1.17.17](#kubernetes-version-v11717)
   - [Amazon Linux 2](#amazon-linux-2-3)
   - [CentOS 7](#centos-7-3)
   - [Ubuntu 20.04 (Focal)](#ubuntu-2004-focal-3)
@@ -27,330 +27,330 @@
 
 <!-- TOC -->
 
-## Kubernetes Version v1.20.1
+## Kubernetes Version v1.20.2
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-07fb84d3d80d1585d |
-| ap-northeast-2 | ami-012eb7f3c00ac6601 |
-| ap-south-1     | ami-0b74cad9c11d1f743 |
-| ap-southeast-1 | ami-0124349ad69c52cd3 |
-| ap-southeast-2 | ami-0a175fe7e620e5696 |
-| ca-central-1   | ami-0cd7051925fc44131 |
-| eu-central-1   | ami-030a4623040119ced |
-| eu-west-1      | ami-0c68fd2a22af9f6eb |
-| eu-west-2      | ami-09577c6b3e4dfc64d |
-| eu-west-3      | ami-0769fb3c9c92cef71 |
-| sa-east-1      | ami-0c75cec4e02d0a8cd |
-| us-east-1      | ami-0fceb871bd214883d |
-| us-east-2      | ami-071d40b0ac16ecfc9 |
-| us-west-1      | ami-00876401317dfe2db |
-| us-west-2      | ami-0603e17bb4ab18840 |
+| ap-northeast-1 | ami-08f1c849e538a5bf2 |
+| ap-northeast-2 | ami-052d9c4e98a186fc7 |
+| ap-south-1     | ami-0afbf3ca9312ea3ed |
+| ap-southeast-1 | ami-078c91d91764e5b96 |
+| ap-southeast-2 | ami-08c4423237227610f |
+| ca-central-1   | ami-08867e553c9fab2ac |
+| eu-central-1   | ami-03c07b1eef58a0f35 |
+| eu-west-1      | ami-02bd40b2b8aef73ff |
+| eu-west-2      | ami-059146cee486edf1d |
+| eu-west-3      | ami-0355b41339e700058 |
+| sa-east-1      | ami-0e75b0bab5c31c9a1 |
+| us-east-1      | ami-0c23a073dd74f28d9 |
+| us-east-2      | ami-042de29361eec629e |
+| us-west-1      | ami-05c189a1d0e1a2e2c |
+| us-west-2      | ami-0ab4a184788d0e794 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-02d9d8569fff5531c |
-| ap-northeast-2 | ami-0d7ca389e767eb158 |
-| ap-south-1     | ami-085bf1ad515b3fa7f |
-| ap-southeast-1 | ami-0489ff46038cfc888 |
-| ap-southeast-2 | ami-0ca97b4b579fe0d55 |
-| ca-central-1   | ami-07938452f16d30228 |
-| eu-central-1   | ami-0d1d35e425738f68f |
-| eu-west-1      | ami-0a0428a225dc131dc |
-| eu-west-2      | ami-09e6866d0f392dbf4 |
-| eu-west-3      | ami-0fb1c1545658220e3 |
-| sa-east-1      | ami-0bef2c84e10e005fd |
-| us-east-1      | ami-08fceaee5e09922f0 |
-| us-east-2      | ami-0d33b13fa243222ae |
-| us-west-1      | ami-03b77d4a167abb48f |
-| us-west-2      | ami-0ee7bf6c3acbc5190 |
+| ap-northeast-1 | ami-06fc83c7dd2ad5352 |
+| ap-northeast-2 | ami-0b3922497d96f01dd |
+| ap-south-1     | ami-0a0a39cc7ed73c9e1 |
+| ap-southeast-1 | ami-005019e8a701676f3 |
+| ap-southeast-2 | ami-0a4012511edb76511 |
+| ca-central-1   | ami-023320f0b34c6edce |
+| eu-central-1   | ami-0802cf31a46a3ae0d |
+| eu-west-1      | ami-0e9900d4dd542eb51 |
+| eu-west-2      | ami-0c3fbfcf55314e380 |
+| eu-west-3      | ami-06e2e6936c9381374 |
+| sa-east-1      | ami-068669a30b7040f67 |
+| us-east-1      | ami-0b1b25eb79deef9f1 |
+| us-east-2      | ami-0fbf61967e4fbf346 |
+| us-west-1      | ami-05f015d1e77e5bc37 |
+| us-west-2      | ami-099b315b80b711f2c |
 
 ### Ubuntu 20.04 (Focal)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0080481ec34e771e7 |
-| ap-northeast-2 | ami-05c147dc4d7ac1eb1 |
-| ap-south-1     | ami-0f5567ea4774095e2 |
-| ap-southeast-1 | ami-0483151d09672625b |
-| ap-southeast-2 | ami-002b7748b42c7baf2 |
-| ca-central-1   | ami-0489190a3a3871280 |
-| eu-central-1   | ami-05aff95c3e3e14192 |
-| eu-west-1      | ami-01e4062a81e647523 |
-| eu-west-2      | ami-0f39b602298b01a72 |
-| eu-west-3      | ami-09c8c9a8f437da3d9 |
-| sa-east-1      | ami-0d3c25e4f36dd8cc8 |
-| us-east-1      | ami-0cc6c0e728a9eadd1 |
-| us-east-2      | ami-0f554c86b79e018d6 |
-| us-west-1      | ami-01850c058657cb1ed |
-| us-west-2      | ami-0fc18749aef0207fb |
+| ap-northeast-1 | ami-03d19e7f9c92f467c |
+| ap-northeast-2 | ami-05800f9d7282864c3 |
+| ap-south-1     | ami-06d923dd1d241aab2 |
+| ap-southeast-1 | ami-0651a02ee1c8a5403 |
+| ap-southeast-2 | ami-05133c2a63775d9d0 |
+| ca-central-1   | ami-04d7097f040c18fe5 |
+| eu-central-1   | ami-08e0a3681d74b6470 |
+| eu-west-1      | ami-0303e8f39ab75fa17 |
+| eu-west-2      | ami-07d9e6d8b52a38c9d |
+| eu-west-3      | ami-0f70faf1041783407 |
+| sa-east-1      | ami-038012d61d38fea5f |
+| us-east-1      | ami-081bce5054146da56 |
+| us-east-2      | ami-08938ad6af018bca5 |
+| us-west-1      | ami-0a0daa6133c12b843 |
+| us-west-2      | ami-0abb213968a99f995 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0946af1df95a48f3c |
-| ap-northeast-2 | ami-0a2ba642ea163e983 |
-| ap-south-1     | ami-0bad82a7f2b375885 |
-| ap-southeast-1 | ami-08bf438e539f97939 |
-| ap-southeast-2 | ami-0fd49725559bcf5d0 |
-| ca-central-1   | ami-0cdc6e4828bcb5f52 |
-| eu-central-1   | ami-06e458bfb2fb6be50 |
-| eu-west-1      | ami-00279a3a2f1dc12b2 |
-| eu-west-2      | ami-0b8e5c54dcad6d28a |
-| eu-west-3      | ami-05423a4a0d6e1d88f |
-| sa-east-1      | ami-00dad5d3dfc293883 |
-| us-east-1      | ami-0de349d67d6a28cd1 |
-| us-east-2      | ami-00eb0d34ab1dfefed |
-| us-west-1      | ami-0ea093e8916dc0a51 |
-| us-west-2      | ami-09bc9bf339b3b90e8 |
+| ap-northeast-1 | ami-0a21ab7116a3289f1 |
+| ap-northeast-2 | ami-0e32bf56354c15522 |
+| ap-south-1     | ami-0a97b388e3ebad8bb |
+| ap-southeast-1 | ami-0580a85d099ccad3a |
+| ap-southeast-2 | ami-0d4ec8fb8e0e2bd6c |
+| ca-central-1   | ami-099ce442fd86bfcc2 |
+| eu-central-1   | ami-0a095b4707c639fc0 |
+| eu-west-1      | ami-020e0586cebbeb315 |
+| eu-west-2      | ami-0d78d7604a07b77b1 |
+| eu-west-3      | ami-0c93410fc7013fbd8 |
+| sa-east-1      | ami-0fdbb8b9ad776a6a8 |
+| us-east-1      | ami-03613efe57327a8ae |
+| us-east-2      | ami-02497177e1cc66c63 |
+| us-west-1      | ami-03322dd754e3f53ae |
+| us-west-2      | ami-03fe46b33dc62e558 |
 
-## Kubernetes Version v1.19.6
+## Kubernetes Version v1.19.7
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0e01d45e33c9f0eee |
-| ap-northeast-2 | ami-0c2294c73518b16a0 |
-| ap-south-1     | ami-0a727586e308d9ac7 |
-| ap-southeast-1 | ami-0ef38f62de472c0c4 |
-| ap-southeast-2 | ami-07a90a3635e1ba001 |
-| ca-central-1   | ami-0f374d3ec69a5e31c |
-| eu-central-1   | ami-0cb0b5dfde3faf88f |
-| eu-west-1      | ami-0189ad5b9e5b914ab |
-| eu-west-2      | ami-03b1914dc08c781cb |
-| eu-west-3      | ami-0f13151c449cbdff3 |
-| sa-east-1      | ami-0123eabd62eb55d1d |
-| us-east-1      | ami-08015819901cb1012 |
-| us-east-2      | ami-086986043358db462 |
-| us-west-1      | ami-0f3b1127adcb777e2 |
-| us-west-2      | ami-00c1b8dc8eb2a18ec |
+| ap-northeast-1 | ami-09e44828e9cb02db6 |
+| ap-northeast-2 | ami-047c93e6ed6fec7c6 |
+| ap-south-1     | ami-0fd163b364e8c9667 |
+| ap-southeast-1 | ami-0ef42dd5d4ce32dfc |
+| ap-southeast-2 | ami-09bd19d8966aa196d |
+| ca-central-1   | ami-028c37652f5c9d6e0 |
+| eu-central-1   | ami-0805022e8f12e4f4e |
+| eu-west-1      | ami-0ce3fa34a21d75a3a |
+| eu-west-2      | ami-0cac25f0f79bdf2d6 |
+| eu-west-3      | ami-0969934ac9167adc4 |
+| sa-east-1      | ami-027358235f0177e2a |
+| us-east-1      | ami-031c9a1c0eddf13e9 |
+| us-east-2      | ami-045843ec18f9ffd53 |
+| us-west-1      | ami-03a03eb8cc10aaa5c |
+| us-west-2      | ami-08b2d361859644ec7 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-01c6f00448f816dc6 |
-| ap-northeast-2 | ami-08f7387dcc360c081 |
-| ap-south-1     | ami-081eab72f9d612bce |
-| ap-southeast-1 | ami-0d75c600d579a06a6 |
-| ap-southeast-2 | ami-05e0e9178841df73d |
-| ca-central-1   | ami-03f0df844e3feba04 |
-| eu-central-1   | ami-01df9e70292801c95 |
-| eu-west-1      | ami-0f39127f0e94dc8a5 |
-| eu-west-2      | ami-049025933438d09df |
-| eu-west-3      | ami-0e6422ae1884afebb |
-| sa-east-1      | ami-06b79a4a3284698b2 |
-| us-east-1      | ami-00f69ffae68884fe9 |
-| us-east-2      | ami-0430ed6e6a515fac8 |
-| us-west-1      | ami-05e2b8c914006aa92 |
-| us-west-2      | ami-0eab08cc890904102 |
+| ap-northeast-1 | ami-0d40972ba1ebf63f7 |
+| ap-northeast-2 | ami-03a0489105949b7a1 |
+| ap-south-1     | ami-048b737b382e5ff07 |
+| ap-southeast-1 | ami-0e2b805c0d6f14b6a |
+| ap-southeast-2 | ami-0435cb65123edf786 |
+| ca-central-1   | ami-0924a1cb97c17a258 |
+| eu-central-1   | ami-0bf02ffbacf64b9ab |
+| eu-west-1      | ami-0d07cbee648cd8d03 |
+| eu-west-2      | ami-01847fd4da2525e53 |
+| eu-west-3      | ami-0783f2debf60740c0 |
+| sa-east-1      | ami-003929e23b6ddec86 |
+| us-east-1      | ami-0ce96248192f29663 |
+| us-east-2      | ami-0bab976d0673b0ab2 |
+| us-west-1      | ami-00517ca0626aa1239 |
+| us-west-2      | ami-0aa17735eaf445298 |
 
 ### Ubuntu 20.04 (Focal)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-04756cd609e1163fe |
-| ap-northeast-2 | ami-08e5477a5a1634bee |
-| ap-south-1     | ami-01cabea6b5fae7409 |
-| ap-southeast-1 | ami-0e789a1237c6403e5 |
-| ap-southeast-2 | ami-07c228160373ea8a7 |
-| ca-central-1   | ami-0d0ff1dbb9ac00e4f |
-| eu-central-1   | ami-0c19243256810a906 |
-| eu-west-1      | ami-02638eb44439050f9 |
-| eu-west-2      | ami-0ef5068755e088df4 |
-| eu-west-3      | ami-02d3560795db16bca |
-| sa-east-1      | ami-031d00e7fc3fbba7d |
-| us-east-1      | ami-0a4e98cebed946aa2 |
-| us-east-2      | ami-055af13990fd4ffa2 |
-| us-west-1      | ami-0fb41e8b53ff0b35d |
-| us-west-2      | ami-01ce34e352f8017ae |
+| ap-northeast-1 | ami-070bc220ec420bdc4 |
+| ap-northeast-2 | ami-0bc2e6b5ea4fa7a36 |
+| ap-south-1     | ami-00f93b360543804ca |
+| ap-southeast-1 | ami-05a66da8b7d281c89 |
+| ap-southeast-2 | ami-040b78e9e4a8ea406 |
+| ca-central-1   | ami-03cf114fb5de086f5 |
+| eu-central-1   | ami-0770637e79b4392db |
+| eu-west-1      | ami-06588046e9728cb8b |
+| eu-west-2      | ami-0a56f7636ea4f9dea |
+| eu-west-3      | ami-0ca9786f7d5c27fe2 |
+| sa-east-1      | ami-0948c43e1ee3115e4 |
+| us-east-1      | ami-072a89e5510b76666 |
+| us-east-2      | ami-051c4ae92248ef6c1 |
+| us-west-1      | ami-01f37859671220327 |
+| us-west-2      | ami-0e1d576466da2ee5c |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-01657bd1fcc450b0e |
-| ap-northeast-2 | ami-090e7b4cf9e3a6e5a |
-| ap-south-1     | ami-0551fc90a57fe0d51 |
-| ap-southeast-1 | ami-053877b1114dbfe6e |
-| ap-southeast-2 | ami-022f0921198a5055d |
-| ca-central-1   | ami-0c76fdf87b931be14 |
-| eu-central-1   | ami-0d3f896be378fab0b |
-| eu-west-1      | ami-0d43c7b06b524040d |
-| eu-west-2      | ami-0b871863b654c6ae0 |
-| eu-west-3      | ami-0affd3647fac7942f |
-| sa-east-1      | ami-029b1a32de70021b5 |
-| us-east-1      | ami-0f0ce06dbe9c2f20d |
-| us-east-2      | ami-0567dee6692fd9178 |
-| us-west-1      | ami-0bffaf3c133fcdb71 |
-| us-west-2      | ami-080df543220e3b580 |
+| ap-northeast-1 | ami-0b436354af2a24f25 |
+| ap-northeast-2 | ami-0cd9af65beb92460b |
+| ap-south-1     | ami-01e33ca1851645539 |
+| ap-southeast-1 | ami-08d9def79ba707b92 |
+| ap-southeast-2 | ami-06bdcf9fc7527eea1 |
+| ca-central-1   | ami-0979e3a6979a4a01f |
+| eu-central-1   | ami-09c026dfd3491a5ba |
+| eu-west-1      | ami-02709a7319a04f0ef |
+| eu-west-2      | ami-0fd8256d374fdd02d |
+| eu-west-3      | ami-0003b7f79b9f9754e |
+| sa-east-1      | ami-045125e0075e31ff0 |
+| us-east-1      | ami-0795593d8010f9fa8 |
+| us-east-2      | ami-07d821126c393a39e |
+| us-west-1      | ami-0074907b68109800a |
+| us-west-2      | ami-06ffa27ce26b22a1b |
 
-## Kubernetes Version v1.18.14
+## Kubernetes Version v1.18.15
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0037ab6bbb0c90053 |
-| ap-northeast-2 | ami-09589b9a51e389a07 |
-| ap-south-1     | ami-00d594d0e1acab96d |
-| ap-southeast-1 | ami-0ec5e312a648ef695 |
-| ap-southeast-2 | ami-060c2a260d9768b92 |
-| ca-central-1   | ami-0232761c128f7c35b |
-| eu-central-1   | ami-03fc434a200580945 |
-| eu-west-1      | ami-0af646d36ad352e25 |
-| eu-west-2      | ami-0263fde08f4bba7ea |
-| eu-west-3      | ami-06ae90bc5b8f323c2 |
-| sa-east-1      | ami-02916e3caaaa34f76 |
-| us-east-1      | ami-0e1bccd0524342c2a |
-| us-east-2      | ami-00c878354407f84c6 |
-| us-west-1      | ami-018afd52bad192543 |
-| us-west-2      | ami-08dbcc3651d93c121 |
+| ap-northeast-1 | ami-05197f8d0bb3ddc9e |
+| ap-northeast-2 | ami-0ca82c2ddeb2b980c |
+| ap-south-1     | ami-0d3993641bc74a485 |
+| ap-southeast-1 | ami-0aee899acce46aa69 |
+| ap-southeast-2 | ami-0f03f90361057feb6 |
+| ca-central-1   | ami-0d3e72481cdb7b066 |
+| eu-central-1   | ami-05956d6ff08966f41 |
+| eu-west-1      | ami-06c71c32e30af1c39 |
+| eu-west-2      | ami-06a0bc7aa8893967a |
+| eu-west-3      | ami-0ad62a39afc153f7a |
+| sa-east-1      | ami-03ff9b9126d18b2ee |
+| us-east-1      | ami-03d666b21e0d81f0b |
+| us-east-2      | ami-0d88bb27b397bbcd7 |
+| us-west-1      | ami-0af3810549971ed32 |
+| us-west-2      | ami-0fe544ab0770de16e |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0e6547e137b5b81c9 |
-| ap-northeast-2 | ami-047c9f80833fc5854 |
-| ap-south-1     | ami-09548a43cf815353c |
-| ap-southeast-1 | ami-087efb4fc89ffe3d7 |
-| ap-southeast-2 | ami-08d5d50237afbedf5 |
-| ca-central-1   | ami-0d6ce42936df81204 |
-| eu-central-1   | ami-00bed183af7d642aa |
-| eu-west-1      | ami-0f4803f2a6a89ff79 |
-| eu-west-2      | ami-0eb3997e1cd341d51 |
-| eu-west-3      | ami-0fdb103c42d1ca70a |
-| sa-east-1      | ami-05faa45f4f2725b4d |
-| us-east-1      | ami-07bfbc1788aa41bd7 |
-| us-east-2      | ami-08ad362a229915a24 |
-| us-west-1      | ami-05a71c9ba5df9df4e |
-| us-west-2      | ami-0687f479bff707c88 |
+| ap-northeast-1 | ami-072484c38f04d7ba3 |
+| ap-northeast-2 | ami-008c51622bb289bef |
+| ap-south-1     | ami-0b7df581fef6422ad |
+| ap-southeast-1 | ami-04fd184a0a605a435 |
+| ap-southeast-2 | ami-078e2e4584f732476 |
+| ca-central-1   | ami-0707d5462172ccbef |
+| eu-central-1   | ami-044ffa65feb3d094e |
+| eu-west-1      | ami-00c5a1952d409e708 |
+| eu-west-2      | ami-05d0c74ccd9c99b77 |
+| eu-west-3      | ami-014e14d17f2e5d963 |
+| sa-east-1      | ami-016f872014ce6cbca |
+| us-east-1      | ami-06e010fd597442afb |
+| us-east-2      | ami-058813d7a05f57679 |
+| us-west-1      | ami-0b27567542837e829 |
+| us-west-2      | ami-0a5f1532a9bf3ea95 |
 
 ### Ubuntu 20.04 (Focal)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-056a0f8aad5da8916 |
-| ap-northeast-2 | ami-01990c256a4d94da7 |
-| ap-south-1     | ami-0b1d43ff089102d20 |
-| ap-southeast-1 | ami-02093b6d7f5fb3c7b |
-| ap-southeast-2 | ami-0873b5a6e3782bd6b |
-| ca-central-1   | ami-08fd9a1d9350211a0 |
-| eu-central-1   | ami-025dade402786f5bb |
-| eu-west-1      | ami-0d55c81ac995d65c9 |
-| eu-west-2      | ami-03cd6d47c752ac682 |
-| eu-west-3      | ami-055c12a90f80e792b |
-| sa-east-1      | ami-0e1141320c838b14c |
-| us-east-1      | ami-0e558d1264acf1981 |
-| us-east-2      | ami-0b277fbc24c16ecf2 |
-| us-west-1      | ami-033686f19b97ab65e |
-| us-west-2      | ami-01a808bf9b5bd0748 |
+| ap-northeast-1 | ami-0538ed9b2dbeddcd9 |
+| ap-northeast-2 | ami-077aded8754b60d7d |
+| ap-south-1     | ami-0f9706a668ca55bff |
+| ap-southeast-1 | ami-0f43c910a927ad721 |
+| ap-southeast-2 | ami-06a21531afe0fc6cf |
+| ca-central-1   | ami-057da5af3449ba914 |
+| eu-central-1   | ami-02326a6f44760aa57 |
+| eu-west-1      | ami-0a01b1aafb683588e |
+| eu-west-2      | ami-02dbe1a5916b5730f |
+| eu-west-3      | ami-0e390bdaf08cb2293 |
+| sa-east-1      | ami-01f05a9f6c6583f0b |
+| us-east-1      | ami-0acae5c2e63423ef0 |
+| us-east-2      | ami-02b41d39a943f7086 |
+| us-west-1      | ami-0bb9dfc34abed43b8 |
+| us-west-2      | ami-0643df9dd36fa2529 |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-01d19d1fc9bf37aed |
-| ap-northeast-2 | ami-0041756144d972ce3 |
-| ap-south-1     | ami-0246b59b79c485a36 |
-| ap-southeast-1 | ami-08425843f070a52e6 |
-| ap-southeast-2 | ami-06b0cf6a7a7ad9890 |
-| ca-central-1   | ami-0e7575fb8870bb245 |
-| eu-central-1   | ami-0455b35f66a867418 |
-| eu-west-1      | ami-029943a49cf9c65fd |
-| eu-west-2      | ami-0df2beea8d16fa396 |
-| eu-west-3      | ami-049aaee3409504082 |
-| sa-east-1      | ami-05588892e5dbe6f06 |
-| us-east-1      | ami-04097592f09bdd904 |
-| us-east-2      | ami-03fe97cdd4c083cbd |
-| us-west-1      | ami-0d3f3b7d7a760725f |
-| us-west-2      | ami-012df423af9e3cf4a |
+| ap-northeast-1 | ami-04fc8c8fa3532596b |
+| ap-northeast-2 | ami-029f5368a40026c1e |
+| ap-south-1     | ami-0033e551d5ab1c8f2 |
+| ap-southeast-1 | ami-0d41c9d3179d13f1b |
+| ap-southeast-2 | ami-042ee0dfc2485480a |
+| ca-central-1   | ami-04ddd8616b671caf0 |
+| eu-central-1   | ami-0b69825d4d1e8abf5 |
+| eu-west-1      | ami-081692aff8588b71b |
+| eu-west-2      | ami-04b8c207efc948644 |
+| eu-west-3      | ami-03e794509cb8e17f1 |
+| sa-east-1      | ami-001201f8be3376e6a |
+| us-east-1      | ami-0d5abbeff2403c59b |
+| us-east-2      | ami-00b76a71ef5a59510 |
+| us-west-1      | ami-0f3b1b5d8902d9c04 |
+| us-west-2      | ami-06b51253777912d30 |
 
-## Kubernetes Version v1.17.16
+## Kubernetes Version v1.17.17
 
 ### Amazon Linux 2
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0151c94334b4ade3c |
-| ap-northeast-2 | ami-0f69526fd32301b89 |
-| ap-south-1     | ami-03bb5d00709a4c4b2 |
-| ap-southeast-1 | ami-0490f7ad0f2bd2791 |
-| ap-southeast-2 | ami-0d3333fe1018560f4 |
-| ca-central-1   | ami-035aa3b93ac4d8146 |
-| eu-central-1   | ami-0a7cf92a0f279f72b |
-| eu-west-1      | ami-01a4f001c3f57754b |
-| eu-west-2      | ami-0f1968f77bb9b316f |
-| eu-west-3      | ami-0cd11641c2ab7adac |
-| sa-east-1      | ami-0652075d2b221785d |
-| us-east-1      | ami-09e7d21f9bc00da4b |
-| us-east-2      | ami-0b8b8d79035eda813 |
-| us-west-1      | ami-08e99eca3ee123712 |
-| us-west-2      | ami-05e32bb894fc8d5c7 |
+| ap-northeast-1 | ami-0e3fbdba7cec45dff |
+| ap-northeast-2 | ami-0d695ebf09a71df92 |
+| ap-south-1     | ami-077a0fce723f359a8 |
+| ap-southeast-1 | ami-05dd874bce2f83e53 |
+| ap-southeast-2 | ami-0f8c75ac803fc626b |
+| ca-central-1   | ami-02e137c33666ca8ca |
+| eu-central-1   | ami-0a6919a059d9ded92 |
+| eu-west-1      | ami-07ea4a66ad4399df2 |
+| eu-west-2      | ami-024f4fbb3076eb49b |
+| eu-west-3      | ami-0fac0f4c0512a2a3e |
+| sa-east-1      | ami-0de58cc202d7e9d17 |
+| us-east-1      | ami-031af266ccc130930 |
+| us-east-2      | ami-00f8cf5a27b695f37 |
+| us-west-1      | ami-04a7564950a2428b1 |
+| us-west-2      | ami-0a813ef7e14f1b935 |
 
 ### CentOS 7
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0b343426a3a004c0e |
-| ap-northeast-2 | ami-005fcc2ddecc76716 |
-| ap-south-1     | ami-0032cf2e680e9ecd3 |
-| ap-southeast-1 | ami-0992464cce7f6ba44 |
-| ap-southeast-2 | ami-0a5ef7bbc0ab3f2a5 |
-| ca-central-1   | ami-0100fc28c8751ed32 |
-| eu-central-1   | ami-021f81a1e75ad97e0 |
-| eu-west-1      | ami-04fcb053c75a4bf5a |
-| eu-west-2      | ami-0718cc54836f73dea |
-| eu-west-3      | ami-09833a2bd916f7865 |
-| sa-east-1      | ami-0880cf60f5c4b2fcb |
-| us-east-1      | ami-0b97fbf3881269034 |
-| us-east-2      | ami-02c7e1da5cd3b79bf |
-| us-west-1      | ami-05641c7ee6e29f24c |
-| us-west-2      | ami-05b8bac8a54b4eedf |
+| ap-northeast-1 | ami-0e1562b121e320890 |
+| ap-northeast-2 | ami-048b0d6dbb5b8ca59 |
+| ap-south-1     | ami-032b822555b256a8c |
+| ap-southeast-1 | ami-0fb72ff3997c8230e |
+| ap-southeast-2 | ami-0e6d3127fbd7d831e |
+| ca-central-1   | ami-01454c116dae88214 |
+| eu-central-1   | ami-07ee31f8ca5b42863 |
+| eu-west-1      | ami-041d71c00024886a7 |
+| eu-west-2      | ami-04abd1f37e8e224da |
+| eu-west-3      | ami-0e9b0a58d83b9d208 |
+| sa-east-1      | ami-02308901ed8d001e8 |
+| us-east-1      | ami-05c2398beaf33aa62 |
+| us-east-2      | ami-00d3c6b34f27d453e |
+| us-west-1      | ami-0729248c323398659 |
+| us-west-2      | ami-05b01a5380daf31f2 |
 
 ### Ubuntu 20.04 (Focal)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0ba86f52e38d43e11 |
-| ap-northeast-2 | ami-0eeb2e8442c55fff2 |
-| ap-south-1     | ami-09b746555e8a4a57f |
-| ap-southeast-1 | ami-061ded98ce1ed7f4d |
-| ap-southeast-2 | ami-0223a1450581d85ec |
-| ca-central-1   | ami-0230caab35f4d9c7d |
-| eu-central-1   | ami-00ca5335ed110a01e |
-| eu-west-1      | ami-0dd1546c60b046fe7 |
-| eu-west-2      | ami-0836852a851bacf96 |
-| eu-west-3      | ami-0f59205b2f0db96b9 |
-| sa-east-1      | ami-0a0343368107d9e92 |
-| us-east-1      | ami-070786693c4ebcea3 |
-| us-east-2      | ami-08b768f129510a647 |
-| us-west-1      | ami-0107dd5e31f4c79a9 |
-| us-west-2      | ami-081e0f604341ed3b1 |
+| ap-northeast-1 | ami-09b75dd5008e2917b |
+| ap-northeast-2 | ami-0be2848ce73d18b6b |
+| ap-south-1     | ami-0231b4074465ac01c |
+| ap-southeast-1 | ami-00008b47fc30163ae |
+| ap-southeast-2 | ami-014aa6fd56948ce00 |
+| ca-central-1   | ami-0acbdea18f9b3c188 |
+| eu-central-1   | ami-093852c891470f525 |
+| eu-west-1      | ami-0782bf1383e67b4a8 |
+| eu-west-2      | ami-06b02324e96e1af50 |
+| eu-west-3      | ami-0fa68d082765945e0 |
+| sa-east-1      | ami-0d036f35ed0e6f37d |
+| us-east-1      | ami-0e440ffd0fe3351ea |
+| us-east-2      | ami-02c4ef6e5c805757b |
+| us-west-1      | ami-0d15c23018d576791 |
+| us-west-2      | ami-0259aac1a60636b2f |
 
 ### Ubuntu 18.04 (Bionic)
 
 | Region         | AMI                   |
 |----------------|-----------------------|
-| ap-northeast-1 | ami-0acbefbeeca8403b5 |
-| ap-northeast-2 | ami-00b63a9347f62d85c |
-| ap-south-1     | ami-0c829e5b0f95c5a71 |
-| ap-southeast-1 | ami-02a5e11261c873172 |
-| ap-southeast-2 | ami-0a65a66bfa63af62f |
-| ca-central-1   | ami-022513e320cebffc0 |
-| eu-central-1   | ami-057df83fc6353e961 |
-| eu-west-1      | ami-09c3eb3753dafd5b0 |
-| eu-west-2      | ami-0c862a33925709571 |
-| eu-west-3      | ami-08ed0f6e37c94448a |
-| sa-east-1      | ami-023220c3cd9c47857 |
-| us-east-1      | ami-086257cfa05f77b5d |
-| us-east-2      | ami-05a4bb76a4710e783 |
-| us-west-1      | ami-0b35ac5d7f19255e6 |
-| us-west-2      | ami-05aea9d24e22cd74a |
+| ap-northeast-1 | ami-038683dcad6632ce8 |
+| ap-northeast-2 | ami-05c9b21ce0684bc95 |
+| ap-south-1     | ami-0feb6b56dc573ab26 |
+| ap-southeast-1 | ami-0f34a91ba35aa1407 |
+| ap-southeast-2 | ami-061fddc1a1b582364 |
+| ca-central-1   | ami-00fe729dda74c66e9 |
+| eu-central-1   | ami-0163c0d6d6a79f4e5 |
+| eu-west-1      | ami-01477ccbb189b5ca4 |
+| eu-west-2      | ami-056328349e02485a9 |
+| eu-west-3      | ami-014eefaef56a19184 |
+| sa-east-1      | ami-0b12b5f398eb0ca90 |
+| us-east-1      | ami-0a76db8d461a104fe |
+| us-east-2      | ami-05cc942e982c6b109 |
+| us-west-1      | ami-047fb570fac2c266d |
+| us-west-2      | ami-026fbe0dd7751428c |


### PR DESCRIPTION

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2205

