### PR TITLE
Add new controller commands to clusterawsadm related to updating bootstrap credentials

### DIFF
--- a/cmd/clusterawsadm/cmd/controller/controller.go
+++ b/cmd/clusterawsadm/cmd/controller/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,26 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ami
+package controller
 
 import (
 	"github.com/spf13/cobra"
-	cp "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/copy"
-	ls "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/list"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/controller/credentials"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/controller/rollout"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
 
-// RootCmd is the root of the `ami command`
+// RootCmd is the root of the `controller command`
 func RootCmd() *cobra.Command {
 	newCmd := &cobra.Command{
-		Use:   "ami [command]",
-		Short: "AMI commands",
+		Use:   "controller [command]",
+		Short: "controller commands",
 		Args:  cobra.NoArgs,
 		Long: cmd.LongDesc(`
-			All AMI related actions such as:
-			# Copy AMIs based on Kubernetes version, OS etc from an AWS account where AMIs are stored
-            to the current AWS account (use case: air-gapped deployments)
-			# (to be implemented) List available AMIs
+			All controller related actions such as:
+			# Zero controller credentials and rollout controllers
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmd.Help(); err != nil {
@@ -43,9 +41,10 @@ func RootCmd() *cobra.Command {
 		},
 	}
 
-	newCmd.AddCommand(cp.CopyAMICmd())
-	newCmd.AddCommand(cp.EncryptedCopyAMICmd())
-	newCmd.AddCommand(ls.ListAMICmd())
+	newCmd.AddCommand(credentials.ZeroCredentialsCmd())
+	newCmd.AddCommand(credentials.UpdateCredentialsCmd())
+	newCmd.AddCommand(credentials.PrintCredentialsCmd())
+	newCmd.AddCommand(rollout.RolloutControllersCmd())
 
 	return newCmd
 }

--- a/cmd/clusterawsadm/cmd/controller/credentials/common.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/common.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	namespace         string
+	kubeconfigPath    string
+	kubeconfigContext string
+)
+
+func addKubeconfigContextFlag(c *cobra.Command) {
+	c.Flags().StringVar(&kubeconfigContext, "kubeconfig-context", "", "Context to be used within the kubeconfig file. If empty, current context will be used.")
+}
+
+func addKubeconfigFlag(c *cobra.Command) {
+	c.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for the management cluster. If empty, default discovery rules apply.")
+}
+
+func addNamespaceFlag(c *cobra.Command) {
+	c.Flags().StringVar(&namespace, "namespace", "capa-system", "Namespace the controllers are in. If empty, default value (capa-system) is used")
+}

--- a/cmd/clusterawsadm/cmd/controller/credentials/print.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/print.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
+)
+
+func PrintCredentialsCmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "print-credentials",
+		Short: "print credentials the controller is using",
+		Long: cmd.LongDesc(`
+			print credentials the controller is using
+		`),
+		Example: cmd.Examples(`
+		# print credentials
+		clusterawsadm controller print-credentials --kubeconfig=kubeconfig --namespace=capa-system
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := controller.GetClient(kubeconfigPath, kubeconfigContext)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to get client-go client for the cluster: %s\n", err.Error())
+				return err
+			}
+
+			secret, err := client.CoreV1().Secrets(namespace).Get(context.TODO(), controller.BootstrapCredsSecret, metav1.GetOptions{})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to get bootstrap credentials secret: %s\n", err.Error())
+				return err
+			}
+
+			controller.PrintBootstrapCredentials(secret)
+			return nil
+		},
+	}
+	addKubeconfigFlag(newCmd)
+	addKubeconfigContextFlag(newCmd)
+	addNamespaceFlag(newCmd)
+	return newCmd
+}

--- a/cmd/clusterawsadm/cmd/controller/credentials/update_credentials.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/update_credentials.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/util"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller/credentials"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
+)
+
+func UpdateCredentialsCmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "update-credentials",
+		Short: "update credentials the controller is using (i.e., update controller bootstrap secret)",
+		Long: cmd.LongDesc(`
+			Update credentials the controller is started with
+		`),
+		Example: cmd.Examples(`
+		# update credentials: AWS_B64ENCODED_CREDENTIALS environment variable must be set and be used to update the bootstrap secret
+		# Kubeconfig file will be searched in default locations
+		clusterawsadm controller update-credentials --namespace=capa-system
+		# Provided kubeconfig file will be used
+		clusterawsadm controller update-credentials --kubeconfig=kubeconfig  --namespace=capa-system
+		# Kubeconfig in the default location will be retrieved and the provided context will be used
+		clusterawsadm controller update-credentials --kubeconfig-context=mgmt-cluster  --namespace=capa-system
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			encodedCreds, err := util.GetEnv("AWS_B64ENCODED_CREDENTIALS")
+			if err != nil {
+				return err
+			}
+
+			return credentials.UpdateCredentials(credentials.UpdateCredentialsInput{
+				KubeconfigPath:    kubeconfigPath,
+				KubeconfigContext: kubeconfigContext,
+				Credentials:       encodedCreds,
+				Namespace:         namespace,
+			})
+		},
+	}
+	addKubeconfigFlag(newCmd)
+	addKubeconfigContextFlag(newCmd)
+	addNamespaceFlag(newCmd)
+	return newCmd
+}

--- a/cmd/clusterawsadm/cmd/controller/credentials/zero_credentials.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/zero_credentials.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller/credentials"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
+)
+
+func ZeroCredentialsCmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "zero-credentials",
+		Short: "zero credentials the controller is started with",
+		Long: cmd.LongDesc(`
+			Zero credentials the controller is started with
+		`),
+		Example: cmd.Examples(`
+		# zero credentials
+		# Kubeconfig file will be searched in default locations
+		clusterawsadm controller zero-credentials --namespace=capa-system
+		# Provided kubeconfig file will be used
+		clusterawsadm controller zero-credentials --kubeconfig=kubeconfig  --namespace=capa-system
+		# Kubeconfig in the default location will be retrieved and the provided context will be used
+		clusterawsadm controller zero-credentials --kubeconfig-context=mgmt-cluster  --namespace=capa-system
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return credentials.ZeroCredentials(credentials.ZeroCredentialsInput{
+				KubeconfigPath:    kubeconfigPath,
+				KubeconfigContext: kubeconfigContext,
+				Namespace:         namespace,
+			})
+		},
+	}
+	addKubeconfigFlag(newCmd)
+	addKubeconfigContextFlag(newCmd)
+	addNamespaceFlag(newCmd)
+	return newCmd
+}

--- a/cmd/clusterawsadm/cmd/controller/rollout/common.go
+++ b/cmd/clusterawsadm/cmd/controller/rollout/common.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func addKubeconfigContextFlag(c *cobra.Command) {
+	c.Flags().StringVar(&kubeconfigContext, "kubeconfig-context", "", "Context to be used within the kubeconfig file. If empty, current context will be used.")
+}
+
+func addKubeconfigFlag(c *cobra.Command) {
+	c.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for the management cluster. If empty, default discovery rules apply.")
+}
+
+func addNamespaceFlag(c *cobra.Command) {
+	c.Flags().StringVar(&namespace, "namespace", "capa-system", "Namespace the controllers are in. If empty, default value (capa-system) is used")
+}

--- a/cmd/clusterawsadm/cmd/controller/rollout/rollout.go
+++ b/cmd/clusterawsadm/cmd/controller/rollout/rollout.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller/rollout"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
+)
+
+var (
+	namespace         string
+	kubeconfigPath    string
+	kubeconfigContext string
+)
+
+func RolloutControllersCmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "rollout-controller",
+		Short: "initiates rollout and restart on capa-controller-manager deployment",
+		Long: cmd.LongDesc(`
+			initiates rollout and restart on capa-controller-manager deployment
+		`),
+		Example: cmd.Examples(`
+		# rollout controller deployment
+		clusterawsadm controller rollout-controller --kubeconfig=kubeconfig --namespace=capa-system
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rollout.RolloutControllers(rollout.RolloutControllersInput{
+				KubeconfigPath:    kubeconfigPath,
+				KubeconfigContext: kubeconfigContext,
+				Namespace:         namespace,
+			})
+		},
+	}
+	addKubeconfigFlag(newCmd)
+	addKubeconfigContextFlag(newCmd)
+	addNamespaceFlag(newCmd)
+	return newCmd
+}

--- a/cmd/clusterawsadm/cmd/root.go
+++ b/cmd/clusterawsadm/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/alpha"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/bootstrap"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/controller"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/eks"
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/version"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
@@ -71,6 +72,7 @@ func RootCmd() *cobra.Command {
 	newCmd.AddCommand(version.VersionCmd(os.Stdout))
 	newCmd.AddCommand(ami.RootCmd())
 	newCmd.AddCommand(eks.RootCmd())
+	newCmd.AddCommand(controller.RootCmd())
 
 	return newCmd
 }

--- a/cmd/clusterawsadm/cmd/util/util.go
+++ b/cmd/clusterawsadm/cmd/util/util.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+)
+
+type ErrEnvironmentVariableNotFound string
+
+func (e ErrEnvironmentVariableNotFound) Error() string {
+	return fmt.Sprintf("environment variable %q not found", string(e))
+}
+
+func GetEnv(key string) (string, error) {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return "", ErrEnvironmentVariableNotFound(key)
+	}
+	return val, nil
+}

--- a/cmd/clusterawsadm/controller/credentials/update_credentials.go
+++ b/cmd/clusterawsadm/controller/credentials/update_credentials.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller"
+)
+
+type UpdateCredentialsInput struct {
+	KubeconfigPath    string
+	KubeconfigContext string
+	Credentials       string
+	Namespace         string
+}
+
+// UpdateCredentials updates the CAPA controller bootstrap secret
+// RolloutControllers() must be called after any change to the controller bootstrap secret to take effect.
+func UpdateCredentials(input UpdateCredentialsInput) error {
+	client, err := controller.GetClient(input.KubeconfigPath, input.KubeconfigContext)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get client-go client for the cluster: %s\n", err.Error())
+		return err
+	}
+
+	creds := input.Credentials
+	if creds == "" {
+		creds = "Cg=="
+	}
+
+	patch := fmt.Sprintf("{\"data\":{\"credentials\": \"%s\"}}", creds)
+	_, err = client.CoreV1().Secrets(input.Namespace).Patch(
+		context.TODO(),
+		controller.BootstrapCredsSecret,
+		types.MergePatchType,
+		[]byte(patch),
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to patch bootstrap credentials secret: %s\n", err.Error())
+		return err
+	}
+
+	secret, err := client.CoreV1().Secrets(input.Namespace).Get(context.TODO(), controller.BootstrapCredsSecret, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get bootstrap credentials secret: %s\n", err.Error())
+		return err
+	}
+	controller.PrintBootstrapCredentials(secret)
+	return nil
+}

--- a/cmd/clusterawsadm/controller/credentials/zero_credentials.go
+++ b/cmd/clusterawsadm/controller/credentials/zero_credentials.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+type ZeroCredentialsInput struct {
+	KubeconfigPath    string
+	KubeconfigContext string
+	Namespace         string
+}
+
+// ZeroCredentials zeroes out the CAPA controller bootstrap secret.
+// RolloutControllers() must be called after any change to the controller bootstrap secret to take effect.
+func ZeroCredentials(input ZeroCredentialsInput) error {
+	return UpdateCredentials(UpdateCredentialsInput{
+		KubeconfigPath:    input.KubeconfigPath,
+		KubeconfigContext: input.KubeconfigContext,
+		Credentials:       "Cg==",
+		Namespace:         input.Namespace,
+	})
+}

--- a/cmd/clusterawsadm/controller/helper.go
+++ b/cmd/clusterawsadm/controller/helper.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/cluster-api-provider-aws/version"
+)
+
+const BootstrapCredsSecret = "capa-manager-bootstrap-credentials"
+
+// GetClient creates the config for a kubernetes client and returns a client-go client for the cluster.
+func GetClient(kubeconfigPath string, kubeconfigContext string) (*kubernetes.Clientset, error) {
+	// If a kubeconfig file isn't provided, find one in the standard locations.
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		rules.ExplicitPath = kubeconfigPath
+	}
+
+	config, err := rules.Load()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load Kubeconfig")
+	}
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+	if kubeconfigContext == "" {
+		configOverrides.CurrentContext = kubeconfigContext
+	}
+
+	restConfig, err := clientcmd.NewDefaultClientConfig(*config, configOverrides).ClientConfig()
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "invalid configuration:") {
+			return nil, errors.New(strings.Replace(err.Error(), "invalid configuration:", "invalid kubeconfig file; clusterawsadm requires a valid kubeconfig file to connect to the management cluster:", 1))
+		}
+		return nil, err
+	}
+	restConfig.UserAgent = fmt.Sprintf("clusterawsadm/%s (%s)", version.Get().GitVersion, version.Get().Platform)
+
+	// Get a client-go client for the cluster
+	cs, err := kubernetes.NewForConfig(restConfig)
+	return cs, err
+}
+
+func PrintBootstrapCredentials(secret *corev1.Secret) {
+	if creds, ok := secret.Data["credentials"]; ok {
+		if base64.StdEncoding.EncodeToString(creds) == "Cg==" {
+			fmt.Println("Credentials are zeroed")
+		} else {
+			fmt.Printf(string(creds))
+		}
+	}
+}

--- a/cmd/clusterawsadm/controller/rollout/rollout.go
+++ b/cmd/clusterawsadm/controller/rollout/rollout.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/controller"
+)
+
+const ControllerDeploymentName = "capa-controller-manager"
+
+type RolloutControllersInput struct {
+	KubeconfigPath    string
+	KubeconfigContext string
+	Namespace         string
+}
+
+// RolloutControllers initiates rollout restrart on the CAPA controller deployment.
+// Must be called after any change to the controller bootstrap secret.
+func RolloutControllers(input RolloutControllersInput) error {
+	client, err := controller.GetClient(input.KubeconfigPath, input.KubeconfigContext)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get client-go client for the cluster: %s\n", err.Error())
+		return err
+	}
+
+	dp, err := client.AppsV1().Deployments(input.Namespace).Get(context.TODO(), ControllerDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get %s deployment: %s\n", ControllerDeploymentName, err.Error())
+		return err
+	}
+
+	initialDeployMarshalled, err := json.Marshal(dp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to marshal controller deployment: %s\n", err.Error())
+		return err
+	}
+
+	updatedDeployment := dp.DeepCopy()
+	updatedDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	updatedDeployMarshalled, err := json.Marshal(updatedDeployment)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to marshal updated controller deployment: %s\n", err.Error())
+		return err
+	}
+
+	patch, err := strategicpatch.CreateTwoWayMergePatch(initialDeployMarshalled, updatedDeployMarshalled, appsv1.Deployment{})
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = client.AppsV1().Deployments(input.Namespace).Patch(
+		context.TODO(),
+		ControllerDeploymentName,
+		types.StrategicMergePatchType,
+		patch,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initiate rollout restart on CAPA controller manager deployment: %s\n", err.Error())
+		return err
+	}
+	return nil
+}

--- a/cmd/clusterawsadm/credentials/credentials.go
+++ b/cmd/clusterawsadm/credentials/credentials.go
@@ -20,8 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"fmt"
-	"os"
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/util"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -42,12 +41,6 @@ aws_session_token = {{ .SessionToken }}
 const AWSDefaultRegion = "us-east-1"
 
 var ErrNoAWSRegionConfigured = errors.New("no AWS region configured. Use --region or set AWS_REGION or DEFAULT_AWS_REGION environment variable")
-
-type ErrEnvironmentVariableNotFound string
-
-func (e ErrEnvironmentVariableNotFound) Error() string {
-	return fmt.Sprintf("environment variable %q not found", string(e))
-}
 
 type AWSCredentials struct {
 	AccessKeyID     string
@@ -83,23 +76,15 @@ func ResolveRegion(explicitRegion string) (string, error) {
 	if explicitRegion != "" {
 		return explicitRegion, nil
 	}
-	region, err := getEnv("AWS_REGION")
+	region, err := util.GetEnv("AWS_REGION")
 	if err == nil {
 		return region, nil
 	}
-	region, err = getEnv("DEFAULT_AWS_REGION")
+	region, err = util.GetEnv("DEFAULT_AWS_REGION")
 	if err == nil {
 		return region, nil
 	}
 	return "", ErrNoAWSRegionConfigured
-}
-
-func getEnv(key string) (string, error) {
-	val, ok := os.LookupEnv(key)
-	if !ok {
-		return "", ErrEnvironmentVariableNotFound(key)
-	}
-	return val, nil
 }
 
 func (c AWSCredentials) RenderAWSDefaultProfile() (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2434

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add controller related commands to clusterawsadm: zero/update/print bootstrap credentials and rollout controllers
```

/kind feature
