### PR TITLE
refactor: Group SSH Key Name validation tests together

### DIFF
--- a/api/v1alpha3/awscluster_webhook.go
+++ b/api/v1alpha3/awscluster_webhook.go
@@ -50,7 +50,7 @@ func (r *AWSCluster) ValidateCreate() error {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, r.Spec.Bastion.Validate()...)
-	allErrs = append(allErrs, isValidSSHKeyName(r.Spec.SSHKeyName)...)
+	allErrs = append(allErrs, r.validateSSHKeyName()...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
@@ -104,4 +104,8 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 func (r *AWSCluster) Default() {
 	SetDefaults_Bastion(&r.Spec.Bastion)
 	SetDefaults_NetworkSpec(&r.Spec.NetworkSpec)
+}
+
+func (r *AWSCluster) validateSSHKeyName() field.ErrorList {
+	return validateSSHKeyName(r.Spec.SSHKeyName)
 }

--- a/api/v1alpha3/awscluster_webhook_test.go
+++ b/api/v1alpha3/awscluster_webhook_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,42 +32,7 @@ func TestAWSCluster_ValidateCreate(t *testing.T) {
 		cluster *AWSCluster
 		wantErr bool
 	}{
-		{
-			name: "SSH key name is not valid",
-			cluster: &AWSCluster{
-				Spec: AWSClusterSpec{
-					SSHKeyName: aws.String("test-capi\t"),
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "SSH key name is valid",
-			cluster: &AWSCluster{
-				Spec: AWSClusterSpec{
-					SSHKeyName: aws.String("test-capi"),
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "SSH key name is an empty string",
-			cluster: &AWSCluster{
-				Spec: AWSClusterSpec{
-					SSHKeyName: aws.String(""),
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "SSH key name field is nil",
-			cluster: &AWSCluster{
-				Spec: AWSClusterSpec{
-					SSHKeyName: nil,
-				},
-			},
-			wantErr: false,
-		},
+		// The SSHKeyName tests were moved to sshkeyname_test.go
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/v1alpha3/awsmachine_webhook.go
+++ b/api/v1alpha3/awsmachine_webhook.go
@@ -52,7 +52,7 @@ func (r *AWSMachine) ValidateCreate() error {
 	allErrs = append(allErrs, r.validateCloudInitSecret()...)
 	allErrs = append(allErrs, r.validateRootVolume()...)
 	allErrs = append(allErrs, r.validateNonRootVolumes()...)
-	allErrs = append(allErrs, isValidSSHKeyName(r.Spec.SSHKeyName)...)
+	allErrs = append(allErrs, r.validateSSHKeyName()...)
 	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
@@ -198,4 +198,8 @@ func (r *AWSMachine) validateAdditionalSecurityGroups() field.ErrorList {
 		}
 	}
 	return allErrs
+}
+
+func (r *AWSMachine) validateSSHKeyName() field.ErrorList {
+	return validateSSHKeyName(r.Spec.SSHKeyName)
 }

--- a/api/v1alpha3/awsmachine_webhook_test.go
+++ b/api/v1alpha3/awsmachine_webhook_test.go
@@ -106,60 +106,6 @@ func TestAWSMachine_Create(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "SSH key is invalid",
-			machine: &AWSMachine{
-				Spec: AWSMachineSpec{
-					SSHKeyName: aws.String("test\t"),
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "SSH key is valid",
-			machine: &AWSMachine{
-				Spec: AWSMachineSpec{
-					SSHKeyName: aws.String("test"),
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "SSH key with underscore is valid",
-			machine: &AWSMachine{
-				Spec: AWSMachineSpec{
-					SSHKeyName: aws.String("test_key"),
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "SSH key with dash is valid",
-			machine: &AWSMachine{
-				Spec: AWSMachineSpec{
-					SSHKeyName: aws.String(`test-key`),
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "SSH key name is an empty string",
-			machine: &AWSMachine{
-				Spec: AWSMachineSpec{
-					SSHKeyName: aws.String(""),
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "SSH key name field is nil",
-			machine: &AWSMachine{
-				Spec: AWSMachineSpec{
-					SSHKeyName: nil,
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name: "additional security groups may have id",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{

--- a/api/v1alpha3/sshkeyname_test.go
+++ b/api/v1alpha3/sshkeyname_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test_SSHKeyName(t *testing.T) {
+	tests := []struct {
+		name       string
+		sshKeyName *string
+		wantErr    bool
+	}{
+		{
+			name:       "SSH key name is nil is valid",
+			sshKeyName: nil,
+			wantErr:    false,
+		},
+		{
+			name:       "SSH key name is an empty string is valid",
+			sshKeyName: aws.String(""),
+			wantErr:    false,
+		},
+		{
+			name:       "SSH key name with alphanumeric characters is valid",
+			sshKeyName: aws.String("test123"),
+			wantErr:    false,
+		},
+		{
+			name:       "SSH key name with underscore is valid",
+			sshKeyName: aws.String("test_key"),
+			wantErr:    false,
+		},
+		{
+			name:       "SSH key name with dash is valid",
+			sshKeyName: aws.String(`test-key`),
+			wantErr:    false,
+		},
+		{
+			name:       "SSH key name with tab is not valid",
+			sshKeyName: aws.String("test-capi\t"),
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cluster-",
+					Namespace:    "default",
+				},
+				Spec: AWSClusterSpec{
+					SSHKeyName: tt.sshKeyName,
+				},
+			}
+			machine := &AWSMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "machine-",
+					Namespace:    "default",
+				},
+				Spec: AWSMachineSpec{
+					SSHKeyName: tt.sshKeyName,
+				},
+			}
+			for _, obj := range []runtime.Object{cluster, machine} {
+				ctx := context.TODO()
+				if err := testEnv.Create(ctx, obj); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateCreate() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}

--- a/api/v1alpha3/validate.go
+++ b/api/v1alpha3/validate.go
@@ -49,7 +49,7 @@ func (b *Bastion) Validate() []*field.Error {
 	return errs
 }
 
-func isValidSSHKeyName(sshKey *string) field.ErrorList {
+func validateSSHKeyName(sshKey *string) field.ErrorList {
 	var allErrs field.ErrorList
 	switch {
 	case sshKey == nil:


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
- There were two, partially overlapping, sets of SSHKeyName field validation tests. Now there is one common set.  (I asked if this change was wanted, and [got a +1](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2308#issuecomment-803022348).)
- Validates SSHKeyName using the same convention (a receiver) used to validate other fields.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
