### PR TITLE
fix: handle LaunchTemplateNameNotFound error

### DIFF
--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -24,24 +24,25 @@ import (
 )
 
 const (
-	AuthFailure             = "AuthFailure"
-	InUseIPAddress          = "InvalidIPAddress.InUse"
-	GroupNotFound           = "InvalidGroup.NotFound"
-	PermissionNotFound      = "InvalidPermission.NotFound"
-	VPCNotFound             = "InvalidVpcID.NotFound"
-	SubnetNotFound          = "InvalidSubnetID.NotFound"
-	InternetGatewayNotFound = "InvalidInternetGatewayID.NotFound"
-	NATGatewayNotFound      = "InvalidNatGatewayID.NotFound"
-	GatewayNotFound         = "InvalidGatewayID.NotFound"
-	EIPNotFound             = "InvalidElasticIpID.NotFound"
-	RouteTableNotFound      = "InvalidRouteTableID.NotFound"
-	LoadBalancerNotFound    = "LoadBalancerNotFound"
-	ResourceNotFound        = "InvalidResourceID.NotFound"
-	InvalidSubnet           = "InvalidSubnet"
-	AssociationIDNotFound   = "InvalidAssociationID.NotFound"
-	InvalidInstanceID       = "InvalidInstanceID.NotFound"
-	ResourceExists          = "ResourceExistsException"
-	NoCredentialProviders   = "NoCredentialProviders"
+	AuthFailure                = "AuthFailure"
+	InUseIPAddress             = "InvalidIPAddress.InUse"
+	GroupNotFound              = "InvalidGroup.NotFound"
+	PermissionNotFound         = "InvalidPermission.NotFound"
+	VPCNotFound                = "InvalidVpcID.NotFound"
+	SubnetNotFound             = "InvalidSubnetID.NotFound"
+	InternetGatewayNotFound    = "InvalidInternetGatewayID.NotFound"
+	NATGatewayNotFound         = "InvalidNatGatewayID.NotFound"
+	GatewayNotFound            = "InvalidGatewayID.NotFound"
+	EIPNotFound                = "InvalidElasticIpID.NotFound"
+	RouteTableNotFound         = "InvalidRouteTableID.NotFound"
+	LoadBalancerNotFound       = "LoadBalancerNotFound"
+	ResourceNotFound           = "InvalidResourceID.NotFound"
+	InvalidSubnet              = "InvalidSubnet"
+	AssociationIDNotFound      = "InvalidAssociationID.NotFound"
+	InvalidInstanceID          = "InvalidInstanceID.NotFound"
+	LaunchTemplateNameNotFound = "InvalidLaunchTemplateName.NotFoundException"
+	ResourceExists             = "ResourceExistsException"
+	NoCredentialProviders      = "NoCredentialProviders"
 )
 
 var _ error = &EC2Error{}
@@ -138,6 +139,8 @@ func IsInvalidNotFoundError(err error) bool {
 		case InvalidInstanceID:
 			return true
 		case ssm.ErrCodeParameterNotFound:
+			return true
+		case LaunchTemplateNameNotFound:
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This function will return a `400` with an error like `InvalidLaunchTemplateName.NotFoundException: The specified launch template, with template name foo, does not exist.`
https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/7eb58f53f56a96a13dc42f3df91f6903e6efe256/pkg/cloud/services/ec2/launchtemplate.go#L77

Added a new `LaunchTemplateNameNotFound` in the `IsInvalidNotFoundError()` function and updated the unit tests to reflect what the AWS API returns.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2402

**Special notes for your reviewer**:
Also tested with a dev image `docker.io/dkoshkin/cluster-api-aws-controller-amd64:LaunchTemplateNameNotFound`

```
➜ kubectl get clusters,awsclusters,machinepools,awsmachinepools
NAME                                                       PHASE
cluster.cluster.x-k8s.io/dkoshkin-launchtemplatenotfound   Provisioned

NAME                                                                         CLUSTER                           READY   VPC                     BASTION IP
awscluster.infrastructure.cluster.x-k8s.io/dkoshkin-launchtemplatenotfound   dkoshkin-launchtemplatenotfound   true    vpc-0fe0999d43337350d

NAME                                                                    REPLICAS   PHASE     VERSION
machinepool.exp.cluster.x-k8s.io/dkoshkin-launchtemplatenotfound-mp-0   1          Running   1.20.6

NAME                                                                                  READY   REPLICAS   MINSIZE   MAXSIZE   LAUNCHTEMPLATE ID
awsmachinepool.infrastructure.cluster.x-k8s.io/dkoshkin-launchtemplatenotfound-mp-0   true    1          1         2         lt-0a2024ddf6e00cfbd
```

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix for reconciling LaunchTemplates.
```
