### PR TITLE
docs: clarify subnet requirements for existing-aws-infrastructure

### DIFF
--- a/docs/book/src/topics/consuming-existing-aws-infrastructure.md
+++ b/docs/book/src/topics/consuming-existing-aws-infrastructure.md
@@ -8,12 +8,11 @@ In order to have Cluster API consume existing AWS infrastructure, you will need 
 
 * A VPC
 * One or more private subnets (subnets that do not have a route to an Internet gateway)
-* A public subnet in the same Availability Zone (AZ) for each private subnet (this is required for NAT gateways to function properly)
-* A NAT gateway for each private subnet, along with associated Elastic IP addresses
-* An Internet gateway for all public subnets
+* A NAT gateway for each private subnet, along with associated Elastic IP addresses (only needed if the nodes require access to the Internet, i.e. pulling public images)
+  * A public subnet in the same Availability Zone (AZ) for each private subnet (this is required for NAT gateways to function properly)
+* An Internet gateway for all public subnets (only required if the workload cluster is set to use an Internet facing load balancer or one or more NAT gateways exist in the VPC)
 * Route table associations that provide connectivity to the Internet through a NAT gateway (for private subnets) or the Internet gateway (for public subnets)
-
-Note that a public subnet (and associated Internet gateway) are required even if the control plane of the workload cluster is set to use an internal load balancer.
+* VPC endpoints for `ec2`, `elasticloadbalancing`, `secretsmanager` an `autoscaling` (if using MachinePools) when the private Subnets do not have a NAT gateway
 
 You will need the ID of the VPC and subnet IDs that Cluster API should use. This information is available via the AWS Management Console or the AWS CLI.
 
@@ -56,7 +55,7 @@ spec:
     - id: subnet-0fdcccba78668e013
 ```
 
-When you use `kubectl apply` to apply the Cluster and AWSCluster specifications to the management cluster, Cluster API will use the specified VPC ID, will discover the associated subnet IDs, and will not create a new VPC, new subnets, or other associated resources. It _will_, however, create a new ELB and new security groups.
+When you use `kubectl apply` to apply the Cluster and AWSCluster specifications to the management cluster, Cluster API will use the specified VPC ID and subnet IDs, and will not create a new VPC, new subnets, or other associated resources. It _will_, however, create a new ELB and new security groups.
 
 ## Placing EC2 Instances in Specific AZs
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind documentation

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Clarifying the requirements for existing subnets.
* Line 59 seemed to be no longer true after https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1721, when I didn't specify the subnets I saw:
```
E0317 17:08:36.026968       1 controller.go:257] controller-runtime/controller "msg"="Reconciler error" "error"="failed to reconcile network for AWSCluster default/dkoshkin-aws: no subnets specified, you must specify the subnets when using an umanaged vpc"
```

* The list of Prerequisites sounds like there is a hard requirement on having public subnets or access to the Internet. Changed the wording a bit to let others know that it is possible to create a managed cluster with only private subnets. (Assuming your bootstrap cluster is either running in the same VPC or has some access to it)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
