### PR TITLE
📖 Add AWSFargatePool ADR

### DIFF
--- a/docs/adr/0004-fargate-pools.md
+++ b/docs/adr/0004-fargate-pools.md
@@ -1,0 +1,45 @@
+# 4. EKS AWSFargateProfiles
+
+- Status: accepted
+- Date: 2021-02-15
+- Authors: @michaelbeaumont
+- Deciders: @michaelbeaumont, @richardcase
+
+## Context
+
+At the time of writing CAPA has the AWS-specific infrastructure resources `AWSMachinePool`s
+and `AWSManagedMachinePool`s.
+These are referred to in `MachinePool`s as `infrastructureRef`s. The
+underlying AWS resources fit the `MachinePool` model very closely. Data about
+the pools, such as `replicas` is reflected back to the `MachinePool` and
+the responsible controllers reconcile the AWS resources using data specified on the
+`MachinePool`, like `.spec.template.spec.version` and `.spec.template.spec.bootstrap`.
+
+Issue #1786 is concerned with supporting EKS Fargate profiles in CAPA. Fargate
+profiles allow users to run pods on an on-demand, serverless compute platform
+called Fargate.
+Nodes are spun up dynamically for pods in specified namespaces or with specific
+labels. These selectors are packaged into a "profile" that also specifies which
+subnets are available for pods to run in.
+
+With CAPA, users would like to create a resource representing such a profile.
+
+This ADR concerns itself with how these resources are specified. The major
+decision is whether a Fargate profile can be represented in the `MachinePool` abstraction.
+
+Some of the fields on `MachinePool` don't really make sense in the Fargate
+context, like the entire `MachineSpec` under `spec.template.spec` (`version`,
+`bootstrap`), `spec.strategy` and the idea of desired replicas.
+
+## Decision
+
+The `AWSFargateProfile` resource is implemented independently from any existing CAPI resource
+and users must only create and manipulate `AWSFargateProfile`s to create and manage
+Fargate profiles. `AWSFargateProfile`s are nevertheless associated with an
+`AWSManagedControlPlane`/`AWSManagedCluster`/`Cluster`.
+
+## Consequences
+
+Users don't have to create a sort of "empty" `MachinePool` resource that points
+to an `AWSFargateProfile` and no ambiguity or confusion arises as to the semantics of the `MachinePool`
+spec in a Fargate context.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Documents a major decision around EKS Fargate support, whether they map to a `MachinePool`.

**Which issue(s) this PR fixes**:
Part of #1786 (https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1786#issuecomment-777599215)

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New ADR to document the decision of how Fargate Profiles will be represented.
```
