### PR TITLE
Updated the PR template to include kind assignment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,26 @@
-<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
-<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->
+<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
+<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->
+
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind feature
+/kind bug
+/kind api-change
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind flake
+/kind regression
+/kind support
+-->
 
 **What this PR does / why we need it**:
+
+<!-- Enter a description of the change and why this change is needed -->
 
 **Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 Fixes #
@@ -9,7 +28,7 @@ Fixes #
 **Special notes for your reviewer**:
 
 **Checklist**:
-<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
+<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->
 
 - [ ] squashed commits
 - [ ] includes documentation
@@ -18,8 +37,9 @@ Fixes #
 
 **Release note**:
 <!--  Write your release note:
-1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
-2. If no release note is required, just write "NONE".
+1. Enter your extended release note in the below block. 
+2. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
 -->
 ```release-note
 


### PR DESCRIPTION
**What type of change is this**:
/kind cleanup

**What this PR does / why we need it**:
With the adoption of the `release-notes` Prow plugin and using the `release-notes` cli we need to have kinds associated with the PRS


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The PR template has been updated to include specifying the kind
```
