### PR TITLE
Update mdbook to 0.4.5 to fix CVE-2020-26297

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MDBOOK_VERSION := v0.4.3
+MDBOOK_VERSION := v0.4.5
 GOLANG_VERSION := 1.13.15
 PLANTUML_VERSION := 1.2020.16
 GH_VERSION := 1.2.0


### PR DESCRIPTION
See https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html for more details.

Thanks!