### PR TITLE
Issue 2358: Add required clustercontrolleridentities to eks rbac

### DIFF
--- a/controlplane/eks/config/rbac/role.yaml
+++ b/controlplane/eks/config/rbac/role.yaml
@@ -60,6 +60,7 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - awsclustercontrolleridentities
   - awsclusterroleidentities
   - awsclusterstaticidentities
   verbs:

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -110,7 +110,7 @@ func (r *AWSManagedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, op
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinepools;awsmachinepools/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=awsmanagedcontrolplanes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=awsmanagedcontrolplanes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusterroleidentities;awsclusterstaticidentities,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusterroleidentities;awsclusterstaticidentities;awsclustercontrolleridentities,verbs=get;list;watch
 
 // Reconcile will reconcile AWSManagedControlPlane Resources
 func (r *AWSManagedControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Result, reterr error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

When using standard setup via `clusterctl init`

```
E0419 12:39:55.208006       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.9/tools/cache/reflector.go:105: Failed to list *v1alpha3.AWSClusterControllerIdentity: awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io is forbidden: User "system:serviceaccount:capa-eks-control-plane-system:capa-eks-control-plane-controller-manager" cannot list resource "awsclustercontrolleridentities" in API group "infrastructure.cluster.x-k8s.io" at the cluster scope
```

Meaning new `awsclustercontrolleridentities` is not in the ClusterRole RBAC

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2358

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Update RBAC with missing awsclustercontrolleridentities permission
```
