### PR TITLE
Add list AMIs command to clusterawsadm

### DIFF
--- a/cmd/clusterawsadm/cmd/ami/ami.go
+++ b/cmd/clusterawsadm/cmd/ami/ami.go
@@ -19,6 +19,7 @@ package ami
 import (
 	"github.com/spf13/cobra"
 	cp "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/copy"
+	ls "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/list"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
 
@@ -44,5 +45,6 @@ func RootCmd() *cobra.Command {
 
 	newCmd.AddCommand(cp.CopyAMICmd())
 	newCmd.AddCommand(cp.EncryptedCopyAMICmd())
+	newCmd.AddCommand(ls.ListAMICmd())
 	return newCmd
 }

--- a/cmd/clusterawsadm/cmd/ami/list/helper.go
+++ b/cmd/clusterawsadm/cmd/ami/list/helper.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package copy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
+	ec2service "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
+	"sigs.k8s.io/cluster-api/test/framework/kubernetesversions"
+)
+
+const latestStableReleaseURL = "https://dl.k8s.io/release/stable%s.txt"
+
+func getSupportedOsList() []string {
+	return []string{"centos-7", "ubuntu-18.04", "ubuntu-20.04", "amazon-2"}
+}
+
+func getimageRegionList() []string {
+	return []string{
+		"ap-northeast-1",
+		"ap-northeast-2",
+		"ap-south-1",
+		"ap-southeast-1",
+		"ap-southeast-2",
+		"ca-central-1",
+		"eu-central-1",
+		"eu-west-1",
+		"eu-west-2",
+		"eu-west-3",
+		"sa-east-1",
+		"us-east-1",
+		"us-east-2",
+		"us-west-1",
+		"us-west-2",
+	}
+}
+
+func getSupportedKubernetesVersions() ([]string, error) {
+	supportedVersions := make([]string, 0)
+	latestVersion, err := latestStableRelease()
+	if err != nil {
+		return nil, err
+	}
+
+	supportedVersions = append(supportedVersions, latestVersion)
+	nMinusOne, err := kubernetesversions.PreviousMinorRelease(latestVersion)
+	if err != nil {
+		return nil, err
+	}
+	supportedVersions = append(supportedVersions, nMinusOne)
+
+	nMinusTwo, err := kubernetesversions.PreviousMinorRelease(nMinusOne)
+	if err != nil {
+		return nil, err
+	}
+	supportedVersions = append(supportedVersions, nMinusTwo)
+
+	return supportedVersions, nil
+}
+
+// latestStableRelease fetches the latest stable Kubernetes version
+// If it is a x.x.0 release, it gets the previous minor version.
+func latestStableRelease() (string, error) {
+	resp, err := http.Get(fmt.Sprintf(latestStableReleaseURL, ""))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	latestVersion := strings.TrimSpace(string(b))
+	tagPrefix := "v"
+	latestVersionSemVer, err := semver.Make(strings.TrimPrefix(latestVersion, tagPrefix))
+	if err != nil {
+		return "", err
+	}
+
+	// If it is the first release, use the previous version instead
+	if latestVersionSemVer.Patch == 0 {
+		latestVersionSemVer.Minor = latestVersionSemVer.Minor - 1
+		// Address to get stable release for a particular version is: https://dl.k8s.io/release/stable-1.19.txt"
+		olderVersion := fmt.Sprintf("-%v.%v", latestVersionSemVer.Major, latestVersionSemVer.Minor)
+		resp, err = http.Get(fmt.Sprintf(latestStableReleaseURL, olderVersion))
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		b, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		latestVersion = strings.TrimSpace(string(b))
+	}
+	return latestVersion, nil
+}
+
+func getAllImages(ec2Client ec2iface.EC2API, ownerID string) (map[string][]*ec2.Image, error) {
+	if ownerID == "" {
+		ownerID = ec2service.DefaultMachineAMIOwnerID
+	}
+
+	describeImageInput := &ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("owner-id"),
+				Values: []*string{aws.String(ownerID)},
+			},
+			{
+				Name:   aws.String("architecture"),
+				Values: []*string{aws.String("x86_64")},
+			},
+			{
+				Name:   aws.String("state"),
+				Values: []*string{aws.String("available")},
+			},
+			{
+				Name:   aws.String("virtualization-type"),
+				Values: []*string{aws.String("hvm")},
+			},
+		},
+	}
+
+	out, err := ec2Client.DescribeImages(describeImageInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch AMIs")
+	}
+	if len(out.Images) == 0 {
+		return nil, errors.Errorf("no AMIs in the account: %q", ownerID)
+	}
+
+	imagesMap := make(map[string][]*ec2.Image)
+	for _, image := range out.Images {
+		arr := strings.Split(aws.StringValue(image.Name), "-")
+		arr = arr[:len(arr)-2]
+		name := strings.Join(arr, "-")
+		images, ok := imagesMap[name]
+		if !ok {
+			images = make([]*ec2.Image, 0)
+		}
+		imagesMap[name] = append(images, image)
+	}
+
+	return imagesMap, nil
+}
+
+func findAMI(imagesMap map[string][]*ec2.Image, baseOS, kubernetesVersion string) (*ec2.Image, error) {
+	amiNameFormat := "capa-ami-{{.BaseOS}}-{{.K8sVersion}}"
+	amiName, err := ec2service.GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to process ami format: %q", amiNameFormat)
+	}
+
+	if val, ok := imagesMap[amiName]; ok {
+		latestImage, err := ec2service.GetLatestImage(val)
+		if err != nil {
+			return nil, err
+		}
+		return latestImage, nil
+	}
+
+	return nil, errors.Errorf("failed to find ami %s", amiName)
+}

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package copy
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/flags"
+	cmdout "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/printers"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
+)
+
+var (
+	kubernetesVersion string
+	opSystem          string
+	outputPrinter     string
+)
+
+type amiInfo struct {
+	OS                string `json:"os"`
+	Region            string `json:"region"`
+	ID                string `json:"amiID"`
+	CreationDate      string `json:"creationDate"`
+	KubernetesVersion string `json:"kubernetesVersion"`
+	Name              string `json:"name"`
+}
+
+func ListAMICmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List AMIs from the default AWS account where AMIs are stored",
+		Long: cmd.LongDesc(`
+			List AMIs based on Kubernetes version, OS, region. If no arguments are provided,
+			it will print all AMIs in all regions, OS types for the supported Kubernetes versions.
+            Supported Kubernetes versions start from the latest stable version and goes 2 release back:
+			if the latest stable release is v1.20.4- v1.19.x and v1.18.x are supported.
+			Note: First release of each version will be skipped, e.g., v1.21.0
+			To list AMIs of unsupported Kubernetes versions, --kubernetes-version flag needs to be provided.
+		`),
+		Example: cmd.Examples(`
+		# List AMIs from the default AWS account where AMIs are stored.
+		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2
+		clusterawsadm ami list --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
+		# To list all supported AMIs in all supported Kubernetes versions, regions, and linux distributions:
+		clusterawsadm ami list
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			supportedOsList := []string{}
+			if opSystem == "" {
+				supportedOsList = getSupportedOsList()
+			} else {
+				supportedOsList = append(supportedOsList, opSystem)
+			}
+			imageRegionList := []string{}
+			region := cmd.Flags().Lookup("region").Value.String()
+			if region == "" {
+				imageRegionList = getimageRegionList()
+			} else {
+				imageRegionList = append(imageRegionList, region)
+			}
+
+			supportedVersions := []string{}
+			if kubernetesVersion == "" {
+				var err error
+				supportedVersions, err = getSupportedKubernetesVersions()
+				if err != nil {
+					fmt.Println("Failed to calculate supported Kubernetes versions")
+					return err
+				}
+			} else {
+				supportedVersions = append(supportedVersions, kubernetesVersion)
+			}
+
+			var sessionCache sync.Map
+			imageMap := make(map[string][]*ec2.Image)
+			for _, region := range imageRegionList {
+				var sess *session.Session
+				var err error
+				if s, ok := sessionCache.Load(region); ok {
+					sess = s.(*session.Session)
+				} else {
+					sess, err = session.NewSessionWithOptions(session.Options{
+						SharedConfigState: session.SharedConfigEnable,
+						Config:            aws.Config{Region: aws.String(region)},
+					})
+					if err != nil {
+						fmt.Printf("Error: %v\n", err)
+						return err
+					}
+					sessionCache.Store(region, sess)
+				}
+
+				ec2Client := ec2.New(sess)
+				imagesForRegion, err := getAllImages(ec2Client, "")
+				if err != nil {
+					fmt.Printf("Error: %v\n", err)
+					return err
+				}
+
+				for key, image := range imagesForRegion {
+					images, ok := imageMap[key]
+					if !ok {
+						images = make([]*ec2.Image, 0)
+					}
+					imageMap[key] = append(images, image...)
+				}
+			}
+
+			listByVersion := amiList{
+				AmiList: []amiInfo{},
+			}
+			for _, version := range supportedVersions {
+				for _, region := range imageRegionList {
+					for _, os := range supportedOsList {
+						image, err := findAMI(imageMap, os, version)
+						if err != nil {
+							return err
+						}
+						listByVersion.AmiList = append(listByVersion.AmiList, amiInfo{
+							OS:                os,
+							Region:            region,
+							ID:                *image.ImageId,
+							CreationDate:      *image.CreationDate,
+							KubernetesVersion: version,
+							Name:              *image.Name,
+						})
+					}
+				}
+			}
+			printer, err := cmdout.New(outputPrinter, os.Stderr)
+			if err != nil {
+				return fmt.Errorf("failed creating output printer: %w", err)
+			}
+
+			if outputPrinter == string(cmdout.PrinterTypeTable) {
+				table := listByVersion.ToTable()
+				printer.Print(table)
+			} else {
+				printer.Print(listByVersion)
+			}
+
+			return nil
+		},
+	}
+
+	flags.AddRegionFlag(newCmd)
+	addOsFlag(newCmd)
+	addKubernetesVersionFlag(newCmd)
+	addOutputFlag(newCmd)
+	return newCmd
+}
+
+func addOsFlag(c *cobra.Command) {
+	c.Flags().StringVar(&opSystem, "os", "", "Operating system of the AMI to be copied")
+}
+
+func addKubernetesVersionFlag(c *cobra.Command) {
+	c.Flags().StringVar(&kubernetesVersion, "kubernetes-version", "", "Kubernetes version of the AMI to be copied")
+}
+
+func addOutputFlag(c *cobra.Command) {
+	c.Flags().StringVarP(&outputPrinter, "output", "o", "table", "The output format of the results. Possible values: table,json,yaml")
+}
+
+type amiList struct {
+	AmiList []amiInfo `json:"AMIs"`
+}
+
+func (a *amiList) ToTable() *metav1.Table {
+	table := &metav1.Table{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: metav1.SchemeGroupVersion.String(),
+			Kind:       "Table",
+		},
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{
+				Name: "Kubernetes-version",
+				Type: "string",
+			},
+			{
+				Name: "Region",
+				Type: "string",
+			},
+			{
+				Name: "OS",
+				Type: "string",
+			},
+			{
+				Name: "Name",
+				Type: "string",
+			},
+			{
+				Name: "Ami-id",
+				Type: "string",
+			},
+		},
+	}
+
+	for _, ami := range a.AmiList {
+
+		row := metav1.TableRow{
+			Cells: []interface{}{ami.KubernetesVersion, ami.Region, ami.OS, ami.Name, ami.ID},
+		}
+		table.Rows = append(table.Rows, row)
+
+	}
+	return table
+}

--- a/cmd/clusterawsadm/printers/printers.go
+++ b/cmd/clusterawsadm/printers/printers.go
@@ -108,7 +108,7 @@ type jsonPrinter struct {
 }
 
 func (p *jsonPrinter) Print(in interface{}) error {
-	data, err := json.Marshal(in)
+	data, err := json.MarshalIndent(in, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshalling object as json: %w", err)
 	}

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -42,13 +42,13 @@ const (
 	// when looking up machine AMIs
 	defaultMachineAMILookupBaseOS = "ubuntu-18.04"
 
-	// defaultAmiNameFormat is defined in the build/ directory of this project.
+	// DefaultAmiNameFormat is defined in the build/ directory of this project.
 	// The pattern is:
 	// 1. the string value `capa-ami-`
 	// 2. the baseOS of the AMI, for example: ubuntu-18.04, centos-7, amazon-2
 	// 3. the kubernetes version as defined by the packages produced by kubernetes/release with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1, v1.17.3
 	// 4. a `-` followed by any additional characters
-	defaultAmiNameFormat = "capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*"
+	DefaultAmiNameFormat = "capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*"
 
 	// Amazon's AMI timestamp format
 	createDateTimestampFormat = "2006-01-02T15:04:05.000Z"
@@ -63,11 +63,11 @@ type AMILookup struct {
 	K8sVersion string
 }
 
-func amiName(amiNameFormat, baseOS, kubernetesVersion string) (string, error) {
+func GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion string) (string, error) {
 	amiNameParameters := AMILookup{baseOS, strings.TrimPrefix(kubernetesVersion, "v")}
 	// revert to default if not specified
 	if amiNameFormat == "" {
-		amiNameFormat = defaultAmiNameFormat
+		amiNameFormat = DefaultAmiNameFormat
 	}
 	var templateBytes bytes.Buffer
 	template, err := template.New("amiName").Parse(amiNameFormat)
@@ -83,7 +83,7 @@ func amiName(amiNameFormat, baseOS, kubernetesVersion string) (string, error) {
 
 func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVersion, amiNameFormat string) (*ec2.Image, error) {
 	if amiNameFormat == "" {
-		amiNameFormat = defaultAmiNameFormat
+		amiNameFormat = DefaultAmiNameFormat
 	}
 	if ownerID == "" {
 		ownerID = DefaultMachineAMIOwnerID
@@ -92,7 +92,7 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 		baseOS = defaultMachineAMILookupBaseOS
 	}
 
-	amiName, err := amiName(amiNameFormat, baseOS, kubernetesVersion)
+	amiName, err := GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to process ami format: %q", amiNameFormat)
 	}
@@ -128,7 +128,7 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 	if len(out.Images) == 0 {
 		return nil, errors.Errorf("found no AMIs with the name: %q", amiName)
 	}
-	latestImage, err := getLatestImage(out.Images)
+	latestImage, err := GetLatestImage(out.Images)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 func (s *Service) defaultAMIIDLookup(amiNameFormat, ownerID, baseOS, kubernetesVersion string) (string, error) {
 	latestImage, err := DefaultAMILookup(s.EC2Client, ownerID, baseOS, kubernetesVersion, amiNameFormat)
 	if err != nil {
-		record.Eventf(s.scope.InfraCluster(), "FailedDescribeImages", "Failed to find ami %q: %v", amiName, err)
+		record.Eventf(s.scope.InfraCluster(), "FailedDescribeImages", "Failed to find ami for OS=%s and Kubernetes-version=%s: %v", baseOS, kubernetesVersion, err)
 		return "", errors.Wrapf(err, "failed to find ami")
 	}
 
@@ -169,8 +169,8 @@ func (i images) Swap(k, j int) {
 	i[k], i[j] = i[j], i[k]
 }
 
-// getLatestImage assumes imgs is not empty. Responsibility of the caller to check.
-func getLatestImage(imgs []*ec2.Image) (*ec2.Image, error) {
+// GetLatestImage assumes imgs is not empty. Responsibility of the caller to check.
+func GetLatestImage(imgs []*ec2.Image) (*ec2.Image, error) {
 	for _, img := range imgs {
 		if _, err := time.Parse(createDateTimestampFormat, aws.StringValue(img.CreationDate)); err != nil {
 			return nil, err

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -559,7 +559,7 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
-				amiName, err := amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
+				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
 				if err != nil {
 					t.Fatalf("Failed to process ami format: %v", err)
 				}
@@ -688,7 +688,7 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
-				amiName, err := amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
+				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
 				if err != nil {
 					t.Fatalf("Failed to process ami format: %v", err)
 				}
@@ -818,7 +818,7 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
-				amiName, err := amiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
+				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "v1.16.1")
 				if err != nil {
 					t.Fatalf("Failed to process ami format: %v", err)
 				}


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds a list command to clusterawsadm to list AMIs based on OS, region, and Kubernetes version.

`clusterawsadm ami list --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
`

If none of the flags are used (`clusterawsadm ami list`), lists AMIs in all supported regions, OSes, and supported Kubernetes versions (N-2).

Example output:

```
$ clusterawsadm ami list --kubernetes-version=v1.19.3 -o json
{
  "AMIs": [
    {
      "os": "centos-7",
      "region": "ap-northeast-1",
      "amiID": "ami-08cc1e47b38d69085",
      "creationDate": "2020-11-14T21:33:51.000Z",
      "kubernetesVersion": "v1.19.3",
      "name": "capa-ami-centos-7-1.19.3-00-1605388645"
    },
    {
      "os": "ubuntu-18.04",
      "region": "ap-northeast-1",
      "amiID": "ami-006d394ac4256d33f",
      "creationDate": "2020-11-14T21:31:13.000Z",
      "kubernetesVersion": "v1.19.3",
      "name": "capa-ami-ubuntu-18.04-1.19.3-00-1605388698"
    },
 ],
}


$ clusterawsadm ami list --os=ubuntu-20.04 --region=us-west-2 -o table    
KUBERNETES-VERSION   REGION      OS             NAME                                          AMI-ID
v1.20.5              us-west-2   ubuntu-20.04   capa-ami-ubuntu-20.04-1.20.5-00-1616559327    ami-0d113dce59b31b889
v1.19.9              us-west-2   ubuntu-20.04   capa-ami-ubuntu-20.04-1.19.9-00-1616561685    ami-08d2e02e495ee1f75
v1.18.17             us-west-2   ubuntu-20.04   capa-ami-ubuntu-20.04-1.18.17-00-1616561896   ami-07ade7df8dc883555


```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2040

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

```release-note
Add `clusterawsadm ami list` command to list AMIs that can be filtered by region, OS, and Kubernetes version.
```
