### PR TITLE
Add generic defaulting create and update validation

### DIFF
--- a/api/v1alpha3/awscluster_webhook_test.go
+++ b/api/v1alpha3/awscluster_webhook_test.go
@@ -26,6 +26,23 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
+func TestAWSCluster_ValidateDefaultCreate(t *testing.T) {
+	g := NewWithT(t)
+	r := &AWSCluster{}
+
+	r.Default()
+	g.Expect(r.ValidateCreate()).To(Succeed())
+}
+
+func TestAWSCluster_ValidateDefaultUpdate(t *testing.T) {
+	g := NewWithT(t)
+	r := &AWSCluster{}
+
+	defaulted := r.DeepCopy()
+	defaulted.Default()
+	g.Expect(defaulted.ValidateUpdate(r)).To(Succeed())
+}
+
 func TestAWSCluster_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/api/v1alpha3/awsmachine_webhook_test.go
+++ b/api/v1alpha3/awsmachine_webhook_test.go
@@ -27,6 +27,23 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+func TestAWSMachine_ValidateDefaultCreate(t *testing.T) {
+	g := NewWithT(t)
+	r := &AWSMachine{}
+
+	r.Default()
+	g.Expect(r.ValidateCreate()).To(Succeed())
+}
+
+func TestAWSMachine_ValidateDefaultUpdate(t *testing.T) {
+	g := NewWithT(t)
+	r := &AWSMachine{}
+
+	defaulted := r.DeepCopy()
+	defaulted.Default()
+	g.Expect(defaulted.ValidateUpdate(r)).To(Succeed())
+}
+
 func TestAWSMachine_Create(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We have envtest tests so technically this should already be covered, but adding a basic test to check for regressions as per https://github.com/kubernetes-sigs/cluster-api/pull/4448 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
