### PR TITLE
✨ Add filters support for additional security groups

### DIFF
--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -94,7 +94,8 @@ type AWSMachineSpec struct {
 
 	// AdditionalSecurityGroups is an array of references to security groups that should be applied to the
 	// instance. These security groups would be set in addition to any security groups defined
-	// at the cluster level or in the actuator.
+	// at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters
+	// will cause additional requests to AWS API and if tags change the attached security groups might change too.
 	// +optional
 	AdditionalSecurityGroups []AWSResourceReference `json:"additionalSecurityGroups,omitempty"`
 

--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -192,9 +192,9 @@ func (r *AWSMachine) Default() {
 func (r *AWSMachine) validateAdditionalSecurityGroups() field.ErrorList {
 	var allErrs field.ErrorList
 
-	for _, additionalSecurityGroups := range r.Spec.AdditionalSecurityGroups {
-		if len(additionalSecurityGroups.Filters) > 0 {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.additionalSecurityGroups"), "filters are not implemented for security groups and will be removed in a future release"))
+	for _, additionalSecurityGroup := range r.Spec.AdditionalSecurityGroups {
+		if len(additionalSecurityGroup.Filters) > 0 && additionalSecurityGroup.ID != nil {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.additionalSecurityGroups"), "only one of ID or Filters may be specified, specifying both is forbidden"))
 		}
 	}
 	return allErrs

--- a/api/v1alpha3/awsmachine_webhook_test.go
+++ b/api/v1alpha3/awsmachine_webhook_test.go
@@ -142,11 +142,43 @@ func TestAWSMachine_Create(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "additional security groups should not have filters",
+			name: "additional security groups may have id",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					AdditionalSecurityGroups: []AWSResourceReference{
 						{
+							ID: aws.String("id"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "additional security groups may have filters",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					AdditionalSecurityGroups: []AWSResourceReference{
+						{
+							Filters: []Filter{
+								{
+									Name:   "example-name",
+									Values: []string{"example-value"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "additional security groups can't have both id and filters",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					AdditionalSecurityGroups: []AWSResourceReference{
+						{
+							ID: aws.String("id"),
 							Filters: []Filter{
 								{
 									Name:   "example-name",

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -247,7 +247,7 @@ spec:
             description: AWSMachineSpec defines the desired state of AWSMachine
             properties:
               additionalSecurityGroups:
-                description: AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.
+                description: AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.
                 items:
                   description: AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.
                   properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -210,7 +210,7 @@ spec:
                     description: Spec is the specification of the desired behavior of the machine.
                     properties:
                       additionalSecurityGroups:
-                        description: AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.
+                        description: AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.
                         items:
                           description: AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.
                           properties:

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -970,3 +970,26 @@ func getInstanceMarketOptionsRequest(spotMarketOptions *infrav1.SpotMarketOption
 
 	return instanceMarketOptionsRequest
 }
+
+// GetFilteredSecurityGroupID get security group ID using filters
+func (s *Service) GetFilteredSecurityGroupID(securityGroup infrav1.AWSResourceReference) (string, error) {
+	if securityGroup.Filters == nil {
+		return "", nil
+	}
+
+	filters := []*ec2.Filter{}
+	for _, f := range securityGroup.Filters {
+		filters = append(filters, &ec2.Filter{Name: aws.String(f.Name), Values: aws.StringSlice(f.Values)})
+	}
+
+	sgs, err := s.EC2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: filters})
+	if err != nil {
+		return "", err
+	}
+
+	if len(sgs.SecurityGroups) == 0 {
+		return "", fmt.Errorf("failed to find security group matching filters: %q, reason: %w", filters, err)
+	}
+
+	return *sgs.SecurityGroups[0].GroupId, nil
+}

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -52,6 +52,7 @@ type EC2MachineInterface interface {
 
 	GetCoreSecurityGroups(machine *scope.MachineScope) ([]string, error)
 	GetInstanceSecurityGroups(instanceID string) (map[string][]string, error)
+	GetFilteredSecurityGroupID(securityGroup infrav1.AWSResourceReference) (string, error)
 	UpdateInstanceSecurityGroups(id string, securityGroups []string) error
 	UpdateResourceTags(resourceID *string, create, remove map[string]string) error
 

--- a/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
@@ -153,6 +153,21 @@ func (mr *MockEC2MachineInterfaceMockRecorder) GetCoreSecurityGroups(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCoreSecurityGroups", reflect.TypeOf((*MockEC2MachineInterface)(nil).GetCoreSecurityGroups), arg0)
 }
 
+// GetFilteredSecurityGroupID mocks base method
+func (m *MockEC2MachineInterface) GetFilteredSecurityGroupID(arg0 v1alpha3.AWSResourceReference) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFilteredSecurityGroupID", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFilteredSecurityGroupID indicates an expected call of GetFilteredSecurityGroupID
+func (mr *MockEC2MachineInterfaceMockRecorder) GetFilteredSecurityGroupID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilteredSecurityGroupID", reflect.TypeOf((*MockEC2MachineInterface)(nil).GetFilteredSecurityGroupID), arg0)
+}
+
 // GetInstanceSecurityGroups mocks base method
 func (m *MockEC2MachineInterface) GetInstanceSecurityGroups(arg0 string) (map[string][]string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds filters support for additional security groups and this change should not break any existing functionality. The current implementation only allows IDs. 

Related issue https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1723

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AWSMachine: Add filters support for additional security groups
```
