### PR TITLE
✨ Implement ASG capacity rebalance

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -235,6 +235,10 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              capacityRebalance:
+                description: Enable or disable the capacity rebalance autoscaling
+                  group feature
+                type: boolean
               defaultCoolDown:
                 description: The amount of time, in seconds, after a scaling activity
                   completes before another scaling activity can start. If no value

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -77,6 +77,10 @@ type AWSMachinePoolSpec struct {
 	// RefreshPreferences describes set of preferences associated with the instance refresh request.
 	// +optional
 	RefreshPreferences *RefreshPreferences `json:"refreshPreferences,omitempty"`
+
+	// Enable or disable the capacity rebalance autoscaling group feature
+	// +optional
+	CapacityRebalance bool `json:"capacityRebalance,omitempty"`
 }
 
 type RefreshPreferences struct {

--- a/exp/api/v1alpha3/types.go
+++ b/exp/api/v1alpha3/types.go
@@ -172,15 +172,16 @@ type Tags map[string]string
 // AutoScalingGroup describes an AWS autoscaling group.
 type AutoScalingGroup struct {
 	// The tags associated with the instance.
-	ID              string          `json:"id,omitempty"`
-	Tags            infrav1.Tags    `json:"tags,omitempty"`
-	Name            string          `json:"name,omitempty"`
-	DesiredCapacity *int32          `json:"desiredCapacity,omitempty"`
-	MaxSize         int32           `json:"maxSize,omitempty"`
-	MinSize         int32           `json:"minSize,omitempty"`
-	PlacementGroup  string          `json:"placementGroup,omitempty"`
-	Subnets         []string        `json:"subnets,omitempty"`
-	DefaultCoolDown metav1.Duration `json:"defaultCoolDown,omitempty"`
+	ID                string          `json:"id,omitempty"`
+	Tags              infrav1.Tags    `json:"tags,omitempty"`
+	Name              string          `json:"name,omitempty"`
+	DesiredCapacity   *int32          `json:"desiredCapacity,omitempty"`
+	MaxSize           int32           `json:"maxSize,omitempty"`
+	MinSize           int32           `json:"minSize,omitempty"`
+	PlacementGroup    string          `json:"placementGroup,omitempty"`
+	Subnets           []string        `json:"subnets,omitempty"`
+	DefaultCoolDown   metav1.Duration `json:"defaultCoolDown,omitempty"`
+	CapacityRebalance bool            `json:"capacityRebalance,omitempty"`
 
 	MixedInstancesPolicy *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
 	Status               ASGStatus

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -495,6 +495,10 @@ func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *infr
 		return true
 	}
 
+	if machinePoolScope.AWSMachinePool.Spec.CapacityRebalance != existingASG.CapacityRebalance {
+		return true
+	}
+
 	if !reflect.DeepEqual(machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy, existingASG.MixedInstancesPolicy) {
 		machinePoolScope.Info("got a mixed diff here", "incoming", machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy, "existing", existingASG.MixedInstancesPolicy)
 		return true

--- a/go.sum
+++ b/go.sum
@@ -109,7 +109,6 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -813,7 +812,6 @@ sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802 h1:L6/8hETA7jvdx3xBcbDifrI
 sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802/go.mod h1:HIZ3PWUezpklcjkqpFbnYOqaqsAE1JeCTEwkgvPLXjk=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v2 v2.0.1/go.mod h1:Wb7vfKAodbKgf6tn1Kl0VvGj7mRH6DGaRcixXEJXTsE=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -37,9 +37,10 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 		ID:   aws.StringValue(v.AutoScalingGroupARN),
 		Name: aws.StringValue(v.AutoScalingGroupName),
 		// TODO(rudoi): this is just terrible
-		DesiredCapacity: aws.Int32(int32(aws.Int64Value(v.DesiredCapacity))),
-		MaxSize:         int32(aws.Int64Value(v.MaxSize)),
-		MinSize:         int32(aws.Int64Value(v.MinSize)),
+		DesiredCapacity:   aws.Int32(int32(aws.Int64Value(v.DesiredCapacity))),
+		MaxSize:           int32(aws.Int64Value(v.MaxSize)),
+		MinSize:           int32(aws.Int64Value(v.MinSize)),
+		CapacityRebalance: aws.BoolValue(v.CapacityRebalance),
 		//TODO: determine what additional values go here and what else should be in the struct
 	}
 
@@ -159,6 +160,7 @@ func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScal
 		MinSize:              scope.AWSMachinePool.Spec.MinSize,
 		Subnets:              subnetIDs,
 		DefaultCoolDown:      scope.AWSMachinePool.Spec.DefaultCoolDown,
+		CapacityRebalance:    scope.AWSMachinePool.Spec.CapacityRebalance,
 		MixedInstancesPolicy: scope.AWSMachinePool.Spec.MixedInstancesPolicy,
 	}
 
@@ -205,6 +207,7 @@ func (s *Service) runPool(i *expinfrav1.AutoScalingGroup, launchTemplateID strin
 		MinSize:              aws.Int64(int64(i.MinSize)),
 		VPCZoneIdentifier:    aws.String(strings.Join(i.Subnets, ", ")),
 		DefaultCooldown:      aws.Int64(int64(i.DefaultCoolDown.Duration.Seconds())),
+		CapacityRebalance:    aws.Bool(i.CapacityRebalance),
 	}
 
 	if i.DesiredCapacity != nil {
@@ -283,6 +286,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 		MaxSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MaxSize)),
 		MinSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MinSize)),
 		VPCZoneIdentifier:    aws.String(strings.Join(subnetIDs, ", ")),
+		CapacityRebalance:    aws.Bool(scope.AWSMachinePool.Spec.CapacityRebalance),
 	}
 
 	if scope.MachinePool.Spec.Replicas != nil {

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -134,6 +134,7 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				DesiredCapacity:      aws.Int64(1234),
 				MaxSize:              aws.Int64(1234),
 				MinSize:              aws.Int64(1234),
+				CapacityRebalance:    aws.Bool(true),
 				MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
 					InstancesDistribution: &autoscaling.InstancesDistribution{
 						OnDemandAllocationStrategy:          aws.String("prioritized"),
@@ -152,11 +153,12 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				},
 			},
 			want: &expinfrav1.AutoScalingGroup{
-				ID:              "test-id",
-				Name:            "test-name",
-				DesiredCapacity: aws.Int32(1234),
-				MaxSize:         int32(1234),
-				MinSize:         int32(1234),
+				ID:                "test-id",
+				Name:              "test-name",
+				DesiredCapacity:   aws.Int32(1234),
+				MaxSize:           int32(1234),
+				MinSize:           int32(1234),
+				CapacityRebalance: true,
 				MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
 					InstancesDistribution: &expinfrav1.InstancesDistribution{
 						OnDemandAllocationStrategy:          expinfrav1.OnDemandAllocationStrategyPrioritized,
@@ -181,6 +183,7 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				DesiredCapacity:      aws.Int64(1234),
 				MaxSize:              aws.Int64(1234),
 				MinSize:              aws.Int64(1234),
+				CapacityRebalance:    aws.Bool(true),
 				MixedInstancesPolicy: nil,
 			},
 			want: &expinfrav1.AutoScalingGroup{
@@ -189,6 +192,7 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				DesiredCapacity:      aws.Int32(1234),
 				MaxSize:              int32(1234),
 				MinSize:              int32(1234),
+				CapacityRebalance:    true,
 				MixedInstancesPolicy: nil,
 			},
 			wantErr: false,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds the ability to enable the new ASG capacity rebalance feature.

This only makes sense when there are Spot instances in the ASG (i.e. when `.spec.mixedInstancesPolicy.instancesDistribution.onDemandPercentageAboveBaseCapacity < 100`) but AWS still allows to enable capacity rebalance even when spot percentage is 0%. Some validation could be added, but I think if the AWS API accepts it we should just set it.

The new `.spec.capacityRebalance` field defaults to `false` and is set as optional for backwards compatibility.

**Special notes for your reviewer**:

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Add ability to toggle the new AWS Capacity Rebalance feature by setting a new `.spec.capacityRebalance` field in `AWSMachinePool` objects.
```
