### PR TITLE
🐛fix for vpc deletion failure

### DIFF
--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -194,6 +194,11 @@ func (s *Service) DeleteSecurityGroups() error {
 		}
 	}
 
+	if s.scope.VPC().ID == "" {
+		s.scope.V(0).Info("skipping cluster owned security group delete, vpc id nil", "vpc-id", s.scope.VPC().ID)
+		return nil
+	}
+
 	clusterGroups, err := s.describeClusterOwnedSecurityGroups()
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes cluster deletion failure.
If a cluster is created with VPC quota limit being exhausted vpc id is not provided, when we try to delete the cluster, it gets stuck at delete security groups because there is no VPC-ID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2227

**Special notes for your reviewer**:

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
