### PR TITLE
Issue 2428: Enforce comments on the codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,12 @@
+linters-settings:
+  # Restrict revive to exported.
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: exported
+        severity: warning
 linters:
   disable-all: true
   enable:
@@ -11,7 +20,6 @@ linters:
     - gofmt
     - goheader
     - goimports
-    - golint
     - goprintffuncname
     - gosimple
     - govet
@@ -29,6 +37,7 @@ linters:
     - unparam
     - unused
     - varcheck
+    - revive
   # Run with --fast=false for more extensive checks
   fast: true
 issues:
@@ -37,8 +46,27 @@ issues:
   # List of regexps of issue texts to exclude, empty list by default.
   exclude-use-default: false
   exclude:
-    - Using the variable on range scope `(tc)|(rt)|(tt)|(test)|(testcase)|(testCase)` in function literal
     - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
+    - "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
+    - "exported: (func|type) name will be used as (.+) by other packages, and that stutters; consider calling this (.+)"
+    # Exclude noctx error for calling http.Get directly.
+    # See https://pkg.go.dev/github.com/sonatard/noctx#readme-how-to-fix for reasons it breaks and ways to fix it.
+    # This exclusion should be removed if the decision is made to fix the error.
+    - "net/http.Get must not be called"
+  exclude-rules:
+    # Exclude revive's exported for certain packages and code, e.g. tests and fake.
+    - linters:
+      - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      source: (func|type).*Fake.*
+    - linters:
+      - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      path: fake_\.go
+    - linters:
+      - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      path: .*test/(providers|framework|e2e).*.go
 run:
   timeout: 10m
   tests: false

--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -91,6 +91,7 @@ type AWSClusterSpec struct {
 	IdentityRef *AWSIdentityReference `json:"identityRef,omitempty"`
 }
 
+// AWSIdentityKind defines allowed AWS identity types
 type AWSIdentityKind string
 
 var (
@@ -115,6 +116,7 @@ type AWSIdentityReference struct {
 	Kind AWSIdentityKind `json:"kind"`
 }
 
+// Bastion defines a bastion host.
 type Bastion struct {
 	// Enabled allows this provider to create a bastion host instance
 	// with a public ip to access the VPC private network.
@@ -208,10 +210,12 @@ type AWSClusterList struct {
 	Items           []AWSCluster `json:"items"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSCluster resource.
 func (r *AWSCluster) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSCluster to the predescribed clusterv1.Conditions.
 func (r *AWSCluster) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/api/v1alpha3/awsidentity_types.go
+++ b/api/v1alpha3/awsidentity_types.go
@@ -21,10 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// AWSClusterIdentitySpec defines the Spec struct for AWSClusterIdentity types.
 type AWSClusterIdentitySpec struct {
 	// AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.
 	// Namespaces can be selected either using an array of namespaces or with label selector.
-	// An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace.
+	// An empty AllowedNamespaces object indicates that AWSClusters can use this identity from any namespace.
 	// If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)
 	// A namespace should be either in the NamespaceList or match with Selector to use the identity.
 	//
@@ -33,6 +34,10 @@ type AWSClusterIdentitySpec struct {
 	AllowedNamespaces *AllowedNamespaces `json:"allowedNamespaces"`
 }
 
+// AllowedNamespaces is a selector of namespaces that AWSClusters can
+// use this ClusterPrincipal from. This is a standard Kubernetes LabelSelector,
+// a label query over a set of resources. The result of matchLabels and
+// matchExpressions are ANDed.
 type AllowedNamespaces struct {
 	// An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.
 	//
@@ -40,17 +45,13 @@ type AllowedNamespaces struct {
 	// +nullable
 	NamespaceList []string `json:"list"`
 
-	// AllowedNamespaces is a selector of namespaces that AWSClusters can
-	// use this ClusterPrincipal from. This is a standard Kubernetes LabelSelector,
-	// a label query over a set of resources. The result of matchLabels and
-	// matchExpressions are ANDed.
-	//
 	// An empty selector indicates that AWSClusters cannot use this
 	// AWSClusterIdentity from any namespace.
 	// +optional
 	Selector metav1.LabelSelector `json:"selector"`
 }
 
+// AWSRoleSpec defines the specifications for all identities based around AWS roles.
 type AWSRoleSpec struct {
 	// The Amazon Resource Name (ARN) of the role to assume.
 	RoleArn string `json:"roleARN"`
@@ -91,6 +92,7 @@ type AWSClusterStaticIdentityList struct {
 	Items           []AWSClusterStaticIdentity `json:"items"`
 }
 
+// AWSClusterStaticIdentitySpec defines the specifications for AWSClusterStaticIdentity.
 type AWSClusterStaticIdentitySpec struct {
 	AWSClusterIdentitySpec `json:",inline"`
 	// Reference to a secret containing the credentials. The secret should
@@ -123,6 +125,7 @@ type AWSClusterRoleIdentityList struct {
 	Items           []AWSClusterRoleIdentity `json:"items"`
 }
 
+// AWSClusterRoleIdentitySpec defines the specifications for AWSClusterRoleIdentity.
 type AWSClusterRoleIdentitySpec struct {
 	AWSClusterIdentitySpec `json:",inline"`
 	AWSRoleSpec            `json:",inline"`
@@ -165,6 +168,7 @@ type AWSClusterControllerIdentityList struct {
 	Items           []AWSClusterControllerIdentity `json:"items"`
 }
 
+// AWSClusterControllerIdentitySpec defines the specifications for AWSClusterControllerIdentity.
 type AWSClusterControllerIdentitySpec struct {
 	AWSClusterIdentitySpec `json:",inline"`
 }

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -255,10 +255,12 @@ type AWSMachine struct {
 	Status AWSMachineStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSMachine resource.
 func (r *AWSMachine) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSMachine to the predescribed clusterv1.Conditions.
 func (r *AWSMachine) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/api/v1alpha3/conditions_consts.go
+++ b/api/v1alpha3/conditions_consts.go
@@ -36,7 +36,7 @@ const (
 )
 
 const (
-	// VpcReady condition reports on the successful reconciliation of a VPC
+	// VpcReadyCondition reports on the successful reconciliation of a VPC
 	VpcReadyCondition clusterv1.ConditionType = "VpcReady"
 	// VpcCreationStartedReason used when attempting to create a VPC for a managed cluster.
 	// Will not be applied to unmanaged clusters.
@@ -46,14 +46,14 @@ const (
 )
 
 const (
-	// SubnetsReady condition reports on the successful reconciliation of subnets.
+	// SubnetsReadyCondition reports on the successful reconciliation of subnets.
 	SubnetsReadyCondition clusterv1.ConditionType = "SubnetsReady"
 	// SubnetsReconciliationFailedReason used to report failures while reconciling subnets
 	SubnetsReconciliationFailedReason = "SubnetsReconciliationFailed"
 )
 
 const (
-	// InternetGatewayReady condition reports on the successful reconciliation of internet gateways.
+	// InternetGatewayReadyCondition reports on the successful reconciliation of internet gateways.
 	// Only applicable to managed clusters.
 	InternetGatewayReadyCondition clusterv1.ConditionType = "InternetGatewayReady"
 	// InternetGatewayFailedReason used when errors occur during internet gateway reconciliation
@@ -61,7 +61,7 @@ const (
 )
 
 const (
-	// NatGatewayReady condition reports successful reconciliation of NAT gateways.
+	// NatGatewaysReadyCondition reports successful reconciliation of NAT gateways.
 	// Only applicable to managed clusters.
 	NatGatewaysReadyCondition clusterv1.ConditionType = "NatGatewaysReady"
 	// NatGatewaysCreationStartedReason set once when creating new NAT gateways.
@@ -71,7 +71,7 @@ const (
 )
 
 const (
-	// RouteTablesReady condition reports successful reconciliation of route tables.
+	// RouteTablesReadyCondition reports successful reconciliation of route tables.
 	// Only applicable to managed clusters.
 	RouteTablesReadyCondition clusterv1.ConditionType = "RouteTablesReady"
 	// RouteTableReconciliationFailedReason used when any errors occur during reconciliation of route tables.
@@ -79,7 +79,7 @@ const (
 )
 
 const (
-	// SecondaryCidrsReady condition reports successful reconciliation of secondary CIDR blocks.
+	// SecondaryCidrsReadyCondition reports successful reconciliation of secondary CIDR blocks.
 	// Only applicable to managed clusters.
 	SecondaryCidrsReadyCondition clusterv1.ConditionType = "SecondaryCidrsReady"
 	// SecondaryCidrReconciliationFailedReason used when any errors occur during reconciliation of secondary CIDR blocks.
@@ -87,7 +87,7 @@ const (
 )
 
 const (
-	// ClusterSecurityGroupsReady condition reports successful reconciliation of security groups.
+	// ClusterSecurityGroupsReadyCondition reports successful reconciliation of security groups.
 	ClusterSecurityGroupsReadyCondition clusterv1.ConditionType = "ClusterSecurityGroupsReady"
 	// ClusterSecurityGroupReconciliationFailedReason used when any errors occur during reconciliation of security groups.
 	ClusterSecurityGroupReconciliationFailedReason = "SecurityGroupReconciliationFailed"
@@ -145,8 +145,9 @@ const (
 )
 
 const (
-	// Only applicable to control plane machines. ELBAttachedCondition will report true when a control plane is successfully registered with an ELB
-	// When set to false, severity can be an Error if the subnet is not found or unavailable in the instance's AZ
+	// ELBAttachedCondition will report true when a control plane is successfully registered with an ELB.
+	// When set to false, severity can be an Error if the subnet is not found or unavailable in the instance's AZ.
+	// Note this is only applicable to control plane machines.
 	ELBAttachedCondition clusterv1.ConditionType = "ELBAttached"
 
 	// ELBAttachFailedReason used when a control plane node fails to attach to the ELB

--- a/api/v1alpha3/conversion.go
+++ b/api/v1alpha3/conversion.go
@@ -24,79 +24,91 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
-// ConvertTo converts this AWSCluster to the Hub version (v1alpha4).
+// ConvertTo converts the v1alpha3 AWSCluster receiver to a v1alpha4 AWSCluster.
 func (r *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSCluster)
 
 	return Convert_v1alpha3_AWSCluster_To_v1alpha4_AWSCluster(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSCluster receiver to a v1alpha3 AWSCluster.
 func (r *AWSCluster) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSCluster)
 
 	return Convert_v1alpha4_AWSCluster_To_v1alpha3_AWSCluster(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSClusterList receiver to a v1alpha4 AWSClusterList.
 func (r *AWSClusterList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSClusterList)
 
 	return Convert_v1alpha3_AWSClusterList_To_v1alpha4_AWSClusterList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSClusterList receiver to a v1alpha3 AWSClusterList.
 func (r *AWSClusterList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSClusterList)
 
 	return Convert_v1alpha4_AWSClusterList_To_v1alpha3_AWSClusterList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSMachine receiver to a v1alpha4 AWSMachine.
 func (r *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSMachine)
 
 	return Convert_v1alpha3_AWSMachine_To_v1alpha4_AWSMachine(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSMachine receiver to a v1alpha3 AWSMachine.
 func (r *AWSMachine) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSMachine)
 
 	return Convert_v1alpha4_AWSMachine_To_v1alpha3_AWSMachine(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSMachineList receiver to a v1alpha4 AWSMachineList.
 func (r *AWSMachineList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSMachineList)
 
 	return Convert_v1alpha3_AWSMachineList_To_v1alpha4_AWSMachineList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSMachineList receiver to a v1alpha3 AWSMachineList.
 func (r *AWSMachineList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSMachineList)
 
 	return Convert_v1alpha4_AWSMachineList_To_v1alpha3_AWSMachineList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSMachineTemplate receiver to a v1alpha4 AWSMachineTemplate.
 func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSMachineTemplate)
 
 	return Convert_v1alpha3_AWSMachineTemplate_To_v1alpha4_AWSMachineTemplate(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSMachineTemplate receiver to a v1alpha3 AWSMachineTemplate.
 func (r *AWSMachineTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSMachineTemplate)
 
 	return Convert_v1alpha4_AWSMachineTemplate_To_v1alpha3_AWSMachineTemplate(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSMachineTemplateList receiver to a v1alpha4 AWSMachineTemplateList.
 func (r *AWSMachineTemplateList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSMachineTemplateList)
 
 	return Convert_v1alpha3_AWSMachineTemplateList_To_v1alpha4_AWSMachineTemplateList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSMachineTemplateList receiver to a v1alpha3 AWSMachineTemplateList.
 func (r *AWSMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSMachineTemplateList)
 
 	return Convert_v1alpha4_AWSMachineTemplateList_To_v1alpha3_AWSMachineTemplateList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSClusterStaticIdentity receiver to a v1alpha4 AWSClusterStaticIdentity.
 func (r *AWSClusterStaticIdentity) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSClusterStaticIdentity)
 	if err := Convert_v1alpha3_AWSClusterStaticIdentity_To_v1alpha4_AWSClusterStaticIdentity(r, dst, nil); err != nil {
@@ -107,6 +119,7 @@ func (r *AWSClusterStaticIdentity) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
+// ConvertFrom converts the v1alpha4 AWSClusterStaticIdentity receiver to a v1alpha3 AWSClusterStaticIdentity.
 func (r *AWSClusterStaticIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSClusterStaticIdentity)
 
@@ -118,60 +131,70 @@ func (r *AWSClusterStaticIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	return nil
 }
 
+// ConvertTo converts the v1alpha3 AWSClusterStaticIdentityList receiver to a v1alpha4 AWSClusterStaticIdentityList.
 func (r *AWSClusterStaticIdentityList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSClusterStaticIdentityList)
 
 	return Convert_v1alpha3_AWSClusterStaticIdentityList_To_v1alpha4_AWSClusterStaticIdentityList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSClusterStaticIdentityList receiver to a v1alpha3 AWSClusterStaticIdentityList.
 func (r *AWSClusterStaticIdentityList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSClusterStaticIdentityList)
 
 	return Convert_v1alpha4_AWSClusterStaticIdentityList_To_v1alpha3_AWSClusterStaticIdentityList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSClusterRoleIdentity receiver to a v1alpha4 AWSClusterRoleIdentity.
 func (r *AWSClusterRoleIdentity) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSClusterRoleIdentity)
 
 	return Convert_v1alpha3_AWSClusterRoleIdentity_To_v1alpha4_AWSClusterRoleIdentity(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSClusterRoleIdentity receiver to a v1alpha3 AWSClusterRoleIdentity.
 func (r *AWSClusterRoleIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSClusterRoleIdentity)
 
 	return Convert_v1alpha4_AWSClusterRoleIdentity_To_v1alpha3_AWSClusterRoleIdentity(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSClusterRoleIdentityList receiver to a v1alpha4 AWSClusterRoleIdentityList.
 func (r *AWSClusterRoleIdentityList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSClusterRoleIdentityList)
 
 	return Convert_v1alpha3_AWSClusterRoleIdentityList_To_v1alpha4_AWSClusterRoleIdentityList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSClusterRoleIdentityList receiver to a v1alpha3 AWSClusterRoleIdentityList.
 func (r *AWSClusterRoleIdentityList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSClusterRoleIdentityList)
 
 	return Convert_v1alpha4_AWSClusterRoleIdentityList_To_v1alpha3_AWSClusterRoleIdentityList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSClusterControllerIdentity receiver to a v1alpha4 AWSClusterControllerIdentity.
 func (r *AWSClusterControllerIdentity) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSClusterControllerIdentity)
 
 	return Convert_v1alpha3_AWSClusterControllerIdentity_To_v1alpha4_AWSClusterControllerIdentity(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSClusterControllerIdentity receiver to a v1alpha3 AWSClusterControllerIdentity.
 func (r *AWSClusterControllerIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSClusterControllerIdentity)
 
 	return Convert_v1alpha4_AWSClusterControllerIdentity_To_v1alpha3_AWSClusterControllerIdentity(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSClusterControllerIdentityList receiver to a v1alpha4 AWSClusterControllerIdentityList.
 func (r *AWSClusterControllerIdentityList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSClusterControllerIdentityList)
 
 	return Convert_v1alpha3_AWSClusterControllerIdentityList_To_v1alpha4_AWSClusterControllerIdentityList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSClusterControllerIdentityList receiver to a v1alpha3 AWSClusterControllerIdentityList.
 func (r *AWSClusterControllerIdentityList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSClusterControllerIdentityList)
 
@@ -188,10 +211,12 @@ func Convert_v1alpha4_APIEndpoint_To_v1alpha3_APIEndpoint(in *apiv1alpha4.APIEnd
 	return apiv1alpha3.Convert_v1alpha4_APIEndpoint_To_v1alpha3_APIEndpoint(in, out, s)
 }
 
+// Convert_v1alpha3_AWSClusterStaticIdentitySpec_To_v1alpha4_AWSClusterStaticIdentitySpec is an autogenerated conversion function.
 func Convert_v1alpha3_AWSClusterStaticIdentitySpec_To_v1alpha4_AWSClusterStaticIdentitySpec(in *AWSClusterStaticIdentitySpec, out *v1alpha4.AWSClusterStaticIdentitySpec, s apiconversion.Scope) error {
 	return autoConvert_v1alpha3_AWSClusterStaticIdentitySpec_To_v1alpha4_AWSClusterStaticIdentitySpec(in, out, s)
 }
 
+// Convert_v1alpha4_AWSClusterStaticIdentitySpec_To_v1alpha3_AWSClusterStaticIdentitySpec is an autogenerated conversion function.
 func Convert_v1alpha4_AWSClusterStaticIdentitySpec_To_v1alpha3_AWSClusterStaticIdentitySpec(in *v1alpha4.AWSClusterStaticIdentitySpec, out *AWSClusterStaticIdentitySpec, s apiconversion.Scope) error {
 	return autoConvert_v1alpha4_AWSClusterStaticIdentitySpec_To_v1alpha3_AWSClusterStaticIdentitySpec(in, out, s)
 }

--- a/api/v1alpha3/tags.go
+++ b/api/v1alpha3/tags.go
@@ -38,7 +38,7 @@ func (t Tags) HasOwned(cluster string) bool {
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
 }
 
-// HasOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of the in-tree cloud provider.
+// HasAWSCloudProviderOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of the in-tree cloud provider.
 func (t Tags) HasAWSCloudProviderOwned(cluster string) bool {
 	value, ok := t[ClusterAWSCloudProviderTagKey(cluster)]
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
@@ -85,7 +85,7 @@ const (
 	// if the cluster is destroyed.
 	ResourceLifecycleShared = ResourceLifecycle("shared")
 
-	// NameKubernetesClusterPrefix is the tag name used by the cloud provider to logically
+	// NameKubernetesAWSCloudProviderPrefix is the tag name used by the cloud provider to logically
 	// separate independent cluster resources. We use it to identify which resources we expect
 	// to be permissive about state changes.
 	// logically independent clusters running in the same AZ.
@@ -107,8 +107,10 @@ const (
 	// dedicated to this cluster api provider implementation.
 	NameAWSClusterAPIRole = NameAWSProviderPrefix + "role"
 
+	// NameAWSSubnetAssociation is the tag name we use to mark subnet associations.
 	NameAWSSubnetAssociation = NameAWSProviderPrefix + "association"
 
+	// SecondarySubnetTagValue describes the value for the secondary subnet.
 	SecondarySubnetTagValue = "secondary"
 
 	// APIServerRoleTagValue describes the value for the apiserver role

--- a/api/v1alpha4/awscluster_types.go
+++ b/api/v1alpha4/awscluster_types.go
@@ -91,6 +91,7 @@ type AWSClusterSpec struct {
 	IdentityRef *AWSIdentityReference `json:"identityRef,omitempty"`
 }
 
+// AWSIdentityKind defines allowed AWS identity types.
 type AWSIdentityKind string
 
 var (
@@ -115,6 +116,7 @@ type AWSIdentityReference struct {
 	Kind AWSIdentityKind `json:"kind"`
 }
 
+// Bastion defines a bastion host.
 type Bastion struct {
 	// Enabled allows this provider to create a bastion host instance
 	// with a public ip to access the VPC private network.
@@ -209,10 +211,12 @@ type AWSClusterList struct {
 	Items           []AWSCluster `json:"items"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSCluster resource.
 func (r *AWSCluster) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSCluster to the predescribed clusterv1.Conditions.
 func (r *AWSCluster) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/api/v1alpha4/awscluster_webhook.go
+++ b/api/v1alpha4/awscluster_webhook.go
@@ -47,6 +47,7 @@ var (
 	_ webhook.Defaulter = &AWSCluster{}
 )
 
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSCluster) ValidateCreate() error {
 	var allErrs field.ErrorList
 
@@ -56,10 +57,12 @@ func (r *AWSCluster) ValidateCreate() error {
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSCluster) ValidateDelete() error {
 	return nil
 }
 
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 	var allErrs field.ErrorList
 
@@ -117,6 +120,7 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 
+// Default satisfies the defaulting webhook interface.
 func (r *AWSCluster) Default() {
 	SetDefaults_Bastion(&r.Spec.Bastion)
 	SetDefaults_NetworkSpec(&r.Spec.NetworkSpec)

--- a/api/v1alpha4/awsclustercontrolleridentity_webhook.go
+++ b/api/v1alpha4/awsclustercontrolleridentity_webhook.go
@@ -47,6 +47,7 @@ var (
 	_ webhook.Defaulter = &AWSClusterControllerIdentity{}
 )
 
+// ValidateCreate will do any extra validation when creating an AWSClusterControllerIdentity.
 func (r *AWSClusterControllerIdentity) ValidateCreate() error {
 	// Ensures AWSClusterControllerIdentity being singleton by only allowing "default" as name
 	if r.Name != AWSClusterControllerIdentityName {
@@ -65,10 +66,12 @@ func (r *AWSClusterControllerIdentity) ValidateCreate() error {
 	return nil
 }
 
+// ValidateDelete allows you to add any extra validation when deleting an AWSClusterControllerIdentity.
 func (r *AWSClusterControllerIdentity) ValidateDelete() error {
 	return nil
 }
 
+// ValidateUpdate will do any extra validation when updating an AWSClusterControllerIdentity.
 func (r *AWSClusterControllerIdentity) ValidateUpdate(old runtime.Object) error {
 	oldP, ok := old.(*AWSClusterControllerIdentity)
 	if !ok {
@@ -93,5 +96,6 @@ func (r *AWSClusterControllerIdentity) ValidateUpdate(old runtime.Object) error 
 	return nil
 }
 
+// Default will set default values for the AWSClusterControllerIdentity.
 func (r *AWSClusterControllerIdentity) Default() {
 }

--- a/api/v1alpha4/awsclusterroleidentity_webhook.go
+++ b/api/v1alpha4/awsclusterroleidentity_webhook.go
@@ -45,6 +45,7 @@ var (
 	_ webhook.Defaulter = &AWSClusterRoleIdentity{}
 )
 
+// ValidateCreate will do any extra validation when creating an AWSClusterRoleIdentity.
 func (r *AWSClusterRoleIdentity) ValidateCreate() error {
 	if r.Spec.SourceIdentityRef == nil {
 		return field.Invalid(field.NewPath("spec", "sourceIdentityRef"),
@@ -62,10 +63,12 @@ func (r *AWSClusterRoleIdentity) ValidateCreate() error {
 	return nil
 }
 
+// ValidateDelete allows you to add any extra validation when deleting an AWSClusterRoleIdentity.
 func (r *AWSClusterRoleIdentity) ValidateDelete() error {
 	return nil
 }
 
+// ValidateUpdate will do any extra validation when updating an AWSClusterRoleIdentity.
 func (r *AWSClusterRoleIdentity) ValidateUpdate(old runtime.Object) error {
 	oldP, ok := old.(*AWSClusterRoleIdentity)
 	if !ok {
@@ -89,5 +92,6 @@ func (r *AWSClusterRoleIdentity) ValidateUpdate(old runtime.Object) error {
 	return nil
 }
 
+// Default will set default values for the AWSClusterRoleIdentity.
 func (r *AWSClusterRoleIdentity) Default() {
 }

--- a/api/v1alpha4/awsclusterstaticidentity_webhook.go
+++ b/api/v1alpha4/awsclusterstaticidentity_webhook.go
@@ -45,6 +45,7 @@ var (
 	_ webhook.Defaulter = &AWSClusterStaticIdentity{}
 )
 
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSClusterStaticIdentity) ValidateCreate() error {
 	// Validate selector parses as Selector
 	if r.Spec.AllowedNamespaces != nil {
@@ -57,10 +58,12 @@ func (r *AWSClusterStaticIdentity) ValidateCreate() error {
 	return nil
 }
 
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSClusterStaticIdentity) ValidateDelete() error {
 	return nil
 }
 
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSClusterStaticIdentity) ValidateUpdate(old runtime.Object) error {
 	oldP, ok := old.(*AWSClusterStaticIdentity)
 	if !ok {
@@ -83,5 +86,6 @@ func (r *AWSClusterStaticIdentity) ValidateUpdate(old runtime.Object) error {
 	return nil
 }
 
+// Default should return the default AWSClusterStaticIdentity.
 func (r *AWSClusterStaticIdentity) Default() {
 }

--- a/api/v1alpha4/awsiam_types.go
+++ b/api/v1alpha4/awsiam_types.go
@@ -23,9 +23,14 @@ import (
 )
 
 type (
-	Effect            string
+	// Effect defines an AWS IAM effect.
+	Effect string
+
+	// ConditionOperator defines an AWS condition operator.
 	ConditionOperator string
-	PrincipalType     string
+
+	// PrincipalType defines an AWS principle type.
+	PrincipalType string
 )
 
 const (
@@ -95,6 +100,7 @@ type Principals map[PrincipalType]PrincipalID
 // Actions is the list of actions
 type Actions []string
 
+// UnmarshalJSON is an Actions Unmarshaler.
 func (actions *Actions) UnmarshalJSON(data []byte) error {
 	var ids []string
 	if err := json.Unmarshal(data, &ids); err == nil {
@@ -115,6 +121,7 @@ type Resources []string
 // PrincipalID represents the list of all identities, such as ARNs
 type PrincipalID []string
 
+// UnmarshalJSON defines an Unmarshaler for a PrincipalID.
 func (identityID *PrincipalID) UnmarshalJSON(data []byte) error {
 	var ids []string
 	if err := json.Unmarshal(data, &ids); err == nil {

--- a/api/v1alpha4/awsidentity_types.go
+++ b/api/v1alpha4/awsidentity_types.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// AWSClusterIdentitySpec defines the Spec struct for AWSClusterIdentity types.
 type AWSClusterIdentitySpec struct {
 	// AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.
 	// Namespaces can be selected either using an array of namespaces or with label selector.
@@ -32,6 +33,10 @@ type AWSClusterIdentitySpec struct {
 	AllowedNamespaces *AllowedNamespaces `json:"allowedNamespaces"`
 }
 
+// AllowedNamespaces is a selector of namespaces that AWSClusters can
+// use this ClusterPrincipal from. This is a standard Kubernetes LabelSelector,
+// a label query over a set of resources. The result of matchLabels and
+// matchExpressions are ANDed.
 type AllowedNamespaces struct {
 	// An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.
 	//
@@ -39,17 +44,13 @@ type AllowedNamespaces struct {
 	// +nullable
 	NamespaceList []string `json:"list"`
 
-	// AllowedNamespaces is a selector of namespaces that AWSClusters can
-	// use this ClusterPrincipal from. This is a standard Kubernetes LabelSelector,
-	// a label query over a set of resources. The result of matchLabels and
-	// matchExpressions are ANDed.
-	//
 	// An empty selector indicates that AWSClusters cannot use this
 	// AWSClusterIdentity from any namespace.
 	// +optional
 	Selector metav1.LabelSelector `json:"selector"`
 }
 
+// AWSRoleSpec defines the specifications for all identities based around AWS roles.
 type AWSRoleSpec struct {
 	// The Amazon Resource Name (ARN) of the role to assume.
 	RoleArn string `json:"roleARN"`
@@ -91,6 +92,7 @@ type AWSClusterStaticIdentityList struct {
 	Items           []AWSClusterStaticIdentity `json:"items"`
 }
 
+// AWSClusterStaticIdentitySpec defines the specifications for AWSClusterStaticIdentity.
 type AWSClusterStaticIdentitySpec struct {
 	AWSClusterIdentitySpec `json:",inline"`
 	// Reference to a secret containing the credentials. The secret should
@@ -124,6 +126,7 @@ type AWSClusterRoleIdentityList struct {
 	Items           []AWSClusterRoleIdentity `json:"items"`
 }
 
+// AWSClusterRoleIdentitySpec defines the specifications for AWSClusterRoleIdentity.
 type AWSClusterRoleIdentitySpec struct {
 	AWSClusterIdentitySpec `json:",inline"`
 	AWSRoleSpec            `json:",inline"`
@@ -167,6 +170,7 @@ type AWSClusterControllerIdentityList struct {
 	Items           []AWSClusterControllerIdentity `json:"items"`
 }
 
+// AWSClusterControllerIdentitySpec defines the specifications for AWSClusterControllerIdentity.
 type AWSClusterControllerIdentitySpec struct {
 	AWSClusterIdentitySpec `json:",inline"`
 }

--- a/api/v1alpha4/awsmachine_types.go
+++ b/api/v1alpha4/awsmachine_types.go
@@ -256,10 +256,12 @@ type AWSMachine struct {
 	Status AWSMachineStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSMachine resource.
 func (r *AWSMachine) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSMachine to the predescribed clusterv1.Conditions.
 func (r *AWSMachine) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/api/v1alpha4/conditions_consts.go
+++ b/api/v1alpha4/conditions_consts.go
@@ -36,7 +36,7 @@ const (
 )
 
 const (
-	// VpcReady condition reports on the successful reconciliation of a VPC
+	// VpcReadyCondition reports on the successful reconciliation of a VPC
 	VpcReadyCondition clusterv1.ConditionType = "VpcReady"
 	// VpcCreationStartedReason used when attempting to create a VPC for a managed cluster.
 	// Will not be applied to unmanaged clusters.
@@ -46,14 +46,14 @@ const (
 )
 
 const (
-	// SubnetsReady condition reports on the successful reconciliation of subnets.
+	// SubnetsReadyCondition reports on the successful reconciliation of subnets.
 	SubnetsReadyCondition clusterv1.ConditionType = "SubnetsReady"
 	// SubnetsReconciliationFailedReason used to report failures while reconciling subnets
 	SubnetsReconciliationFailedReason = "SubnetsReconciliationFailed"
 )
 
 const (
-	// InternetGatewayReady condition reports on the successful reconciliation of internet gateways.
+	// InternetGatewayReadyCondition reports on the successful reconciliation of internet gateways.
 	// Only applicable to managed clusters.
 	InternetGatewayReadyCondition clusterv1.ConditionType = "InternetGatewayReady"
 	// InternetGatewayFailedReason used when errors occur during internet gateway reconciliation
@@ -61,7 +61,7 @@ const (
 )
 
 const (
-	// NatGatewayReady condition reports successful reconciliation of NAT gateways.
+	// NatGatewaysReadyCondition reports successful reconciliation of NAT gateways.
 	// Only applicable to managed clusters.
 	NatGatewaysReadyCondition clusterv1.ConditionType = "NatGatewaysReady"
 	// NatGatewaysCreationStartedReason set once when creating new NAT gateways.
@@ -71,7 +71,7 @@ const (
 )
 
 const (
-	// RouteTablesReady condition reports successful reconciliation of route tables.
+	// RouteTablesReadyCondition reports successful reconciliation of route tables.
 	// Only applicable to managed clusters.
 	RouteTablesReadyCondition clusterv1.ConditionType = "RouteTablesReady"
 	// RouteTableReconciliationFailedReason used when any errors occur during reconciliation of route tables.
@@ -79,7 +79,7 @@ const (
 )
 
 const (
-	// SecondaryCidrsReady condition reports successful reconciliation of secondary CIDR blocks.
+	// SecondaryCidrsReadyCondition reports successful reconciliation of secondary CIDR blocks.
 	// Only applicable to managed clusters.
 	SecondaryCidrsReadyCondition clusterv1.ConditionType = "SecondaryCidrsReady"
 	// SecondaryCidrReconciliationFailedReason used when any errors occur during reconciliation of secondary CIDR blocks.
@@ -87,7 +87,7 @@ const (
 )
 
 const (
-	// ClusterSecurityGroupsReady condition reports successful reconciliation of security groups.
+	// ClusterSecurityGroupsReadyCondition reports successful reconciliation of security groups.
 	ClusterSecurityGroupsReadyCondition clusterv1.ConditionType = "ClusterSecurityGroupsReady"
 	// ClusterSecurityGroupReconciliationFailedReason used when any errors occur during reconciliation of security groups.
 	ClusterSecurityGroupReconciliationFailedReason = "SecurityGroupReconciliationFailed"
@@ -145,8 +145,9 @@ const (
 )
 
 const (
-	// Only applicable to control plane machines. ELBAttachedCondition will report true when a control plane is successfully registered with an ELB
-	// When set to false, severity can be an Error if the subnet is not found or unavailable in the instance's AZ
+	// ELBAttachedCondition will report true when a control plane is successfully registered with an ELB.
+	// When set to false, severity can be an Error if the subnet is not found or unavailable in the instance's AZ.
+	// Note this is only applicable to control plane machines.
 	ELBAttachedCondition clusterv1.ConditionType = "ELBAttached"
 
 	// ELBAttachFailedReason used when a control plane node fails to attach to the ELB

--- a/api/v1alpha4/tags.go
+++ b/api/v1alpha4/tags.go
@@ -38,7 +38,7 @@ func (t Tags) HasOwned(cluster string) bool {
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
 }
 
-// HasOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of the in-tree cloud provider.
+// HasAWSCloudProviderOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of the in-tree cloud provider.
 func (t Tags) HasAWSCloudProviderOwned(cluster string) bool {
 	value, ok := t[ClusterAWSCloudProviderTagKey(cluster)]
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
@@ -85,7 +85,7 @@ const (
 	// if the cluster is destroyed.
 	ResourceLifecycleShared = ResourceLifecycle("shared")
 
-	// NameKubernetesClusterPrefix is the tag name used by the cloud provider to logically
+	// NameKubernetesAWSCloudProviderPrefix is the tag name used by the cloud provider to logically
 	// separate independent cluster resources. We use it to identify which resources we expect
 	// to be permissive about state changes.
 	// logically independent clusters running in the same AZ.
@@ -107,8 +107,10 @@ const (
 	// dedicated to this cluster api provider implementation.
 	NameAWSClusterAPIRole = NameAWSProviderPrefix + "role"
 
+	// NameAWSSubnetAssociation is the tag name we use to mark subnet associations.
 	NameAWSSubnetAssociation = NameAWSProviderPrefix + "association"
 
+	// SecondarySubnetTagValue describes the value for the secondary subnet.
 	SecondarySubnetTagValue = "secondary"
 
 	// APIServerRoleTagValue describes the value for the apiserver role

--- a/bootstrap/eks/api/v1alpha3/conversion.go
+++ b/bootstrap/eks/api/v1alpha3/conversion.go
@@ -21,48 +21,56 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
+// ConvertTo converts the v1alpha3 EKSConfig receiver to a v1alpha4 EKSConfig.
 func (r *EKSConfig) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.EKSConfig)
 
 	return Convert_v1alpha3_EKSConfig_To_v1alpha4_EKSConfig(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 EKSConfig receiver to a v1alpha3 EKSConfig.
 func (r *EKSConfig) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.EKSConfig)
 
 	return Convert_v1alpha4_EKSConfig_To_v1alpha3_EKSConfig(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 EKSConfigList receiver to a v1alpha4 EKSConfigList.
 func (r *EKSConfigList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.EKSConfigList)
 
 	return Convert_v1alpha3_EKSConfigList_To_v1alpha4_EKSConfigList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 EKSConfigList receiver to a v1alpha3 EKSConfigList.
 func (r *EKSConfigList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.EKSConfigList)
 
 	return Convert_v1alpha4_EKSConfigList_To_v1alpha3_EKSConfigList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 EKSConfigTemplate receiver to a v1alpha4 EKSConfigTemplate.
 func (r *EKSConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.EKSConfigTemplate)
 
 	return Convert_v1alpha3_EKSConfigTemplate_To_v1alpha4_EKSConfigTemplate(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 EKSConfigTemplate receiver to a v1alpha3 EKSConfigTemplate.
 func (r *EKSConfigTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.EKSConfigTemplate)
 
 	return Convert_v1alpha4_EKSConfigTemplate_To_v1alpha3_EKSConfigTemplate(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 EKSConfigTemplateList receiver to a v1alpha4 EKSConfigTemplateList.
 func (r *EKSConfigTemplateList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.EKSConfigTemplateList)
 
 	return Convert_v1alpha3_EKSConfigTemplateList_To_v1alpha4_EKSConfigTemplateList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 EKSConfigTemplateList receiver to a v1alpha3 EKSConfigTemplateList.
 func (r *EKSConfigTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.EKSConfigTemplateList)
 

--- a/bootstrap/eks/api/v1alpha3/eksconfig_types.go
+++ b/bootstrap/eks/api/v1alpha3/eksconfig_types.go
@@ -72,10 +72,12 @@ type EKSConfig struct {
 	Status EKSConfigStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the EKSConfig resource.
 func (r *EKSConfig) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the EKSConfig to the predescribed clusterv1.Conditions.
 func (r *EKSConfig) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/bootstrap/eks/api/v1alpha4/eksconfig_types.go
+++ b/bootstrap/eks/api/v1alpha4/eksconfig_types.go
@@ -73,10 +73,12 @@ type EKSConfig struct {
 	Status EKSConfigStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the EKSConfig resource.
 func (r *EKSConfig) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the EKSConfig to the predescribed clusterv1.Conditions.
 func (r *EKSConfig) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/bootstrap/eks/main.go
+++ b/bootstrap/eks/main.go
@@ -83,6 +83,7 @@ var (
 	webhookCertDir              string
 )
 
+// InitFlags initializes this manager's flags.
 func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&metricsAddr, "metrics-bind-addr", ":8080",
 		"The address the metric endpoint binds to.")

--- a/cmd/clusterawsadm/ami/copy.go
+++ b/cmd/clusterawsadm/ami/copy.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
+// CopyInput defines input that can be copied to create an AWSAMI.
 type CopyInput struct {
 	SourceRegion      string
 	DestinationRegion string
@@ -44,6 +45,7 @@ type CopyInput struct {
 	Log               logr.Logger
 }
 
+// Copy will create an AWSAMI from a CopyInput.
 func Copy(input CopyInput) (*amiv1.AWSAMI, error) {
 
 	sourceSession, err := session.NewSessionWithOptions(session.Options{

--- a/cmd/clusterawsadm/ami/list.go
+++ b/cmd/clusterawsadm/ami/list.go
@@ -27,12 +27,14 @@ import (
 	amiv1 "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/api/ami/v1alpha1"
 )
 
+// ListInput defines the specs required to construct an AWSAMIList.
 type ListInput struct {
 	Region            string
 	KubernetesVersion string
 	OperatingSystem   string
 }
 
+// List will create an AWSAMIList from a given ListInput.
 func List(input ListInput) (*amiv1.AWSAMIList, error) {
 	supportedOsList := []string{}
 	if input.OperatingSystem == "" {

--- a/cmd/clusterawsadm/api/ami/v1alpha1/types.go
+++ b/cmd/clusterawsadm/api/ami/v1alpha1/types.go
@@ -22,11 +22,14 @@ import (
 )
 
 const (
-	AWSAMIKind     = "AWSAMI"
+	// AWSAMIKind defines an AMI kind.
+	AWSAMIKind = "AWSAMI"
+
+	// AWSAMIListKind defines an AWSAMIList kind.
 	AWSAMIListKind = "AWSAMIList"
 )
 
-// AWSAMI defines an AMI
+// AWSAMISpec defines an AMI
 type AWSAMISpec struct {
 	OS                string `json:"os"`
 	Region            string `json:"region"`
@@ -36,7 +39,8 @@ type AWSAMISpec struct {
 
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// AMI defines an AMI
+
+// AWSAMI defines an AMI
 type AWSAMI struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -45,6 +49,7 @@ type AWSAMI struct {
 
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AWSAMIList defines a list of AMIs
 type AWSAMIList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -52,6 +57,7 @@ type AWSAMIList struct {
 	Items           []AWSAMI `json:"items"`
 }
 
+// ToTable will convert an AWSAMIList to a Table.
 func (a *AWSAMIList) ToTable() *metav1.Table {
 	table := &metav1.Table{
 		TypeMeta: metav1.TypeMeta{
@@ -93,6 +99,7 @@ func (a *AWSAMIList) ToTable() *metav1.Table {
 	return table
 }
 
+// GetObjectKind will return the ObjectKind of an AWSAMI.
 func (a *AWSAMI) GetObjectKind() schema.ObjectKind {
 	return &metav1.TypeMeta{
 		APIVersion: SchemeGroupVersion.String(),
@@ -100,6 +107,7 @@ func (a *AWSAMI) GetObjectKind() schema.ObjectKind {
 	}
 }
 
+// GetObjectKind will return the ObjectKind of an AWSAMIList.
 func (a *AWSAMIList) GetObjectKind() schema.ObjectKind {
 	return &metav1.TypeMeta{
 		APIVersion: SchemeGroupVersion.String(),

--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/defaults.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/defaults.go
@@ -28,7 +28,7 @@ const (
 	DefaultBootstrapUserName = "bootstrapper.cluster-api-provider-aws.sigs.k8s.io"
 	// DefaultStackName is the default CloudFormation stack name.
 	DefaultStackName = "cluster-api-provider-aws-sigs-k8s-io"
-	// DefaultParittionName is the default security partition for AWS ARNs.
+	// DefaultPartitionName is the default security partition for AWS ARNs.
 	DefaultPartitionName = "aws"
 )
 

--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
@@ -142,6 +142,7 @@ type Nodes struct {
 
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AWSIAMConfiguration controls the creation of AWS Identity and Access Management (IAM) resources for use
 // by Kubernetes clusters and Kubernetes Cluster API Provider AWS.
 type AWSIAMConfiguration struct {
@@ -196,10 +197,12 @@ type AWSIAMConfigurationSpec struct {
 	SecureSecretsBackends []infrav1.SecretBackend `json:"secureSecretBackends,omitempty"`
 }
 
+// GetObjectKind returns the AAWSIAMConfiguration's TypeMeta.
 func (obj *AWSIAMConfiguration) GetObjectKind() schema.ObjectKind {
 	return &obj.TypeMeta
 }
 
+// NewAWSIAMConfiguration will generate a new default AWSIAMConfiguration.
 func NewAWSIAMConfiguration() *AWSIAMConfiguration {
 	conf := &AWSIAMConfiguration{}
 	SetObjectDefaults_AWSIAMConfiguration(conf)

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -73,6 +73,7 @@ func (t Template) controllersRolePolicy() []cfn_iam.Role_Policy {
 	return policies
 }
 
+// ControllersPolicy will create a policy from a Template for AWS Controllers.
 func (t Template) ControllersPolicy() *infrav1.PolicyDocument {
 	statement := []infrav1.StatementEntry{
 		{

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fargate.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fargate.go
@@ -24,9 +24,7 @@ import (
 func fargateProfilePolicies(roleSpec *bootstrapv1.AWSIAMRoleSpec) []string {
 	policies := eks.FargateRolePolicies()
 	if roleSpec.ExtraPolicyAttachments != nil {
-		for _, policy := range roleSpec.ExtraPolicyAttachments {
-			policies = append(policies, policy)
-		}
+		policies = append(policies, roleSpec.ExtraPolicyAttachments...)
 	}
 
 	return policies

--- a/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
@@ -20,16 +20,19 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
-	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 
+	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/converters"
 )
 
+// PolicyName defines the name of a managed IAM policy.
 type PolicyName string
 
 // ManagedIAMPolicyNames slice of managed IAM policies
 var ManagedIAMPolicyNames = [4]PolicyName{ControllersPolicy, ControlPlanePolicy, NodePolicy, CSIPolicy}
 
+// IsValid will check if a given policy name is valid. That is, it will check if the given policy name is
+// one of the ManagedIAMPolicyNames.
 func (p PolicyName) IsValid() bool {
 	for i := range ManagedIAMPolicyNames {
 		if ManagedIAMPolicyNames[i] == p {
@@ -67,6 +70,7 @@ func (t Template) policyFunctionMap() map[PolicyName]func() *v1alpha4.PolicyDocu
 	}
 }
 
+// GetPolicyDocFromPolicyName returns a Template's policy document.
 func (t Template) GetPolicyDocFromPolicyName(policyName PolicyName) *v1alpha4.PolicyDocument {
 	return t.policyFunctionMap()[policyName]()
 }

--- a/cmd/clusterawsadm/cloudformation/bootstrap/managed_nodegroup.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/managed_nodegroup.go
@@ -21,9 +21,7 @@ import "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/eks"
 func (t Template) eksMachinePoolPolicies() []string {
 	policies := eks.NodegroupRolePolicies()
 	if t.Spec.EKS.ManagedMachinePool.ExtraPolicyAttachments != nil {
-		for _, policy := range t.Spec.EKS.ManagedMachinePool.ExtraPolicyAttachments {
-			policies = append(policies, policy)
-		}
+		policies = append(policies, t.Spec.EKS.ManagedMachinePool.ExtraPolicyAttachments...)
 	}
 
 	return policies

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template.go
@@ -18,18 +18,20 @@ package bootstrap
 
 import (
 	"fmt"
-	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 
 	"github.com/awslabs/goformation/v4/cloudformation"
 	cfn_iam "github.com/awslabs/goformation/v4/cloudformation/iam"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/api/bootstrap/v1alpha1"
+
+	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/converters"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha4"
 	eksiam "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/eks/iam"
 )
 
+// Constants that define resources for a Template.
 const (
 	AWSIAMGroupBootstrapper                      = "AWSIAMGroupBootstrapper"
 	AWSIAMInstanceProfileControllers             = "AWSIAMInstanceProfileControllers"
@@ -48,10 +50,13 @@ const (
 	CSIPolicy                         PolicyName = "AWSEBSCSIPolicyController"
 )
 
+// Template is an AWS CloudFormation template to bootstrap
+// IAM policies, users and roles for use by Cluster API Provider AWS.
 type Template struct {
 	Spec *bootstrapv1.AWSIAMConfigurationSpec
 }
 
+// NewTemplate will generate a new Template.
 func NewTemplate() Template {
 	conf := bootstrapv1.NewAWSIAMConfiguration()
 	return Template{
@@ -65,8 +70,7 @@ func (t Template) NewManagedName(name string) string {
 	return fmt.Sprintf("%s%s%s", t.Spec.NamePrefix, name, *t.Spec.NameSuffix)
 }
 
-// Template is an AWS CloudFormation template to bootstrap
-// IAM policies, users and roles for use by Cluster API Provider AWS
+// RenderCloudFormation will render and return a cloudformation Template.
 func (t Template) RenderCloudFormation() *cloudformation.Template {
 	template := cloudformation.NewTemplate()
 
@@ -197,14 +201,17 @@ func ec2AssumeRolePolicy() *v1alpha4.PolicyDocument {
 	return AssumeRolePolicy(v1alpha4.PrincipalService, []string{"ec2.amazonaws.com"})
 }
 
+// AWSArnAssumeRolePolicy will assume Policies using PolicyArns.
 func AWSArnAssumeRolePolicy(identityID string) *v1alpha4.PolicyDocument {
 	return AssumeRolePolicy(v1alpha4.PrincipalAWS, []string{identityID})
 }
 
+// AWSServiceAssumeRolePolicy will assume an AWS Service policy.
 func AWSServiceAssumeRolePolicy(identityID string) *v1alpha4.PolicyDocument {
 	return AssumeRolePolicy(v1alpha4.PrincipalService, []string{identityID})
 }
 
+// AssumeRolePolicy will create a role session and pass session policies programmatically.
 func AssumeRolePolicy(identityType v1alpha4.PrincipalType, principalIDs []string) *v1alpha4.PolicyDocument {
 	return &v1alpha4.PolicyDocument{
 		Version: v1alpha4.CurrentVersion,

--- a/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
+++ b/cmd/clusterawsadm/cmd/alpha/bootstrap/bootstrap.go
@@ -73,10 +73,6 @@ func bootstrapTemplateFromCmdLine() cfnBootstrap.Template {
 	}
 }
 
-func getPartitionFlag(cmd *cobra.Command) string {
-	return cmd.Flags().Lookup("partition").Value.String()
-}
-
 func generateCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "generate-cloudformation [AWS Account ID]",

--- a/cmd/clusterawsadm/cmd/ami/copy/common.go
+++ b/cmd/clusterawsadm/cmd/ami/copy/common.go
@@ -36,6 +36,7 @@ func addSourceRegion(c *cobra.Command) {
 	c.Flags().String("source-region", "", "Set if wanting to copy an AMI from a different region")
 }
 
+// GetSourceRegion returns the source region.
 func GetSourceRegion(c *cobra.Command) (string, error) {
 	explicitRegion := c.Flags().Lookup("source-region").Value.String()
 	if explicitRegion != "" {

--- a/cmd/clusterawsadm/cmd/ami/copy/copy.go
+++ b/cmd/clusterawsadm/cmd/ami/copy/copy.go
@@ -28,6 +28,7 @@ import (
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
+// CopyAMICmd will copy AMIs from an AWS account to the AWS account which credentials are provided.
 func CopyAMICmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "copy",

--- a/cmd/clusterawsadm/cmd/ami/copy/encryptedcopy.go
+++ b/cmd/clusterawsadm/cmd/ami/copy/encryptedcopy.go
@@ -32,6 +32,7 @@ var (
 	kmsKeyID string
 )
 
+// EncryptedCopyAMICmd is a command to encrypt and copy AMI snapshots, then create an AMI with that snapshot.
 func EncryptedCopyAMICmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "encrypted-copy",

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -33,6 +33,7 @@ var (
 	outputPrinter     string
 )
 
+// ListAMICmd is a CLI command that will list AMIs from the default AWS account where AMIs are stored.
 func ListAMICmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "list",

--- a/cmd/clusterawsadm/cmd/bootstrap/credentials/credentials.go
+++ b/cmd/clusterawsadm/cmd/bootstrap/credentials/credentials.go
@@ -56,7 +56,8 @@ const (
 	  3. Check for the DEFAULT_AWS_REGION environment variable.
 	  4. Check that a region is specified in the shared configuration file.
 	`
-
+	// EncodingHelp provides an explanation for how clusterawsadm will generate ini-files
+	// for the resolved credentials.
 	EncodingHelp = `
 	The utility will then generate an ini-file with a default profile corresponding to
 	the resolved credentials.

--- a/cmd/clusterawsadm/cmd/bootstrap/iam/cloudformation.go
+++ b/cmd/clusterawsadm/cmd/bootstrap/iam/cloudformation.go
@@ -179,12 +179,3 @@ func resolveTemplateRegion(t *bootstrap.Template, cmd *cobra.Command) error {
 	}
 	return nil
 }
-
-func renderTemplate(t *bootstrap.Template) (string, error) {
-	cfnTemplate := t.RenderCloudFormation()
-	yml, err := cfnTemplate.YAML()
-	if err != nil {
-		return "", err
-	}
-	return string(yml), nil
-}

--- a/cmd/clusterawsadm/cmd/controller/credentials/print.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/print.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
 
+// PrintCredentialsCmd is a CLI command that will print credentials the controller is using.
 func PrintCredentialsCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "print-credentials",

--- a/cmd/clusterawsadm/cmd/controller/credentials/update_credentials.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/update_credentials.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
 
+// UpdateCredentialsCmd is a CLI command that will update credentials the controller is using.
 func UpdateCredentialsCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "update-credentials",

--- a/cmd/clusterawsadm/cmd/controller/credentials/zero_credentials.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/zero_credentials.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
 
+// ZeroCredentialsCmd is a CLI command that will zero credentials the controller is started with.
 func ZeroCredentialsCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "zero-credentials",

--- a/cmd/clusterawsadm/cmd/controller/rollout/rollout.go
+++ b/cmd/clusterawsadm/cmd/controller/rollout/rollout.go
@@ -28,6 +28,7 @@ var (
 	kubeconfigContext string
 )
 
+// RolloutControllersCmd is a CLI command that initiates rollout and restart on capa-controller-manager deployment.
 func RolloutControllersCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "rollout-controller",

--- a/cmd/clusterawsadm/cmd/eks/addons/addons.go
+++ b/cmd/clusterawsadm/cmd/eks/addons/addons.go
@@ -18,6 +18,7 @@ package addons
 
 import "github.com/spf13/cobra"
 
+// RootCmd is EKS addons root CLI command.
 func RootCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "addons",

--- a/cmd/clusterawsadm/cmd/eks/eks.go
+++ b/cmd/clusterawsadm/cmd/eks/eks.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/eks/addons"
 )
 
+// RootCmd is an EKS root CLI command.
 func RootCmd() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "eks",

--- a/cmd/clusterawsadm/cmd/flags/common.go
+++ b/cmd/clusterawsadm/cmd/flags/common.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 )
 
+// ResolveAWSError will attempt to resolve an AWS error.
 func ResolveAWSError(err error) error {
 	code, _ := awserrors.Code(err)
 	if code == awserrors.NoCredentialProviders {
@@ -34,15 +35,19 @@ func ResolveAWSError(err error) error {
 	return err
 }
 
+// AddRegionFlag will add a region flag to the cli.
 func AddRegionFlag(c *cobra.Command) {
 	c.Flags().String("region", "", "The AWS region in which to provision")
 }
 
+// GetRegion will return the region of the resource.
 func GetRegion(c *cobra.Command) (string, error) {
 	explicitRegion := c.Flags().Lookup("region").Value.String()
 	return credentials.ResolveRegion(explicitRegion)
 }
 
+// GetRegionWithError will return the region of the resource along with an error message
+// if it could not be resolved.
 func GetRegionWithError(c *cobra.Command) (string, error) {
 	region, err := GetRegion(c)
 	if err != nil {
@@ -52,10 +57,12 @@ func GetRegionWithError(c *cobra.Command) (string, error) {
 	return region, nil
 }
 
+// MarkAlphaDeprecated will mark a command as deprecated.
 func MarkAlphaDeprecated(c *cobra.Command) {
 	c.Deprecated = "and will be removed in 0.6.0"
 }
 
+// CredentialWarning will output a credential warning.
 func CredentialWarning(c *cobra.Command) {
 	fmt.Fprintf(os.Stderr, "\nWARNING: `%s` should only be used for bootstrapping.\n\n", c.Name())
 }

--- a/cmd/clusterawsadm/cmd/util/util.go
+++ b/cmd/clusterawsadm/cmd/util/util.go
@@ -21,12 +21,15 @@ import (
 	"os"
 )
 
+// ErrEnvironmentVariableNotFound is an error string for environment variable not found error.
 type ErrEnvironmentVariableNotFound string
 
+// Error defines the error interface for ErrEnvironmentVariableNotFound.
 func (e ErrEnvironmentVariableNotFound) Error() string {
 	return fmt.Sprintf("environment variable %q not found", string(e))
 }
 
+// GetEnv will lookup and return an environment variable.
 func GetEnv(key string) (string, error) {
 	val, ok := os.LookupEnv(key)
 	if !ok {

--- a/cmd/clusterawsadm/controller/credentials/update_credentials.go
+++ b/cmd/clusterawsadm/controller/credentials/update_credentials.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller"
 )
 
+// UpdateCredentialsInput defines the specs for update credentials input.
 type UpdateCredentialsInput struct {
 	KubeconfigPath    string
 	KubeconfigContext string

--- a/cmd/clusterawsadm/controller/credentials/zero_credentials.go
+++ b/cmd/clusterawsadm/controller/credentials/zero_credentials.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package credentials
 
+// ZeroCredentialsInput defines the specs for zero credentials input.
 type ZeroCredentialsInput struct {
 	KubeconfigPath    string
 	KubeconfigContext string

--- a/cmd/clusterawsadm/controller/helper.go
+++ b/cmd/clusterawsadm/controller/helper.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/version"
 )
 
+// BootstrapCredsSecret defines the tag for capa manager bootstrap credentials.
 const BootstrapCredsSecret = "capa-manager-bootstrap-credentials"
 
 // GetClient creates the config for a kubernetes client and returns a client-go client for the cluster.
@@ -62,12 +63,13 @@ func GetClient(kubeconfigPath string, kubeconfigContext string) (*kubernetes.Cli
 	return cs, err
 }
 
+// PrintBootstrapCredentials will print the bootstrap credentials.
 func PrintBootstrapCredentials(secret *corev1.Secret) {
 	if creds, ok := secret.Data["credentials"]; ok {
 		if base64.StdEncoding.EncodeToString(creds) == "Cg==" {
 			fmt.Println("Credentials are zeroed")
 		} else {
-			fmt.Printf(string(creds))
+			fmt.Println(string(creds))
 		}
 	}
 }

--- a/cmd/clusterawsadm/controller/rollout/rollout.go
+++ b/cmd/clusterawsadm/controller/rollout/rollout.go
@@ -30,8 +30,10 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller"
 )
 
+// ControllerDeploymentName is a tag for capa controller manager.
 const ControllerDeploymentName = "capa-controller-manager"
 
+// RolloutControllersInput defines the specs for rollout controllers input.
 type RolloutControllersInput struct {
 	KubeconfigPath    string
 	KubeconfigContext string

--- a/cmd/clusterawsadm/converters/iam.go
+++ b/cmd/clusterawsadm/converters/iam.go
@@ -18,10 +18,11 @@ package converters
 
 import (
 	"encoding/json"
+
 	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 )
 
-// JSON is the JSON output of the policy document
+// IAMPolicyDocumentToJSON is the JSON output of the policy document.
 func IAMPolicyDocumentToJSON(p v1alpha4.PolicyDocument) (string, error) {
 	b, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {

--- a/cmd/clusterawsadm/credentials/credentials.go
+++ b/cmd/clusterawsadm/credentials/credentials.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/util"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/util"
 )
 
 // AWSCredentialsTemplate generates an AWS credentials file that can
@@ -38,10 +39,13 @@ aws_session_token = {{ .SessionToken }}
 {{end}}
 `
 
+// AWSDefaultRegion is the default AWS region.
 const AWSDefaultRegion = "us-east-1"
 
+// ErrNoAWSRegionConfigured is an error singleton for when no AWS region is configured.
 var ErrNoAWSRegionConfigured = errors.New("no AWS region configured. Use --region or set AWS_REGION or DEFAULT_AWS_REGION environment variable")
 
+// AWSCredentials defines the specs for AWS credentials.
 type AWSCredentials struct {
 	AccessKeyID     string
 	SecretAccessKey string
@@ -49,6 +53,8 @@ type AWSCredentials struct {
 	Region          string
 }
 
+// NewAWSCredentialFromDefaultChain will create a new credential provider chain from the
+// default chain.
 func NewAWSCredentialFromDefaultChain(region string) (*AWSCredentials, error) {
 	creds := AWSCredentials{}
 	conf := aws.NewConfig()
@@ -72,6 +78,7 @@ func NewAWSCredentialFromDefaultChain(region string) (*AWSCredentials, error) {
 	return &creds, nil
 }
 
+// ResolveRegion will attempt to resolve an AWS region based on the customer's configuration.
 func ResolveRegion(explicitRegion string) (string, error) {
 	if explicitRegion != "" {
 		return explicitRegion, nil
@@ -87,6 +94,7 @@ func ResolveRegion(explicitRegion string) (string, error) {
 	return "", ErrNoAWSRegionConfigured
 }
 
+// RenderAWSDefaultProfile will render the AWS default profile.
 func (c AWSCredentials) RenderAWSDefaultProfile() (string, error) {
 	tmpl, err := template.New("AWS Credentials").Parse(AWSCredentialsTemplate)
 	if err != nil {
@@ -102,6 +110,7 @@ func (c AWSCredentials) RenderAWSDefaultProfile() (string, error) {
 	return credsFileStr.String(), nil
 }
 
+// RenderBase64EncodedAWSDefaultProfile will render the AWS default profile, encoded in base 64.
 func (c AWSCredentials) RenderBase64EncodedAWSDefaultProfile() (string, error) {
 	profile, err := c.RenderAWSDefaultProfile()
 	if err != nil {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
@@ -46,7 +46,7 @@ spec:
                 description: AllowedNamespaces is used to identify which namespaces
                   are allowed to use the identity from. Namespaces can be selected
                   either using an array of namespaces or with label selector. An empty
-                  allowedNamespaces object indicates that AWSClusters can use this
+                  AllowedNamespaces object indicates that AWSClusters can use this
                   identity from any namespace. If this object is nil, no namespaces
                   will be allowed (default behaviour, if this field is not provided)
                   A namespace should be either in the NamespaceList or match with
@@ -61,12 +61,8 @@ spec:
                     nullable: true
                     type: array
                   selector:
-                    description: "AllowedNamespaces is a selector of namespaces that
-                      AWSClusters can use this ClusterPrincipal from. This is a standard
-                      Kubernetes LabelSelector, a label query over a set of resources.
-                      The result of matchLabels and matchExpressions are ANDed. \n
-                      An empty selector indicates that AWSClusters cannot use this
-                      AWSClusterIdentity from any namespace."
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
@@ -155,12 +151,8 @@ spec:
                     nullable: true
                     type: array
                   selector:
-                    description: "AllowedNamespaces is a selector of namespaces that
-                      AWSClusters can use this ClusterPrincipal from. This is a standard
-                      Kubernetes LabelSelector, a label query over a set of resources.
-                      The result of matchLabels and matchExpressions are ANDed. \n
-                      An empty selector indicates that AWSClusters cannot use this
-                      AWSClusterIdentity from any namespace."
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
@@ -45,7 +45,7 @@ spec:
                 description: AllowedNamespaces is used to identify which namespaces
                   are allowed to use the identity from. Namespaces can be selected
                   either using an array of namespaces or with label selector. An empty
-                  allowedNamespaces object indicates that AWSClusters can use this
+                  AllowedNamespaces object indicates that AWSClusters can use this
                   identity from any namespace. If this object is nil, no namespaces
                   will be allowed (default behaviour, if this field is not provided)
                   A namespace should be either in the NamespaceList or match with
@@ -60,12 +60,8 @@ spec:
                     nullable: true
                     type: array
                   selector:
-                    description: "AllowedNamespaces is a selector of namespaces that
-                      AWSClusters can use this ClusterPrincipal from. This is a standard
-                      Kubernetes LabelSelector, a label query over a set of resources.
-                      The result of matchLabels and matchExpressions are ANDed. \n
-                      An empty selector indicates that AWSClusters cannot use this
-                      AWSClusterIdentity from any namespace."
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
@@ -212,12 +208,8 @@ spec:
                     nullable: true
                     type: array
                   selector:
-                    description: "AllowedNamespaces is a selector of namespaces that
-                      AWSClusters can use this ClusterPrincipal from. This is a standard
-                      Kubernetes LabelSelector, a label query over a set of resources.
-                      The result of matchLabels and matchExpressions are ANDed. \n
-                      An empty selector indicates that AWSClusters cannot use this
-                      AWSClusterIdentity from any namespace."
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
@@ -46,7 +46,7 @@ spec:
                 description: AllowedNamespaces is used to identify which namespaces
                   are allowed to use the identity from. Namespaces can be selected
                   either using an array of namespaces or with label selector. An empty
-                  allowedNamespaces object indicates that AWSClusters can use this
+                  AllowedNamespaces object indicates that AWSClusters can use this
                   identity from any namespace. If this object is nil, no namespaces
                   will be allowed (default behaviour, if this field is not provided)
                   A namespace should be either in the NamespaceList or match with
@@ -61,12 +61,8 @@ spec:
                     nullable: true
                     type: array
                   selector:
-                    description: "AllowedNamespaces is a selector of namespaces that
-                      AWSClusters can use this ClusterPrincipal from. This is a standard
-                      Kubernetes LabelSelector, a label query over a set of resources.
-                      The result of matchLabels and matchExpressions are ANDed. \n
-                      An empty selector indicates that AWSClusters cannot use this
-                      AWSClusterIdentity from any namespace."
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
@@ -171,12 +167,8 @@ spec:
                     nullable: true
                     type: array
                   selector:
-                    description: "AllowedNamespaces is a selector of namespaces that
-                      AWSClusters can use this ClusterPrincipal from. This is a standard
-                      Kubernetes LabelSelector, a label query over a set of resources.
-                      The result of matchLabels and matchExpressions are ANDed. \n
-                      An empty selector indicates that AWSClusters cannot use this
-                      AWSClusterIdentity from any namespace."
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -248,13 +248,13 @@ spec:
                 type: string
               maxSize:
                 default: 1
-                description: The maximum size of the group.
+                description: MaxSize defines the maximum size of the group.
                 format: int32
                 minimum: 1
                 type: integer
               minSize:
                 default: 1
-                description: The minimum size of the group.
+                description: MinSize defines the minimum size of the group.
                 format: int32
                 minimum: 1
                 type: integer
@@ -465,6 +465,8 @@ spec:
                 description: Instances contains the status for each instance in the
                   pool
                 items:
+                  description: AWSMachinePoolInstanceStatus defines the status of
+                    the AWSMachinePoolInstance.
                   properties:
                     instanceID:
                       description: InstanceID is the identification of the Machine
@@ -720,13 +722,13 @@ spec:
                 type: string
               maxSize:
                 default: 1
-                description: The maximum size of the group.
+                description: MaxSize defines the maximum size of the group.
                 format: int32
                 minimum: 1
                 type: integer
               minSize:
                 default: 1
-                description: The minimum size of the group.
+                description: MinSize defines the minimum size of the group.
                 format: int32
                 minimum: 1
                 type: integer
@@ -937,6 +939,8 @@ spec:
                 description: Instances contains the status for each instance in the
                   pool
                 items:
+                  description: AWSMachinePoolInstanceStatus defines the status of
+                    the AWSMachinePoolInstance.
                   properties:
                     instanceID:
                       description: InstanceID is the identification of the Machine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -369,6 +369,7 @@ spec:
                 description: Taints specifies the taints to apply to the nodes of
                   the machine pool
                 items:
+                  description: Taint defines the specs for a Kubernetes taint.
                   properties:
                     effect:
                       description: Effect specifies the effect for the taint

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+// InstanceIDIndex defines the aws machine controller's instance ID index.
 const InstanceIDIndex = ".spec.instanceID"
 
 // AWSMachineReconciler reconciles a AwsMachine object

--- a/controlplane/eks/api/v1alpha3/conversion.go
+++ b/controlplane/eks/api/v1alpha3/conversion.go
@@ -26,24 +26,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
+// ConvertTo converts the v1alpha3 AWSManagedControlPlane receiver to a v1alpha4 AWSManagedControlPlane.
 func (r *AWSManagedControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSManagedControlPlane)
 
 	return Convert_v1alpha3_AWSManagedControlPlane_To_v1alpha4_AWSManagedControlPlane(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSManagedControlPlane receiver to a v1alpha3 AWSManagedControlPlane.
 func (r *AWSManagedControlPlane) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSManagedControlPlane)
 
 	return Convert_v1alpha4_AWSManagedControlPlane_To_v1alpha3_AWSManagedControlPlane(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSManagedControlPlaneList receiver to a v1alpha4 AWSManagedControlPlaneList.
 func (r *AWSManagedControlPlaneList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSManagedControlPlaneList)
 
 	return Convert_v1alpha3_AWSManagedControlPlaneList_To_v1alpha4_AWSManagedControlPlaneList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSManagedControlPlaneList receiver to a v1alpha3 AWSManagedControlPlaneList.
 func (r *AWSManagedControlPlaneList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSManagedControlPlaneList)
 

--- a/controlplane/eks/api/v1alpha3/validate.go
+++ b/controlplane/eks/api/v1alpha3/validate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Errors for validation of Amazon EKS nodes that are registered with the control plane.
 var (
 	ErrRoleARNRequired  = errors.New("rolearn is required")
 	ErrUserARNRequired  = errors.New("userarn is required")

--- a/controlplane/eks/api/v1alpha4/validate.go
+++ b/controlplane/eks/api/v1alpha4/validate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Errors for validation of Amazon EKS nodes that are registered with the control plane.
 var (
 	ErrRoleARNRequired  = errors.New("rolearn is required")
 	ErrUserARNRequired  = errors.New("userarn is required")

--- a/controlplane/eks/main.go
+++ b/controlplane/eks/main.go
@@ -86,6 +86,7 @@ var (
 	errEKSInvalidFlags       = errors.New("invalid EKS flag combination")
 )
 
+// InitFlags initializes this manager's flags.
 func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080",
 		"The address the metric endpoint binds to.")

--- a/docs/book/cmd/amilist/main.go
+++ b/docs/book/cmd/amilist/main.go
@@ -48,6 +48,7 @@ func main() {
 	lambda.Start(LambdaHandler)
 }
 
+// LambdaHandler defines a Lambda function handler.
 func LambdaHandler() error {
 	amis, err := ami.List(
 		ami.ListInput{},

--- a/exp/api/v1alpha3/awsfargateprofile_types.go
+++ b/exp/api/v1alpha3/awsfargateprofile_types.go
@@ -143,10 +143,12 @@ type AWSFargateProfile struct {
 	Status FargateProfileStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSFargateProfile resource.
 func (r *AWSFargateProfile) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSFargateProfile to the predescribed clusterv1.Conditions.
 func (r *AWSFargateProfile) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -25,7 +25,10 @@ import (
 )
 
 const (
-	MachinePoolFinalizer        = "awsmachinepool.infrastructure.cluster.x-k8s.io"
+	// MachinePoolFinalizer is the finalizer for the machine pool.
+	MachinePoolFinalizer = "awsmachinepool.infrastructure.cluster.x-k8s.io"
+
+	// LaunchTemplateLatestVersion defines the launching of the latest version of the template.
 	LaunchTemplateLatestVersion = "$Latest"
 )
 
@@ -35,12 +38,12 @@ type AWSMachinePoolSpec struct {
 	// +optional
 	ProviderID string `json:"providerID,omitempty"`
 
-	// The minimum size of the group.
+	// MinSize defines the minimum size of the group.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
 	MinSize int32 `json:"minSize"`
 
-	// The maximum size of the group.
+	// MaxSize defines the maximum size of the group.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
 	MaxSize int32 `json:"maxSize"`
@@ -83,6 +86,7 @@ type AWSMachinePoolSpec struct {
 	CapacityRebalance bool `json:"capacityRebalance,omitempty"`
 }
 
+// RefreshPreferences defines the specs for instance refreshing.
 type RefreshPreferences struct {
 	// The strategy to use for the instance refresh. The only valid value is Rolling.
 	// A rolling update is an update that is applied to all instances in an Auto
@@ -163,6 +167,8 @@ type AWSMachinePoolStatus struct {
 
 	ASGStatus *ASGStatus `json:"asgStatus,omitempty"`
 }
+
+// AWSMachinePoolInstanceStatus defines the status of the AWSMachinePoolInstance.
 type AWSMachinePoolInstanceStatus struct {
 	// InstanceID is the identification of the Machine Instance within ASG
 	// +optional
@@ -204,18 +210,22 @@ func init() {
 	SchemeBuilder.Register(&AWSMachinePool{}, &AWSMachinePoolList{})
 }
 
+// GetConditions returns the observations of the operational state of the AWSMachinePool resource.
 func (r *AWSMachinePool) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSMachinePool to the predescribed clusterv1.Conditions.
 func (r *AWSMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }
 
+// GetObjectKind will return the ObjectKind of an AWSMachinePool.
 func (r *AWSMachinePool) GetObjectKind() schema.ObjectKind {
 	return &r.TypeMeta
 }
 
+// GetObjectKind will return the ObjectKind of an AWSMachinePoolList.
 func (r *AWSMachinePoolList) GetObjectKind() schema.ObjectKind {
 	return &r.TypeMeta
 }

--- a/exp/api/v1alpha3/awsmanagedmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmanagedmachinepool_types.go
@@ -207,10 +207,12 @@ type AWSManagedMachinePool struct {
 	Status AWSManagedMachinePoolStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSManagedMachinePool resource.
 func (r *AWSManagedMachinePool) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSManagedMachinePool to the predescribed clusterv1.Conditions.
 func (r *AWSManagedMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha3/conversion.go
+++ b/exp/api/v1alpha3/conversion.go
@@ -30,30 +30,35 @@ import (
 	infrav1alpha4exp "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha4"
 )
 
+// ConvertTo converts the v1alpha3 AWSMachinePool receiver to a v1alpha4 AWSMachinePool.
 func (r *AWSMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSMachinePool)
 
 	return Convert_v1alpha3_AWSMachinePool_To_v1alpha4_AWSMachinePool(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSMachinePool receiver to a v1alpha3 AWSMachinePool.
 func (r *AWSMachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSMachinePool)
 
 	return Convert_v1alpha4_AWSMachinePool_To_v1alpha3_AWSMachinePool(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSMachinePoolList receiver to a v1alpha4 AWSMachinePoolList.
 func (r *AWSMachinePoolList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSMachinePoolList)
 
 	return Convert_v1alpha3_AWSMachinePoolList_To_v1alpha4_AWSMachinePoolList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSMachinePoolList receiver to a v1alpha3 AWSMachinePoolList.
 func (r *AWSMachinePoolList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSMachinePoolList)
 
 	return Convert_v1alpha4_AWSMachinePoolList_To_v1alpha3_AWSMachinePoolList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSManagedMachinePool receiver to a v1alpha4 AWSManagedMachinePool.
 func (r *AWSManagedMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSManagedMachinePool)
 	if err := Convert_v1alpha3_AWSManagedMachinePool_To_v1alpha4_AWSManagedMachinePool(r, dst, nil); err != nil {
@@ -70,6 +75,7 @@ func (r *AWSManagedMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
+// ConvertFrom converts the v1alpha4 AWSManagedMachinePool receiver to a v1alpha3 AWSManagedMachinePool.
 func (r *AWSManagedMachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSManagedMachinePool)
 
@@ -84,60 +90,70 @@ func (r *AWSManagedMachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 	return nil
 }
 
+// ConvertTo converts the v1alpha3 AWSManagedMachinePoolList receiver to a v1alpha4 AWSManagedMachinePoolList.
 func (r *AWSManagedMachinePoolList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSManagedMachinePoolList)
 
 	return Convert_v1alpha3_AWSManagedMachinePoolList_To_v1alpha4_AWSManagedMachinePoolList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSManagedMachinePoolList receiver to a v1alpha3 AWSManagedMachinePoolList.
 func (r *AWSManagedMachinePoolList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSManagedMachinePoolList)
 
 	return Convert_v1alpha4_AWSManagedMachinePoolList_To_v1alpha3_AWSManagedMachinePoolList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSManagedCluster receiver to a v1alpha4 AWSManagedCluster.
 func (r *AWSManagedCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSManagedCluster)
 
 	return Convert_v1alpha3_AWSManagedCluster_To_v1alpha4_AWSManagedCluster(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSManagedCluster receiver to a v1alpha3 AWSManagedCluster.
 func (r *AWSManagedCluster) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSManagedCluster)
 
 	return Convert_v1alpha4_AWSManagedCluster_To_v1alpha3_AWSManagedCluster(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSManagedClusterList receiver to a v1alpha4 AWSManagedClusterList.
 func (r *AWSManagedClusterList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSManagedClusterList)
 
 	return Convert_v1alpha3_AWSManagedClusterList_To_v1alpha4_AWSManagedClusterList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSManagedClusterList receiver to a v1alpha3 AWSManagedClusterList.
 func (r *AWSManagedClusterList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSManagedClusterList)
 
 	return Convert_v1alpha4_AWSManagedClusterList_To_v1alpha3_AWSManagedClusterList(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSFargateProfile receiver to a v1alpha4 AWSFargateProfile.
 func (r *AWSFargateProfile) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSFargateProfile)
 
 	return Convert_v1alpha3_AWSFargateProfile_To_v1alpha4_AWSFargateProfile(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSFargateProfile receiver to a v1alpha3 AWSFargateProfile.
 func (r *AWSFargateProfile) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSFargateProfile)
 
 	return Convert_v1alpha4_AWSFargateProfile_To_v1alpha3_AWSFargateProfile(src, r, nil)
 }
 
+// ConvertTo converts the v1alpha3 AWSFargateProfileList receiver to a v1alpha4 AWSFargateProfileList.
 func (r *AWSFargateProfileList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha4.AWSFargateProfileList)
 
 	return Convert_v1alpha3_AWSFargateProfileList_To_v1alpha4_AWSFargateProfileList(r, dst, nil)
 }
 
+// ConvertFrom converts the v1alpha4 AWSFargateProfileList receiver to a v1alpha3 AWSFargateProfileList.
 func (r *AWSFargateProfileList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha4.AWSFargateProfileList)
 
@@ -164,6 +180,7 @@ func Convert_v1alpha4_AWSResourceReference_To_v1alpha3_AWSResourceReference(in *
 	return infrav1alpha3.Convert_v1alpha4_AWSResourceReference_To_v1alpha3_AWSResourceReference(in, out, s)
 }
 
+// Convert_v1alpha4_AWSManagedMachinePoolSpec_To_v1alpha3_AWSManagedMachinePoolSpec is an autogenerated conversion function.
 func Convert_v1alpha4_AWSManagedMachinePoolSpec_To_v1alpha3_AWSManagedMachinePoolSpec(in *infrav1alpha4exp.AWSManagedMachinePoolSpec, out *AWSManagedMachinePoolSpec, s apiconversion.Scope) error {
 	return autoConvert_v1alpha4_AWSManagedMachinePoolSpec_To_v1alpha3_AWSManagedMachinePoolSpec(in, out, s)
 }

--- a/exp/api/v1alpha3/types.go
+++ b/exp/api/v1alpha3/types.go
@@ -41,7 +41,7 @@ type EBS struct {
 	VolumeType string `json:"volumeType,omitempty"`
 }
 
-// BlockDeviceMappings specifies the block devices for the instance.
+// BlockDeviceMapping specifies the block devices for the instance.
 // You can specify virtual devices and EBS volumes.
 type BlockDeviceMapping struct {
 	// The device name exposed to the EC2 instance (for example, /dev/sdh or xvdh).
@@ -53,7 +53,7 @@ type BlockDeviceMapping struct {
 	Ebs EBS `json:"ebs,omitempty"`
 }
 
-// AwsLaunchTemplate defines the desired state of AWSLaunchTemplate
+// AWSLaunchTemplate defines the desired state of AWSLaunchTemplate
 type AWSLaunchTemplate struct {
 	// The name of the launch template.
 	Name string `json:"name,omitempty"`
@@ -166,7 +166,7 @@ type MixedInstancesPolicy struct {
 	Overrides             []Overrides            `json:"overrides,omitempty"`
 }
 
-// Tags
+// Tags is a mapping for tags.
 type Tags map[string]string
 
 // AutoScalingGroup describes an AWS autoscaling group.

--- a/exp/api/v1alpha4/awsfargateprofile_types.go
+++ b/exp/api/v1alpha4/awsfargateprofile_types.go
@@ -144,10 +144,12 @@ type AWSFargateProfile struct {
 	Status FargateProfileStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSFargateProfile resource.
 func (r *AWSFargateProfile) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSFargateProfile to the predescribed clusterv1.Conditions.
 func (r *AWSFargateProfile) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha4/awsfargateprofile_webhook.go
+++ b/exp/api/v1alpha4/awsfargateprofile_webhook.go
@@ -65,6 +65,7 @@ func (r *AWSFargateProfile) Default() {
 	}
 }
 
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSFargateProfile) ValidateUpdate(oldObj runtime.Object) error {
 	gv := r.GroupVersionKind().GroupKind()
 	old, ok := oldObj.(*AWSFargateProfile)
@@ -105,10 +106,12 @@ func (r *AWSFargateProfile) ValidateUpdate(oldObj runtime.Object) error {
 	)
 }
 
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSFargateProfile) ValidateCreate() error {
 	return nil
 }
 
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSFargateProfile) ValidateDelete() error {
 	return nil
 }

--- a/exp/api/v1alpha4/awsmachinepool_types.go
+++ b/exp/api/v1alpha4/awsmachinepool_types.go
@@ -25,7 +25,10 @@ import (
 )
 
 const (
-	MachinePoolFinalizer        = "awsmachinepool.infrastructure.cluster.x-k8s.io"
+	// MachinePoolFinalizer is the finalizer for the machine pool.
+	MachinePoolFinalizer = "awsmachinepool.infrastructure.cluster.x-k8s.io"
+
+	// LaunchTemplateLatestVersion defines the launching of the latest version of the template.
 	LaunchTemplateLatestVersion = "$Latest"
 )
 
@@ -35,12 +38,12 @@ type AWSMachinePoolSpec struct {
 	// +optional
 	ProviderID string `json:"providerID,omitempty"`
 
-	// The minimum size of the group.
+	// MinSize defines the minimum size of the group.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
 	MinSize int32 `json:"minSize"`
 
-	// The maximum size of the group.
+	// MaxSize defines the maximum size of the group.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
 	MaxSize int32 `json:"maxSize"`
@@ -83,6 +86,7 @@ type AWSMachinePoolSpec struct {
 	CapacityRebalance bool `json:"capacityRebalance,omitempty"`
 }
 
+// RefreshPreferences defines the specs for instance refreshing.
 type RefreshPreferences struct {
 	// The strategy to use for the instance refresh. The only valid value is Rolling.
 	// A rolling update is an update that is applied to all instances in an Auto
@@ -163,6 +167,8 @@ type AWSMachinePoolStatus struct {
 
 	ASGStatus *ASGStatus `json:"asgStatus,omitempty"`
 }
+
+// AWSMachinePoolInstanceStatus defines the status of the AWSMachinePoolInstance.
 type AWSMachinePoolInstanceStatus struct {
 	// InstanceID is the identification of the Machine Instance within ASG
 	// +optional
@@ -205,18 +211,22 @@ func init() {
 	SchemeBuilder.Register(&AWSMachinePool{}, &AWSMachinePoolList{})
 }
 
+// GetConditions returns the observations of the operational state of the AWSMachinePool resource.
 func (r *AWSMachinePool) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSMachinePool to the predescribed clusterv1.Conditions.
 func (r *AWSMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }
 
+// GetObjectKind will return the ObjectKind of an AWSMachinePool.
 func (r *AWSMachinePool) GetObjectKind() schema.ObjectKind {
 	return &r.TypeMeta
 }
 
+// GetObjectKind will return the ObjectKind of an AWSMachinePoolList.
 func (r *AWSMachinePoolList) GetObjectKind() schema.ObjectKind {
 	return &r.TypeMeta
 }

--- a/exp/api/v1alpha4/awsmachinepool_webhook.go
+++ b/exp/api/v1alpha4/awsmachinepool_webhook.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1alpha4
 
 import (
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/exp/api/v1alpha4/awsmanagedmachinepool_types.go
+++ b/exp/api/v1alpha4/awsmanagedmachinepool_types.go
@@ -212,10 +212,12 @@ type AWSManagedMachinePool struct {
 	Status AWSManagedMachinePoolStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the observations of the operational state of the AWSManagedMachinePool resource.
 func (r *AWSManagedMachinePool) GetConditions() clusterv1.Conditions {
 	return r.Status.Conditions
 }
 
+// SetConditions sets the underlying service state of the AWSManagedMachinePool to the predescribed clusterv1.Conditions.
 func (r *AWSManagedMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha4/types.go
+++ b/exp/api/v1alpha4/types.go
@@ -41,7 +41,7 @@ type EBS struct {
 	VolumeType string `json:"volumeType,omitempty"`
 }
 
-// BlockDeviceMappings specifies the block devices for the instance.
+// BlockDeviceMapping specifies the block devices for the instance.
 // You can specify virtual devices and EBS volumes.
 type BlockDeviceMapping struct {
 	// The device name exposed to the EC2 instance (for example, /dev/sdh or xvdh).
@@ -53,7 +53,7 @@ type BlockDeviceMapping struct {
 	Ebs EBS `json:"ebs,omitempty"`
 }
 
-// AwsLaunchTemplate defines the desired state of AWSLaunchTemplate
+// AWSLaunchTemplate defines the desired state of AWSLaunchTemplate
 type AWSLaunchTemplate struct {
 	// The name of the launch template.
 	Name string `json:"name,omitempty"`
@@ -166,7 +166,7 @@ type MixedInstancesPolicy struct {
 	Overrides             []Overrides            `json:"overrides,omitempty"`
 }
 
-// Tags
+// Tags is a mapping for tags.
 type Tags map[string]string
 
 // AutoScalingGroup describes an AWS autoscaling group.
@@ -212,6 +212,7 @@ var (
 	TaintEffectPreferNoSchedule = TaintEffect("prefer-no-schedule")
 )
 
+// Taint defines the specs for a Kubernetes taint.
 type Taint struct {
 	// Effect specifies the effect for the taint
 	// +kubebuilder:validation:Required

--- a/exp/instancestate/awsinstancestate_controller.go
+++ b/exp/instancestate/awsinstancestate_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// Ec2InstanceStateLabelKey defines an ec2 instance state label.
 const Ec2InstanceStateLabelKey = "ec2-instance-state"
 
 // AwsInstanceStateReconciler reconciles a AwsInstanceState object

--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
+// Error singletons for AWS errors.
 const (
 	AuthFailure                = "AuthFailure"
 	InUseIPAddress             = "InvalidIPAddress.InUse"
@@ -91,6 +92,7 @@ func NewConflict(msg string) error {
 	}
 }
 
+// IsResourceExists checks the state of the resource.
 func IsResourceExists(err error) bool {
 	if code, ok := Code(err); ok {
 		return code == ResourceExists

--- a/pkg/cloud/logs/logs.go
+++ b/pkg/cloud/logs/logs.go
@@ -26,6 +26,7 @@ const (
 	logWithHTTPBody   = 10
 )
 
+// GetAWSLogLevel will return the log level of an AWS Logger.
 func GetAWSLogLevel(logger logr.Logger) aws.LogLevelType {
 	if logger.V(logWithHTTPBody).Enabled() {
 		return aws.LogDebugWithHTTPBody
@@ -38,6 +39,7 @@ func GetAWSLogLevel(logger logr.Logger) aws.LogLevelType {
 	return aws.LogOff
 }
 
+// NewWrapLogr will create an AWS Logger wrapper.
 func NewWrapLogr(logger logr.Logger) aws.Logger {
 	return &logrWrapper{
 		log: logger,

--- a/pkg/cloud/metrics/metrics.go
+++ b/pkg/cloud/metrics/metrics.go
@@ -67,6 +67,7 @@ func init() {
 	metrics.Registry.MustRegister(awsCallRetries)
 }
 
+// CaptureRequestMetrics will monitor and capture request metrics.
 func CaptureRequestMetrics(controller string) func(r *request.Request) {
 	return func(r *request.Request) {
 		duration := time.Since(r.AttemptTime)

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -155,7 +155,7 @@ func (s *ClusterScope) Namespace() string {
 	return s.Cluster.Namespace
 }
 
-// Name returns the AWS cluster name.
+// InfraClusterName returns the AWS cluster name.
 func (s *ClusterScope) InfraClusterName() string {
 	return s.AWSCluster.Name
 }

--- a/pkg/cloud/scope/ec2.go
+++ b/pkg/cloud/scope/ec2.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 )
 
-// Scope is the interface for the scoep to be used with the ec2 service
+// EC2Scope is the interface for the scoep to be used with the ec2 service
 type EC2Scope interface {
 	cloud.ClusterScoper
 

--- a/pkg/cloud/scope/elb.go
+++ b/pkg/cloud/scope/elb.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 )
 
-// Scope is a scope for use with the ELB reconciling service
+// ELBScope is a scope for use with the ELB reconciling service
 type ELBScope interface {
 	cloud.ClusterScoper
 

--- a/pkg/cloud/scope/getters.go
+++ b/pkg/cloud/scope/getters.go
@@ -17,26 +17,35 @@ limitations under the License.
 package scope
 
 var (
+	// DefaultClusterScopeGetter defines the default cluster scope getter.
 	DefaultClusterScopeGetter ClusterScopeGetter = ClusterScopeGetterFunc(NewClusterScope)
+
+	// DefaultMachineScopeGetter defines the default machine scope getter.
 	DefaultMachineScopeGetter MachineScopeGetter = MachineScopeGetterFunc(NewMachineScope)
 )
 
+// ClusterScopeGetter defines the cluster scope getter interface.
 type ClusterScopeGetter interface {
 	ClusterScope(params ClusterScopeParams) (*ClusterScope, error)
 }
 
+// ClusterScopeGetterFunc defines handler types for cluster scope getters.
 type ClusterScopeGetterFunc func(params ClusterScopeParams) (*ClusterScope, error)
 
+// ClusterScope will return the cluster scope.
 func (f ClusterScopeGetterFunc) ClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 	return f(params)
 }
 
+// MachineScopeGetter defines the machine scope getter interface.
 type MachineScopeGetter interface {
 	MachineScope(params MachineScopeParams) (*MachineScope, error)
 }
 
+// MachineScopeGetterFunc defines handler types for machine scope getters.
 type MachineScopeGetterFunc func(params MachineScopeParams) (*MachineScope, error)
 
+// MachineScope will return the machine scope.
 func (f MachineScopeGetterFunc) MachineScope(params MachineScopeParams) (*MachineScope, error) {
 	return f(params)
 }

--- a/pkg/cloud/scope/global.go
+++ b/pkg/cloud/scope/global.go
@@ -41,12 +41,14 @@ func NewGlobalScope(params GlobalScopeParams) (*GlobalScope, error) {
 	}, nil
 }
 
+// GlobalScopeParams defines the parameters acceptable for GlobalScope.
 type GlobalScopeParams struct {
 	ControllerName string
 	Region         string
 	Endpoints      []ServiceEndpoint
 }
 
+// GlobalScope defines the specs for the GlobalScope.
 type GlobalScope struct {
 	session         awsclient.ConfigProvider
 	serviceLimiters throttle.ServiceLimiters
@@ -58,6 +60,7 @@ func (s *GlobalScope) Session() awsclient.ConfigProvider {
 	return s.session
 }
 
+// ServiceLimiter returns the AWS SDK session. Used for creating clients.
 func (s *GlobalScope) ServiceLimiter(service string) *throttle.ServiceLimiter {
 	if sl, ok := s.serviceLimiters[service]; ok {
 		return sl
@@ -65,6 +68,8 @@ func (s *GlobalScope) ServiceLimiter(service string) *throttle.ServiceLimiter {
 	return nil
 }
 
+// ControllerName returns the name of the controller that
+// created the GlobalScope
 func (s *GlobalScope) ControllerName() string {
 	return s.controllerName
 }

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -317,33 +317,40 @@ func (m *MachineScope) AdditionalTags() infrav1.Tags {
 	return tags
 }
 
+// HasFailed returns the failure state of the machine scope.
 func (m *MachineScope) HasFailed() bool {
 	return m.AWSMachine.Status.FailureReason != nil || m.AWSMachine.Status.FailureMessage != nil
 }
 
+// InstanceIsRunning returns the instance state of the machine scope.
 func (m *MachineScope) InstanceIsRunning() bool {
 	state := m.GetInstanceState()
 	return state != nil && infrav1.InstanceRunningStates.Has(string(*state))
 }
 
+// InstanceIsOperational returns the operational state of the machine scope.
 func (m *MachineScope) InstanceIsOperational() bool {
 	state := m.GetInstanceState()
 	return state != nil && infrav1.InstanceOperationalStates.Has(string(*state))
 }
 
+// InstanceIsInKnownState checks if the machine scope's instance state is known.
 func (m *MachineScope) InstanceIsInKnownState() bool {
 	state := m.GetInstanceState()
 	return state != nil && infrav1.InstanceKnownStates.Has(string(*state))
 }
 
+// AWSMachineIsDeleted checks if the machine was deleted.
 func (m *MachineScope) AWSMachineIsDeleted() bool {
 	return !m.AWSMachine.ObjectMeta.DeletionTimestamp.IsZero()
 }
 
+// IsEKSManaged checks if the machine is EKS managed.
 func (m *MachineScope) IsEKSManaged() bool {
 	return m.InfraCluster.InfraCluster().GetObjectKind().GroupVersionKind().Kind == "AWSManagedControlPlane"
 }
 
+// IsExternallyManaged checks if the machine is externally managed.
 func (m *MachineScope) IsExternallyManaged() bool {
 	return annotations.IsExternallyManaged(m.InfraCluster.InfraCluster())
 }

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -214,6 +214,7 @@ func (m *MachinePoolScope) SetLaunchTemplateIDStatus(id string) {
 	m.AWSMachinePool.Status.LaunchTemplateID = id
 }
 
+// IsEKSManaged checks if the AWSMachinePool is EKS managed.
 func (m *MachinePoolScope) IsEKSManaged() bool {
 	return m.InfraCluster.InfraCluster().GetObjectKind().GroupVersionKind().Kind == "AWSManagedControlPlane"
 }

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -184,6 +184,7 @@ func (s *ManagedControlPlaneScope) SecurityGroups() map[infrav1.SecurityGroupRol
 	return s.ControlPlane.Status.Network.SecurityGroups
 }
 
+// SecondaryCidrBlock returns the SecondaryCidrBlock of the control plane.
 func (s *ManagedControlPlaneScope) SecondaryCidrBlock() *string {
 	return s.ControlPlane.Spec.SecondaryCidrBlock
 }
@@ -198,7 +199,7 @@ func (s *ManagedControlPlaneScope) Name() string {
 	return s.Cluster.Name
 }
 
-// Name returns the AWS cluster name.
+// InfraClusterName returns the AWS cluster name.
 func (s *ManagedControlPlaneScope) InfraClusterName() string {
 	return s.ControlPlane.Name
 }

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -230,6 +230,7 @@ func (s *Service) runPool(i *expinfrav1.AutoScalingGroup, launchTemplateID strin
 	return nil
 }
 
+// DeleteASGAndWait will delete an ASG and wait until it is deleted.
 func (s *Service) DeleteASGAndWait(name string) error {
 	if err := s.DeleteASG(name); err != nil {
 		return err
@@ -248,6 +249,7 @@ func (s *Service) DeleteASGAndWait(name string) error {
 	return nil
 }
 
+// DeleteASG will delete the ASG of a service.
 func (s *Service) DeleteASG(name string) error {
 	s.scope.V(2).Info("Attempting to delete ASG", "name", name)
 
@@ -264,6 +266,7 @@ func (s *Service) DeleteASG(name string) error {
 	return nil
 }
 
+// UpdateASG will update the ASG of a service.
 func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 	subnetIDs := make([]string, len(scope.AWSMachinePool.Spec.Subnets))
 	for i, v := range scope.AWSMachinePool.Spec.Subnets {
@@ -304,6 +307,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 	return nil
 }
 
+// CanStartASGInstanceRefresh will start an ASG instance with refresh.
 func (s *Service) CanStartASGInstanceRefresh(scope *scope.MachinePoolScope) (bool, error) {
 	describeInput := &autoscaling.DescribeInstanceRefreshesInput{AutoScalingGroupName: aws.String(scope.Name())}
 	refreshes, err := s.ASGClient.DescribeInstanceRefreshes(describeInput)
@@ -326,6 +330,7 @@ func (s *Service) CanStartASGInstanceRefresh(scope *scope.MachinePoolScope) (boo
 	return true, nil
 }
 
+// StartASGInstanceRefresh will start an ASG instance with refresh.
 func (s *Service) StartASGInstanceRefresh(scope *scope.MachinePoolScope) error {
 	strategy := pointer.StringPtr(autoscaling.RefreshStrategyRolling)
 	var minHealthyPercentage, instanceWarmup *int64

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -40,6 +40,7 @@ const (
 	awsNodeNamespace = "kube-system"
 )
 
+// ReconcileCNI will reconcile the CNI of a service.
 func (s *Service) ReconcileCNI(ctx context.Context) error {
 	s.scope.Info("Reconciling aws-node DaemonSet in cluster", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
 

--- a/pkg/cloud/services/awsnode/errors.go
+++ b/pkg/cloud/services/awsnode/errors.go
@@ -19,5 +19,6 @@ package awsnode
 import "errors"
 
 var (
+	// ErrCNIMissing defines an error for when an aws node's CNI daemonset is missing.
 	ErrCNIMissing = errors.New("aws-node CNI daemonset missing")
 )

--- a/pkg/cloud/services/awsnode/service.go
+++ b/pkg/cloud/services/awsnode/service.go
@@ -39,11 +39,13 @@ type Scope interface {
 	DisableVPCCNI() bool
 }
 
+// Service defines the spec for a service.
 type Service struct {
 	scope  Scope
 	client client.Client
 }
 
+// NewService will create a new service.
 func NewService(awsnodeScope Scope) *Service {
 	client, _ := awsnodeScope.RemoteClient()
 	return &Service{

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -63,6 +63,7 @@ type AMILookup struct {
 	K8sVersion string
 }
 
+// GenerateAmiName will generate an AMI name.
 func GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion string) (string, error) {
 	amiNameParameters := AMILookup{baseOS, strings.TrimPrefix(kubernetesVersion, "v")}
 	// revert to default if not specified
@@ -81,6 +82,7 @@ func GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion string) (string, e
 	return templateBytes.String(), nil
 }
 
+// DefaultAMILookup will do a default AMI lookup.
 func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVersion, amiNameFormat string) (*ec2.Image, error) {
 	if amiNameFormat == "" {
 		amiNameFormat = DefaultAmiNameFormat

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -393,7 +393,7 @@ func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, er
 	return ids, nil
 }
 
-// GetCoreSecurityGroups looks up the security group IDs managed by this actuator
+// GetCoreNodeSecurityGroups looks up the security group IDs managed by this actuator
 // They are considered "core" to its proper functioning
 func (s *Service) GetCoreNodeSecurityGroups(scope *scope.MachinePoolScope) ([]string, error) {
 	// These are common across both controlplane and node machines

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -62,7 +62,7 @@ func (s *Service) GetLaunchTemplate(launchTemplateName string) (*expinfrav1.AWSL
 	return s.SDKToLaunchTemplate(out.LaunchTemplateVersions[0])
 }
 
-// GetLaunchTemplateId returns the existing LaunchTemplateId or empty string if it doesn't exist.
+// GetLaunchTemplateID returns the existing LaunchTemplateId or empty string if it doesn't exist.
 func (s *Service) GetLaunchTemplateID(launchTemplateName string) (string, error) {
 	if launchTemplateName == "" {
 		return "", nil
@@ -133,6 +133,7 @@ func (s *Service) CreateLaunchTemplate(scope *scope.MachinePoolScope, imageID *s
 	return aws.StringValue(result.LaunchTemplate.LaunchTemplateId), nil
 }
 
+// CreateLaunchTemplateVersion will create a launch template.
 func (s *Service) CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, imageID *string, userData []byte) error {
 	s.scope.V(2).Info("creating new launch template version", "machine-pool", scope.Name())
 
@@ -324,6 +325,7 @@ func (s *Service) LaunchTemplateNeedsUpdate(scope *scope.MachinePoolScope, incom
 	return false, nil
 }
 
+// DiscoverLaunchTemplateAMI will discover the AMI launch template.
 func (s *Service) DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*string, error) {
 	lt := scope.AWSMachinePool.Spec.AWSLaunchTemplate
 

--- a/pkg/cloud/services/eks/service.go
+++ b/pkg/cloud/services/eks/service.go
@@ -28,11 +28,13 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/eks/iam"
 )
 
+// EKSAPI defines the EKS API interface.
 type EKSAPI interface {
 	eksiface.EKSAPI
 	WaitUntilClusterUpdating(input *eks.DescribeClusterInput, opts ...request.WaiterOption) error
 }
 
+// EKSClient defines a wrapper over EKS API.
 type EKSClient struct {
 	eksiface.EKSAPI
 }

--- a/pkg/cloud/services/iamauth/errors.go
+++ b/pkg/cloud/services/iamauth/errors.go
@@ -19,6 +19,10 @@ package iamauth
 import "errors"
 
 var (
+	// ErrInvalidBackendType defines an error for an invalid backend type.
 	ErrInvalidBackendType = errors.New("invalid backend type")
-	ErrClientRequired     = errors.New("k8s client required")
+
+	// ErrClientRequired defines an error for when a k8s client is required but
+	// not supplied.
+	ErrClientRequired = errors.New("k8s client required")
 )

--- a/pkg/cloud/services/iamauth/service.go
+++ b/pkg/cloud/services/iamauth/service.go
@@ -34,6 +34,7 @@ type Scope interface {
 	IAMAuthConfig() *ekscontrolplanev1.IAMAuthenticatorConfig
 }
 
+// Service defines the specs for a service.
 type Service struct {
 	scope     Scope
 	backend   BackendType
@@ -41,6 +42,7 @@ type Service struct {
 	STSClient stsiface.STSAPI
 }
 
+// NewService will create a new Service object.
 func NewService(iamScope Scope, backend BackendType, client client.Client) *Service {
 	return &Service{
 		scope:     iamScope,

--- a/pkg/cloud/services/instancestate/ec2events.go
+++ b/pkg/cloud/services/instancestate/ec2events.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package instancestate
 
+// ReconcileEC2Events will reconcile a Service's EC2 events.
 func (s Service) ReconcileEC2Events() error {
 	if err := s.reconcileSQSQueue(); err != nil {
 		return err
@@ -27,6 +28,7 @@ func (s Service) ReconcileEC2Events() error {
 	return nil
 }
 
+// DeleteEC2Events will delete a Service's EC2 events.
 func (s Service) DeleteEC2Events() error {
 	if err := s.deleteRules(); err != nil {
 		return err

--- a/pkg/cloud/services/instancestate/queue.go
+++ b/pkg/cloud/services/instancestate/queue.go
@@ -19,12 +19,14 @@ package instancestate
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/pkg/errors"
+
 	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
-	"strings"
 )
 
 func (s *Service) reconcileSQSQueue() error {
@@ -94,6 +96,7 @@ func (s *Service) createPolicyForRule(input *createPolicyForRuleInput) error {
 	return errors.Wrap(err, "unable to update queue attributes")
 }
 
+// GenerateQueueName will generate a queue name.
 func GenerateQueueName(clusterName string) string {
 	adjusted := strings.Replace(clusterName, ".", "-", -1)
 	return fmt.Sprintf("%s-queue", adjusted)

--- a/pkg/cloud/services/instancestate/rule.go
+++ b/pkg/cloud/services/instancestate/rule.go
@@ -19,14 +19,17 @@ package instancestate
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/pkg/errors"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 )
 
+// Ec2StateChangeNotification defines the EC2 instance's state change notification.
 const Ec2StateChangeNotification = "EC2 Instance State-change Notification"
 
 // reconcileRules creates rules and attaches the queue as a target
@@ -157,6 +160,7 @@ func (s Service) deleteRules() error {
 	return err
 }
 
+// AddInstanceToEventPattern will add an instance to an event pattern.
 func (s Service) AddInstanceToEventPattern(instanceID string) error {
 	ruleResp, err := s.EventBridgeClient.DescribeRule(&eventbridge.DescribeRuleInput{
 		Name: aws.String(s.getEC2RuleName()),

--- a/pkg/cloud/services/instancestate/service.go
+++ b/pkg/cloud/services/instancestate/service.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
 
+// Service defines the specs for a service.
 type Service struct {
 	scope             scope.EC2Scope
 	EventBridgeClient eventbridgeiface.EventBridgeAPI

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -60,6 +60,7 @@ var (
 	}
 )
 
+// ReconcileSecurityGroups will reconcile security groups against the Service object.
 func (s *Service) ReconcileSecurityGroups() error {
 	s.scope.V(2).Info("Reconciling security groups")
 
@@ -261,6 +262,7 @@ func (s *Service) ec2SecurityGroupToSecurityGroup(ec2SecurityGroup *ec2.Security
 	return sg
 }
 
+// DeleteSecurityGroups will delete a service's security groups.
 func (s *Service) DeleteSecurityGroups() error {
 	conditions.MarkFalse(s.scope.InfraCluster(), infrav1.ClusterSecurityGroupsReadyCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
 	if s.scope.VPC().ID == "" {

--- a/pkg/cloud/tags/tags.go
+++ b/pkg/cloud/tags/tags.go
@@ -31,8 +31,11 @@ import (
 )
 
 var (
+	// ErrBuildParamsRequired defines an error for when no build params are supplied.
 	ErrBuildParamsRequired = errors.New("no build params supplied")
-	ErrApplyFuncRequired   = errors.New("no tags apply function supplied")
+
+	// ErrApplyFuncRequired defines an error for when tags are not supplied.
+	ErrApplyFuncRequired = errors.New("no tags apply function supplied")
 )
 
 // BuilderOption represents an option when creating a tags builder
@@ -108,7 +111,7 @@ func WithEC2(ec2client ec2iface.EC2API) BuilderOption {
 	}
 }
 
-// WithEKS is used to specify that the tags builder will be targetting EKS
+// WithEKS is used to specify that the tags builder will be targeting EKS
 func WithEKS(eksclient eksiface.EKSAPI) BuilderOption {
 	return func(b *Builder) {
 		b.applyFunc = func(params *infrav1.BuildParams) error {

--- a/pkg/cloudtest/cloudtest.go
+++ b/pkg/cloudtest/cloudtest.go
@@ -42,9 +42,20 @@ func RuntimeRawExtension(t *testing.T, p interface{}) *runtime.RawExtension {
 // test log messages.
 type Log struct{}
 
+// Error implements Log errors.
 func (l *Log) Error(err error, msg string, keysAndValues ...interface{}) {}
-func (l *Log) V(level int) logr.InfoLogger                               { return l }
-func (l *Log) WithValues(keysAndValues ...interface{}) logr.Logger       { return l }
-func (l *Log) WithName(name string) logr.Logger                          { return l }
-func (l *Log) Info(msg string, keysAndValues ...interface{})             {}
-func (l *Log) Enabled() bool                                             { return false }
+
+// V returns the Logger's log level.
+func (l *Log) V(level int) logr.Logger { return l }
+
+// WithValues returns logs with specific values.
+func (l *Log) WithValues(keysAndValues ...interface{}) logr.Logger { return l }
+
+// WithName returns the logger with a specific name.
+func (l *Log) WithName(name string) logr.Logger { return l }
+
+// Info implements info messages for the logger.
+func (l *Log) Info(msg string, keysAndValues ...interface{}) {}
+
+// Enabled returns the state of the logger.
+func (l *Log) Enabled() bool { return false }

--- a/pkg/eks/addons/plan.go
+++ b/pkg/eks/addons/plan.go
@@ -116,14 +116,3 @@ func convertTags(tags infrav1.Tags) map[string]*string {
 
 	return converted
 }
-
-func convertSDKTags(tags map[string]*string) infrav1.Tags {
-	converted := infrav1.Tags{}
-
-	for k, v := range tags {
-		copiedVal := v
-		converted[k] = *copiedVal
-	}
-
-	return converted
-}

--- a/pkg/eks/addons/procedures.go
+++ b/pkg/eks/addons/procedures.go
@@ -26,8 +26,11 @@ import (
 )
 
 var (
-	ErrNilAddon           = errors.New("nil addon returned from create")
-	ErrAddonNotFound      = errors.New("addon not found")
+	// ErrNilAddon defines an error for when a nil addon is returned.
+	ErrNilAddon = errors.New("nil addon returned from create")
+	// ErrAddonNotFound defines an error for when an addon is not found.
+	ErrAddonNotFound = errors.New("addon not found")
+	// ErrAddonAlreadyExists defines an error for when an addon already exists.
 	ErrAddonAlreadyExists = errors.New("addon already exists")
 )
 

--- a/pkg/internal/rate/rate.go
+++ b/pkg/internal/rate/rate.go
@@ -20,10 +20,11 @@ package rate
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"math"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // Limit defines the maximum frequency of some events.

--- a/pkg/internal/rate/reset.go
+++ b/pkg/internal/rate/reset.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package rate
 
+// ResetTokens will reset all tokens.
 func (lim *Limiter) ResetTokens() {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()

--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -52,12 +52,12 @@ func Eventf(object runtime.Object, reason, message string, args ...interface{}) 
 	defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
 }
 
-// Event constructs a warning event from the given information and puts it in the queue for sending.
+// Warn constructs a warning event from the given information and puts it in the queue for sending.
 func Warn(object runtime.Object, reason, message string) {
 	defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
 }
 
-// Eventf is just like Event, but with Sprintf for the message field.
+// Warnf is just like Event, but with Sprintf for the message field.
 func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
 	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
 }

--- a/test/helpers/external/cluster.go
+++ b/test/helpers/external/cluster.go
@@ -30,7 +30,10 @@ const (
 )
 
 var (
+	// TestClusterCRD will generate a test cluster CustomResourceDefinition.
 	TestClusterCRD = generateTestClusterAPICRD("cluster", "clusters")
+
+	// TestMachineCRD will generate a test machine CustomResourceDefinition.
 	TestMachineCRD = generateTestClusterAPICRD("machine", "machines")
 )
 

--- a/util/system/util.go
+++ b/util/system/util.go
@@ -48,6 +48,7 @@ func GetManagerNamespace() string {
 	return managerNamespace
 }
 
+// GetNamespaceFromFile returns the namespace from a file.
 // This code is copied from controller-runtime, because it is a private method there.
 // https://github.com/kubernetes-sigs/controller-runtime/blob/316aea4229158103123166a5e45076f1a86bd807/pkg/leaderelection/leader_election.go#L104
 func GetNamespaceFromFile(nsFilePath string) (string, error) {

--- a/version/version.go
+++ b/version/version.go
@@ -32,6 +32,7 @@ var (
 	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
+// Info defines the version.
 type Info struct {
 	Major         string `json:"major,omitempty"`
 	Minor         string `json:"minor,omitempty"`
@@ -45,6 +46,7 @@ type Info struct {
 	Platform      string `json:"platform,omitempty"`
 }
 
+// Get returns metadata and information regarding the version.
 func Get() Info {
 	return Info{
 		Major:         gitMajor,


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind support

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR enforces comments on the codebase via `revive`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2428 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Enforced comments on the codebase using Revive (swapped with Golint), and resolved all linter errors.

The following linter errors were resolved:
* Resolve goimports errors
* Resolve deadcode errors by removing unused code
* Resolve misspell error by correcting spelling
* Resolve staticcheck errors
* Staticcheck linter was complaining about fmt.Printf being used with dynamic
first argument and no other arguments (SA1006). This can lead to unexpected
output. To solve this fmt.Printf was switched with fmt.Println.
Also, pkg/cloudtest/cloudtest.go V(level int) returned a logr.InfoLogger which
is deprecated, which Staticcheck complained about. This was swapped with the
newer logr.Logger.
* Exclude noctx error with descriptive comments
* Resolve gosimple errors

Since comments were updated, yamls had to be regenerated using `make regenerate`.

Also, the golangci exclude line "Using the variable on range scope `(tc)|(rt)|(tt)|
(test)|(testcase)|(testCase)` in function literal" was removed because it was
blocking what seemed to be a larger net of linters than it was supposed to, and
because it became redundant after the linter issues were resolved.
```
