### PR TITLE
:bug: AWSMachinePool: When userdata changes, create new LaunchTemplate version, but don't start Instance Refresh - backport to release-0.6

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
 	asg "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/autoscaling"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 )
 
 // AWSMachinePoolReconciler reconciles a AWSMachinePool object
@@ -380,15 +381,16 @@ func (r *AWSMachinePoolReconciler) findASG(machinePoolScope *scope.MachinePoolSc
 }
 
 func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *scope.MachinePoolScope, ec2Scope scope.EC2Scope) error {
-	userData, err := machinePoolScope.GetRawBootstrapData()
+	bootstrapData, err := machinePoolScope.GetRawBootstrapData()
 	if err != nil {
 		r.Recorder.Eventf(machinePoolScope.AWSMachinePool, corev1.EventTypeWarning, "FailedGetBootstrapData", err.Error())
 	}
+	bootstrapDataHash := userdata.ComputeHash(bootstrapData)
 
 	ec2svc := r.getEC2Service(ec2Scope)
 
 	machinePoolScope.Info("checking for existing launch template")
-	launchTemplate, _, err := ec2svc.GetLaunchTemplate(machinePoolScope.Name())
+	launchTemplate, launchTemplateUserDataHash, err := ec2svc.GetLaunchTemplate(machinePoolScope.Name())
 	if err != nil {
 		conditions.MarkUnknown(machinePoolScope.AWSMachinePool, infrav1exp.LaunchTemplateReadyCondition, infrav1exp.LaunchTemplateNotFoundReason, err.Error())
 		return err
@@ -402,7 +404,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 
 	if launchTemplate == nil {
 		machinePoolScope.Info("no existing launch template found, creating")
-		launchTemplateID, err := ec2svc.CreateLaunchTemplate(machinePoolScope, imageID, userData)
+		launchTemplateID, err := ec2svc.CreateLaunchTemplate(machinePoolScope, imageID, bootstrapData)
 		if err != nil {
 			conditions.MarkFalse(machinePoolScope.AWSMachinePool, infrav1exp.LaunchTemplateReadyCondition, infrav1exp.LaunchTemplateCreateFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return err
@@ -439,7 +441,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 
 	// If there is a change: before changing the template, check if there exist an ongoing instance refresh,
 	// because only 1 instance refresh can be "InProgress". If template is updated when refresh cannot be started,
-	// that change will not trigger a refresh.
+	// that change will not trigger a refresh. Do not start an instance refresh if only userdata changed.
 	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID {
 		asgSvc := r.getASGService(ec2Scope)
 		canStart, err := asgSvc.CanStartASGInstanceRefresh(machinePoolScope)
@@ -452,25 +454,34 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 		}
 	}
 
-	// create a new launch template version if there's a difference in configuration, tags,
-	// OR we've discovered a new AMI ID
-	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID {
+	// Create a new launch template version if there's a difference in configuration, tags,
+	// userdata, OR we've discovered a new AMI ID.
+	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID || launchTemplateUserDataHash != bootstrapDataHash {
 		machinePoolScope.Info("creating new version for launch template", "existing", launchTemplate, "incoming", machinePoolScope.AWSMachinePool.Spec.AWSLaunchTemplate)
-		if err := ec2svc.CreateLaunchTemplateVersion(machinePoolScope, imageID, userData); err != nil {
+		if err := ec2svc.CreateLaunchTemplateVersion(machinePoolScope, imageID, bootstrapData); err != nil {
 			return err
 		}
+	}
+
+	// After creating a new version of launch template, instance refresh is required
+	// to trigger a rolling replacement of all previously launched instances.
+	// If ONLY the userdata changed, previously launched instances continue to use the old launch
+	// template.
+	//
+	// FIXME(dlipovetsky,sedefsavas): If the controller terminates, or the StartASGInstanceRefresh returns an error,
+	// this conditional will not evaluate to true the next reconcile. If any machines use an older
+	// Launch Template version, and the difference between the older and current versions is _more_
+	// than userdata, we should start an Instance Refresh.
+	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID {
 		machinePoolScope.Info("starting instance refresh", "number of instances", machinePoolScope.MachinePool.Spec.Replicas)
-
 		asgSvc := r.getASGService(ec2Scope)
-		// After creating a new version of launch template, instance refresh is required
-		// to trigger a rolling replacement of all previously launched instances.
-
 		if err := asgSvc.StartASGInstanceRefresh(machinePoolScope); err != nil {
 			conditions.MarkFalse(machinePoolScope.AWSMachinePool, infrav1exp.InstanceRefreshStartedCondition, infrav1exp.InstanceRefreshFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return err
 		}
 		conditions.MarkTrue(machinePoolScope.AWSMachinePool, infrav1exp.InstanceRefreshStartedCondition)
 	}
+
 	return nil
 }
 

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -315,7 +315,7 @@ func (r *AWSMachinePoolReconciler) reconcileDelete(machinePoolScope *scope.Machi
 	}
 
 	launchTemplateID := machinePoolScope.AWSMachinePool.Status.LaunchTemplateID
-	launchTemplate, err := ec2Svc.GetLaunchTemplate(machinePoolScope.Name())
+	launchTemplate, _, err := ec2Svc.GetLaunchTemplate(machinePoolScope.Name())
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -388,7 +388,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 	ec2svc := r.getEC2Service(ec2Scope)
 
 	machinePoolScope.Info("checking for existing launch template")
-	launchTemplate, err := ec2svc.GetLaunchTemplate(machinePoolScope.Name())
+	launchTemplate, _, err := ec2svc.GetLaunchTemplate(machinePoolScope.Name())
 	if err != nil {
 		conditions.MarkUnknown(machinePoolScope.AWSMachinePool, infrav1exp.LaunchTemplateReadyCondition, infrav1exp.LaunchTemplateNotFoundReason, err.Error())
 		return err

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -161,7 +161,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			expectedErr := errors.New("no connection available ")
 
 			BeforeEach(func() {
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", expectedErr).AnyTimes()
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 			})
 
@@ -220,7 +220,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			It("it should look up by provider ID when one exists", func() {
 				expectedErr := errors.New("no connection available ")
 				var launchtemplate *expinfrav1.AWSLaunchTemplate
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(launchtemplate, expectedErr)
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(launchtemplate, "", expectedErr)
 				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs)
 				Expect(errors.Cause(err)).To(MatchError(expectedErr))
 			})
@@ -228,7 +228,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			It("should try to create a new machinepool if none exists", func() {
 				expectedErr := errors.New("Invalid instance")
 				asgSvc.EXPECT().ASGIfExists(gomock.Any()).Return(nil, nil).AnyTimes()
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil)
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any()).Return(nil, nil)
 				ec2Svc.EXPECT().CreateLaunchTemplate(gomock.Any(), gomock.Any(), gomock.Any()).Return("", expectedErr).AnyTimes()
 
@@ -239,7 +239,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 
 		When("ASG creation succeeds", func() {
 			BeforeEach(func() {
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 				ec2Svc.EXPECT().CreateLaunchTemplate(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil).AnyTimes()
 			})
@@ -264,7 +264,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 
 		It("should log and remove finalizer when no machinepool exists", func() {
 			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil)
-			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
+			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
@@ -282,7 +282,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 				Status: expinfrav1.ASGStatusDeleteInProgress,
 			}
 			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(&inProgressASG, nil)
-			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
+			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)

--- a/go.sum
+++ b/go.sum
@@ -463,7 +463,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -499,7 +498,6 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -753,7 +751,6 @@ gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71 h1:Xe2gvTZUJpsvOWUnvmL/tmhVBZUmHSvLbMjRj6NUUKo=
 gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -1558,7 +1558,6 @@ k8s.io/component-base v0.18.8/go.mod h1:00frPRDas29rx58pPCxNkhUfPbwajlyyvu8ruNgS
 k8s.io/csi-translation-lib v0.18.8/go.mod h1:6cA6Btlzxy9s3QrS4BCZzQqclIWnTLr6Jx3H2ctAzY4=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20201203183100-97869a43a9d9 h1:1bLA4Agvs1DILmc+q2Bbcqjx6jOHO7YEFA+G+0aTZoc=
 k8s.io/gengo v0.0.0-20201203183100-97869a43a9d9/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -267,9 +267,9 @@ func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1
 	}
 
 	for _, id := range v.SecurityGroupIds {
-		// This will include the core security groups as well, making the "Additional" a bit
-		// dishonest. However, including the core groups drastically simplifies comparison with
-		// the incoming security groups.
+		// FIXME(dlipovetsky): This will include the core security groups as well, making the
+		// "Additional" a bit dishonest. However, including the core groups drastically simplifies
+		// comparison with the incoming security groups.
 		i.AdditionalSecurityGroups = append(i.AdditionalSecurityGroups, infrav1.AWSResourceReference{ID: id})
 	}
 
@@ -284,7 +284,10 @@ func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1
 	return i, userdata.ComputeHash(decodedUserData), nil
 }
 
-// LaunchTemplateNeedsUpdate checks if a new launch template version is needed
+// LaunchTemplateNeedsUpdate checks if a new launch template version is needed.
+//
+// FIXME(dlipovetsky): This check should account for changed userdata, but does not yet do so.
+// Although userdata is stored in an EC2 Launch Template, it is not a field of AWSLaunchTemplate.
 func (s *Service) LaunchTemplateNeedsUpdate(scope *scope.MachinePoolScope, incoming *expinfrav1.AWSLaunchTemplate, existing *expinfrav1.AWSLaunchTemplate) (bool, error) {
 	if incoming.IamInstanceProfile != existing.IamInstanceProfile {
 		return true, nil

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -30,13 +30,14 @@ import (
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 )
 
 // GetLaunchTemplate returns the existing LaunchTemplate or nothing if it doesn't exist.
 // For now by name until we need the input to be something different
-func (s *Service) GetLaunchTemplate(launchTemplateName string) (*expinfrav1.AWSLaunchTemplate, error) {
+func (s *Service) GetLaunchTemplate(launchTemplateName string) (*expinfrav1.AWSLaunchTemplate, string, error) {
 	if launchTemplateName == "" {
-		return nil, nil
+		return nil, "", nil
 	}
 
 	s.scope.V(2).Info("Looking for existing LaunchTemplates")
@@ -49,14 +50,14 @@ func (s *Service) GetLaunchTemplate(launchTemplateName string) (*expinfrav1.AWSL
 	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
 	switch {
 	case awserrors.IsNotFound(err):
-		return nil, nil
+		return nil, "", nil
 	case err != nil:
 		s.scope.Info("", "aerr", err.Error())
-		return nil, err
+		return nil, "", err
 	}
 
 	if len(out.LaunchTemplateVersions) == 0 {
-		return nil, nil
+		return nil, "", nil
 	}
 
 	return s.SDKToLaunchTemplate(out.LaunchTemplateVersions[0])
@@ -244,7 +245,7 @@ func (s *Service) DeleteLaunchTemplate(id string) error {
 }
 
 // SDKToLaunchTemplate converts an AWS EC2 SDK instance to the CAPA instance type.
-func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1.AWSLaunchTemplate, error) {
+func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1.AWSLaunchTemplate, string, error) {
 	v := d.LaunchTemplateData
 	i := &expinfrav1.AWSLaunchTemplate{
 		Name: aws.StringValue(d.LaunchTemplateName),
@@ -272,7 +273,15 @@ func (s *Service) SDKToLaunchTemplate(d *ec2.LaunchTemplateVersion) (*expinfrav1
 		i.AdditionalSecurityGroups = append(i.AdditionalSecurityGroups, infrav1.AWSResourceReference{ID: id})
 	}
 
-	return i, nil
+	if v.UserData == nil {
+		return i, userdata.ComputeHash(nil), nil
+	}
+	decodedUserData, err := base64.StdEncoding.DecodeString(*v.UserData)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "unable to decode UserData")
+	}
+
+	return i, userdata.ComputeHash(decodedUserData), nil
 }
 
 // LaunchTemplateNeedsUpdate checks if a new launch template version is needed

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ec2
 
 import (
+	"encoding/base64"
 	"reflect"
 	"testing"
 
@@ -28,7 +29,46 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2/mock_ec2iface"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+const (
+	testUserData = `## template: jinja
+#cloud-config
+
+write_files:
+-   path: /tmp/kubeadm-join-config.yaml
+	owner: root:root
+	permissions: '0640'
+	content: |
+	  ---
+	  apiVersion: kubeadm.k8s.io/v1beta2
+	  discovery:
+		bootstrapToken:
+		  apiServerEndpoint: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		  caCertHashes:
+		  - sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		  token: xxxxxx.xxxxxxxxxxxxxxxx
+		  unsafeSkipCAVerification: false
+	  kind: JoinConfiguration
+	  nodeRegistration:
+		kubeletExtraArgs:
+		  cloud-provider: aws
+		name: '{{ ds.meta_data.local_hostname }}'
+
+runcmd:
+  - kubeadm join --config /tmp/kubeadm-join-config.yaml
+users:
+  - name: xxxxxxxx
+	sudo: ALL=(ALL) NOPASSWD:ALL
+	ssh_authorized_keys:
+	  - ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx user@example.com
+`
+)
+
+var (
+	testUserDataHash = userdata.ComputeHash([]byte(testUserData))
 )
 
 func TestGetLaunchTemplate(t *testing.T) {
@@ -39,7 +79,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 		name               string
 		launchTemplateName string
 		expect             func(m *mock_ec2iface.MockEC2APIMockRecorder)
-		check              func(launchtemplate *expinfrav1.AWSLaunchTemplate, err error)
+		check              func(launchtemplate *expinfrav1.AWSLaunchTemplate, userdatahash string, err error)
 	}{
 		{
 			name:               "does not exist",
@@ -51,9 +91,13 @@ func TestGetLaunchTemplate(t *testing.T) {
 				})).
 					Return(nil, awserrors.NewNotFound("not found"))
 			},
-			check: func(launchtemplate *expinfrav1.AWSLaunchTemplate, err error) {
+			check: func(launchtemplate *expinfrav1.AWSLaunchTemplate, userdatahash string, err error) {
 				if err != nil {
 					t.Fatalf("did not expect error: %v", err)
+				}
+
+				if userdatahash != "" {
+					t.Fatalf("Did not expect a userdata hash, but got something: %s", userdatahash)
 				}
 
 				if launchtemplate != nil {
@@ -80,18 +124,19 @@ func TestGetLaunchTemplate(t *testing.T) {
 			s := NewService(scope)
 			s.EC2Client = ec2Mock
 
-			launchtemplate, err := s.GetLaunchTemplate(tc.launchTemplateName)
-			tc.check(launchtemplate, err)
+			launchtemplate, userdatahash, err := s.GetLaunchTemplate(tc.launchTemplateName)
+			tc.check(launchtemplate, userdatahash, err)
 		})
 	}
 }
 
 func TestService_SDKToLaunchTemplate(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   *ec2.LaunchTemplateVersion
-		want    *expinfrav1.AWSLaunchTemplate
-		wantErr bool
+		name     string
+		input    *ec2.LaunchTemplateVersion
+		wantLT   *expinfrav1.AWSLaunchTemplate
+		wantHash string
+		wantErr  bool
 	}{
 		{
 			name: "lots of input",
@@ -120,10 +165,11 @@ func TestService_SDKToLaunchTemplate(t *testing.T) {
 							Groups:      []*string{aws.String("foo-group")},
 						},
 					},
+					UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(testUserData))),
 				},
 				VersionNumber: aws.Int64(1),
 			},
-			want: &expinfrav1.AWSLaunchTemplate{
+			wantLT: &expinfrav1.AWSLaunchTemplate{
 				Name: "foo",
 				AMI: infrav1.AWSResourceReference{
 					ID: aws.String("foo-image"),
@@ -132,17 +178,21 @@ func TestService_SDKToLaunchTemplate(t *testing.T) {
 				SSHKeyName:         aws.String("foo-keyname"),
 				VersionNumber:      aws.Int64(1),
 			},
+			wantHash: testUserDataHash,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Service{}
-			got, err := s.SDKToLaunchTemplate(tt.input)
+			gotLT, gotHash, err := s.SDKToLaunchTemplate(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error mismatch: got %v, wantErr %v", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("launchtemplate mismatch: got %v, want %v", got, tt.want)
+			if !reflect.DeepEqual(gotLT, tt.wantLT) {
+				t.Fatalf("launchtemplate mismatch: got %v, want %v", gotLT, tt.wantLT)
+			}
+			if !reflect.DeepEqual(gotHash, tt.wantHash) {
+				t.Fatalf("userdatahash mismatch: got %v, want %v", gotHash, tt.wantHash)
 			}
 		})
 	}

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -61,7 +61,7 @@ type EC2MachineInterface interface {
 
 	DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*string, error)
 	GetLaunchTemplate(id string) (lt *expinfrav1.AWSLaunchTemplate, userDataHash string, err error)
-	GetLaunchTemplateID(id string) (string, error)
+	GetLaunchTemplateID(launchTemplateName string) (string, error)
 	CreateLaunchTemplate(scope *scope.MachinePoolScope, imageID *string, userData []byte) (string, error)
 	CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, imageID *string, userData []byte) error
 	DeleteLaunchTemplate(id string) error

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -60,7 +60,7 @@ type EC2MachineInterface interface {
 	DetachSecurityGroupsFromNetworkInterface(groups []string, interfaceID string) error
 
 	DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*string, error)
-	GetLaunchTemplate(id string) (*expinfrav1.AWSLaunchTemplate, error)
+	GetLaunchTemplate(id string) (lt *expinfrav1.AWSLaunchTemplate, userDataHash string, err error)
 	GetLaunchTemplateID(id string) (string, error)
 	CreateLaunchTemplate(scope *scope.MachinePoolScope, imageID *string, userData []byte) (string, error)
 	CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, imageID *string, userData []byte) error

--- a/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
@@ -184,12 +184,13 @@ func (mr *MockEC2MachineInterfaceMockRecorder) GetInstanceSecurityGroups(arg0 in
 }
 
 // GetLaunchTemplate mocks base method
-func (m *MockEC2MachineInterface) GetLaunchTemplate(arg0 string) (*v1alpha30.AWSLaunchTemplate, error) {
+func (m *MockEC2MachineInterface) GetLaunchTemplate(arg0 string) (*v1alpha30.AWSLaunchTemplate, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLaunchTemplate", arg0)
 	ret0, _ := ret[0].(*v1alpha30.AWSLaunchTemplate)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetLaunchTemplate indicates an expected call of GetLaunchTemplate

--- a/pkg/cloud/services/userdata/utils.go
+++ b/pkg/cloud/services/userdata/utils.go
@@ -19,7 +19,9 @@ package userdata
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -54,4 +56,9 @@ func GzipBytes(dat []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// ComputeHash returns the SHA256 hash of the user data byte array.
+func ComputeHash(dat []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(dat))
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind backport
/kind bug

**What this PR does / why we need it**:
Backports #2354

Previously, when the AWSMachinePool controller scaled an AutoScaling Group, and the configuration was the same, apart from the userdata, it would not update the Launch Template. The existing userdata would contain an expired bootstrap token, and new instances could not join the cluster.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2321

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix: When the AWSMachinePool controller scales an AutoScaling Group, it updates the Launch Template with a valid bootstrap token.
```
