### PR TITLE
feat: ability to delete amazon vpc cni

### DIFF
--- a/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
@@ -28,7 +28,7 @@ const (
 )
 
 // AWSManagedControlPlaneSpec defines the desired state of AWSManagedControlPlane
-type AWSManagedControlPlaneSpec struct {
+type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// EKSClusterName allows you to specify the name of the EKS cluster in
 	// AWS. If you don't specify a name then a default name will be created
 	// based on the namespace and name of the managed control plane.
@@ -148,6 +148,14 @@ type AWSManagedControlPlaneSpec struct {
 	// Addons defines the EKS addons to enable with the EKS cluster.
 	// +optional
 	Addons *[]Addon `json:"addons,omitempty"`
+
+	// DisableVPCCNI indcates the the Amazon VPC CNI should be disabled. With EKS clusters that
+	// the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want
+	// to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI
+	// should be deleted. You cannot set this to true if you are using the
+	// Amazon VPC CNI addon or if you have specified a secondary CIDR block.
+	// +kubebuilder:default=false
+	DisableVPCCNI bool `json:"disableVPCCNI,omitempty"`
 }
 
 // EndpointAccess specifies how control plane endpoints are accessible

--- a/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/controlplane/eks/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -152,6 +152,16 @@ spec:
                 - host
                 - port
                 type: object
+              disableVPCCNI:
+                default: false
+                description: DisableVPCCNI indcates the the Amazon VPC CNI should
+                  be disabled. With EKS clusters that the Amazon VPC CNI is automatically
+                  installed into the cluster. For clusters where you want to use an
+                  alternate CNI this option provides a way to specify that the Amazon
+                  VPC CNI should be deleted. You cannot set this to true if you are
+                  using the Amazon VPC CNI addon or if you have specified a secondary
+                  CIDR block.
+                type: boolean
               eksClusterName:
                 description: EKSClusterName allows you to specify the name of the
                   EKS cluster in AWS. If you don't specify a name then a default name

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -236,7 +236,7 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile control plane for AWSManagedControlPlane %s/%s: %w", awsManagedControlPlane.Namespace, awsManagedControlPlane.Name, err)
 	}
 
-	if err := awsnodeService.ReconcileCNI(); err != nil {
+	if err := awsnodeService.ReconcileCNI(ctx); err != nil {
 		conditions.MarkFalse(managedScope.InfraCluster(), infrav1.SecondaryCidrsReadyCondition, infrav1.SecondaryCidrReconciliationFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile control plane for AWSManagedControlPlane %s/%s: %w", awsManagedControlPlane.Namespace, awsManagedControlPlane.Name, err)
 	}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [EKS Support](./topics/eks/index.md)
     - [Prerequisites](./topics/eks/prerequisites.md)
     - [Enabling EKS Support](./topics/eks/enabling.md)
+    - [Pod Networking](./topics/eks/pod-networking.ms)
     - [Creating a cluster](./topics/eks/creating-a-cluster.md)
     - [Using EKS Console](./topics/eks/eks-console.md)
     - [Using EKS Addons](./topics/eks/addons.md)

--- a/docs/book/src/topics/eks/pod-networking.md
+++ b/docs/book/src/topics/eks/pod-networking.md
@@ -1,0 +1,34 @@
+# Pod Networking
+
+When creating a EKS cluster the Amazon VPC CNI will be used by default for Pod Networking.
+
+> When using the AWS Console to create an EKS cluster with a Kubernetes version of v1.18 or greater you are required to select a specific version of the VPC CNI to use.
+
+## Using the VPC CNI Addon
+You can use an explicit version of the Amazon VPC CNI by using the **vpc-cni** EKS addon. See the [addons](./addons.md) documentation for further details of how to use addons.
+
+## Using an alternative CNI
+
+There may be scenarios where you do not want to use the Amazon VPC CNI. EKS supports a number of alternative CNIs such as Calico and Weave Net (see [docs](https://docs.aws.amazon.com/eks/latest/userguide/alternate-cni-plugins.html) for full list).
+
+There are a number of ways to install an alternative CNI into the cluster. One option is to use a [ClusterResourceSet](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) to apply the required artifacts to a newly provisioned cluster.
+
+When using an alternative CNI you will want to delete the Amazon VPC CNI, especially for a cluster using v1.17 or less. This can be done via the **disableVPCCNI** property of the **AWSManagedControlPlane**:
+
+```yaml
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: "capi-managed-test-control-plane"
+spec:
+  region: "eu-west-2"
+  sshKeyName: "capi-management"
+  version: "v1.18.0"
+  disableVPCCNI: true
+```
+
+> You cannot set **disableVPCCNI** to true if you are using the VPC CNI addon or if you have specified a secondary CIDR block.
+
+## Additional Information
+
+See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html) for further details of EKS pod networking.

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -337,3 +337,8 @@ func (s *ManagedControlPlaneScope) Addons() []ekscontrolplanev1.Addon {
 	}
 	return *s.ControlPlane.Spec.Addons
 }
+
+// DisableVPCCNI returns whether the AWS VPC CNI should be disabled
+func (s *ManagedControlPlaneScope) DisableVPCCNI() bool {
+	return s.ControlPlane.Spec.DisableVPCCNI
+}

--- a/pkg/cloud/services/awsnode/service.go
+++ b/pkg/cloud/services/awsnode/service.go
@@ -35,6 +35,8 @@ type Scope interface {
 	SecondaryCidrBlock() *string
 	// SecurityGroups returns the control plane security groups as a map, it creates the map if empty.
 	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+	// DisableVPCCNI returns whether the AWS VPC CNI should be disabled
+	DisableVPCCNI() bool
 }
 
 type Service struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
A new property called **disableVPCCNI** has been introduced that can be used to ensure that the Amazon VPC CNI is deleted as part of the **AWSManageControlPlane** reconciliation. This is useful in scenarios where a different CNI is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2287 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Ability to declaratively remove the Amazon VPC CNI when using an alternate CNI
```
