### PR TITLE
Add v1alpha3 to v1alpha4 conversion unit tests

### DIFF
--- a/api/v1alpha3/webhook_suite_test.go
+++ b/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"path"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+func TestMain(m *testing.M) {
+	code := 0
+	defer func() { os.Exit(code) }()
+	setup()
+	defer teardown()
+	code = m.Run()
+}
+
+func setup() {
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	utilruntime.Must(v1alpha4.AddToScheme(scheme.Scheme))
+
+	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
+		path.Join("config", "crd", "bases"),
+	},
+	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
+	var err error
+	testEnv, err = testEnvConfig.Build()
+	if err != nil {
+		panic(err)
+	}
+	if err := (&infrav1.AWSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSCluster webhook: %v", err))
+	}
+	if err := (&infrav1.AWSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSMachine webhook: %v", err))
+	}
+	if err := (&infrav1.AWSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSMachineTemplate webhook: %v", err))
+	}
+	if err := (&infrav1.AWSMachineList{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSMachineList webhook: %v", err))
+	}
+	go func() {
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	testEnv.WaitForWebhooks()
+}
+
+func teardown() {
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
+	}
+}

--- a/api/v1alpha3/webhook_test.go
+++ b/api/v1alpha3/webhook_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAWSClusterConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	clusterName := fmt.Sprintf("test-cluster-%s", util.RandomString(5))
+	cluster := &AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, cluster)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, cluster)
+}
+
+func TestAWSMachineConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	machineName := fmt.Sprintf("test-machine-%s", util.RandomString(5))
+	machine := &AWSMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineName,
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, machine)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, machine)
+}
+
+func TestAWSMachineTemplateConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	machineTemplateName := fmt.Sprintf("test-machine-%s", util.RandomString(5))
+	machine := &AWSMachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineTemplateName,
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, machine)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, machine)
+}

--- a/bootstrap/eks/api/v1alpha3/webhook_suite_test.go
+++ b/bootstrap/eks/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	bootstrapv1alpha4 "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+func TestMain(m *testing.M) {
+	code := 0
+	defer func() { os.Exit(code) }()
+	setup()
+	defer teardown()
+	code = m.Run()
+}
+
+func setup() {
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	utilruntime.Must(bootstrapv1alpha4.AddToScheme(scheme.Scheme))
+
+	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
+		path.Join( "bootstrap", "eks", "config", "crd", "bases"),
+	},
+	).WithWebhookConfiguration("unmanaged", path.Join("bootstrap", "eks", "config", "webhook", "manifests.yaml"))
+	var err error
+	testEnv, err = testEnvConfig.Build()
+	if err != nil {
+		panic(err)
+	}
+	if err := (&bootstrapv1alpha4.EKSConfig{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSCluster webhook: %v", err))
+	}
+	if err := (&bootstrapv1alpha4.EKSConfigTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSCluster webhook: %v", err))
+	}
+	go func() {
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	testEnv.WaitForWebhooks()
+}
+
+func teardown() {
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
+	}
+}

--- a/bootstrap/eks/api/v1alpha3/webhook_test.go
+++ b/bootstrap/eks/api/v1alpha3/webhook_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestEKSConfigConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	eksConfig := &EKSConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-eksconfig-%s", util.RandomString(5)),
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, eksConfig)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, eksConfig)
+}
+
+func TestEKSConfigTemplateConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	eksConfigTemplate := &EKSConfigTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-eksconfig-%s", util.RandomString(5)),
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, eksConfigTemplate)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, eksConfigTemplate)
+}

--- a/bootstrap/eks/api/v1alpha4/eksconfig_webhook.go
+++ b/bootstrap/eks/api/v1alpha4/eksconfig_webhook.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// SetupWebhookWithManager will setup the webhooks for the EKSConfig
+func (r *EKSConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfig,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=eksconfig,versions=v1alpha4,name=validation.eksconfigs.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfig,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=eksconfig,versions=v1alpha4,name=default.eksconfigs.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+
+var _ webhook.Defaulter = &EKSConfig{}
+var _ webhook.Validator = &EKSConfig{}
+
+// ValidateCreate will do any extra validation when creating a EKSConfig
+func (r *EKSConfig) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate will do any extra validation when updating a EKSConfig
+func (r *EKSConfig) ValidateUpdate(old runtime.Object) error {
+	return nil
+}
+
+// ValidateDelete allows you to add any extra validation when deleting
+func (r *EKSConfig) ValidateDelete() error {
+	return nil
+}
+
+// Default will set default values for the EKSConfig
+func (r *EKSConfig) Default() {
+}

--- a/bootstrap/eks/api/v1alpha4/eksconfigtemplate_webhook.go
+++ b/bootstrap/eks/api/v1alpha4/eksconfigtemplate_webhook.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// SetupWebhookWithManager will setup the webhooks for the EKSConfigTemplate
+func (r *EKSConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=eksconfigtemplate,versions=v1alpha4,name=validation.eksconfigtemplates.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfigtemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=eksconfigtemplate,versions=v1alpha4,name=default.eksconfigtemplates.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+
+var _ webhook.Defaulter = &EKSConfigTemplate{}
+var _ webhook.Validator = &EKSConfigTemplate{}
+
+// ValidateCreate will do any extra validation when creating a EKSConfigTemplate
+func (r *EKSConfigTemplate) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate will do any extra validation when updating a EKSConfigTemplate
+func (r *EKSConfigTemplate) ValidateUpdate(old runtime.Object) error {
+	return nil
+}
+
+// ValidateDelete allows you to add any extra validation when deleting
+func (r *EKSConfigTemplate) ValidateDelete() error {
+	return nil
+}
+
+// Default will set default values for the EKSConfigTemplate
+func (r *EKSConfigTemplate) Default() {
+}

--- a/bootstrap/eks/api/v1alpha4/zz_generated.deepcopy.go
+++ b/bootstrap/eks/api/v1alpha4/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha4
 
 import (
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 

--- a/bootstrap/eks/config/webhook/manifests.yaml
+++ b/bootstrap/eks/config/webhook/manifests.yaml
@@ -1,28 +1,100 @@
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.eksconfigs.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eksconfig
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfigtemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.eksconfigtemplates.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eksconfigtemplate
+  sideEffects: None
+
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha3-eksconfig
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfig
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: validation.eksconfig.bootstrap.cluster.x-k8s.io
+  name: validation.eksconfigs.bootstrap.cluster.x-k8s.io
   rules:
   - apiGroups:
     - bootstrap.cluster.x-k8s.io
     apiVersions:
-    - v1alpha3
+    - v1alpha4
     operations:
     - CREATE
     - UPDATE
     resources:
-    - eksconfigs
+    - eksconfig
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfigtemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.eksconfigtemplates.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eksconfigtemplate
   sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -137,6 +137,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmanagedcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsmanagedcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmanagedclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmanagedmachinepool
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -306,6 +327,27 @@ webhooks:
     - UPDATE
     resources:
     - awsmachinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmanagedcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmanagedcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmanagedclusters
   sideEffects: None
 - admissionReviewVersions:
   - v1beta1

--- a/controlplane/eks/api/v1alpha3/webhook_suite_test.go
+++ b/controlplane/eks/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	controlplanev1alpha4 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+func TestMain(m *testing.M) {
+	code := 0
+	defer func() { os.Exit(code) }()
+	setup()
+	defer teardown()
+	code = m.Run()
+}
+
+func setup() {
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	utilruntime.Must(controlplanev1alpha4.AddToScheme(scheme.Scheme))
+
+	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
+		path.Join("..", "config", "crd", "bases"),
+	},
+	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
+	var err error
+	testEnv, err = testEnvConfig.Build()
+	if err != nil {
+		panic(err)
+	}
+	if err := (&controlplanev1alpha4.AWSManagedControlPlane{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSCluster webhook: %v", err))
+	}
+
+	go func() {
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	testEnv.WaitForWebhooks()
+}
+
+func teardown() {
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
+	}
+}

--- a/controlplane/eks/api/v1alpha3/webhook_test.go
+++ b/controlplane/eks/api/v1alpha3/webhook_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAWSManagedControlPlaneConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	controlPlane := &AWSManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-controlplane-%s", util.RandomString(5)),
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, controlPlane)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, controlPlane)
+}

--- a/controlplane/eks/main.go
+++ b/controlplane/eks/main.go
@@ -32,10 +32,13 @@ import (
 	cgrecord "k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
-	controlplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4"
+	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
+	controlplanev1alpha3 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha3"
+	controlplanev1alpha4 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/controllers"
-	infrav1exp "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha4"
+	expinfrav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
+	expinfrav1alpha4 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-aws/feature"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/endpoints"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
@@ -55,9 +58,12 @@ var (
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
-	_ = controlplanev1.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
-	_ = infrav1exp.AddToScheme(scheme)
+	_ = controlplanev1alpha3.AddToScheme(scheme)
+	_ = controlplanev1alpha4.AddToScheme(scheme)
+	_ = infrav1alpha3.AddToScheme(scheme)
+	_ = infrav1alpha4.AddToScheme(scheme)
+	_ = expinfrav1alpha3.AddToScheme(scheme)
+	_ = expinfrav1alpha4.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
@@ -226,7 +232,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, enableIAM bool, all
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&controlplanev1.AWSManagedControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&controlplanev1alpha4.AWSManagedControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AWSManagedControlPlane")
 		os.Exit(1)
 	}

--- a/exp/api/v1alpha3/webhook_suite_test.go
+++ b/exp/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	expv1alpha4 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+func TestMain(m *testing.M) {
+	code := 0
+	defer func() { os.Exit(code) }()
+	setup()
+	defer teardown()
+	code = m.Run()
+}
+
+func setup() {
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	utilruntime.Must(expv1alpha4.AddToScheme(scheme.Scheme))
+
+	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
+		path.Join( "config", "crd", "bases"),
+	},
+	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
+	var err error
+	testEnv, err = testEnvConfig.Build()
+	if err != nil {
+		panic(err)
+	}
+	if err := (&expv1alpha4.AWSMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSMachinePool webhook: %v", err))
+	}
+	if err := (&expv1alpha4.AWSManagedCluster{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSManagedCluster webhook: %v", err))
+	}
+	if err := (&expv1alpha4.AWSManagedMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSManagedMachinePool webhook: %v", err))
+	}
+	if err := (&expv1alpha4.AWSFargateProfile{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSManagedMachinePool webhook: %v", err))
+	}
+	go func() {
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	testEnv.WaitForWebhooks()
+}
+
+func teardown() {
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
+	}
+}

--- a/exp/api/v1alpha3/webhook_test.go
+++ b/exp/api/v1alpha3/webhook_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAWSMachinePoolConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	machinepool := &AWSMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-machinepool-%s", util.RandomString(5)),
+			Namespace: ns.Name,
+		},
+		Spec: AWSMachinePoolSpec{
+			MinSize:              1,
+			MaxSize:              3,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, machinepool)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, machinepool)
+}
+
+func TestAWSManagedMachinePoolConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	managedMachinepool := &AWSManagedMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-managedmachinepool-%s", util.RandomString(5)),
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, managedMachinepool)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, managedMachinepool)
+}
+
+func TestAWSFargateProfileConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	fargateProfile := &AWSFargateProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-fargate-%s", util.RandomString(5)),
+			Namespace: ns.Name,
+		},
+		Spec: FargateProfileSpec{
+			ClusterName:    "cluster-name",
+			ProfileName:    "name",
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, fargateProfile)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, fargateProfile)
+}

--- a/exp/api/v1alpha4/awsmanagecluster_webhook.go
+++ b/exp/api/v1alpha4/awsmanagecluster_webhook.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// SetupWebhookWithManager will setup the webhooks for the AWSManagedCluster
+func (r *AWSManagedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmanagedcluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=awsmanagedclusters,versions=v1alpha4,name=default.awsmanagedcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmanagedcluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=awsmanagedclusters,versions=v1alpha4,name=validation.awsmanagedcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+
+var _ webhook.Defaulter = &AWSManagedCluster{}
+var _ webhook.Validator = &AWSManagedCluster{}
+
+// Default will set default values for the AWSManagedCluster
+func (r *AWSManagedCluster) Default() {
+}
+
+// ValidateCreate will do any extra validation when creating a AWSManagedCluster
+func (r *AWSManagedCluster) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate will do any extra validation when updating a AWSManagedCluster
+func (r *AWSManagedCluster) ValidateUpdate(old runtime.Object) error {
+	return nil
+}
+
+// ValidateDelete allows you to add any extra validation when deleting
+func (r *AWSManagedCluster) ValidateDelete() error {
+	return nil
+}

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -33,12 +33,12 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/cluster-api-provider-aws/test/helpers/external"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/log"
+	"sigs.k8s.io/cluster-api/test/helpers"
 	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +58,6 @@ var (
 )
 
 func init() {
-	klog.InitFlags(nil)
 	logger := klogr.New()
 	// use klog as the internal logger for this envtest environment.
 	log.SetLogger(logger)
@@ -93,12 +92,9 @@ type TestEnvironmentConfiguration struct {
 
 // TestEnvironment encapsulates a Kubernetes local test environment.
 type TestEnvironment struct {
-	manager.Manager
-	client.Client
-	Config *rest.Config
-
-	cancel context.CancelFunc
+	helpers.TestEnvironment
 	env    *envtest.Environment
+	cancel context.CancelFunc
 }
 
 // NewTestEnvironmentConfiguration creates a new test environment configuration for running tests
@@ -168,10 +164,12 @@ func (t *TestEnvironmentConfiguration) Build() (*TestEnvironment, error) {
 	}
 
 	return &TestEnvironment{
-		Manager: mgr,
-		Client:  mgr.GetClient(),
-		Config:  mgr.GetConfig(),
-		env:     t.env,
+		TestEnvironment: helpers.TestEnvironment{
+			Manager: mgr,
+			Client:  mgr.GetClient(),
+			Config:  mgr.GetConfig(),
+		},
+		env: t.env,
 	}, nil
 
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR adds unit tests to make sure conversion webhooks are working correctly.
Similar to cluster-api PR: https://github.com/kubernetes-sigs/cluster-api/pull/4417

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
