### PR TITLE
Minor Makefile release fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,7 @@ release-alias-tag: # Adds the tag to the last build tag.
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES) ## Generate release notes
-	$(RELEASE_NOTES) $(ARGS)
+	$(RELEASE_NOTES) --org $(GH_ORG_NAME) --repo $(GH_REPO_NAME)
 
 .PHONY: release-templates
 release-templates: $(RELEASE_DIR) ## Generate release templates

--- a/docs/book/src/development/releasing.md
+++ b/docs/book/src/development/releasing.md
@@ -9,7 +9,7 @@
 5. Push the commit of the tag to the release branch: `git push origin HEAD:release-0.6`
 6. Set environment variables `PREVIOUS_VERSION` which is the last release tag and `VERSION` which is the current release version.
 7. Checkout the tag you've just created and make sure git is in a clean state
-8. Run `make release`
+8. Export the current branch `BRANCH=release-0.6` and run `make release`
 9. A prow job will start running to push images to the staging repo, can be seen [here](https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#post-cluster-api-provider-aws-push-images).
 10. Run `make create-gh-release` to create a draft release on Github, copying the generated release notes from `out/CHANGELOG.md` into the draft.
 11. Run `make upload-gh-artifacts` to upload artifacts from .out/ directory, however you may run into API limit errors, so verify artifacts at next step

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -92,7 +92,7 @@ $(GH_SHARE)/gh.tar.gz: $(GH_SHARE)
 	curl -L "https://github.com/cli/cli/releases/download/v$(GH_VERSION)/gh_$(GH_VERSION)_$(GH_ARCH_SUFFIX).tar.gz" -o $@
 
 GH := $(BIN_DIR)/gh
-GH: $(GTAR) $(GH_SHARE)/gh.tar.gz
+$(GH): $(GTAR) $(GH_SHARE)/gh.tar.gz
 	$(GTAR) -xvf share/gh/gh.tar.gz gh_$(GH_VERSION)_$(GH_ARCH_SUFFIX)/bin/gh --strip-components 1 --directory $(BIN_DIR)
 	chmod +x $@
 	touch -m $@


### PR DESCRIPTION
**What this PR does / why we need it**:
`make release` was failing due to these minor errors. Just fixing v0.6 release for now until we do a v0.7 release and see if these issues exist there as well.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
