### PR TITLE
Fix e2e multi cluster test

### DIFF
--- a/test/e2e/suites/unmanaged/unmanaged_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/cluster-api-provider-aws/exp/instancestate"
 	"strconv"
 	"strings"
 	"time"
@@ -360,12 +359,13 @@ var _ = Describe("functional tests - unmanaged", func() {
 				Expect(len(machines)).Should(BeNumerically(">", 0))
 				terminateInstance(*machines[0].Spec.ProviderID)
 
-				By("Waiting for AWSMachine to be labelled as terminated")
-				Eventually(func() bool {
-					machineList := getAWSMachinesForDeployment(ns2.Name, *md2[0])
-					labels := machineList.Items[0].GetLabels()
-					return labels[instancestate.Ec2InstanceStateLabelKey] == string(infrav1.InstanceStateTerminated)
-				}, e2eCtx.E2EConfig.GetIntervals("", "wait-machine-status")...).Should(Equal(true))
+				// TODO: uncomment once EventBridgeInstanceState is enabled for the tests
+				//By("Waiting for AWSMachine to be labelled as terminated")
+				//Eventually(func() bool {
+				//	machineList := getAWSMachinesForDeployment(ns2.Name, *md2[0])
+				//	labels := machineList.Items[0].GetLabels()
+				//	return labels[instancestate.Ec2InstanceStateLabelKey] == string(infrav1.InstanceStateTerminated)
+				//}, e2eCtx.E2EConfig.GetIntervals("", "wait-machine-status")...).Should(Equal(true))
 
 				By("Waiting for machine to reach Failed state")
 				statusChecks := []framework.MachineStatusCheck{framework.MachinePhaseCheck(string(clusterv1.MachinePhaseFailed))}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
e2e multicluster test were failing because we disabled event-bridge feature.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-e2e-v1alpha3/1367465445199712256

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
