### PR TITLE
Get LaunchTemplates by name

### DIFF
--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -204,9 +204,14 @@ func (m *MachinePoolScope) GetASGStatus() *expinfrav1.ASGStatus {
 	return m.AWSMachinePool.Status.ASGStatus
 }
 
-// SetASGStatus sets the AWSMachine status instance state.
+// SetASGStatus sets the AWSMachinePool status instance state.
 func (m *MachinePoolScope) SetASGStatus(v expinfrav1.ASGStatus) {
 	m.AWSMachinePool.Status.ASGStatus = &v
+}
+
+// SetLaunchTemplateIDStatus sets the AWSMachinePool LaunchTemplateID status.
+func (m *MachinePoolScope) SetLaunchTemplateIDStatus(id string) {
+	m.AWSMachinePool.Status.LaunchTemplateID = id
 }
 
 func (m *MachinePoolScope) IsEKSManaged() bool {

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -34,16 +34,16 @@ import (
 
 // GetLaunchTemplate returns the existing LaunchTemplate or nothing if it doesn't exist.
 // For now by name until we need the input to be something different
-func (s *Service) GetLaunchTemplate(id string) (*expinfrav1.AWSLaunchTemplate, error) {
-	if id == "" {
+func (s *Service) GetLaunchTemplate(launchTemplateName string) (*expinfrav1.AWSLaunchTemplate, error) {
+	if launchTemplateName == "" {
 		return nil, nil
 	}
 
 	s.scope.V(2).Info("Looking for existing LaunchTemplates")
 
 	input := &ec2.DescribeLaunchTemplateVersionsInput{
-		LaunchTemplateId: aws.String(id),
-		Versions:         aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
+		LaunchTemplateName: aws.String(launchTemplateName),
+		Versions:           aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
 	}
 
 	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
@@ -59,6 +59,32 @@ func (s *Service) GetLaunchTemplate(id string) (*expinfrav1.AWSLaunchTemplate, e
 	}
 
 	return s.SDKToLaunchTemplate(out.LaunchTemplateVersions[0])
+}
+
+// GetLaunchTemplateId returns the existing LaunchTemplateId or empty string if it doesn't exist.
+func (s *Service) GetLaunchTemplateID(launchTemplateName string) (string, error) {
+	if launchTemplateName == "" {
+		return "", nil
+	}
+
+	input := &ec2.DescribeLaunchTemplateVersionsInput{
+		LaunchTemplateName: aws.String(launchTemplateName),
+		Versions:           aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
+	}
+
+	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
+	switch {
+	case awserrors.IsNotFound(err):
+		return "", nil
+	case err != nil:
+		s.scope.Info("", "aerr", err.Error())
+	}
+
+	if len(out.LaunchTemplateVersions) == 0 {
+		return "", nil
+	}
+
+	return aws.StringValue(out.LaunchTemplateVersions[0].LaunchTemplateId), nil
 }
 
 // CreateLaunchTemplate generates a launch template to be used with the autoscaling group

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -46,7 +46,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 			launchTemplateName: "foo",
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
 				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
-					LaunchTemplateId: aws.String("foo"),
+					LaunchTemplateName: aws.String("foo"),
 					Versions:         []*string{aws.String("$Latest")},
 				})).
 					Return(nil, awserrors.NewNotFound("not found"))

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -61,6 +61,7 @@ type EC2MachineInterface interface {
 
 	DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*string, error)
 	GetLaunchTemplate(id string) (*expinfrav1.AWSLaunchTemplate, error)
+	GetLaunchTemplateID(id string) (string, error)
 	CreateLaunchTemplate(scope *scope.MachinePoolScope, imageID *string, userData []byte) (string, error)
 	CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, imageID *string, userData []byte) error
 	DeleteLaunchTemplate(id string) error

--- a/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
@@ -198,6 +198,21 @@ func (mr *MockEC2MachineInterfaceMockRecorder) GetLaunchTemplate(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLaunchTemplate", reflect.TypeOf((*MockEC2MachineInterface)(nil).GetLaunchTemplate), arg0)
 }
 
+// GetLaunchTemplateID mocks base method
+func (m *MockEC2MachineInterface) GetLaunchTemplateID(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLaunchTemplateID", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLaunchTemplateID indicates an expected call of GetLaunchTemplateID
+func (mr *MockEC2MachineInterfaceMockRecorder) GetLaunchTemplateID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLaunchTemplateID", reflect.TypeOf((*MockEC2MachineInterface)(nil).GetLaunchTemplateID), arg0)
+}
+
 // GetRunningInstanceByTags mocks base method
 func (m *MockEC2MachineInterface) GetRunningInstanceByTags(arg0 *scope.MachineScope) (*v1alpha3.Instance, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
During AWSMachinePool reconcile we use LaunchTemplateID in the status to get launch template but we can get it by just name. Since status fields are not reliable (e.g., during `clusterctl move` the LaunchTemplateID gets wiped off, which results in error in this [issue](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2393).)


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2393

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix for reconciling LaunchTemplates after `clusterctl move`.
```
