### PR TITLE
🐛 Fix bastion  and AWSMachinePool connectivity

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -395,6 +395,8 @@ func (s *Service) GetCoreNodeSecurityGroups(scope *scope.MachinePoolScope) ([]st
 
 	if !scope.IsEKSManaged() {
 		sgRoles = append(sgRoles, infrav1.SecurityGroupLB)
+	} else {
+		sgRoles = append(sgRoles, infrav1.SecurityGroupEKSNodeAdditional)
 	}
 
 	ids := make([]string, 0, len(sgRoles))

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -329,7 +329,6 @@ func (s *Service) createCluster(eksClusterName string) (*eks.Cluster, error) {
 	}
 
 	v := versionToEKS(parseEKSVersion(*s.scope.ControlPlane.Spec.Version))
-	s.scope.SecurityGroups()
 	input := &eks.CreateClusterInput{
 		Name: aws.String(eksClusterName),
 		//ClientRequestToken: aws.String(uuid.New().String()),


### PR DESCRIPTION
**What this PR does / why we need it:**

Add missing security groups into node launch template.

Fixes #1985 

I will send another PR to solve #2231. It needs some refactor in Launch template stuff to be reusable between AWSMachinePool  and  AWSManagedMachinePool 

