### PR TITLE
fix: added missing kms permissions required for EKS encryption (backport)

### DIFF
--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/defaults.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/defaults.go
@@ -30,6 +30,8 @@ const (
 	DefaultStackName = "cluster-api-provider-aws-sigs-k8s-io"
 	// DefaultParittionName is the default security partition for AWS ARNs.
 	DefaultPartitionName = "aws"
+	// DefaultKMSAliasPattern is the default KMS alias
+	DefaultKMSAliasPattern = "cluster-api-provider-aws-*"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -84,6 +86,9 @@ func SetDefaults_AWSIAMConfigurationSpec(obj *AWSIAMConfigurationSpec) { //nolin
 		obj.SecureSecretsBackends = []infrav1.SecretBackend{
 			infrav1.SecretBackendSecretsManager,
 		}
+	}
+	if len(obj.EKS.KMSAliasPrefix) == 0 {
+		obj.EKS.KMSAliasPrefix = DefaultKMSAliasPattern
 	}
 }
 

--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
@@ -108,6 +108,10 @@ type EKSConfig struct {
 	// Fargate controls the configuration of the AWS IAM role for
 	// used by EKS managed machine pools.
 	Fargate *AWSIAMRoleSpec `json:"fargate,omitempty"`
+	// KMSAliasPrefix is prefix to use to restrict permission to KMS keys to only those that have an alias
+	// name that is prefixed by this.
+	// Defaults to cluster-api-provider-aws-*
+	KMSAliasPrefix string `json:"kmsAliasPrefix,omitempty"`
 }
 
 // EventBridgeConfig represents configuration for enabling experimental feature to consume

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -361,6 +361,21 @@ func (t Template) ControllersPolicy() *iamv1.PolicyDocument {
 				},
 				Effect: iamv1.EffectAllow,
 			},
+			{
+				Action: iamv1.Actions{
+					"kms:CreateGrant",
+					"kms:DescribeKey",
+				},
+				Resource: iamv1.Resources{
+					"*",
+				},
+				Effect: iamv1.EffectAllow,
+				Condition: iamv1.Conditions{
+					"ForAnyValue:StringLike": map[string]string{
+						"kms:ResourceAliases": fmt.Sprintf("alias/%s", t.Spec.EKS.KMSAliasPrefix),
+					},
+				},
+			},
 		}...)
 
 	}

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
@@ -330,6 +330,15 @@ Resources:
           Effect: Allow
           Resource:
           - '*'
+        - Action:
+          - kms:CreateGrant
+          - kms:DescribeKey
+          Condition:
+            ForAnyValue:StringLike:
+              kms:ResourceAliases: alias/cluster-api-provider-aws-*
+          Effect: Allow
+          Resource:
+          - '*'
         Version: 2012-10-17
       Roles:
       - Ref: AWSIAMRoleControllers

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -335,7 +335,7 @@ Resources:
           - kms:DescribeKey
           Condition:
             ForAnyValue:StringLike:
-              kms:ResourceAliases: alias/cluster-api-provider-aws-*
+              kms:ResourceAliases: alias/custom-prefix-*
           Effect: Allow
           Resource:
           - '*'
@@ -369,54 +369,6 @@ Resources:
             - ec2.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
-    Type: AWS::IAM::Role
-  AWSIAMRoleEKSControlPlane:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Action:
-          - sts:AssumeRole
-          Effect: Allow
-          Principal:
-            Service:
-            - eks.amazonaws.com
-        Version: 2012-10-17
-      ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-      RoleName: eks-controlplane.cluster-api-provider-aws.sigs.k8s.io
-    Type: AWS::IAM::Role
-  AWSIAMRoleEKSFargate:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Action:
-          - sts:AssumeRole
-          Effect: Allow
-          Principal:
-            Service:
-            - eks-fargate-pods.amazonaws.com
-        Version: 2012-10-17
-      ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy
-      RoleName: eks-fargate.cluster-api-provider-aws.sigs.k8s.io
-    Type: AWS::IAM::Role
-  AWSIAMRoleEKSNodegroup:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Action:
-          - sts:AssumeRole
-          Effect: Allow
-          Principal:
-            Service:
-            - ec2.amazonaws.com
-            - eks.amazonaws.com
-        Version: 2012-10-17
-      ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-      - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-      RoleName: eks-nodegroup.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role
   AWSIAMRoleNodes:
     Properties:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
@@ -117,6 +117,16 @@ func Test_RenderCloudformation(t *testing.T) {
 			},
 		},
 		{
+			fixture: "with_eks_kms_prefix",
+			template: func() Template {
+				t := NewTemplate()
+				t.Spec.EKS.Enable = true
+				t.Spec.Nodes.EC2ContainerRegistryReadOnly = true
+				t.Spec.EKS.KMSAliasPrefix = "custom-prefix-*"
+				return t
+			},
+		},
+		{
 			fixture: "with_extra_statements",
 			template: func() Template {
 				t := NewTemplate()

--- a/docs/book/src/SUMMARY_PREFIX.md
+++ b/docs/book/src/SUMMARY_PREFIX.md
@@ -15,6 +15,7 @@
     - [Creating a cluster](./topics/eks/creating-a-cluster.md)
     - [Using EKS Console](./topics/eks/eks-console.md)
     - [Using EKS Addons](./topics/eks/addons.md)
+    - [Enabling Encryption](./topics/eks/encryption.md)
     - [Cluster Upgrades](./topics/eks/cluster-upgrades.md)
   - [Consuming Existing AWS Infrastructure](./topics/consuming-existing-aws-infrastructure.md)
   - [Specifying the IAM Role to use for Management Components](./topics/specify-management-iam-role.md)

--- a/docs/book/src/topics/eks/encryption.md
+++ b/docs/book/src/topics/eks/encryption.md
@@ -1,0 +1,39 @@
+# Enabling Encryption
+
+To enable encryption when creating a cluster you need to create a new KMS key that has an alias name starting with `cluster-api-provider-aws-`.
+
+For example, `arn:aws:kms:eu-north-1:12345678901:alias/cluster-api-provider-aws-key1`.
+
+You then need to specify this alias in the `encryptionConfig` of the `AWSManagedControlPlane`:
+
+```yaml
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+metadata:
+  name: "capi-managed-test-control-plane"
+spec:
+  ...
+  encryptionConfig:
+    provider: "arn:aws:kms:eu-north-1:12345678901:alias/cluster-api-provider-aws-key1"
+    resources:
+    - "secrets"
+```
+
+## Custom KMS Alias Prefix
+
+If you would like to use a different alias prefix then you can use the `kmsAliasPrefix` in the optional configuration file for **clusterawsadm**:
+
+```bash
+clusterawsadm bootstrap iam create-stack --config custom-prefix.yaml
+```
+
+And the contents of the configuration file:
+
+```yaml
+apiVersion: bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1
+kind: AWSIAMConfiguration
+spec:
+  eks:
+    enable: true
+    kmsAliasPrefix: "my-prefix-*
+```

--- a/docs/book/src/topics/eks/index.md
+++ b/docs/book/src/topics/eks/index.md
@@ -31,4 +31,5 @@ And a number of new templates are available in the templates folder for creating
 * [Creating a cluster](creating-a-cluster.md)
 * [Using EKS Console](eks-console.md)
 * [Using EKS Addons](addons.md)
+* [Enabling Encryption](encryption.md)
 * [Cluster Upgrades](cluster-upgrades.md)


### PR DESCRIPTION
Signed-off-by: Richard Case <richard@weave.works>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If you are using encryption with EKS there are missing permission on the controllers policy to allow using the specified KMS key.

Added missing IAM permission required to use EKS encryption. The permissions are scoped to KMS keys that have an alias name with a prefix of cluster-api-provider-aws-*.

The prefix is configurable via clusterawsadm config file.

This is a backport of #2447 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #2432 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
action required
Controllers policy updated with missing KMS permissions required to use EKS encryption, if you are planning to use EKS encryption then you will need to update your controllers policy by running `clusterawsadm bootstrap iam create-cloudformation-stack` again.  And then when you create a cluster with encryption enabled you will need to use a KMS key that has an alias name starting with `cluster-api-provider-aws-`. For further information see docs. 
```
