### PR TITLE
chore: remove usage of AWSManagedCluster from templates / docs

### DIFF
--- a/docs/book/src/topics/eks/index.md
+++ b/docs/book/src/topics/eks/index.md
@@ -18,7 +18,6 @@ Experimental support for EKS has been introduced in the AWS provider. Currently 
 The implementation introduces new CRD kinds:
 
 - AWSManagedControlPlane - specifies the EKS Cluster in AWS and used by the Cluster API AWS Managed Control plane (MACP)
-- AWSManagedCluster - holds details of the EKS cluster for use by CAPI
 - AWSManagedMachinePool - defines the managed node pool for the cluster
 - EKSConfig - used by Cluster API bootstrap provider EKS (CABPE)
 

--- a/templates/cluster-template-eks-managedmachinepool-vpccni.yaml
+++ b/templates/cluster-template-eks-managedmachinepool-vpccni.yaml
@@ -8,18 +8,13 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSManagedCluster
-    name: "${CLUSTER_NAME}"
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
   controlPlaneRef:
     kind: AWSManagedControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSManagedCluster
-metadata:
-  name: "${CLUSTER_NAME}"
 ---
 kind: AWSManagedControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/cluster-template-eks-managedmachinepool.yaml
+++ b/templates/cluster-template-eks-managedmachinepool.yaml
@@ -8,18 +8,13 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSManagedCluster
-    name: "${CLUSTER_NAME}"
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
   controlPlaneRef:
     kind: AWSManagedControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSManagedCluster
-metadata:
-  name: "${CLUSTER_NAME}"
 ---
 kind: AWSManagedControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/cluster-template-eks.yaml
+++ b/templates/cluster-template-eks.yaml
@@ -8,18 +8,13 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSManagedCluster
-    name: "${CLUSTER_NAME}"
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
   controlPlaneRef:
     kind: AWSManagedControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSManagedCluster
-metadata:
-  name: "${CLUSTER_NAME}"
 ---
 kind: AWSManagedControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
@@ -8,18 +8,13 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSManagedCluster
-    name: "${CLUSTER_NAME}"
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
   controlPlaneRef:
     kind: AWSManagedControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSManagedCluster
-metadata:
-  name: "${CLUSTER_NAME}"
 ---
 kind: AWSManagedControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/test/e2e/data/eks/cluster-template-eks-control-plane-only.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-control-plane-only.yaml
@@ -8,18 +8,13 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSManagedCluster
-    name: "${CLUSTER_NAME}"
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
   controlPlaneRef:
     kind: AWSManagedControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSManagedCluster
-metadata:
-  name: "${CLUSTER_NAME}"
 ---
 kind: AWSManagedControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/test/e2e/data/eks/cluster-template-eks-managedmachinepool.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-managedmachinepool.yaml
@@ -8,18 +8,13 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSManagedCluster
-    name: "${CLUSTER_NAME}"
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: "${CLUSTER_NAME}-control-plane"
   controlPlaneRef:
     kind: AWSManagedControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSManagedCluster
-metadata:
-  name: "${CLUSTER_NAME}"
 ---
 kind: AWSManagedControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/test/e2e/suites/managed/README.md
+++ b/test/e2e/suites/managed/README.md
@@ -6,7 +6,7 @@ Where possible we re-use an EKS cluster and have tried not to create clusters in
 
 For example, in [eks_test.go](eks_test.go) we perform the following steps:
 
-1. Apply a AWSManagedCluster/AWSManagedControlPlane to create a EKS cluster without any nodes
+1. Apply an AWSManagedControlPlane to create a EKS cluster without any nodes
 2. Perform tests against the control plane
 3. Apply a MachineDeployment
 4. Perform tests against the machine deployment


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This removes the usage of AWSManagedCluster from the templates and docs to help with the deprecation in v1alpha4


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:

```release-note
Removal of AWSManagedCluster from templates/docs to help with the future deprecation in v1alpha4
```
