### PR TITLE
e2e spot instance test: delete spot option from control plane machines

### DIFF
--- a/test/e2e/data/infrastructure-aws/cluster-template-spot-instances.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template-spot-instances.yaml
@@ -66,8 +66,6 @@ spec:
       instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
-      spotMarketOptions:
-        maxPrice: ""
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment

--- a/test/e2e/suites/unmanaged/unmanaged_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_test.go
@@ -430,7 +430,6 @@ var _ = Describe("functional tests - unmanaged", func() {
 			Expect(len(workerMachines)).To(Equal(1))
 			assertSpotInstanceType(*workerMachines[0].Spec.ProviderID)
 			Expect(len(controlPlaneMachines)).To(Equal(1))
-			assertSpotInstanceType(*controlPlaneMachines[0].Spec.ProviderID)
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Control plane nodes should not be spot instances. This may solve e2e spot instance flake.


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

```release-note
NONE
```
/kind flake