### PR TITLE
🌱 AWSManagedMachinePool: Make public access to SSH explicit

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -83,8 +83,11 @@ spec:
               remoteAccess:
                 description: RemoteAccess specifies how machines can be accessed remotely
                 properties:
+                  public:
+                    description: Public specifies whether to open port 22 to the public internet
+                    type: boolean
                   sourceSecurityGroups:
-                    description: SourceSecurityGroups specifies which security groups are allowed access An empty array opens port 22 to the public internet
+                    description: SourceSecurityGroups specifies which security groups are allowed access
                     items:
                       type: string
                     type: array

--- a/controlplane/eks/api/v1alpha3/types.go
+++ b/controlplane/eks/api/v1alpha3/types.go
@@ -208,3 +208,9 @@ type AddonIssue struct {
 	// ResourceIDs is a list of resource ids for the issue
 	ResourceIDs []*string `json:"resourceIds,omitempty"`
 }
+
+const (
+	// SecurityGroupCluster is the security group for communication between EKS
+	// control plane and managed node groups
+	SecurityGroupCluster = infrav1.SecurityGroupRole("cluster")
+)

--- a/exp/api/v1alpha3/awsmanagedmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmanagedmachinepool_types.go
@@ -129,8 +129,10 @@ type ManagedRemoteAccess struct {
 	SSHKeyName *string `json:"sshKeyName,omitempty"`
 
 	// SourceSecurityGroups specifies which security groups are allowed access
-	// An empty array opens port 22 to the public internet
 	SourceSecurityGroups []string `json:"sourceSecurityGroups,omitempty"`
+
+	// Public specifies whether to open port 22 to the public internet
+	Public bool `json:"public,omitempty"`
 }
 
 // AWSManagedMachinePoolStatus defines the observed state of AWSManagedMachinePool


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Restricts access to SSH for `AWSManagedMachinePool`s to specific security groups by default. Until now the default matches the AWS API defaults where if SSH access is enabled with some SSH key then access is allowed from any IP. Now the user must set `public: true`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1990 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required: New `AWSManagedMachinePool` resources with non-empty `remoteAccess` now require `remoteAccess.public: true` in order to allow public access to SSH on port 22
```
