### PR TITLE
:bug: Accept empty string SSHKeyName in AWSCluster & AWSMachine validation webhooks

### DIFF
--- a/api/v1alpha3/awscluster_webhook.go
+++ b/api/v1alpha3/awscluster_webhook.go
@@ -50,7 +50,7 @@ func (r *AWSCluster) ValidateCreate() error {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, r.Spec.Bastion.Validate()...)
-	allErrs = append(allErrs, isValidSSHKey(r.Spec.SSHKeyName)...)
+	allErrs = append(allErrs, isValidSSHKeyName(r.Spec.SSHKeyName)...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }

--- a/api/v1alpha3/awscluster_webhook_test.go
+++ b/api/v1alpha3/awscluster_webhook_test.go
@@ -43,10 +43,28 @@ func TestAWSCluster_ValidateCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "SSH key name should valid",
+			name: "SSH key name is valid",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					SSHKeyName: aws.String("test-capi"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "SSH key name is an empty string",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					SSHKeyName: aws.String(""),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "SSH key name field is nil",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					SSHKeyName: nil,
 				},
 			},
 			wantErr: false,

--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -52,7 +52,7 @@ func (r *AWSMachine) ValidateCreate() error {
 	allErrs = append(allErrs, r.validateCloudInitSecret()...)
 	allErrs = append(allErrs, r.validateRootVolume()...)
 	allErrs = append(allErrs, r.validateNonRootVolumes()...)
-	allErrs = append(allErrs, isValidSSHKey(r.Spec.SSHKeyName)...)
+	allErrs = append(allErrs, isValidSSHKeyName(r.Spec.SSHKeyName)...)
 	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)

--- a/api/v1alpha3/awsmachine_webhook_test.go
+++ b/api/v1alpha3/awsmachine_webhook_test.go
@@ -142,6 +142,24 @@ func TestAWSMachine_Create(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "SSH key name is an empty string",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					SSHKeyName: aws.String(""),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "SSH key name field is nil",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					SSHKeyName: nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "additional security groups may have id",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{

--- a/api/v1alpha3/validate.go
+++ b/api/v1alpha3/validate.go
@@ -19,8 +19,13 @@ package v1alpha3
 import (
 	"fmt"
 	"net"
+	"regexp"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var (
+	sshKeyValidNameRegex = regexp.MustCompile(`^[[:graph:]]+([[:print:]]*[[:graph:]]+)*$`)
 )
 
 // Validate will validate the bastion fields
@@ -42,4 +47,17 @@ func (b *Bastion) Validate() []*field.Error {
 		}
 	}
 	return errs
+}
+
+func isValidSSHKeyName(sshKey *string) field.ErrorList {
+	var allErrs field.ErrorList
+	switch {
+	case sshKey == nil:
+	// nil is accepted
+	case sshKey != nil && *sshKey == "":
+	// empty string is accepted
+	case sshKey != nil && !sshKeyValidNameRegex.Match([]byte(*sshKey)):
+		allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
+	}
+	return allErrs
 }

--- a/api/v1alpha3/webhooks.go
+++ b/api/v1alpha3/webhooks.go
@@ -17,15 +17,9 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"regexp"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-)
-
-var (
-	sshKeyValidNameRegex = regexp.MustCompile(`^[[:graph:]]+([[:print:]]*[[:graph:]]+)*$`)
 )
 
 func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorList) error {
@@ -38,17 +32,4 @@ func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorLis
 		name,
 		allErrs,
 	)
-}
-
-func isValidSSHKey(sshKey *string) field.ErrorList {
-	var allErrs field.ErrorList
-	switch {
-	case sshKey == nil:
-	// nil is accepted
-	case sshKey != nil && *sshKey == "":
-	// empty string is accepted
-	case sshKey != nil && !sshKeyValidNameRegex.Match([]byte(*sshKey)):
-		allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
-	}
-	return allErrs
 }

--- a/api/v1alpha3/webhooks.go
+++ b/api/v1alpha3/webhooks.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"regexp"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"regexp"
 )
 
 var (
@@ -41,11 +42,13 @@ func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorLis
 
 func isValidSSHKey(sshKey *string) field.ErrorList {
 	var allErrs field.ErrorList
-	if sshKey != nil {
-		if sshKey != nil && !sshKeyValidNameRegex.Match([]byte(*sshKey)) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
-		}
+	switch {
+	case sshKey == nil:
+	// nil is accepted
+	case sshKey != nil && *sshKey == "":
+	// empty string is accepted
+	case sshKey != nil && !sshKeyValidNameRegex.Match([]byte(*sshKey)):
+		allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
 	}
-
 	return allErrs
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Makes the AWSCluster & AWSMachine validation webhooks accept an empty string for `SSHKeyName`. That value is supported by the API.
 
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2306 

**Special notes for your reviewer**:
- The webhook test files have slightly different sets of SSHKeyName validation tests. The SSHKeyName field is common to both AWSCluster and AWSMachine, so I think there should be one set of tests for the field. I can do this in a follow-up PR. WDYT?
- The first two commits add tests; they are expected to fail. The third commit adds the fix.
- 
**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix the AWSCluster & AWSMachine validation webhooks, so that they accept an empty string for the `SSHKeyName` field.
```
