### PR TITLE
Add Apidiff script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ CONFORMANCE_CI_TEMPLATE := $(ARTIFACTS)/templates/cluster-template-conformance-c
 EXP_DIR := exp
 
 # Binaries.
+GO_APIDIFF := $(TOOLS_BIN_DIR)/go-apidiff
 CLUSTERCTL := $(BIN_DIR)/clusterctl
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
 CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -58,6 +58,11 @@ $(SHARE_DIR):
 $(GTAR):
 	@$(GTAR) --version > /dev/null || (echo Install GNU Tar with brew install gnu-tar && exit -1)
 
+
+GO_APIDIFF := $(BIN_DIR)/go-apidiff
+$(GO_APIDIFF): $(BIN_DIR) go.mod go.sum
+	go build -tags=tools -o $@ github.com/joelanford/go-apidiff
+
 CONTROLLER_GEN := $(BIN_DIR)/controller-gen
 $(CONTROLLER_GEN): $(BIN_DIR) go.mod go.sum # Build controller-gen from tools folder.
 	go build -tags=tools -o $@ sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -801,6 +801,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+APIDIFF="hack/tools/bin/go-apidiff"
+
+cd "${REPO_ROOT}" && make ${APIDIFF}
+echo "*** Running go-apidiff ***"
+
+${APIDIFF} "${PULL_BASE_SHA}" --print-compatible

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 
 	SetDefaultEventuallyTimeout(20 * time.Minute)
 	SetDefaultEventuallyPollingInterval(10 * time.Second)
-	Context("Running the quick-start spec", func() {
+	Context("Running the quick-start spec [PR-Blocking]", func() {
 		capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
 			return capi_e2e.QuickStartSpecInput{
 				E2EConfig:             e2eCtx.E2EConfig,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds apidiff script which is added to a job here: https://github.com/kubernetes/test-infra/pull/21451

Also adds PR-blocking tag to the CAPI's quick start test, it is added as PR-blocking presubmit job (https://github.com/kubernetes/test-infra/pull/21451)

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2130

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
