### PR TITLE
bug: make sure that controllers run on controll plane nodes

### DIFF
--- a/bootstrap/eks/config/manager/manager.yaml
+++ b/bootstrap/eks/config/manager/manager.yaml
@@ -26,4 +26,17 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
           key: node-role.kubernetes.io/master
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            # remove once usage of node-role.kubernetes.io/master is removed from Kubernetes
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists

--- a/bootstrap/eks/config/manager/manager.yaml
+++ b/bootstrap/eks/config/manager/manager.yaml
@@ -26,15 +26,15 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+          key: ${K8S_CP_LABEL:=node-role.kubernetes.io/control-plane}
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
+              - key: ${K8S_CP_LABEL:=node-role.kubernetes.io/control-plane}
                 operator: Exists
             # remove once usage of node-role.kubernetes.io/master is removed from Kubernetes
             - matchExpressions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,4 +40,17 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            # remove once usage of node-role.kubernetes.io/master is removed from Kubernetes
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       serviceAccountName: manager

--- a/controlplane/eks/config/manager/manager.yaml
+++ b/controlplane/eks/config/manager/manager.yaml
@@ -27,3 +27,16 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            # remove once usage of node-role.kubernetes.io/master is removed from Kubernetes
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes #2361


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Cluster API Provider AWS will now be preferentially pinned to control plane nodes. This is especially helpful when running self-managed management clusters in AWS as for EC2-based control planes, the control plane EC2 instances have the controlplane.cluster-api.sigs.k8s.io IAM role which has sufficient permissions for CAPA to run.
Action Required: Please ensure your control plane nodes have sufficient resources to run Cluster API Provider AWS.
```
