### PR TITLE
test: Ensure teardown runs

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -50,12 +50,11 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	code := 0
+	defer func() { os.Exit(code) }()
 	setup()
-	defer func() {
-		teardown()
-	}()
-	code := m.Run()
-	os.Exit(code)
+	defer teardown()
+	code = m.Run()
 }
 
 func setup() {

--- a/exp/controlleridentitycreator/suite_test.go
+++ b/exp/controlleridentitycreator/suite_test.go
@@ -53,12 +53,11 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	code := 0
+	defer func() { os.Exit(code) }()
 	setup()
-	defer func() {
-		teardown()
-	}()
-	code := m.Run()
-	os.Exit(code)
+	defer teardown()
+	code = m.Run()
 }
 
 func setup() {

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -58,12 +59,11 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	code := 0
+	defer func() { os.Exit(code) }()
 	setup()
-	defer func() {
-		teardown()
-	}()
-	code := m.Run()
-	os.Exit(code)
+	defer teardown()
+	code = m.Run()
 }
 
 func setup() {


### PR DESCRIPTION
Prior to this change, TestMain deferred the `teardown` call. After running the tests, it called `os.Exit`, which exits immediately, ignoring any deferred functions. Therefore `teardown` was not called, and left testenv kube-apiserver and etcd processes running.

Demo of:
- old behavior: https://play.golang.org/p/LKynhlOi8K1
- new behavior: https://play.golang.org/p/Efu0Q-rQxvI

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Make sure controller tests clean up after themselves.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```