### PR TITLE
🐛 hack: fix semver comparison in ensure-kind

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -40,8 +40,8 @@ verify_kind_version() {
   fi
 
   local kind_version
-  kind_version=$(kind version)
-  if ! [[ "${kind_version}" =~ ${MINIMUM_KIND_VERSION} ]]; then
+  kind_version="v$(kind version -q)"
+  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -s -t. -k 1,1n -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kind version: ${kind_version}.
 Requires ${MINIMUM_KIND_VERSION} or greater.


### PR DESCRIPTION
**What this PR does / why we need it**:

`ensure-kind.sh` should compare semantic versions correctly, instead of checking for the exact number.
Otherwise it could fail even when the local kind version is `v0.10.0`, which is obviously greater than the minimum version `v0.6.1`.

So let's follow mostly the way how other ensure scripts are implemented:
read the kind version, run version sort with the minimum version, and compare it to the minimum version.

**Release note:**
```
NONE
```