### PR TITLE
Adding v1alpha4 webhook validation checks

### DIFF
--- a/api/v1alpha4/awsclustercontrolleridentity_webhook.go
+++ b/api/v1alpha4/awsclustercontrolleridentity_webhook.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,6 +54,14 @@ func (r *AWSClusterControllerIdentity) ValidateCreate() error {
 			r.Name, "AWSClusterControllerIdentity is a singleton and only acceptable name is default")
 	}
 
+	// Validate selector parses as Selector if AllowedNameSpaces is populated
+	if r.Spec.AllowedNamespaces != nil {
+		_, err := metav1.LabelSelectorAsSelector(&r.Spec.AllowedNamespaces.Selector)
+		if err != nil {
+			return field.Invalid(field.NewPath("spec", "allowedNamespaces", "selector"), r.Spec.AllowedNamespaces.Selector, err.Error())
+		}
+	}
+
 	return nil
 }
 
@@ -74,6 +83,13 @@ func (r *AWSClusterControllerIdentity) ValidateUpdate(old runtime.Object) error 
 		return field.Invalid(field.NewPath("name"),
 			r.Name, "AWSClusterControllerIdentity is a singleton and only acceptable name is default")
 	}
+
+	// Validate selector parses as Selector
+	_, err := metav1.LabelSelectorAsSelector(&r.Spec.AllowedNamespaces.Selector)
+	if err != nil {
+		return field.Invalid(field.NewPath("spec", "allowedNamespaces", "selectors"), r.Spec.AllowedNamespaces.Selector, err.Error())
+	}
+
 	return nil
 }
 

--- a/api/v1alpha4/awsclusterroleidentity_webhook.go
+++ b/api/v1alpha4/awsclusterroleidentity_webhook.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,6 +50,15 @@ func (r *AWSClusterRoleIdentity) ValidateCreate() error {
 		return field.Invalid(field.NewPath("spec", "sourceIdentityRef"),
 			r.Spec.SourceIdentityRef, "field cannot be set to nil")
 	}
+
+	// Validate selector parses as Selector
+	if r.Spec.AllowedNamespaces != nil {
+		_, err := metav1.LabelSelectorAsSelector(&r.Spec.AllowedNamespaces.Selector)
+		if err != nil {
+			return field.Invalid(field.NewPath("spec", "allowedNamespaces", "selector"), r.Spec.AllowedNamespaces.Selector, err.Error())
+		}
+	}
+
 	return nil
 }
 
@@ -66,6 +76,14 @@ func (r *AWSClusterRoleIdentity) ValidateUpdate(old runtime.Object) error {
 	if oldP.Spec.SourceIdentityRef != nil && r.Spec.SourceIdentityRef == nil {
 		return field.Invalid(field.NewPath("spec", "sourceIdentityRef"),
 			r.Spec.SourceIdentityRef, "field cannot be set to nil")
+	}
+
+	// Validate selector parses as Selector
+	if r.Spec.AllowedNamespaces != nil {
+		_, err := metav1.LabelSelectorAsSelector(&r.Spec.AllowedNamespaces.Selector)
+		if err != nil {
+			return field.Invalid(field.NewPath("spec", "allowedNamespaces", "selector"), r.Spec.AllowedNamespaces.Selector, err.Error())
+		}
 	}
 
 	return nil

--- a/api/v1alpha4/awsclusterstaticidentity_webhook.go
+++ b/api/v1alpha4/awsclusterstaticidentity_webhook.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var _ = logf.Log.WithName("awsclusterstaticidentity-resource")
+
+func (r *AWSClusterStaticIdentity) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterstaticidentity,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=awsclusterstaticidentities,versions=v1alpha4,name=validation.awsclusterstaticidentity.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterstaticidentity,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=awsclusterstaticidentities,versions=v1alpha4,name=default.awsclusterstaticidentity.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+
+var (
+	_ webhook.Validator = &AWSClusterStaticIdentity{}
+	_ webhook.Defaulter = &AWSClusterStaticIdentity{}
+)
+
+func (r *AWSClusterStaticIdentity) ValidateCreate() error {
+	// Validate selector parses as Selector
+	if r.Spec.AllowedNamespaces != nil {
+		_, err := metav1.LabelSelectorAsSelector(&r.Spec.AllowedNamespaces.Selector)
+		if err != nil {
+			return field.Invalid(field.NewPath("spec", "allowedNamespaces", "selector"), r.Spec.AllowedNamespaces.Selector, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *AWSClusterStaticIdentity) ValidateDelete() error {
+	return nil
+}
+
+func (r *AWSClusterStaticIdentity) ValidateUpdate(old runtime.Object) error {
+	oldP, ok := old.(*AWSClusterStaticIdentity)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected an AWSClusterStaticIdentity but got a %T", old))
+	}
+
+	if oldP.Spec.SecretRef != r.Spec.SecretRef {
+		return field.Invalid(field.NewPath("spec", "secretRef"),
+			r.Spec.SecretRef, "field cannot be updated")
+	}
+
+	// Validate selector parses as Selector
+	if r.Spec.AllowedNamespaces != nil {
+		_, err := metav1.LabelSelectorAsSelector(&r.Spec.AllowedNamespaces.Selector)
+		if err != nil {
+			return field.Invalid(field.NewPath("spec", "allowedNamespaces", "selector"), r.Spec.AllowedNamespaces.Selector, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *AWSClusterStaticIdentity) Default() {
+}

--- a/api/v1alpha4/suite_test.go
+++ b/api/v1alpha4/suite_test.go
@@ -83,6 +83,10 @@ func setup() {
 	if err := (&AWSClusterRoleIdentity{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSClusterRoleIdentity webhook: %v", err))
 	}
+	if err := (&AWSClusterStaticIdentity{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSClusterStaticIdentity webhook: %v", err))
+	}
+
 	go func() {
 		fmt.Println("Starting the manager")
 		if err := testEnv.StartManager(ctx); err != nil {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -75,6 +75,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterstaticidentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsclusterstaticidentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusterstaticidentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmachine
   failurePolicy: Fail
   name: mutation.awsmachine.infrastructure.cluster.x-k8s.io
@@ -243,6 +264,27 @@ webhooks:
     - UPDATE
     resources:
     - awsclusterroleidentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterstaticidentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsclusterstaticidentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusterstaticidentities
   sideEffects: None
 - admissionReviewVersions:
   - v1beta1

--- a/main.go
+++ b/main.go
@@ -196,6 +196,10 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AWSClusterRoleIdentity")
 		os.Exit(1)
 	}
+	if err = (&infrav1alpha4.AWSClusterStaticIdentity{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "AWSClusterStaticIdentity")
+		os.Exit(1)
+	}
 	if err = (&infrav1alpha4.AWSMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AWSMachine")
 		os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves webhook validation checks for v1alpha4 types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2391


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
* Validate label selector for AWS Identity CRDs
* Add AWSClusterStaticIdentity webhook with validation checks
```