### PR TITLE
Ensure mirrored OCI images are pulled before building Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,15 +307,15 @@ docker-build:
 	$(MAKE) ARCH=$(ARCH) docker-build-eks-controlplane
 
 .PHONY: docker-build-core
-docker-build-core: ## Build the docker image for controller-manager
+docker-build-core: docker-pull-prerequisites ## Build the docker image for controller-manager
 	docker build --pull --build-arg ARCH=$(ARCH) --build-arg LDFLAGS="$(LDFLAGS)" . -t $(CORE_CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-build-eks-bootstrap
-docker-build-eks-bootstrap:
+docker-build-eks-bootstrap: docker-pull-prerequisites
 	docker build --pull --build-arg ARCH=$(ARCH) --build-arg LDFLAGS="$(LDFLAGS)" --build-arg package=./bootstrap/eks . -t $(EKS_BOOTSTRAP_CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-build-eks-controlplane
-docker-build-eks-controlplane:
+docker-build-eks-controlplane: docker-pull-prerequisites
 	docker build --pull --build-arg ARCH=$(ARCH) --build-arg LDFLAGS="$(LDFLAGS)" --build-arg package=./controlplane/eks . -t $(EKS_CONTROLPLANE_CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
@@ -323,6 +323,12 @@ docker-push: ## Push the docker image
 	docker push $(CORE_CONTROLLER_IMG)-$(ARCH):$(TAG)
 	docker push $(EKS_BOOTSTRAP_CONTROLLER_IMG)-$(ARCH):$(TAG)
 	docker push $(EKS_CONTROLPLANE_CONTROLLER_IMG)-$(ARCH):$(TAG)
+
+.PHONY: docker-pull-prerequisites
+docker-pull-prerequisites:
+	docker pull docker.io/docker/dockerfile:1.1-experimental
+	docker pull docker.io/library/golang:$(GOLANG_VERSION)
+	docker pull gcr.io/distroless/static:latest
 
 ## --------------------------------------
 ## Docker — All ARCH


### PR DESCRIPTION
As we now pull from a GCR mirror, mirrors are not supported directly
when using experimental build features, so pre-pull images from mirror
first.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

