### PR TITLE
:bug: AWSMachinePool: When userdata changes, create new LaunchTemplate version, but don't start Instance Refresh

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	asg "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/autoscaling"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/util"
@@ -377,15 +378,16 @@ func (r *AWSMachinePoolReconciler) findASG(machinePoolScope *scope.MachinePoolSc
 }
 
 func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *scope.MachinePoolScope, ec2Scope scope.EC2Scope) error {
-	userData, err := machinePoolScope.GetRawBootstrapData()
+	bootstrapData, err := machinePoolScope.GetRawBootstrapData()
 	if err != nil {
 		r.Recorder.Eventf(machinePoolScope.AWSMachinePool, corev1.EventTypeWarning, "FailedGetBootstrapData", err.Error())
 	}
+	bootstrapDataHash := userdata.ComputeHash(bootstrapData)
 
 	ec2svc := r.getEC2Service(ec2Scope)
 
 	machinePoolScope.Info("checking for existing launch template")
-	launchTemplate, _, err := ec2svc.GetLaunchTemplate(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID)
+	launchTemplate, launchTemplateUserDataHash, err := ec2svc.GetLaunchTemplate(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID)
 	if err != nil {
 		conditions.MarkUnknown(machinePoolScope.AWSMachinePool, infrav1exp.LaunchTemplateReadyCondition, infrav1exp.LaunchTemplateNotFoundReason, err.Error())
 		return err
@@ -399,7 +401,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 
 	if launchTemplate == nil {
 		machinePoolScope.Info("no existing launch template found, creating")
-		launchTemplateID, err := ec2svc.CreateLaunchTemplate(machinePoolScope, imageID, userData)
+		launchTemplateID, err := ec2svc.CreateLaunchTemplate(machinePoolScope, imageID, bootstrapData)
 		if err != nil {
 			conditions.MarkFalse(machinePoolScope.AWSMachinePool, infrav1exp.LaunchTemplateReadyCondition, infrav1exp.LaunchTemplateCreateFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return err
@@ -425,7 +427,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 
 	// If there is a change: before changing the template, check if there exist an ongoing instance refresh,
 	// because only 1 instance refresh can be "InProgress". If template is updated when refresh cannot be started,
-	// that change will not trigger a refresh.
+	// that change will not trigger a refresh. Do not start an instance refresh if only userdata changed.
 	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID {
 		asgSvc := r.getASGService(ec2Scope)
 		canStart, err := asgSvc.CanStartASGInstanceRefresh(machinePoolScope)
@@ -438,25 +440,34 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 		}
 	}
 
-	// create a new launch template version if there's a difference in configuration, tags,
-	// OR we've discovered a new AMI ID
-	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID {
+	// Create a new launch template version if there's a difference in configuration, tags,
+	// userdata, OR we've discovered a new AMI ID.
+	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID || launchTemplateUserDataHash != bootstrapDataHash {
 		machinePoolScope.Info("creating new version for launch template", "existing", launchTemplate, "incoming", machinePoolScope.AWSMachinePool.Spec.AWSLaunchTemplate)
-		if err := ec2svc.CreateLaunchTemplateVersion(machinePoolScope, imageID, userData); err != nil {
+		if err := ec2svc.CreateLaunchTemplateVersion(machinePoolScope, imageID, bootstrapData); err != nil {
 			return err
 		}
+	}
+
+	// After creating a new version of launch template, instance refresh is required
+	// to trigger a rolling replacement of all previously launched instances.
+	// If ONLY the userdata changed, previously launched instances continue to use the old launch
+	// template.
+	//
+	// FIXME(dlipovetsky,sedefsavas): If the controller terminates, or the StartASGInstanceRefresh returns an error,
+	// this conditional will not evaluate to true the next reconcile. If any machines use an older
+	// Launch Template version, and the difference between the older and current versions is _more_
+	// than userdata, we should start an Instance Refresh.
+	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID {
 		machinePoolScope.Info("starting instance refresh", "number of instances", machinePoolScope.MachinePool.Spec.Replicas)
-
 		asgSvc := r.getASGService(ec2Scope)
-		// After creating a new version of launch template, instance refresh is required
-		// to trigger a rolling replacement of all previously launched instances.
-
 		if err := asgSvc.StartASGInstanceRefresh(machinePoolScope); err != nil {
 			conditions.MarkFalse(machinePoolScope.AWSMachinePool, infrav1exp.InstanceRefreshStartedCondition, infrav1exp.InstanceRefreshFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return err
 		}
 		conditions.MarkTrue(machinePoolScope.AWSMachinePool, infrav1exp.InstanceRefreshStartedCondition)
 	}
+
 	return nil
 }
 

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -312,7 +312,7 @@ func (r *AWSMachinePoolReconciler) reconcileDelete(machinePoolScope *scope.Machi
 	}
 
 	launchTemplateID := machinePoolScope.AWSMachinePool.Status.LaunchTemplateID
-	launchTemplate, err := ec2Svc.GetLaunchTemplate(launchTemplateID)
+	launchTemplate, _, err := ec2Svc.GetLaunchTemplate(launchTemplateID)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -385,7 +385,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 	ec2svc := r.getEC2Service(ec2Scope)
 
 	machinePoolScope.Info("checking for existing launch template")
-	launchTemplate, err := ec2svc.GetLaunchTemplate(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID)
+	launchTemplate, _, err := ec2svc.GetLaunchTemplate(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID)
 	if err != nil {
 		conditions.MarkUnknown(machinePoolScope.AWSMachinePool, infrav1exp.LaunchTemplateReadyCondition, infrav1exp.LaunchTemplateNotFoundReason, err.Error())
 		return err

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -158,7 +158,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			expectedErr := errors.New("no connection available ")
 
 			BeforeEach(func() {
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", expectedErr).AnyTimes()
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 			})
 
@@ -217,7 +217,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			It("it should look up by provider ID when one exists", func() {
 				expectedErr := errors.New("no connection available ")
 				var launchtemplate *expinfrav1.AWSLaunchTemplate
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(launchtemplate, expectedErr)
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(launchtemplate, "", expectedErr)
 				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs)
 				Expect(errors.Cause(err)).To(MatchError(expectedErr))
 			})
@@ -225,7 +225,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			It("should try to create a new machinepool if none exists", func() {
 				expectedErr := errors.New("Invalid instance")
 				asgSvc.EXPECT().ASGIfExists(gomock.Any()).Return(nil, nil).AnyTimes()
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil)
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any()).Return(nil, nil)
 				ec2Svc.EXPECT().CreateLaunchTemplate(gomock.Any(), gomock.Any(), gomock.Any()).Return("", expectedErr).AnyTimes()
 
@@ -236,7 +236,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 
 		When("ASG creation succeeds", func() {
 			BeforeEach(func() {
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 				ec2Svc.EXPECT().CreateLaunchTemplate(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil).AnyTimes()
 			})
@@ -261,7 +261,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 
 		It("should log and remove finalizer when no machinepool exists", func() {
 			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil)
-			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
+			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
@@ -279,7 +279,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 				Status: expinfrav1.ASGStatusDeleteInProgress,
 			}
 			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(&inProgressASG, nil)
-			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
+			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -240,9 +240,9 @@ func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1
 	}
 
 	for _, id := range v.SecurityGroupIds {
-		// This will include the core security groups as well, making the "Additional" a bit
-		// dishonest. However, including the core groups drastically simplifies comparison with
-		// the incoming security groups.
+		// FIXME(dlipovetsky): This will include the core security groups as well, making the
+		// "Additional" a bit dishonest. However, including the core groups drastically simplifies
+		// comparison with the incoming security groups.
 		i.AdditionalSecurityGroups = append(i.AdditionalSecurityGroups, infrav1.AWSResourceReference{ID: id})
 	}
 
@@ -257,7 +257,10 @@ func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1
 	return i, userdata.ComputeHash(decodedUserData), nil
 }
 
-// LaunchTemplateNeedsUpdate checks if a new launch template version is needed
+// LaunchTemplateNeedsUpdate checks if a new launch template version is needed.
+//
+// FIXME(dlipovetsky): This check should account for changed userdata, but does not yet do so.
+// Although userdata is stored in an EC2 Launch Template, it is not a field of AWSLaunchTemplate.
 func (s *Service) LaunchTemplateNeedsUpdate(scope *scope.MachinePoolScope, incoming *expinfrav1.AWSLaunchTemplate, existing *expinfrav1.AWSLaunchTemplate) (bool, error) {
 	if incoming.IamInstanceProfile != existing.IamInstanceProfile {
 		return true, nil

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package ec2
 
 import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -31,7 +33,46 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+const (
+	testUserData = `## template: jinja
+#cloud-config
+
+write_files:
+-   path: /tmp/kubeadm-join-config.yaml
+	owner: root:root
+	permissions: '0640'
+	content: |
+	  ---
+	  apiVersion: kubeadm.k8s.io/v1beta2
+	  discovery:
+		bootstrapToken:
+		  apiServerEndpoint: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		  caCertHashes:
+		  - sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		  token: xxxxxx.xxxxxxxxxxxxxxxx
+		  unsafeSkipCAVerification: false
+	  kind: JoinConfiguration
+	  nodeRegistration:
+		kubeletExtraArgs:
+		  cloud-provider: aws
+		name: '{{ ds.meta_data.local_hostname }}'
+
+runcmd:
+  - kubeadm join --config /tmp/kubeadm-join-config.yaml
+users:
+  - name: xxxxxxxx
+	sudo: ALL=(ALL) NOPASSWD:ALL
+	ssh_authorized_keys:
+	  - ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx user@example.com
+`
+)
+
+var (
+	testUserDataHash = userdata.ComputeHash([]byte(testUserData))
 )
 
 func TestGetLaunchTemplate(t *testing.T) {
@@ -42,7 +83,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 		name               string
 		launchTemplateName string
 		expect             func(m *mock_ec2iface.MockEC2APIMockRecorder)
-		check              func(launchtemplate *expinfrav1.AWSLaunchTemplate, err error)
+		check              func(launchtemplate *expinfrav1.AWSLaunchTemplate, userdatahash string, err error)
 	}{
 		{
 			name:               "does not exist",
@@ -54,9 +95,13 @@ func TestGetLaunchTemplate(t *testing.T) {
 				})).
 					Return(nil, awserrors.NewNotFound("not found"))
 			},
-			check: func(launchtemplate *expinfrav1.AWSLaunchTemplate, err error) {
+			check: func(launchtemplate *expinfrav1.AWSLaunchTemplate, userdatahash string, err error) {
 				if err != nil {
 					t.Fatalf("did not expect error: %v", err)
+				}
+
+				if userdatahash != "" {
+					t.Fatalf("Did not expect a userdata hash, but got something: %s", userdatahash)
 				}
 
 				if launchtemplate != nil {
@@ -74,7 +119,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 			_ = infrav1.AddToScheme(scheme)
 			client := fake.NewClientBuilder().WithScheme(scheme).Build()
 			scope, err := scope.NewClusterScope(scope.ClusterScopeParams{
-				Client: client,
+				Client:     client,
 				Cluster:    &clusterv1.Cluster{},
 				AWSCluster: &infrav1.AWSCluster{},
 			})
@@ -87,18 +132,19 @@ func TestGetLaunchTemplate(t *testing.T) {
 			s := NewService(scope)
 			s.EC2Client = ec2Mock
 
-			launchtemplate, err := s.GetLaunchTemplate(tc.launchTemplateName)
-			tc.check(launchtemplate, err)
+			launchtemplate, userdatahash, err := s.GetLaunchTemplate(tc.launchTemplateName)
+			tc.check(launchtemplate, userdatahash, err)
 		})
 	}
 }
 
 func TestService_SDKToLaunchTemplate(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   *ec2.LaunchTemplateVersion
-		want    *expinfrav1.AWSLaunchTemplate
-		wantErr bool
+		name     string
+		input    *ec2.LaunchTemplateVersion
+		wantLT   *expinfrav1.AWSLaunchTemplate
+		wantHash string
+		wantErr  bool
 	}{
 		{
 			name: "lots of input",
@@ -127,10 +173,11 @@ func TestService_SDKToLaunchTemplate(t *testing.T) {
 							Groups:      []*string{aws.String("foo-group")},
 						},
 					},
+					UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(testUserData))),
 				},
 				VersionNumber: aws.Int64(1),
 			},
-			want: &expinfrav1.AWSLaunchTemplate{
+			wantLT: &expinfrav1.AWSLaunchTemplate{
 				Name: "foo",
 				AMI: infrav1.AWSResourceReference{
 					ID: aws.String("foo-image"),
@@ -139,17 +186,21 @@ func TestService_SDKToLaunchTemplate(t *testing.T) {
 				SSHKeyName:         aws.String("foo-keyname"),
 				VersionNumber:      aws.Int64(1),
 			},
+			wantHash: testUserDataHash,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Service{}
-			got, err := s.SDKToLaunchTemplate(tt.input)
+			gotLT, gotHash, err := s.SDKToLaunchTemplate(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error mismatch: got %v, wantErr %v", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("launchtemplate mismatch: got %v, want %v", got, tt.want)
+			if !reflect.DeepEqual(gotLT, tt.wantLT) {
+				t.Fatalf("launchtemplate mismatch: got %v, want %v", gotLT, tt.wantLT)
+			}
+			if !reflect.DeepEqual(gotHash, tt.wantHash) {
+				t.Fatalf("userdatahash mismatch: got %v, want %v", gotHash, tt.wantHash)
 			}
 		})
 	}

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -60,7 +60,7 @@ type EC2MachineInterface interface {
 	DetachSecurityGroupsFromNetworkInterface(groups []string, interfaceID string) error
 
 	DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*string, error)
-	GetLaunchTemplate(id string) (*expinfrav1.AWSLaunchTemplate, error)
+	GetLaunchTemplate(id string) (lt *expinfrav1.AWSLaunchTemplate, userDataHash string, err error)
 	CreateLaunchTemplate(scope *scope.MachinePoolScope, imageID *string, userData []byte) (string, error)
 	CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, imageID *string, userData []byte) error
 	DeleteLaunchTemplate(id string) error

--- a/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
@@ -184,12 +184,13 @@ func (mr *MockEC2MachineInterfaceMockRecorder) GetInstanceSecurityGroups(arg0 in
 }
 
 // GetLaunchTemplate mocks base method
-func (m *MockEC2MachineInterface) GetLaunchTemplate(arg0 string) (*v1alpha40.AWSLaunchTemplate, error) {
+func (m *MockEC2MachineInterface) GetLaunchTemplate(arg0 string) (*v1alpha40.AWSLaunchTemplate, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLaunchTemplate", arg0)
 	ret0, _ := ret[0].(*v1alpha40.AWSLaunchTemplate)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetLaunchTemplate indicates an expected call of GetLaunchTemplate

--- a/pkg/cloud/services/userdata/utils.go
+++ b/pkg/cloud/services/userdata/utils.go
@@ -19,7 +19,9 @@ package userdata
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -54,4 +56,9 @@ func GzipBytes(dat []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// ComputeHash returns the SHA256 hash of the user data byte array.
+func ComputeHash(dat []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(dat))
 }


### PR DESCRIPTION
**TODO:**
- [x] ~Test: Verify that KubeadmConfig update triggers a Reconcile~
- [x] Feat: Add a new condition (Userdata changes) to trigger the creation of a new LaunchTemplate version
- [x] Test: Verify that Userdata change triggers creation of a new LaunchTemplate version
- [x] Do not start an ASG Instance Refresh when updating only the userdata of the Launch Template.
- [x] ~Emit an Event when updating the Launch Template, but not starting an Instance Refresh.~ (I don't see precedent in this controller...)
- [x] ~Verify that scaling an MachinePool in turn scales an ASG, and that new instances in the ASG join the cluster. (Modify existing e2e test, or create a new one).~ (Test already exists)


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Previously, when the AWSMachinePool controller scaled an AutoScaling Group, and the configuration was the same, apart from the userdata, it would not update the Launch Template. The existing userdata would contain an expired bootstrap token, and new instances could not join the cluster.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2321

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix: When the AWSMachinePool controller scales an AutoScaling Group, it updates the Launch Template with a valid bootstrap token.
```
