### PR TITLE
fix: missing iam permission for key pairs

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -128,6 +128,7 @@ func (t Template) ControllersPolicy() *iamv1.PolicyDocument {
 				"ec2:DescribeLaunchTemplateVersions",
 				"ec2:DeleteLaunchTemplate",
 				"ec2:DeleteLaunchTemplateVersions",
+				"ec2:DescribeKeyPairs",
 			},
 		},
 		{

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -200,6 +200,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -200,6 +200,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -206,6 +206,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -205,6 +205,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -205,6 +205,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -200,6 +200,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -200,6 +200,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
@@ -200,6 +200,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -205,6 +205,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -200,6 +200,7 @@ Resources:
           - ec2:DescribeLaunchTemplateVersions
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
           Effect: Allow
           Resource:
           - '*'

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -137,7 +137,7 @@ intervals:
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-controllers: ["3m", "10s"]
-  default/wait-delete-cluster: ["30m", "10s"]
+  default/wait-delete-cluster: ["35m", "10s"]
   default/wait-delete-machine: ["10m", "10s"]
   default/wait-delete-machine-deployment: ["10m", "10s"]
   default/wait-delete-machine-pool: ["20m", "10s"]


### PR DESCRIPTION
Signed-off-by: Richard Case <richard@weave.works>


**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
There is a missing permission for keypairs that stops the managed machine pool reconciling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2389 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
action required
Controllers policy updated with missing key pairs permission, if you are using or plan to use AWSManagedMachinePool with an SSH key then you will need to update your controllers policy by running `clusterawsadm bootstrap iam create-cloudformation-stack` again. 
```
