### PR TITLE
:bug: Refer to `sshKeyName` field in error

### DIFF
--- a/api/v1alpha3/validate.go
+++ b/api/v1alpha3/validate.go
@@ -49,15 +49,15 @@ func (b *Bastion) Validate() []*field.Error {
 	return errs
 }
 
-func validateSSHKeyName(sshKey *string) field.ErrorList {
+func validateSSHKeyName(sshKeyName *string) field.ErrorList {
 	var allErrs field.ErrorList
 	switch {
-	case sshKey == nil:
+	case sshKeyName == nil:
 	// nil is accepted
-	case sshKey != nil && *sshKey == "":
+	case sshKeyName != nil && *sshKeyName == "":
 	// empty string is accepted
-	case sshKey != nil && !sshKeyValidNameRegex.Match([]byte(*sshKey)):
-		allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
+	case sshKeyName != nil && !sshKeyValidNameRegex.Match([]byte(*sshKeyName)):
+		allErrs = append(allErrs, field.Invalid(field.NewPath("sshKeyName"), sshKeyName, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
 	}
 	return allErrs
 }


### PR DESCRIPTION
There is no `sshKey` field.

**What type of PR is this?**
/kind bug
/kind api-change

**What this PR does / why we need it**:
The current error refers to the `sshKey` field, which does not exist:
```
Error from server (AWSCluster.infrastructure.cluster.x-k8s.io "test" is invalid: sshKey: Invalid value: ...
```
This PR corrects the field name in the error:
```
Error from server (AWSCluster.infrastructure.cluster.x-k8s.io "test" is invalid: sshKeyName: Invalid value: ...
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
If the error string is considered part of the API, then this PR changes the API.

**Checklist**:

**Release note**:
<!--  Write your release note:
-->
```release-note
The error reported as the result of an invalid `sshKeyName` field is changed to refer to that field. 
```
