### PR TITLE
Fix Govcloud support for CloudFormation generation

### DIFF
--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/defaults.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/defaults.go
@@ -28,6 +28,8 @@ const (
 	DefaultBootstrapUserName = "bootstrapper.cluster-api-provider-aws.sigs.k8s.io"
 	// DefaultStackName is the default CloudFormation stack name.
 	DefaultStackName = "cluster-api-provider-aws-sigs-k8s-io"
+	// DefaultParittionName is the default security partition for AWS ARNs.
+	DefaultPartitionName = "aws"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -43,6 +45,9 @@ func SetDefaults_BootstrapUser(obj *BootstrapUser) { //nolint:golint,stylecheck
 func SetDefaults_AWSIAMConfigurationSpec(obj *AWSIAMConfigurationSpec) { //nolint:golint,stylecheck
 	if obj.NameSuffix == nil {
 		obj.NameSuffix = utilpointer.StringPtr(infrav1.DefaultNameSuffix)
+	}
+	if obj.Partition == "" {
+		obj.Partition = DefaultPartitionName
 	}
 	if obj.StackName == "" {
 		obj.StackName = DefaultStackName

--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
@@ -184,6 +184,9 @@ type AWSIAMConfigurationSpec struct {
 	// EventBridge controls configuration for consuming EventBridge events
 	EventBridge *EventBridgeConfig `json:"eventBridge,omitempty"`
 
+	// Partition is the AWS security partition being used. Defaults to "aws"
+	Partition string `json:"partition,omitempty"`
+
 	// SecureSecretsBackend, when set to parameter-store will create AWS Systems Manager
 	// Parameter Storage policies. By default or with the value of secrets-manager,
 	// will generate AWS Secrets Manager policies instead.

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	EKSClusterPolicy = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+	eksClusterPolicyName = "AmazonEKSClusterPolicy"
 )
 
 func (t Template) controllersPolicyGroups() []string {
@@ -132,7 +132,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 		{
 			Effect: iamv1.EffectAllow,
 			Resource: iamv1.Resources{
-				"arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*",
+				"arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*",
 			},
 			Action: iamv1.Actions{
 				"autoscaling:CreateAutoScalingGroup",
@@ -223,7 +223,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 		statement = append(statement, iamv1.StatementEntry{
 			Effect: iamv1.EffectAllow,
 			Resource: iamv1.Resources{
-				"arn:aws:ssm:*:*:parameter/aws/service/eks/optimized-ami/*",
+				"arn:*:ssm:*:*:parameter/aws/service/eks/optimized-ami/*",
 			},
 			Action: iamv1.Actions{
 				"ssm:GetParameter",
@@ -236,7 +236,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 				"iam:CreateServiceLinkedRole",
 			},
 			Resource: iamv1.Resources{
-				"arn:aws:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS",
+				"arn:*:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS",
 			},
 			Condition: iamv1.Conditions{
 				iamv1.StringLike: map[string]string{"iam:AWSServiceName": "eks.amazonaws.com"},
@@ -249,7 +249,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 				"iam:CreateServiceLinkedRole",
 			},
 			Resource: iamv1.Resources{
-				"arn:aws:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",
+				"arn:*:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",
 			},
 			Condition: iamv1.Conditions{
 				iamv1.StringLike: map[string]string{"iam:AWSServiceName": "eks-nodegroup.amazonaws.com"},
@@ -283,7 +283,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 			{
 				Action: allowedIAMActions,
 				Resource: iamv1.Resources{
-					"arn:aws:iam::*:role/*",
+					"arn:*:iam::*:role/*",
 				},
 				Effect: iamv1.EffectAllow,
 			}, {
@@ -291,7 +291,7 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 					"iam:GetPolicy",
 				},
 				Resource: iamv1.Resources{
-					EKSClusterPolicy,
+					t.generateAWSManagedPolicyARN(eksClusterPolicyName),
 				},
 				Effect: iamv1.EffectAllow,
 			}, {
@@ -311,8 +311,8 @@ func (t Template) controllersPolicy() *iamv1.PolicyDocument {
 					"eks:CreateNodegroup",
 				},
 				Resource: iamv1.Resources{
-					"arn:aws:eks:*:*:cluster/*",
-					"arn:aws:eks:*:*:nodegroup/*/*/*",
+					"arn:*:eks:*:*:cluster/*",
+					"arn:*:eks:*:*:nodegroup/*/*/*",
 				},
 				Effect: iamv1.EffectAllow,
 			}, {

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_node.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_node.go
@@ -69,12 +69,13 @@ func (t Template) nodeManagedPolicies() []string {
 
 	if t.Spec.EKS.Enable {
 		policies = append(policies,
-			"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
-			"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy")
+			t.generateAWSManagedPolicyARN("AmazonEKSWorkerNodePolicy"),
+			t.generateAWSManagedPolicyARN("AmazonEKS_CNI_Policy"),
+		)
 	}
 
 	if t.Spec.Nodes.EC2ContainerRegistryReadOnly {
-		policies = append(policies, "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly")
+		policies = append(policies, t.generateAWSManagedPolicyARN("AmazonEC2ContainerRegistryReadOnly"))
 	}
 
 	return policies
@@ -94,4 +95,8 @@ func (t Template) nodePolicy() *iamv1.PolicyDocument {
 	)
 
 	return policyDocument
+}
+
+func (t Template) generateAWSManagedPolicyARN(name string) string {
+	return "arn:" + t.Spec.Partition + ":iam::aws:policy/" + name
 }

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -211,7 +211,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -211,7 +211,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -217,7 +217,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -216,7 +216,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -211,7 +211,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -211,7 +211,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:
@@ -252,7 +252,7 @@ Resources:
           - ssm:GetParameter
           Effect: Allow
           Resource:
-          - arn:aws:ssm:*:*:parameter/aws/service/eks/optimized-ami/*
+          - arn:*:ssm:*:*:parameter/aws/service/eks/optimized-ami/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:
@@ -260,7 +260,7 @@ Resources:
               iam:AWSServiceName: eks.amazonaws.com
           Effect: Allow
           Resource:
-          - arn:aws:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS
+          - arn:*:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:
@@ -268,13 +268,13 @@ Resources:
               iam:AWSServiceName: eks-nodegroup.amazonaws.com
           Effect: Allow
           Resource:
-          - arn:aws:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup
+          - arn:*:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup
         - Action:
           - iam:GetRole
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:
-          - arn:aws:iam::*:role/*
+          - arn:*:iam::*:role/*
         - Action:
           - iam:GetPolicy
           Effect: Allow
@@ -296,8 +296,8 @@ Resources:
           - eks:CreateNodegroup
           Effect: Allow
           Resource:
-          - arn:aws:eks:*:*:cluster/*
-          - arn:aws:eks:*:*:nodegroup/*/*/*
+          - arn:*:eks:*:*:cluster/*
+          - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
           - eks:ListAddons
           - eks:CreateAddon

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
@@ -211,7 +211,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:
@@ -252,7 +252,7 @@ Resources:
           - ssm:GetParameter
           Effect: Allow
           Resource:
-          - arn:aws:ssm:*:*:parameter/aws/service/eks/optimized-ami/*
+          - arn:*:ssm:*:*:parameter/aws/service/eks/optimized-ami/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:
@@ -260,7 +260,7 @@ Resources:
               iam:AWSServiceName: eks.amazonaws.com
           Effect: Allow
           Resource:
-          - arn:aws:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS
+          - arn:*:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:
@@ -268,13 +268,13 @@ Resources:
               iam:AWSServiceName: eks-nodegroup.amazonaws.com
           Effect: Allow
           Resource:
-          - arn:aws:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup
+          - arn:*:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup
         - Action:
           - iam:GetRole
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:
-          - arn:aws:iam::*:role/*
+          - arn:*:iam::*:role/*
         - Action:
           - iam:GetPolicy
           Effect: Allow
@@ -296,8 +296,8 @@ Resources:
           - eks:CreateNodegroup
           Effect: Allow
           Resource:
-          - arn:aws:eks:*:*:cluster/*
-          - arn:aws:eks:*:*:nodegroup/*/*/*
+          - arn:*:eks:*:*:cluster/*
+          - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
           - eks:ListAddons
           - eks:CreateAddon

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -211,7 +211,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -211,7 +211,7 @@ Resources:
           - autoscaling:DeleteTags
           Effect: Allow
           Resource:
-          - arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
         - Action:
           - iam:CreateServiceLinkedRole
           Condition:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/managed_control_plane.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/managed_control_plane.go
@@ -17,7 +17,7 @@ limitations under the License.
 package bootstrap
 
 func (t Template) eksControlPlanePolicies() []string {
-	policies := []string{EKSClusterPolicy}
+	policies := []string{t.generateAWSManagedPolicyARN(eksClusterPolicyName)}
 	if t.Spec.EKS.DefaultControlPlaneRole.ExtraPolicyAttachments != nil {
 		for _, policy := range t.Spec.EKS.DefaultControlPlaneRole.ExtraPolicyAttachments {
 			additionalPolicy := policy


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind regression
-->

**What this PR does / why we need it**:
Govcloud support was broken for CloudFormation since only there was hardcoded references to the AWS partition. A new global `partition` filed is added for referencing AWS managed policies.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x ] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Restore GovCloud and other AWS partition support for CloudFormation generation. If using EKS, you must provide the relevant value for `partition` in your clusterawsadm configuration file.
```
