### PR TITLE
🌱 Fix the version to match release series in metadata

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,6 +2,6 @@
   "name": "infrastructure-aws",
   "config": {
     "componentsFile": "infrastructure-components.yaml",
-    "nextVersion": "v0.7.0"
+    "nextVersion": "v0.6.0"
   }
 }


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In cluster-api, when running the create-local-repository script, it uses
`infrastructure-aws` in the `clusterctl-settings.json` with the CAPA metadata.yaml file. 
Since release 0.7.0 doesn't exist, the `clusterctl init` dev experience is affected.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests

**^^ Love this checklist!**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
