### PR TITLE
✨  Add a log debug log configuration to the AWS clients

### DIFF
--- a/pkg/cloud/logs/logs.go
+++ b/pkg/cloud/logs/logs.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/go-logr/logr"
+)
+
+const (
+	logWithHTTPHeader = 9
+	logWithHTTPBody   = 10
+)
+
+func GetAWSLogLevel(logger logr.Logger) aws.LogLevelType {
+	if logger.V(logWithHTTPBody).Enabled() {
+		return aws.LogDebugWithHTTPBody
+	}
+
+	if logger.V(logWithHTTPHeader).Enabled() {
+		return aws.LogDebug
+	}
+
+	return aws.LogOff
+}
+
+func NewWrapLogr(logger logr.Logger) aws.Logger {
+	return &logrWrapper{
+		log: logger,
+	}
+}
+
+type logrWrapper struct {
+	log logr.Logger
+}
+
+func (l *logrWrapper) Log(msgs ...interface{}) {
+	switch len(msgs) {
+	case 0:
+		return
+	case 1:
+		l.log.Info(msgs[0].(string))
+	default:
+		l.log.Info(msgs[0].(string), msgs[:1]...)
+	}
+}

--- a/pkg/cloud/services/autoscaling/service.go
+++ b/pkg/cloud/services/autoscaling/service.go
@@ -35,6 +35,6 @@ type Service struct {
 func NewService(clusterScope cloud.ClusterScoper) *Service {
 	return &Service{
 		scope:     clusterScope,
-		ASGClient: scope.NewASGClient(clusterScope, clusterScope, clusterScope.InfraCluster()),
+		ASGClient: scope.NewASGClient(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/ec2/service.go
+++ b/pkg/cloud/services/ec2/service.go
@@ -38,7 +38,7 @@ type Service struct {
 func NewService(clusterScope scope.EC2Scope) *Service {
 	return &Service{
 		scope:     clusterScope,
-		EC2Client: scope.NewEC2Client(clusterScope, clusterScope, clusterScope.InfraCluster()),
-		SSMClient: scope.NewSSMClient(clusterScope, clusterScope, clusterScope.InfraCluster()),
+		EC2Client: scope.NewEC2Client(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
+		SSMClient: scope.NewSSMClient(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/eks/service.go
+++ b/pkg/cloud/services/eks/service.go
@@ -52,15 +52,15 @@ type Service struct {
 func NewService(controlPlaneScope *scope.ManagedControlPlaneScope) *Service {
 	return &Service{
 		scope:     controlPlaneScope,
-		EC2Client: scope.NewEC2Client(controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
+		EC2Client: scope.NewEC2Client(controlPlaneScope, controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
 		EKSClient: EKSClient{
-			EKSAPI: scope.NewEKSClient(controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
+			EKSAPI: scope.NewEKSClient(controlPlaneScope, controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
 		},
 		IAMService: iam.IAMService{
 			Logger:    controlPlaneScope.Logger,
-			IAMClient: scope.NewIAMClient(controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
+			IAMClient: scope.NewIAMClient(controlPlaneScope, controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
 		},
-		STSClient: scope.NewSTSClient(controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
+		STSClient: scope.NewSTSClient(controlPlaneScope, controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
 	}
 }
 
@@ -79,12 +79,12 @@ type NodegroupService struct {
 func NewNodegroupService(machinePoolScope *scope.ManagedMachinePoolScope) *NodegroupService {
 	return &NodegroupService{
 		scope:             machinePoolScope,
-		AutoscalingClient: scope.NewASGClient(machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
-		EKSClient:         scope.NewEKSClient(machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
+		AutoscalingClient: scope.NewASGClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
+		EKSClient:         scope.NewEKSClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
 		IAMService: iam.IAMService{
 			Logger:    machinePoolScope.Logger,
-			IAMClient: scope.NewIAMClient(machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
+			IAMClient: scope.NewIAMClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
 		},
-		STSClient: scope.NewSTSClient(machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
+		STSClient: scope.NewSTSClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
 	}
 }

--- a/pkg/cloud/services/elb/service.go
+++ b/pkg/cloud/services/elb/service.go
@@ -38,8 +38,8 @@ type Service struct {
 func NewService(elbScope scope.ELBScope) *Service {
 	return &Service{
 		scope:                 elbScope,
-		EC2Client:             scope.NewEC2Client(elbScope, elbScope, elbScope.InfraCluster()),
-		ELBClient:             scope.NewELBClient(elbScope, elbScope, elbScope.InfraCluster()),
-		ResourceTaggingClient: scope.NewResourgeTaggingClient(elbScope, elbScope, elbScope.InfraCluster()),
+		EC2Client:             scope.NewEC2Client(elbScope, elbScope, elbScope, elbScope.InfraCluster()),
+		ELBClient:             scope.NewELBClient(elbScope, elbScope, elbScope, elbScope.InfraCluster()),
+		ResourceTaggingClient: scope.NewResourgeTaggingClient(elbScope, elbScope, elbScope, elbScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/iamauth/service.go
+++ b/pkg/cloud/services/iamauth/service.go
@@ -46,6 +46,6 @@ func NewService(iamScope Scope, backend BackendType, client client.Client) *Serv
 		scope:     iamScope,
 		backend:   backend,
 		client:    client,
-		STSClient: scope.NewSTSClient(iamScope, iamScope, iamScope.InfraCluster()),
+		STSClient: scope.NewSTSClient(iamScope, iamScope, iamScope, iamScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/network/service.go
+++ b/pkg/cloud/services/network/service.go
@@ -59,6 +59,6 @@ type Service struct {
 func NewService(networkScope Scope) *Service {
 	return &Service{
 		scope:     networkScope,
-		EC2Client: scope.NewEC2Client(networkScope, networkScope, networkScope.InfraCluster()),
+		EC2Client: scope.NewEC2Client(networkScope, networkScope, networkScope, networkScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/secretsmanager/service.go
+++ b/pkg/cloud/services/secretsmanager/service.go
@@ -35,6 +35,6 @@ type Service struct {
 func NewService(secretsScope cloud.ClusterScoper) *Service {
 	return &Service{
 		scope:                secretsScope,
-		SecretsManagerClient: scope.NewSecretsManagerClient(secretsScope, secretsScope, secretsScope.InfraCluster()),
+		SecretsManagerClient: scope.NewSecretsManagerClient(secretsScope, secretsScope, secretsScope, secretsScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/securitygroup/service.go
+++ b/pkg/cloud/services/securitygroup/service.go
@@ -61,7 +61,7 @@ func NewService(sgScope Scope) *Service {
 	return &Service{
 		scope:     sgScope,
 		roles:     defaultRoles,
-		EC2Client: scope.NewEC2Client(sgScope, sgScope, sgScope.InfraCluster()),
+		EC2Client: scope.NewEC2Client(sgScope, sgScope, sgScope, sgScope.InfraCluster()),
 	}
 }
 
@@ -71,6 +71,6 @@ func NewServiceWithRoles(sgScope Scope, roles []infrav1.SecurityGroupRole) *Serv
 	return &Service{
 		scope:     sgScope,
 		roles:     roles,
-		EC2Client: scope.NewEC2Client(sgScope, sgScope, sgScope.InfraCluster()),
+		EC2Client: scope.NewEC2Client(sgScope, sgScope, sgScope, sgScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/ssm/service.go
+++ b/pkg/cloud/services/ssm/service.go
@@ -35,6 +35,6 @@ type Service struct {
 func NewService(secretsScope cloud.ClusterScoper) *Service {
 	return &Service{
 		scope:     secretsScope,
-		SSMClient: scope.NewSSMClient(secretsScope, secretsScope, secretsScope.InfraCluster()),
+		SSMClient: scope.NewSSMClient(secretsScope, secretsScope, secretsScope, secretsScope.InfraCluster()),
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2181

```release-note
Adds the ability to enable the AWS SDK debug logging. Use verbosity level of 9 to enable debugging and a verbosity level of 10 to include HTTP request bodies.
```

