### PR TITLE
:bug: Ensure EKS controllers are preloaded in e2e

### DIFF
--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -19,6 +19,10 @@ images:
   # Use local dev images built source tree;
   - name: gcr.io/k8s-staging-cluster-api/capa-manager:e2e
     loadBehavior: mustLoad
+  - name: gcr.io/k8s-staging-cluster-api/capa-eks-bootstrap-manager:e2e
+    loadBehavior: mustLoad
+  - name: gcr.io/k8s-staging-cluster-api/capa-eks-controlplane-manager:e2e
+    loadBehavior: mustLoad        
   - name: quay.io/jetstack/cert-manager-cainjector:v0.16.1
     loadBehavior: tryLoad
   - name: quay.io/jetstack/cert-manager-webhook:v0.16.1


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Locally built e2e images need to be preloaded into kind.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

