### PR TITLE
Automated cherry pick of #2362: fix: Properly handle empty string SSH key name in ASG

### DIFF
--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -129,12 +129,18 @@ func (s *Service) CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, ima
 func (s *Service) createLaunchTemplateData(scope *scope.MachinePoolScope, imageID *string, userData []byte) (*ec2.RequestLaunchTemplateData, error) {
 	lt := scope.AWSMachinePool.Spec.AWSLaunchTemplate
 
+	// An explicit empty string for SSHKeyName means do not specify a key in the ASG launch
+	var sshKeyNamePtr *string
+	if lt.SSHKeyName != nil && *lt.SSHKeyName != "" {
+		sshKeyNamePtr = lt.SSHKeyName
+	}
+
 	data := &ec2.RequestLaunchTemplateData{
 		InstanceType: aws.String(lt.InstanceType),
 		IamInstanceProfile: &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{
 			Name: aws.String(lt.IamInstanceProfile),
 		},
-		KeyName:  lt.SSHKeyName,
+		KeyName:  sshKeyNamePtr,
 		UserData: pointer.StringPtr(base64.StdEncoding.EncodeToString(userData)),
 	}
 


### PR DESCRIPTION
Cherry pick of #2362 on release-0.6.

#2362: fix: Properly handle empty string SSH key name in ASG

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.