### PR TITLE
fix: Process extra statements for Cluster API Controllers

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation"
+	cfn_iam "github.com/awslabs/goformation/v4/cloudformation/iam"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 )
@@ -53,6 +54,23 @@ func (t Template) controllersTrustPolicy() *infrav1.PolicyDocument {
 	policyDocument := ec2AssumeRolePolicy()
 	policyDocument.Statement = append(policyDocument.Statement, t.Spec.ClusterAPIControllers.TrustStatements...)
 	return policyDocument
+}
+
+func (t Template) controllersRolePolicy() []cfn_iam.Role_Policy {
+	policies := []cfn_iam.Role_Policy{}
+
+	if t.Spec.ClusterAPIControllers.ExtraStatements != nil {
+		policies = append(policies,
+			cfn_iam.Role_Policy{
+				PolicyName: t.Spec.StackName,
+				PolicyDocument: infrav1.PolicyDocument{
+					Statement: t.Spec.ClusterAPIControllers.ExtraStatements,
+					Version:   infrav1.CurrentVersion,
+				},
+			},
+		)
+	}
+	return policies
 }
 
 func (t Template) ControllersPolicy() *infrav1.PolicyDocument {

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -294,6 +294,16 @@ Resources:
             Service:
             - ec2.amazonaws.com
         Version: 2012-10-17
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Action:
+            - test:controller-action
+            Effect: Allow
+            Resource:
+            - '*'
+          Version: 2012-10-17
+        PolicyName: cluster-api-provider-aws-sigs-k8s-io
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role
   AWSIAMRoleNodes:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template.go
@@ -130,6 +130,7 @@ func (t Template) RenderCloudFormation() *cloudformation.Template {
 	template.Resources[AWSIAMRoleControllers] = &cfn_iam.Role{
 		RoleName:                 t.NewManagedName("controllers"),
 		AssumeRolePolicyDocument: t.controllersTrustPolicy(),
+		Policies:                 t.controllersRolePolicy(),
 		Tags:                     converters.MapToCloudFormationTags(t.Spec.ClusterAPIControllers.Tags),
 	}
 

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
@@ -141,6 +141,13 @@ func Test_RenderCloudformation(t *testing.T) {
 						Action:   infrav1.Actions{"test:user-action"},
 					},
 				}
+				t.Spec.ClusterAPIControllers.ExtraStatements = infrav1.Statements{
+					{
+						Effect:   infrav1.EffectAllow,
+						Resource: infrav1.Resources{infrav1.Any},
+						Action:   infrav1.Actions{"test:controller-action"},
+					},
+				}
 				return t
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

This PR fixes the bug causing `extraStatements` section to be ignored for `clusterAPIControllers` when creating IAM role.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2387

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Process extra statements for Cluster API Controllers
```
