### PR TITLE
Add e2e parallelization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ E2E_UNMANAGED_FOCUS ?= "functional tests - unmanaged"
 # For running CAPI e2e tests: E2E_UNMANAGED_FOCUS := "Cluster API E2E tests"
 USE_EXISTING_CLUSTER ?= "false"
 
-GINKGO_NODES ?= 2
+GINKGO_NODES ?= 3
 GINKGO_ARGS ?=
 
 ## --------------------------------------
@@ -148,7 +148,7 @@ test: ## Run tests
 
 .PHONY: test-e2e ## Run e2e tests using clusterctl
 test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run e2e tests
-	time $(GINKGO) -trace -progress -v -tags=e2e -focus=$(E2E_UNMANAGED_FOCUS) $(GINKGO_ARGS) ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" $(E2E_ARGS) -use-existing-cluster=$(USE_EXISTING_CLUSTER)
+	time $(GINKGO) -trace -stream -progress -v -tags=e2e -focus=$(E2E_UNMANAGED_FOCUS) $(GINKGO_ARGS) -nodes=$(GINKGO_NODES) ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" $(E2E_ARGS) -use-existing-cluster=$(USE_EXISTING_CLUSTER)
 
 .PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
 test-e2e-eks: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/awslabs/goformation/v4 v4.15.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.4.0
+	github.com/gofrs/flock v0.8.0
 	github.com/golang/mock v1.4.4
 	github.com/google/goexpect v0.0.0-20200816234442-b5b77125c2c5
 	github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2 // indirect
@@ -23,6 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
+	golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.0-beta.1
 	k8s.io/apiextensions-apiserver v0.21.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/gobuffalo/flect v0.2.2/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20j
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/gofrs/flock v0.7.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/flock v0.8.0 h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=
+github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -943,8 +945,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073 h1:8qxJSnu+7dRq6upnbntrmriWByIakBuct5OM/MdQC1M=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 h1:RX8C8PRZc2hTIod4ds8ij+/4RQX3AqhYj3uOHmyaz4E=
+golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -127,6 +127,7 @@ providers:
         targetName: "cluster-template-simple-multitenancy.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template-nested-multitenancy.yaml"
         targetName: "cluster-template-nested-multitenancy.yaml"
+
 variables:
   CNI: "../../data/cni/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"

--- a/test/e2e/data/infrastructure-aws/cluster-template-nested-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template-nested-multitenancy.yaml
@@ -33,13 +33,6 @@ spec:
       availabilityZoneUsageLimit: 1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
-kind: AWSClusterControllerIdentity
-metadata:
-  name: default
-spec:
-  allowedNamespaces: {}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AWSClusterRoleIdentity
 metadata:
   name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}"

--- a/test/e2e/data/infrastructure-aws/cluster-template-simple-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template-simple-multitenancy.yaml
@@ -33,13 +33,6 @@ spec:
       availabilityZoneUsageLimit: 1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
-kind: AWSClusterControllerIdentity
-metadata:
-  name: default
-spec:
-  allowedNamespaces: {}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AWSClusterRoleIdentity
 metadata:
   name: "${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}"

--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -29,11 +29,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func SetupSpecNamespace(ctx context.Context, specName string, e2eCtx *E2EContext) *corev1.Namespace {
@@ -201,4 +203,22 @@ func SetEnvVar(key, value string, private bool) {
 
 	Byf("Setting environment variable: key=%s, value=%s", key, printableValue)
 	os.Setenv(key, value)
+}
+
+func CreateAWSClusterControllerIdentity(k8sclient crclient.Client) {
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       string(infrav1.ControllerIdentityKind),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: infrav1.AWSClusterControllerIdentityName,
+		},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	k8sclient.Create(context.TODO(), controllerIdentity)
 }

--- a/test/e2e/shared/context.go
+++ b/test/e2e/shared/context.go
@@ -97,7 +97,7 @@ type Settings struct {
 	UseCIArtifacts bool
 	// SourceTemplate specifies which source template to use
 	SourceTemplate string
-	// FileLock is the lock to be used to  specifies which source template to use
+	// FileLock is the lock to be used to read the resource quotas file
 	FileLock *flock.Flock
 }
 

--- a/test/e2e/shared/context.go
+++ b/test/e2e/shared/context.go
@@ -20,21 +20,19 @@ package shared
 
 import (
 	"context"
-	"github.com/awslabs/goformation/v4/cloudformation"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/iam"
-
+	"github.com/awslabs/goformation/v4/cloudformation"
+	"github.com/gofrs/flock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
+	cfn_bootstrap "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cloudformation/bootstrap"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-
-	cfn_bootstrap "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cloudformation/bootstrap"
 )
 
 // Option represents an option to use when creating a e2e context
@@ -99,6 +97,8 @@ type Settings struct {
 	UseCIArtifacts bool
 	// SourceTemplate specifies which source template to use
 	SourceTemplate string
+	// FileLock is the lock to be used to  specifies which source template to use
+	FileLock *flock.Flock
 }
 
 // RuntimeEnvironment represents the runtime environment of the test

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -51,6 +51,7 @@ const (
 	StorageClassFailureZoneLabel = "failure-domain.beta.kubernetes.io/zone"
 )
 
+var ResourceQuotaFilePath = "/tmp/capa-e2e-resource-usage.lock"
 var (
 	MultiTenancySimpleRole = MultitenancyRole("Simple")
 	MultiTenancyJumpRole   = MultitenancyRole("Jump")
@@ -104,6 +105,46 @@ func (m MultitenancyRole) RoleARN(prov client.ConfigProvider) (string, error) {
 	roleARN := aws.StringValue(role.Role.Arn)
 	roleLookupCache[m.RoleName()] = roleARN
 	return roleARN, nil
+}
+
+func getLimitedResources() map[string]*ServiceQuota {
+	serviceQuotas := map[string]*ServiceQuota{}
+	serviceQuotas["igw"] = &ServiceQuota{
+		ServiceCode: "vpc",
+		QuotaName:   "Internet gateways per Region",
+		QuotaCode:   "L-A4707A72",
+	}
+
+	serviceQuotas["ngw"] = &ServiceQuota{
+		ServiceCode: "vpc",
+		QuotaName:   "NAT gateways per Availability Zone",
+		QuotaCode:   "L-FE5A380F",
+	}
+
+	serviceQuotas["vpc"] = &ServiceQuota{
+		ServiceCode: "vpc",
+		QuotaName:   "VPCs per Region",
+		QuotaCode:   "L-F678F1CE",
+	}
+
+	serviceQuotas["ec2"] = &ServiceQuota{
+		ServiceCode: "ec2",
+		QuotaName:   "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances",
+		QuotaCode:   "L-1216C47A",
+	}
+
+	serviceQuotas["eip"] = &ServiceQuota{
+		ServiceCode: "ec2",
+		QuotaName:   "EC2-VPC Elastic IPs",
+		QuotaCode:   "L-0263D0A3",
+	}
+
+	serviceQuotas["classiclb"] = &ServiceQuota{
+		ServiceCode: "elasticloadbalancing",
+		QuotaName:   "Classic Load Balancers per Region",
+		QuotaCode:   "L-E9E9831D",
+	}
+	return serviceQuotas
 }
 
 // DefaultScheme returns the default scheme to use for testing

--- a/test/e2e/shared/resource.go
+++ b/test/e2e/shared/resource.go
@@ -1,0 +1,234 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/gofrs/flock"
+	"sigs.k8s.io/yaml"
+)
+
+type TestResource struct {
+	EC2       int `json:"ec2"`
+	VPC       int `json:"vpc"`
+	EIP       int `json:"eip"`
+	IGW       int `json:"igw"`
+	NGW       int `json:"ngw"`
+	ClassicLB int `json:"classiclb"`
+}
+
+func WriteResourceQuotesToFile(serviceQuotas map[string]*ServiceQuota) {
+	if _, err := os.Stat(ResourceQuotaFilePath); err == nil {
+		// If resource-quotas file exists, remove it. Should not fail on error, another ginkgo node might have already deleted it.
+		os.Remove(ResourceQuotaFilePath)
+	}
+
+	resources := TestResource{
+		EC2:       serviceQuotas["ec2"].Value,
+		VPC:       serviceQuotas["vpc"].Value,
+		EIP:       serviceQuotas["eip"].Value,
+		IGW:       serviceQuotas["igw"].Value,
+		NGW:       serviceQuotas["ngw"].Value,
+		ClassicLB: serviceQuotas["classiclb"].Value,
+	}
+	data, err := yaml.Marshal(resources)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ioutil.WriteFile(ResourceQuotaFilePath, data, 0644)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (r *TestResource) String() string {
+	return fmt.Sprintf("{ec2:%v, vpc:%v, eip:%v, ngw:%v, igw:%v, classiclb:%v}", r.EC2, r.VPC, r.EIP, r.NGW, r.IGW, r.ClassicLB)
+}
+
+func (r *TestResource) WriteRequestedResources(e2eCtx *E2EContext, testName string) {
+	requestedResourceFilePath := path.Join(e2eCtx.Settings.ArtifactFolder, "requested-resources.yaml")
+	if _, err := os.Stat(ResourceQuotaFilePath); err != nil {
+		// If requested-resources file does not exist, create it
+		f, err := os.Create(requestedResourceFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Close()).NotTo(HaveOccurred())
+	}
+
+	fileLock := flock.New(requestedResourceFilePath)
+	defer func() error {
+		if err := fileLock.Unlock(); err != nil {
+			return err
+		}
+		return nil
+	}()
+
+	err := fileLock.Lock()
+	Expect(err).NotTo(HaveOccurred())
+
+	requestedResources, err := ioutil.ReadFile(requestedResourceFilePath)
+	Expect(err).NotTo(HaveOccurred())
+
+	resources := struct {
+		TestResourceMap map[string]TestResource `json:"requested-resources"`
+	}{}
+	err = yaml.Unmarshal(requestedResources, &resources)
+	Expect(err).NotTo(HaveOccurred())
+
+	if resources.TestResourceMap == nil {
+		resources.TestResourceMap = make(map[string]TestResource, 0)
+	}
+	resources.TestResourceMap[testName] = *r
+	str, err := yaml.Marshal(resources)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ioutil.WriteFile(requestedResourceFilePath, str, 0644)).To(Succeed())
+}
+
+func (r *TestResource) doesSatisfy(request *TestResource) bool {
+	if request.EC2 != 0 && r.EC2 < request.EC2{
+		return false
+	}
+	if request.IGW != 0 && r.IGW < request.IGW{
+		return false
+	}
+	if request.NGW != 0 && r.NGW < request.NGW{
+		return false
+	}
+	if request.ClassicLB != 0 && r.ClassicLB < request.ClassicLB{
+		return false
+	}
+	if request.VPC != 0 && r.VPC < request.VPC{
+		return false
+	}
+	if request.EIP != 0 && r.EIP < request.EIP{
+		return false
+	}
+
+	return true
+}
+
+func (r *TestResource) acquire(request *TestResource) {
+	r.EC2 -= request.EC2
+	r.VPC -= request.VPC
+	r.EIP -= request.EIP
+	r.NGW -= request.NGW
+	r.IGW -= request.IGW
+	r.ClassicLB -= request.ClassicLB
+}
+
+func (r *TestResource) release(request *TestResource) {
+	r.EC2 += request.EC2
+	r.VPC += request.VPC
+	r.EIP += request.EIP
+	r.NGW += request.NGW
+	r.IGW += request.IGW
+	r.ClassicLB += request.ClassicLB
+}
+
+func AcquireResources(request *TestResource, nodeNum int, fileLock *flock.Flock) error {
+	timeoutInSec := 60 * 60
+	defer func() error {
+		if err := fileLock.Unlock(); err != nil {
+			return err
+		}
+		return nil
+	}()
+
+	var tryCount = 0
+	for range time.Tick(1 * time.Second) {
+		tryCount++
+		if tryCount > timeoutInSec {
+			break
+		}
+		err := fileLock.Lock()
+		if err != nil {
+			continue
+		}
+		resourceText, err := ioutil.ReadFile(ResourceQuotaFilePath)
+		if err != nil {
+			return err
+		}
+
+		resources := &TestResource{}
+		if err = yaml.Unmarshal(resourceText, resources); err != nil {
+			return err
+		}
+
+		if resources.doesSatisfy(request) {
+			resources.acquire(request)
+			data, err := yaml.Marshal(resources)
+			if err != nil {
+				return err
+			}
+			if err := ioutil.WriteFile(ResourceQuotaFilePath, data, 0644); err != nil {
+				return err
+			}
+			Byf("Node %s acquired resources: ",strconv.Itoa(nodeNum), request.String())
+			return nil
+		}
+		if err := fileLock.Unlock(); err != nil {
+			return err
+		}
+	}
+	return errors.New("giving up on releasing resource due to timeout")
+}
+
+func ReleaseResources(request *TestResource, nodeNum int, fileLock *flock.Flock) error {
+	timeoutInSec := 20
+
+	defer fileLock.Unlock()
+	var tryCount = 0
+	for range time.Tick(1 * time.Second) {
+		tryCount++
+		if tryCount > timeoutInSec {
+			break
+		}
+		if err := fileLock.Lock(); err != nil {
+			continue
+		}
+		resourceText, err := ioutil.ReadFile(ResourceQuotaFilePath)
+		if err != nil {
+			return err
+		}
+		resources := &TestResource{}
+		if err := yaml.Unmarshal(resourceText, resources); err != nil {
+			return err
+		}
+		resources.release(request)
+		data, err := yaml.Marshal(resources)
+		if err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(ResourceQuotaFilePath, data, 0644); err != nil {
+			return err
+		}
+		Byf("Node %s released resources: ",strconv.Itoa(nodeNum), request.String())
+		return nil
+	}
+	return errors.New("giving up on releasing resource due to timeout")
+}
+
+func DeleteResourceQuotaFile()  {
+	Expect(os.Remove(ResourceQuotaFilePath)).To(Succeed())
+}

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -148,7 +148,7 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 	SetEnvVar("AWS_B64ENCODED_CREDENTIALS", encodeCredentials(e2eCtx.Environment.BootstrapAccessKey, boostrapTemplate.Spec.Region), true)
 
 	By("Writing AWS service quotas to a file for parallel tests")
-	WriteResourceQuotesToFile(GetServiceQuotas(e2eCtx.AWSSession))
+	WriteResourceQuotesToFile(GetServiceQuotas(e2eCtx.BootstratpUserAWSSession))
 
 	By("Initializing the bootstrap cluster")
 	initBootstrapCluster(e2eCtx)

--- a/test/e2e/shared/template.go
+++ b/test/e2e/shared/template.go
@@ -91,7 +91,22 @@ func newBootstrapTemplate(e2eCtx *E2EContext) *cfn_bootstrap.Template {
 func renderCustomCloudFormation(t *cfn_bootstrap.Template) *cloudformation.Template {
 	cloudformationTemplate := t.RenderCloudFormation()
 	appendMultiTenancyRoles(t, cloudformationTemplate)
+	appendGetQuotasPolicyToBootstrap(t)
 	return cloudformationTemplate
+}
+
+func appendGetQuotasPolicyToBootstrap(t *cfn_bootstrap.Template) {
+	t.Spec.BootstrapUser.ExtraStatements = append(t.Spec.BootstrapUser.ExtraStatements, iamv1.StatementEntry{
+		Effect: iamv1.EffectAllow,
+		Resource: iamv1.Resources{
+			"*",
+		},
+		Action: iamv1.Actions{
+			"servicequotas:GetServiceQuota",
+			"elasticloadbalancing:DescribeAccountLimits",
+			"ec2:DescribeAccountLimits",
+		},
+	})
 }
 
 func appendMultiTenancyRoles(t *cfn_bootstrap.Template, cfnt *cloudformation.Template) {

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -26,9 +26,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+	"github.com/gofrs/flock"
+	"github.com/onsi/ginkgo/config"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
-	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
 var _ = Describe("Cluster API E2E tests - unmanaged", func() {
@@ -45,11 +47,19 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
 		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
+		shared.CreateAWSClusterControllerIdentity(e2eCtx.Environment.BootstrapClusterProxy.GetClient())
+		time.Sleep(5 * time.Second)
 	})
 
 	SetDefaultEventuallyTimeout(20 * time.Minute)
 	SetDefaultEventuallyPollingInterval(10 * time.Second)
 	Context("Running the quick-start spec [PR-Blocking]", func() {
+		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
+		BeforeEach(func() {
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-quick-start-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
 		capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
 			return capi_e2e.QuickStartSpecInput{
 				E2EConfig:             e2eCtx.E2EConfig,
@@ -59,8 +69,17 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
 			}
 		})
+		AfterEach(func() {
+			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+		})
 	})
 	Context("Running the KCP upgrade spec", func() {
+		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
+		BeforeEach(func() {
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-kcp-upgrade-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
 		capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
 			return capi_e2e.KCPUpgradeSpecInput{
 				E2EConfig:             e2eCtx.E2EConfig,
@@ -70,8 +89,18 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
 			}
 		})
+		AfterEach(func() {
+			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+		})
 	})
 	Context("Running the MachineDeployment upgrade spec", func() {
+		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
+		BeforeEach(func() {
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-machinedeployment-upgrade-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
+
 		capi_e2e.MachineDeploymentUpgradesSpec(context.TODO(), func() capi_e2e.MachineDeploymentUpgradesSpecInput {
 			return capi_e2e.MachineDeploymentUpgradesSpecInput{
 				E2EConfig:             e2eCtx.E2EConfig,
@@ -81,8 +110,18 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
 			}
 		})
+		AfterEach(func() {
+			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+		})
 	})
 	Context("Running the MachineRemediation spec", func() {
+		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
+		BeforeEach(func() {
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-remediation-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
+
 		capi_e2e.MachineRemediationSpec(context.TODO(), func() capi_e2e.MachineRemediationSpecInput {
 			return capi_e2e.MachineRemediationSpecInput{
 				E2EConfig:             e2eCtx.E2EConfig,
@@ -92,9 +131,18 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
 			}
 		})
+		AfterEach(func() {
+			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+		})
 	})
-
 	Context("Running the Machine pool spec", func() {
+		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1}
+		BeforeEach(func() {
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-machinepool-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
+
 		capi_e2e.MachinePoolSpec(context.TODO(), func() capi_e2e.MachinePoolInput {
 			return capi_e2e.MachinePoolInput{
 				E2EConfig:             e2eCtx.E2EConfig,
@@ -103,6 +151,9 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 				ArtifactFolder:        filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName()),
 				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
 			}
+		})
+		AfterEach(func() {
+			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
 		})
 	})
 

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 	SetDefaultEventuallyTimeout(20 * time.Minute)
 	SetDefaultEventuallyPollingInterval(10 * time.Second)
 	Context("Running the quick-start spec [PR-Blocking]", func() {
-		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
 		BeforeEach(func() {
 			requiredResources.WriteRequestedResources(e2eCtx, "capi-quick-start-test")
@@ -74,7 +74,7 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 		})
 	})
 	Context("Running the KCP upgrade spec", func() {
-		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
 		BeforeEach(func() {
 			requiredResources.WriteRequestedResources(e2eCtx, "capi-kcp-upgrade-test")
@@ -94,7 +94,7 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 		})
 	})
 	Context("Running the MachineDeployment upgrade spec", func() {
-		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
 		BeforeEach(func() {
 			requiredResources.WriteRequestedResources(e2eCtx, "capi-machinedeployment-upgrade-test")
@@ -115,7 +115,7 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 		})
 	})
 	Context("Running the MachineRemediation spec", func() {
-		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
 		BeforeEach(func() {
 			requiredResources.WriteRequestedResources(e2eCtx, "capi-remediation-test")
@@ -136,7 +136,7 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 		})
 	})
 	Context("Running the Machine pool spec", func() {
-		// As the resources cannot be defines by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1}
 		BeforeEach(func() {
 			requiredResources.WriteRequestedResources(e2eCtx, "capi-machinepool-test")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows to run e2e test in parallel: 

- Collects service quotas in the account: Internet gateway, NAT gateway, EC2, Classic LB, VPC, elastic IP
- Writes the quotas on a file
- Defines how much resources each test requires
- Each time a ginkgo node picks up a test, first checks if there are enough resources, if not waits; if there is, reduce the resource by the amount that test needs. 
- At the end of the test, release the resources by increasing the values at the doc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2131

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Parallelize e2e tests
```
