### PR TITLE
Add enum validation for loadbalancer scheme

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -114,6 +114,8 @@ type Bastion struct {
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer
 type AWSLoadBalancerSpec struct {
 	// Scheme sets the scheme of the load balancer (defaults to Internet-facing)
+	// +kubebuilder:default=Internet-facing
+	// +kubebuilder:validation:Enum=Internet-facing;internal
 	// +optional
 	Scheme *ClassicELBScheme `json:"scheme,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -539,8 +539,12 @@ spec:
                       to false."
                     type: boolean
                   scheme:
+                    default: Internet-facing
                     description: Scheme sets the scheme of the load balancer (defaults
                       to Internet-facing)
+                    enum:
+                    - Internet-facing
+                    - internal
                     type: string
                   subnets:
                     description: Subnets sets the subnets that should be applied to


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Added enum check for loadbalancer scheme.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2155


-->
```release-note
Add validation for loadbalancer scheme to allow only Internet-facing and internal values. 
```
