### PR TITLE
Set the UserAgent to "capa-controller"

### DIFF
--- a/bootstrap/eks/main.go
+++ b/bootstrap/eks/main.go
@@ -124,7 +124,9 @@ func main() {
 		}()
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = "cluster-api-provider-aws-controller"
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,

--- a/controlplane/eks/main.go
+++ b/controlplane/eks/main.go
@@ -156,7 +156,9 @@ func main() {
 		BurstSize: 100,
 	})
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = "cluster-api-provider-aws-controller"
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		LeaderElection:         enableLeaderElection,

--- a/main.go
+++ b/main.go
@@ -109,7 +109,9 @@ func main() {
 		BurstSize: 100,
 	})
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = "cluster-api-provider-aws-controller"
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Doing the same change with CAPI: https://github.com/kubernetes-sigs/cluster-api/pull/4257
> Set the UserAgent to "capa-controller".
> This string is used to identify actors within a Kubernetes system; for instance it appears in managedFields.



-->
```release-note
NONE
```
