### PR TITLE
fix: remove usage of slices of struct pointers

### DIFF
--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -119,7 +119,7 @@ type AWSMachineSpec struct {
 
 	// Configuration options for the non root storage volumes.
 	// +optional
-	NonRootVolumes []*Volume `json:"nonRootVolumes,omitempty"`
+	NonRootVolumes []Volume `json:"nonRootVolumes,omitempty"`
 
 	// NetworkInterfaces is a list of ENIs to associate with the instance.
 	// A maximum of 2 may be specified.

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -135,7 +135,7 @@ type ClassicELB struct {
 	SecurityGroupIDs []string `json:"securityGroupIds,omitempty"`
 
 	// Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.
-	Listeners []*ClassicELBListener `json:"listeners,omitempty"`
+	Listeners []ClassicELBListener `json:"listeners,omitempty"`
 
 	// HealthCheck is the classic elb health check associated with the load balancer.
 	HealthCheck *ClassicELBHealthCheck `json:"healthChecks,omitempty"`
@@ -289,13 +289,13 @@ func (s *SubnetSpec) String() string {
 }
 
 // Subnets is a slice of Subnet.
-type Subnets []*SubnetSpec
+type Subnets []SubnetSpec
 
 // ToMap returns a map from id to subnet.
 func (s Subnets) ToMap() map[string]*SubnetSpec {
 	res := make(map[string]*SubnetSpec)
 	for _, x := range s {
-		res[x.ID] = x
+		res[x.ID] = &x
 	}
 	return res
 }
@@ -313,7 +313,7 @@ func (s Subnets) IDs() []string {
 func (s Subnets) FindByID(id string) *SubnetSpec {
 	for _, x := range s {
 		if x.ID == id {
-			return x
+			return &x
 		}
 	}
 
@@ -326,7 +326,7 @@ func (s Subnets) FindByID(id string) *SubnetSpec {
 func (s Subnets) FindEqual(spec *SubnetSpec) *SubnetSpec {
 	for _, x := range s {
 		if (spec.ID != "" && x.ID == spec.ID) || (spec.CidrBlock == x.CidrBlock) {
-			return x
+			return &x
 		}
 	}
 	return nil
@@ -382,8 +382,8 @@ type CNISpec struct {
 	CNIIngressRules CNIIngressRules `json:"cniIngressRules,omitempty"`
 }
 
-// CNIIngressRules is a slice of CNIIngressRule.
-type CNIIngressRules []*CNIIngressRule
+// CNIIngressRules is a slice of CNIIngressRule
+type CNIIngressRules []CNIIngressRule
 
 // CNIIngressRule defines an AWS ingress rule for CNI requirements.
 type CNIIngressRule struct {
@@ -487,14 +487,14 @@ func (i *IngressRule) String() string {
 }
 
 // IngressRules is a slice of AWS ingress rules for security groups.
-type IngressRules []*IngressRule
+type IngressRules []IngressRule
 
 // Difference returns the difference between this slice and the other slice.
 func (i IngressRules) Difference(o IngressRules) (out IngressRules) {
 	for _, x := range i {
 		found := false
 		for _, y := range o {
-			if x.Equals(y) {
+			if x.Equals(&y) {
 				found = true
 				break
 			}
@@ -655,7 +655,7 @@ type Instance struct {
 
 	// Configuration options for the non root storage volumes.
 	// +optional
-	NonRootVolumes []*Volume `json:"nonRootVolumes,omitempty"`
+	NonRootVolumes []Volume `json:"nonRootVolumes,omitempty"`
 
 	// Specifies ENIs attached to instance
 	NetworkInterfaces []string `json:"networkInterfaces,omitempty"`

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -294,7 +294,8 @@ type Subnets []SubnetSpec
 // ToMap returns a map from id to subnet.
 func (s Subnets) ToMap() map[string]*SubnetSpec {
 	res := make(map[string]*SubnetSpec)
-	for _, x := range s {
+	for i := range s {
+		x := s[i]
 		res[x.ID] = &x
 	}
 	return res
@@ -491,9 +492,11 @@ type IngressRules []IngressRule
 
 // Difference returns the difference between this slice and the other slice.
 func (i IngressRules) Difference(o IngressRules) (out IngressRules) {
-	for _, x := range i {
+	for index := range i {
+		x := i[index]
 		found := false
-		for _, y := range o {
+		for oIndex := range o {
+			y := o[oIndex]
 			if x.Equals(&y) {
 				found = true
 				break

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1058,7 +1058,7 @@ func autoConvert_v1alpha3_AWSMachineSpec_To_v1alpha4_AWSMachineSpec(in *AWSMachi
 	out.Subnet = (*v1alpha4.AWSResourceReference)(unsafe.Pointer(in.Subnet))
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))
 	out.RootVolume = (*v1alpha4.Volume)(unsafe.Pointer(in.RootVolume))
-	out.NonRootVolumes = *(*[]*v1alpha4.Volume)(unsafe.Pointer(&in.NonRootVolumes))
+	out.NonRootVolumes = *(*[]v1alpha4.Volume)(unsafe.Pointer(&in.NonRootVolumes))
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.UncompressedUserData = (*bool)(unsafe.Pointer(in.UncompressedUserData))
 	if err := Convert_v1alpha3_CloudInit_To_v1alpha4_CloudInit(&in.CloudInit, &out.CloudInit, s); err != nil {
@@ -1092,7 +1092,7 @@ func autoConvert_v1alpha4_AWSMachineSpec_To_v1alpha3_AWSMachineSpec(in *v1alpha4
 	out.Subnet = (*AWSResourceReference)(unsafe.Pointer(in.Subnet))
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))
 	out.RootVolume = (*Volume)(unsafe.Pointer(in.RootVolume))
-	out.NonRootVolumes = *(*[]*Volume)(unsafe.Pointer(&in.NonRootVolumes))
+	out.NonRootVolumes = *(*[]Volume)(unsafe.Pointer(&in.NonRootVolumes))
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.UncompressedUserData = (*bool)(unsafe.Pointer(in.UncompressedUserData))
 	if err := Convert_v1alpha4_CloudInit_To_v1alpha3_CloudInit(&in.CloudInit, &out.CloudInit, s); err != nil {
@@ -1421,7 +1421,7 @@ func autoConvert_v1alpha3_ClassicELB_To_v1alpha4_ClassicELB(in *ClassicELB, out 
 	out.AvailabilityZones = *(*[]string)(unsafe.Pointer(&in.AvailabilityZones))
 	out.SubnetIDs = *(*[]string)(unsafe.Pointer(&in.SubnetIDs))
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
-	out.Listeners = *(*[]*v1alpha4.ClassicELBListener)(unsafe.Pointer(&in.Listeners))
+	out.Listeners = *(*[]v1alpha4.ClassicELBListener)(unsafe.Pointer(&in.Listeners))
 	out.HealthCheck = (*v1alpha4.ClassicELBHealthCheck)(unsafe.Pointer(in.HealthCheck))
 	if err := Convert_v1alpha3_ClassicELBAttributes_To_v1alpha4_ClassicELBAttributes(&in.Attributes, &out.Attributes, s); err != nil {
 		return err
@@ -1442,7 +1442,7 @@ func autoConvert_v1alpha4_ClassicELB_To_v1alpha3_ClassicELB(in *v1alpha4.Classic
 	out.AvailabilityZones = *(*[]string)(unsafe.Pointer(&in.AvailabilityZones))
 	out.SubnetIDs = *(*[]string)(unsafe.Pointer(&in.SubnetIDs))
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
-	out.Listeners = *(*[]*ClassicELBListener)(unsafe.Pointer(&in.Listeners))
+	out.Listeners = *(*[]ClassicELBListener)(unsafe.Pointer(&in.Listeners))
 	out.HealthCheck = (*ClassicELBHealthCheck)(unsafe.Pointer(in.HealthCheck))
 	if err := Convert_v1alpha4_ClassicELBAttributes_To_v1alpha3_ClassicELBAttributes(&in.Attributes, &out.Attributes, s); err != nil {
 		return err
@@ -1626,7 +1626,7 @@ func autoConvert_v1alpha3_Instance_To_v1alpha4_Instance(in *Instance, out *v1alp
 	out.ENASupport = (*bool)(unsafe.Pointer(in.ENASupport))
 	out.EBSOptimized = (*bool)(unsafe.Pointer(in.EBSOptimized))
 	out.RootVolume = (*v1alpha4.Volume)(unsafe.Pointer(in.RootVolume))
-	out.NonRootVolumes = *(*[]*v1alpha4.Volume)(unsafe.Pointer(&in.NonRootVolumes))
+	out.NonRootVolumes = *(*[]v1alpha4.Volume)(unsafe.Pointer(&in.NonRootVolumes))
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.AvailabilityZone = in.AvailabilityZone
@@ -1656,7 +1656,7 @@ func autoConvert_v1alpha4_Instance_To_v1alpha3_Instance(in *v1alpha4.Instance, o
 	out.ENASupport = (*bool)(unsafe.Pointer(in.ENASupport))
 	out.EBSOptimized = (*bool)(unsafe.Pointer(in.EBSOptimized))
 	out.RootVolume = (*Volume)(unsafe.Pointer(in.RootVolume))
-	out.NonRootVolumes = *(*[]*Volume)(unsafe.Pointer(&in.NonRootVolumes))
+	out.NonRootVolumes = *(*[]Volume)(unsafe.Pointer(&in.NonRootVolumes))
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.AvailabilityZone = in.AvailabilityZone

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -568,14 +568,8 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 	}
 	if in.NonRootVolumes != nil {
 		in, out := &in.NonRootVolumes, &out.NonRootVolumes
-		*out = make([]*Volume, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Volume)
-				**out = **in
-			}
-		}
+		*out = make([]Volume, len(*in))
+		copy(*out, *in)
 	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
@@ -882,13 +876,7 @@ func (in CNIIngressRules) DeepCopyInto(out *CNIIngressRules) {
 	{
 		in := &in
 		*out = make(CNIIngressRules, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(CNIIngressRule)
-				**out = **in
-			}
-		}
+		copy(*out, *in)
 	}
 }
 
@@ -908,13 +896,7 @@ func (in *CNISpec) DeepCopyInto(out *CNISpec) {
 	if in.CNIIngressRules != nil {
 		in, out := &in.CNIIngressRules, &out.CNIIngressRules
 		*out = make(CNIIngressRules, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(CNIIngressRule)
-				**out = **in
-			}
-		}
+		copy(*out, *in)
 	}
 }
 
@@ -948,14 +930,8 @@ func (in *ClassicELB) DeepCopyInto(out *ClassicELB) {
 	}
 	if in.Listeners != nil {
 		in, out := &in.Listeners, &out.Listeners
-		*out = make([]*ClassicELBListener, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ClassicELBListener)
-				**out = **in
-			}
-		}
+		*out = make([]ClassicELBListener, len(*in))
+		copy(*out, *in)
 	}
 	if in.HealthCheck != nil {
 		in, out := &in.HealthCheck, &out.HealthCheck
@@ -1093,11 +1069,7 @@ func (in IngressRules) DeepCopyInto(out *IngressRules) {
 		in := &in
 		*out = make(IngressRules, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(IngressRule)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }
@@ -1162,14 +1134,8 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 	}
 	if in.NonRootVolumes != nil {
 		in, out := &in.NonRootVolumes, &out.NonRootVolumes
-		*out = make([]*Volume, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Volume)
-				**out = **in
-			}
-		}
+		*out = make([]Volume, len(*in))
+		copy(*out, *in)
 	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
@@ -1231,11 +1197,7 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 		in, out := &in.Subnets, &out.Subnets
 		*out = make(Subnets, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(SubnetSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.CNI != nil {
@@ -1284,11 +1246,7 @@ func (in *SecurityGroup) DeepCopyInto(out *SecurityGroup) {
 		in, out := &in.IngressRules, &out.IngressRules
 		*out = make(IngressRules, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(IngressRule)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Tags != nil {
@@ -1368,11 +1326,7 @@ func (in Subnets) DeepCopyInto(out *Subnets) {
 		in := &in
 		*out = make(Subnets, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(SubnetSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/api/v1alpha4/awsmachine_types.go
+++ b/api/v1alpha4/awsmachine_types.go
@@ -119,7 +119,7 @@ type AWSMachineSpec struct {
 
 	// Configuration options for the non root storage volumes.
 	// +optional
-	NonRootVolumes []*Volume `json:"nonRootVolumes,omitempty"`
+	NonRootVolumes []Volume `json:"nonRootVolumes,omitempty"`
 
 	// NetworkInterfaces is a list of ENIs to associate with the instance.
 	// A maximum of 2 may be specified.

--- a/api/v1alpha4/awsmachine_webhook_test.go
+++ b/api/v1alpha4/awsmachine_webhook_test.go
@@ -79,7 +79,7 @@ func TestAWSMachine_Create(t *testing.T) {
 			name: "ensure non root volume have device names",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
-					NonRootVolumes: []*Volume{
+					NonRootVolumes: []Volume{
 						{},
 					},
 				},
@@ -90,7 +90,7 @@ func TestAWSMachine_Create(t *testing.T) {
 			name: "ensure ensure IOPS exists if type equal to io1 for non root volumes",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
-					NonRootVolumes: []*Volume{
+					NonRootVolumes: []Volume{
 						{
 							DeviceName: "name",
 							Type:       "io1",
@@ -104,7 +104,7 @@ func TestAWSMachine_Create(t *testing.T) {
 			name: "ensure ensure IOPS exists if type equal to io2 for non root volumes",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
-					NonRootVolumes: []*Volume{
+					NonRootVolumes: []Volume{
 						{
 							DeviceName: "name",
 							Type:       "io2",

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -135,7 +135,7 @@ type ClassicELB struct {
 	SecurityGroupIDs []string `json:"securityGroupIds,omitempty"`
 
 	// Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.
-	Listeners []*ClassicELBListener `json:"listeners,omitempty"`
+	Listeners []ClassicELBListener `json:"listeners,omitempty"`
 
 	// HealthCheck is the classic elb health check associated with the load balancer.
 	HealthCheck *ClassicELBHealthCheck `json:"healthChecks,omitempty"`
@@ -289,13 +289,13 @@ func (s *SubnetSpec) String() string {
 }
 
 // Subnets is a slice of Subnet.
-type Subnets []*SubnetSpec
+type Subnets []SubnetSpec
 
 // ToMap returns a map from id to subnet.
 func (s Subnets) ToMap() map[string]*SubnetSpec {
 	res := make(map[string]*SubnetSpec)
 	for _, x := range s {
-		res[x.ID] = x
+		res[x.ID] = &x
 	}
 	return res
 }
@@ -313,7 +313,7 @@ func (s Subnets) IDs() []string {
 func (s Subnets) FindByID(id string) *SubnetSpec {
 	for _, x := range s {
 		if x.ID == id {
-			return x
+			return &x
 		}
 	}
 
@@ -326,7 +326,7 @@ func (s Subnets) FindByID(id string) *SubnetSpec {
 func (s Subnets) FindEqual(spec *SubnetSpec) *SubnetSpec {
 	for _, x := range s {
 		if (spec.ID != "" && x.ID == spec.ID) || (spec.CidrBlock == x.CidrBlock) {
-			return x
+			return &x
 		}
 	}
 	return nil
@@ -382,8 +382,8 @@ type CNISpec struct {
 	CNIIngressRules CNIIngressRules `json:"cniIngressRules,omitempty"`
 }
 
-// CNIIngressRules is a slice of CNIIngressRule.
-type CNIIngressRules []*CNIIngressRule
+// CNIIngressRules is a slice of CNIIngressRule
+type CNIIngressRules []CNIIngressRule
 
 // CNIIngressRule defines an AWS ingress rule for CNI requirements.
 type CNIIngressRule struct {
@@ -487,14 +487,14 @@ func (i *IngressRule) String() string {
 }
 
 // IngressRules is a slice of AWS ingress rules for security groups.
-type IngressRules []*IngressRule
+type IngressRules []IngressRule
 
 // Difference returns the difference between this slice and the other slice.
 func (i IngressRules) Difference(o IngressRules) (out IngressRules) {
 	for _, x := range i {
 		found := false
 		for _, y := range o {
-			if x.Equals(y) {
+			if x.Equals(&y) {
 				found = true
 				break
 			}
@@ -655,7 +655,7 @@ type Instance struct {
 
 	// Configuration options for the non root storage volumes.
 	// +optional
-	NonRootVolumes []*Volume `json:"nonRootVolumes,omitempty"`
+	NonRootVolumes []Volume `json:"nonRootVolumes,omitempty"`
 
 	// Specifies ENIs attached to instance
 	NetworkInterfaces []string `json:"networkInterfaces,omitempty"`

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -294,7 +294,8 @@ type Subnets []SubnetSpec
 // ToMap returns a map from id to subnet.
 func (s Subnets) ToMap() map[string]*SubnetSpec {
 	res := make(map[string]*SubnetSpec)
-	for _, x := range s {
+	for i := range s {
+		x := s[i]
 		res[x.ID] = &x
 	}
 	return res
@@ -491,9 +492,11 @@ type IngressRules []IngressRule
 
 // Difference returns the difference between this slice and the other slice.
 func (i IngressRules) Difference(o IngressRules) (out IngressRules) {
-	for _, x := range i {
+	for index := range i {
+		x := i[index]
 		found := false
-		for _, y := range o {
+		for oIndex := range o {
+			y := o[oIndex]
 			if x.Equals(&y) {
 				found = true
 				break

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -567,14 +567,8 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 	}
 	if in.NonRootVolumes != nil {
 		in, out := &in.NonRootVolumes, &out.NonRootVolumes
-		*out = make([]*Volume, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Volume)
-				**out = **in
-			}
-		}
+		*out = make([]Volume, len(*in))
+		copy(*out, *in)
 	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
@@ -900,13 +894,7 @@ func (in CNIIngressRules) DeepCopyInto(out *CNIIngressRules) {
 	{
 		in := &in
 		*out = make(CNIIngressRules, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(CNIIngressRule)
-				**out = **in
-			}
-		}
+		copy(*out, *in)
 	}
 }
 
@@ -926,13 +914,7 @@ func (in *CNISpec) DeepCopyInto(out *CNISpec) {
 	if in.CNIIngressRules != nil {
 		in, out := &in.CNIIngressRules, &out.CNIIngressRules
 		*out = make(CNIIngressRules, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(CNIIngressRule)
-				**out = **in
-			}
-		}
+		copy(*out, *in)
 	}
 }
 
@@ -966,14 +948,8 @@ func (in *ClassicELB) DeepCopyInto(out *ClassicELB) {
 	}
 	if in.Listeners != nil {
 		in, out := &in.Listeners, &out.Listeners
-		*out = make([]*ClassicELBListener, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ClassicELBListener)
-				**out = **in
-			}
-		}
+		*out = make([]ClassicELBListener, len(*in))
+		copy(*out, *in)
 	}
 	if in.HealthCheck != nil {
 		in, out := &in.HealthCheck, &out.HealthCheck
@@ -1111,11 +1087,7 @@ func (in IngressRules) DeepCopyInto(out *IngressRules) {
 		in := &in
 		*out = make(IngressRules, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(IngressRule)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }
@@ -1180,14 +1152,8 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 	}
 	if in.NonRootVolumes != nil {
 		in, out := &in.NonRootVolumes, &out.NonRootVolumes
-		*out = make([]*Volume, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Volume)
-				**out = **in
-			}
-		}
+		*out = make([]Volume, len(*in))
+		copy(*out, *in)
 	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
@@ -1249,11 +1215,7 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 		in, out := &in.Subnets, &out.Subnets
 		*out = make(Subnets, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(SubnetSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.CNI != nil {
@@ -1391,11 +1353,7 @@ func (in *SecurityGroup) DeepCopyInto(out *SecurityGroup) {
 		in, out := &in.IngressRules, &out.IngressRules
 		*out = make(IngressRules, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(IngressRule)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Tags != nil {
@@ -1552,11 +1510,7 @@ func (in Subnets) DeepCopyInto(out *Subnets) {
 		in := &in
 		*out = make(Subnets, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(SubnetSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
@@ -225,7 +225,7 @@ type AWSManagedControlPlaneStatus struct {
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 	// Addons holds the current status of the EKS addons
 	// +optional
-	Addons []*AddonState `json:"addons,omitempty"`
+	Addons []AddonState `json:"addons,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/controlplane/eks/api/v1alpha3/types.go
+++ b/controlplane/eks/api/v1alpha3/types.go
@@ -196,7 +196,7 @@ type AddonState struct {
 	// Status is the status of the addon
 	Status *string `json:"status,omitempty"`
 	// Issues is a list of issue associated with the addon
-	Issues []*AddonIssue `json:"issues,omitempty"`
+	Issues []AddonIssue `json:"issues,omitempty"`
 }
 
 // AddonIssue represents an issue with an addon
@@ -206,7 +206,7 @@ type AddonIssue struct {
 	// Message is the textual description of the issue
 	Message *string `json:"message,omitempty"`
 	// ResourceIDs is a list of resource ids for the issue
-	ResourceIDs []*string `json:"resourceIds,omitempty"`
+	ResourceIDs []string `json:"resourceIds,omitempty"`
 }
 
 const (

--- a/controlplane/eks/api/v1alpha3/zz_generated.conversion.go
+++ b/controlplane/eks/api/v1alpha3/zz_generated.conversion.go
@@ -400,7 +400,7 @@ func autoConvert_v1alpha3_AWSManagedControlPlaneStatus_To_v1alpha4_AWSManagedCon
 	out.Ready = in.Ready
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*apiv1alpha4.Conditions)(unsafe.Pointer(&in.Conditions))
-	out.Addons = *(*[]*v1alpha4.AddonState)(unsafe.Pointer(&in.Addons))
+	out.Addons = *(*[]v1alpha4.AddonState)(unsafe.Pointer(&in.Addons))
 	return nil
 }
 
@@ -423,7 +423,7 @@ func autoConvert_v1alpha4_AWSManagedControlPlaneStatus_To_v1alpha3_AWSManagedCon
 	out.Ready = in.Ready
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*apiv1alpha3.Conditions)(unsafe.Pointer(&in.Conditions))
-	out.Addons = *(*[]*AddonState)(unsafe.Pointer(&in.Addons))
+	out.Addons = *(*[]AddonState)(unsafe.Pointer(&in.Addons))
 	return nil
 }
 
@@ -461,7 +461,7 @@ func Convert_v1alpha4_Addon_To_v1alpha3_Addon(in *v1alpha4.Addon, out *Addon, s 
 func autoConvert_v1alpha3_AddonIssue_To_v1alpha4_AddonIssue(in *AddonIssue, out *v1alpha4.AddonIssue, s conversion.Scope) error {
 	out.Code = (*string)(unsafe.Pointer(in.Code))
 	out.Message = (*string)(unsafe.Pointer(in.Message))
-	out.ResourceIDs = *(*[]*string)(unsafe.Pointer(&in.ResourceIDs))
+	out.ResourceIDs = *(*[]string)(unsafe.Pointer(&in.ResourceIDs))
 	return nil
 }
 
@@ -473,7 +473,7 @@ func Convert_v1alpha3_AddonIssue_To_v1alpha4_AddonIssue(in *AddonIssue, out *v1a
 func autoConvert_v1alpha4_AddonIssue_To_v1alpha3_AddonIssue(in *v1alpha4.AddonIssue, out *AddonIssue, s conversion.Scope) error {
 	out.Code = (*string)(unsafe.Pointer(in.Code))
 	out.Message = (*string)(unsafe.Pointer(in.Message))
-	out.ResourceIDs = *(*[]*string)(unsafe.Pointer(&in.ResourceIDs))
+	out.ResourceIDs = *(*[]string)(unsafe.Pointer(&in.ResourceIDs))
 	return nil
 }
 
@@ -490,7 +490,7 @@ func autoConvert_v1alpha3_AddonState_To_v1alpha4_AddonState(in *AddonState, out 
 	out.CreatedAt = in.CreatedAt
 	out.ModifiedAt = in.ModifiedAt
 	out.Status = (*string)(unsafe.Pointer(in.Status))
-	out.Issues = *(*[]*v1alpha4.AddonIssue)(unsafe.Pointer(&in.Issues))
+	out.Issues = *(*[]v1alpha4.AddonIssue)(unsafe.Pointer(&in.Issues))
 	return nil
 }
 
@@ -507,7 +507,7 @@ func autoConvert_v1alpha4_AddonState_To_v1alpha3_AddonState(in *v1alpha4.AddonSt
 	out.CreatedAt = in.CreatedAt
 	out.ModifiedAt = in.ModifiedAt
 	out.Status = (*string)(unsafe.Pointer(in.Status))
-	out.Issues = *(*[]*AddonIssue)(unsafe.Pointer(&in.Issues))
+	out.Issues = *(*[]AddonIssue)(unsafe.Pointer(&in.Issues))
 	return nil
 }
 

--- a/controlplane/eks/api/v1alpha3/zz_generated.deepcopy.go
+++ b/controlplane/eks/api/v1alpha3/zz_generated.deepcopy.go
@@ -212,13 +212,9 @@ func (in *AWSManagedControlPlaneStatus) DeepCopyInto(out *AWSManagedControlPlane
 	}
 	if in.Addons != nil {
 		in, out := &in.Addons, &out.Addons
-		*out = make([]*AddonState, len(*in))
+		*out = make([]AddonState, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(AddonState)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }
@@ -273,14 +269,8 @@ func (in *AddonIssue) DeepCopyInto(out *AddonIssue) {
 	}
 	if in.ResourceIDs != nil {
 		in, out := &in.ResourceIDs, &out.ResourceIDs
-		*out = make([]*string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 
@@ -311,13 +301,9 @@ func (in *AddonState) DeepCopyInto(out *AddonState) {
 	}
 	if in.Issues != nil {
 		in, out := &in.Issues, &out.Issues
-		*out = make([]*AddonIssue, len(*in))
+		*out = make([]AddonIssue, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(AddonIssue)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_types.go
@@ -225,7 +225,7 @@ type AWSManagedControlPlaneStatus struct {
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 	// Addons holds the current status of the EKS addons
 	// +optional
-	Addons []*AddonState `json:"addons,omitempty"`
+	Addons []AddonState `json:"addons,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook_test.go
@@ -51,7 +51,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	defaultNetworkSpec := infrav1.NetworkSpec{
 		VPC: defaultVPCSpec,
 		CNI: &infrav1.CNISpec{
-			CNIIngressRules: []*infrav1.CNIIngressRule{
+			CNIIngressRules: []infrav1.CNIIngressRule{
 				{
 					Description: "bgp (calico)",
 					Protocol:    "tcp",

--- a/controlplane/eks/api/v1alpha4/types.go
+++ b/controlplane/eks/api/v1alpha4/types.go
@@ -196,7 +196,7 @@ type AddonState struct {
 	// Status is the status of the addon
 	Status *string `json:"status,omitempty"`
 	// Issues is a list of issue associated with the addon
-	Issues []*AddonIssue `json:"issues,omitempty"`
+	Issues []AddonIssue `json:"issues,omitempty"`
 }
 
 // AddonIssue represents an issue with an addon
@@ -206,7 +206,7 @@ type AddonIssue struct {
 	// Message is the textual description of the issue
 	Message *string `json:"message,omitempty"`
 	// ResourceIDs is a list of resource ids for the issue
-	ResourceIDs []*string `json:"resourceIds,omitempty"`
+	ResourceIDs []string `json:"resourceIds,omitempty"`
 }
 
 const (

--- a/controlplane/eks/api/v1alpha4/zz_generated.deepcopy.go
+++ b/controlplane/eks/api/v1alpha4/zz_generated.deepcopy.go
@@ -212,13 +212,9 @@ func (in *AWSManagedControlPlaneStatus) DeepCopyInto(out *AWSManagedControlPlane
 	}
 	if in.Addons != nil {
 		in, out := &in.Addons, &out.Addons
-		*out = make([]*AddonState, len(*in))
+		*out = make([]AddonState, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(AddonState)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }
@@ -273,14 +269,8 @@ func (in *AddonIssue) DeepCopyInto(out *AddonIssue) {
 	}
 	if in.ResourceIDs != nil {
 		in, out := &in.ResourceIDs, &out.ResourceIDs
-		*out = make([]*string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 
@@ -311,13 +301,9 @@ func (in *AddonState) DeepCopyInto(out *AddonState) {
 	}
 	if in.Issues != nil {
 		in, out := &in.Issues, &out.Issues
-		*out = make([]*AddonIssue, len(*in))
+		*out = make([]AddonIssue, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(AddonIssue)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/docs/book/src/SUMMARY_SUFFIX.md
+++ b/docs/book/src/SUMMARY_SUFFIX.md
@@ -1,5 +1,6 @@
 - [Developer Guide](./development/development.md)
   - [Development with Tilt](./development/tilt-setup.md)
+  - [Coding Conventions](./development/conventions.md)
 - [CRD Reference](./crd/index.md)
   - [Cluster API Provider AWS](./crd/cluster-api-aws.md)
   - [EKS Control Plane](./crd/eks-control-plane.md)-

--- a/docs/book/src/development/conventions.md
+++ b/docs/book/src/development/conventions.md
@@ -1,0 +1,38 @@
+# Coding Conventions
+
+Below is a collection of conventions, guidlines and general tips for writing code for this project. 
+
+## API Definitions
+
+### Don't Expose 3rd Party Package Types
+
+When adding new or modifying API types don't expose 3rd party package types/enums via the CAPA API definitions. Instead create our own versions and where provide mapping functions. 
+
+For example:
+
+    - AWS SDK [InstaneState](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/)
+    - CAPA [InstanceState](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/api/v1alpha4/types.go#L560:L581)
+
+### Don't use struct pointer slices
+
+When adding new fields to an API type don't use a slice of struct pointers. This can cause issues with the code generator for the conversion functions. Instead use struct slices. 
+
+For example: 
+
+Instead of this
+
+```go
+	// Configuration options for the non root storage volumes.
+	// +optional
+	NonRootVolumes []*Volume `json:"nonRootVolumes,omitempty"`
+```
+
+use
+
+```go
+	// Configuration options for the non root storage volumes.
+	// +optional
+	NonRootVolumes []Volume `json:"nonRootVolumes,omitempty"`
+```
+
+And then within the code you can check the length or range over the slice.

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -123,7 +123,7 @@ type AWSMachinePoolStatus struct {
 
 	// Instances contains the status for each instance in the pool
 	// +optional
-	Instances []*AWSMachinePoolInstanceStatus `json:"instances"`
+	Instances []AWSMachinePoolInstanceStatus `json:"instances,omitempty"`
 
 	// The ID of the launch template
 	LaunchTemplateID string `json:"launchTemplateID,omitempty"`

--- a/exp/api/v1alpha3/zz_generated.conversion.go
+++ b/exp/api/v1alpha3/zz_generated.conversion.go
@@ -627,7 +627,7 @@ func autoConvert_v1alpha3_AWSMachinePoolStatus_To_v1alpha4_AWSMachinePoolStatus(
 	out.Ready = in.Ready
 	out.Replicas = in.Replicas
 	out.Conditions = *(*apiv1alpha4.Conditions)(unsafe.Pointer(&in.Conditions))
-	out.Instances = *(*[]*v1alpha4.AWSMachinePoolInstanceStatus)(unsafe.Pointer(&in.Instances))
+	out.Instances = *(*[]v1alpha4.AWSMachinePoolInstanceStatus)(unsafe.Pointer(&in.Instances))
 	out.LaunchTemplateID = in.LaunchTemplateID
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
@@ -644,7 +644,7 @@ func autoConvert_v1alpha4_AWSMachinePoolStatus_To_v1alpha3_AWSMachinePoolStatus(
 	out.Ready = in.Ready
 	out.Replicas = in.Replicas
 	out.Conditions = *(*apiv1alpha3.Conditions)(unsafe.Pointer(&in.Conditions))
-	out.Instances = *(*[]*AWSMachinePoolInstanceStatus)(unsafe.Pointer(&in.Instances))
+	out.Instances = *(*[]AWSMachinePoolInstanceStatus)(unsafe.Pointer(&in.Instances))
 	out.LaunchTemplateID = in.LaunchTemplateID
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))

--- a/exp/api/v1alpha3/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha3/zz_generated.deepcopy.go
@@ -266,13 +266,9 @@ func (in *AWSMachinePoolStatus) DeepCopyInto(out *AWSMachinePoolStatus) {
 	}
 	if in.Instances != nil {
 		in, out := &in.Instances, &out.Instances
-		*out = make([]*AWSMachinePoolInstanceStatus, len(*in))
+		*out = make([]AWSMachinePoolInstanceStatus, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(AWSMachinePoolInstanceStatus)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.FailureReason != nil {

--- a/exp/api/v1alpha4/awsmachinepool_types.go
+++ b/exp/api/v1alpha4/awsmachinepool_types.go
@@ -123,7 +123,7 @@ type AWSMachinePoolStatus struct {
 
 	// Instances contains the status for each instance in the pool
 	// +optional
-	Instances []*AWSMachinePoolInstanceStatus `json:"instances"`
+	Instances []AWSMachinePoolInstanceStatus `json:"instances,omitempty"`
 
 	// The ID of the launch template
 	LaunchTemplateID string `json:"launchTemplateID,omitempty"`

--- a/exp/api/v1alpha4/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha4/zz_generated.deepcopy.go
@@ -266,13 +266,9 @@ func (in *AWSMachinePoolStatus) DeepCopyInto(out *AWSMachinePoolStatus) {
 	}
 	if in.Instances != nil {
 		in, out := &in.Instances, &out.Instances
-		*out = make([]*AWSMachinePoolInstanceStatus, len(*in))
+		*out = make([]AWSMachinePoolInstanceStatus, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(AWSMachinePoolInstanceStatus)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.FailureReason != nil {

--- a/pkg/cloud/converters/eks.go
+++ b/pkg/cloud/converters/eks.go
@@ -59,7 +59,7 @@ func AddonSDKToAddonState(eksAddon *eks.Addon) *ekscontrolplanev1.AddonState {
 	return addonState
 }
 
-// FromAWSStringSlice will converts an AWS string pointer slice
+// FromAWSStringSlice will converts an AWS string pointer slice.
 func FromAWSStringSlice(from []*string) []string {
 	converted := []string{}
 	for _, s := range from {

--- a/pkg/cloud/converters/eks.go
+++ b/pkg/cloud/converters/eks.go
@@ -44,19 +44,29 @@ func AddonSDKToAddonState(eksAddon *eks.Addon) *ekscontrolplanev1.AddonState {
 		ModifiedAt:            metav1.NewTime(*eksAddon.ModifiedAt),
 		Status:                eksAddon.Status,
 		ServiceAccountRoleArn: eksAddon.ServiceAccountRoleArn,
-		Issues:                []*ekscontrolplanev1.AddonIssue{},
+		Issues:                []ekscontrolplanev1.AddonIssue{},
 	}
 	if eksAddon.Health != nil {
 		for _, issue := range eksAddon.Health.Issues {
-			addonState.Issues = append(addonState.Issues, &ekscontrolplanev1.AddonIssue{
+			addonState.Issues = append(addonState.Issues, ekscontrolplanev1.AddonIssue{
 				Code:        issue.Code,
 				Message:     issue.Message,
-				ResourceIDs: issue.ResourceIds,
+				ResourceIDs: FromAWSStringSlice(issue.ResourceIds),
 			})
 		}
 	}
 
 	return addonState
+}
+
+// FromAWSStringSlice will converts an AWS string pointer slice
+func FromAWSStringSlice(from []*string) []string {
+	converted := []string{}
+	for _, s := range from {
+		converted = append(converted, *s)
+	}
+
+	return converted
 }
 
 // TaintToSDK is used to a CAPA Taint to AWS SDK taint.

--- a/pkg/cloud/scope/fargate.go
+++ b/pkg/cloud/scope/fargate.go
@@ -148,8 +148,8 @@ func (s *FargateProfileScope) RoleName() string {
 }
 
 // ControlPlaneSubnets returns the control plane subnets.
-func (s *FargateProfileScope) ControlPlaneSubnets() infrav1.Subnets {
-	return s.ControlPlane.Spec.NetworkSpec.Subnets
+func (s *FargateProfileScope) ControlPlaneSubnets() *infrav1.Subnets {
+	return &s.ControlPlane.Spec.NetworkSpec.Subnets
 }
 
 // SubnetIDs returns the machine pool subnet IDs.

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -259,9 +259,9 @@ func (m *MachinePoolScope) UpdateInstanceStatuses(ctx context.Context, instances
 	}
 
 	var readyReplicas int32
-	instanceStatuses := make([]*expinfrav1.AWSMachinePoolInstanceStatus, len(instances))
+	instanceStatuses := make([]expinfrav1.AWSMachinePoolInstanceStatus, len(instances))
 	for i, instance := range instances {
-		instanceStatuses[i] = &expinfrav1.AWSMachinePoolInstanceStatus{
+		instanceStatuses[i] = expinfrav1.AWSMachinePoolInstanceStatus{
 			InstanceID: instance.ID,
 		}
 

--- a/pkg/cloud/scope/shared_test.go
+++ b/pkg/cloud/scope/shared_test.go
@@ -44,15 +44,15 @@ func TestSubnetPlacement(t *testing.T) {
 			specAZs:       []string{"eu-west-1b"},
 			parentAZs:     []string{"eu-west-1c"},
 			controlPlaneSubnets: infrav1.Subnets{
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az1",
 					AvailabilityZone: "eu-west-1a",
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az3",
 					AvailabilityZone: "eu-west-1c",
 				},
@@ -67,15 +67,15 @@ func TestSubnetPlacement(t *testing.T) {
 			specAZs:       []string{"eu-west-1b"},
 			parentAZs:     []string{"eu-west-1c"},
 			controlPlaneSubnets: infrav1.Subnets{
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az1",
 					AvailabilityZone: "eu-west-1a",
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az3",
 					AvailabilityZone: "eu-west-1c",
 				},
@@ -90,15 +90,15 @@ func TestSubnetPlacement(t *testing.T) {
 			specAZs:       []string{},
 			parentAZs:     []string{"eu-west-1c"},
 			controlPlaneSubnets: infrav1.Subnets{
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az1",
 					AvailabilityZone: "eu-west-1a",
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az3",
 					AvailabilityZone: "eu-west-1c",
 				},
@@ -113,17 +113,17 @@ func TestSubnetPlacement(t *testing.T) {
 			specAZs:       []string{},
 			parentAZs:     []string{},
 			controlPlaneSubnets: infrav1.Subnets{
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az1",
 					AvailabilityZone: "eu-west-1a",
 					IsPublic:         false,
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
 					IsPublic:         false,
 				},
-				&infrav1.SubnetSpec{
+				infrav1.SubnetSpec{
 					ID:               "az3",
 					AvailabilityZone: "eu-west-1c",
 					IsPublic:         true,

--- a/pkg/cloud/services/awsnode/subnets.go
+++ b/pkg/cloud/services/awsnode/subnets.go
@@ -22,7 +22,7 @@ func (s *Service) secondarySubnets() []*v1alpha4.SubnetSpec {
 	subnets := []*v1alpha4.SubnetSpec{}
 	for _, sub := range s.scope.Subnets() {
 		if val, ok := sub.Tags[v1alpha4.NameAWSSubnetAssociation]; ok && val == v1alpha4.SecondarySubnetTagValue {
-			subnets = append(subnets, sub)
+			subnets = append(subnets, &sub)
 		}
 	}
 	return subnets

--- a/pkg/cloud/services/awsnode/subnets.go
+++ b/pkg/cloud/services/awsnode/subnets.go
@@ -21,8 +21,9 @@ import "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
 func (s *Service) secondarySubnets() []*v1alpha4.SubnetSpec {
 	subnets := []*v1alpha4.SubnetSpec{}
 	for _, sub := range s.scope.Subnets() {
-		if val, ok := sub.Tags[v1alpha4.NameAWSSubnetAssociation]; ok && val == v1alpha4.SecondarySubnetTagValue {
-			subnets = append(subnets, &sub)
+		subnet := sub.DeepCopy()
+		if val, ok := subnet.Tags[v1alpha4.NameAWSSubnetAssociation]; ok && val == v1alpha4.SecondarySubnetTagValue {
+			subnets = append(subnets, subnet)
 		}
 	}
 	return subnets

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -527,36 +527,34 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 		})
 	}
 
-	if i.NonRootVolumes != nil {
-		for _, nonRootVolume := range i.NonRootVolumes {
-			if nonRootVolume.DeviceName == "" {
-				return nil, errors.Errorf("non root volume should have device name specified")
-			}
-
-			ebsDevice := &ec2.EbsBlockDevice{
-				DeleteOnTermination: aws.Bool(true),
-				VolumeSize:          aws.Int64(nonRootVolume.Size),
-				Encrypted:           aws.Bool(nonRootVolume.Encrypted),
-			}
-
-			if nonRootVolume.IOPS != 0 {
-				ebsDevice.Iops = aws.Int64(nonRootVolume.IOPS)
-			}
-
-			if nonRootVolume.EncryptionKey != "" {
-				ebsDevice.Encrypted = aws.Bool(true)
-				ebsDevice.KmsKeyId = aws.String(nonRootVolume.EncryptionKey)
-			}
-
-			if nonRootVolume.Type != "" {
-				ebsDevice.VolumeType = aws.String(nonRootVolume.Type)
-			}
-
-			blockdeviceMappings = append(blockdeviceMappings, &ec2.BlockDeviceMapping{
-				DeviceName: &nonRootVolume.DeviceName,
-				Ebs:        ebsDevice,
-			})
+	for _, nonRootVolume := range i.NonRootVolumes {
+		if nonRootVolume.DeviceName == "" {
+			return nil, errors.Errorf("non root volume should have device name specified")
 		}
+
+		ebsDevice := &ec2.EbsBlockDevice{
+			DeleteOnTermination: aws.Bool(true),
+			VolumeSize:          aws.Int64(nonRootVolume.Size),
+			Encrypted:           aws.Bool(nonRootVolume.Encrypted),
+		}
+
+		if nonRootVolume.IOPS != 0 {
+			ebsDevice.Iops = aws.Int64(nonRootVolume.IOPS)
+		}
+
+		if nonRootVolume.EncryptionKey != "" {
+			ebsDevice.Encrypted = aws.Bool(true)
+			ebsDevice.KmsKeyId = aws.String(nonRootVolume.EncryptionKey)
+		}
+
+		if nonRootVolume.Type != "" {
+			ebsDevice.VolumeType = aws.String(nonRootVolume.Type)
+		}
+
+		blockdeviceMappings = append(blockdeviceMappings, &ec2.BlockDeviceMapping{
+			DeviceName: &nonRootVolume.DeviceName,
+			Ebs:        ebsDevice,
+		})
 	}
 
 	if len(blockdeviceMappings) != 0 {

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -527,7 +527,9 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 		})
 	}
 
-	for _, nonRootVolume := range i.NonRootVolumes {
+	for vi := range i.NonRootVolumes {
+		nonRootVolume := i.NonRootVolumes[vi]
+
 		if nonRootVolume.DeviceName == "" {
 			return nil, errors.Errorf("non root volume should have device name specified")
 		}

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -321,11 +321,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -414,22 +414,22 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:               "subnet-1",
 								AvailabilityZone: "us-east-1a",
 								IsPublic:         false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:               "subnet-2",
 								AvailabilityZone: "us-east-1b",
 								IsPublic:         false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:               "subnet-3",
 								AvailabilityZone: "us-east-1c",
 								IsPublic:         false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:               "subnet-3-public",
 								AvailabilityZone: "us-east-1c",
 								IsPublic:         true,
@@ -523,11 +523,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -652,11 +652,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -783,11 +783,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1083,7 +1083,7 @@ func TestCreateInstance(t *testing.T) {
 					ID: aws.String("abc"),
 				},
 				InstanceType: "m5.large",
-				NonRootVolumes: []*infrav1.Volume{{
+				NonRootVolumes: []infrav1.Volume{{
 					DeviceName: "device-2",
 					Size:       8,
 				}},
@@ -1093,11 +1093,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1194,11 +1194,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1324,11 +1324,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1432,11 +1432,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1542,11 +1542,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1652,11 +1652,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1759,11 +1759,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},
@@ -1866,11 +1866,11 @@ func TestCreateInstance(t *testing.T) {
 				Spec: infrav1.AWSClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								ID:       "subnet-1",
 								IsPublic: false,
 							},
-							&infrav1.SubnetSpec{
+							infrav1.SubnetSpec{
 								IsPublic: false,
 							},
 						},

--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -139,10 +139,10 @@ func (s *Service) getClusterAddonsInstalled(eksClusterName string, addonNames []
 	return addonsInstalled, nil
 }
 
-func (s *Service) getInstalledState(eksClusterName string, addonNames []*string) ([]*ekscontrolplanev1.AddonState, error) {
+func (s *Service) getInstalledState(eksClusterName string, addonNames []*string) ([]ekscontrolplanev1.AddonState, error) {
 	s.V(2).Info("getting eks addons installed to create state")
 
-	addonState := []*ekscontrolplanev1.AddonState{}
+	addonState := []ekscontrolplanev1.AddonState{}
 	if len(addonNames) == 0 {
 		s.scope.Info("no eks addons installed in cluster", "cluster", eksClusterName)
 		return addonState, nil
@@ -164,7 +164,7 @@ func (s *Service) getInstalledState(eksClusterName string, addonNames []*string)
 		s.scope.V(2).Info("describe output", "output", describeOutput.Addon)
 
 		installedAddonState := converters.AddonSDKToAddonState(describeOutput.Addon)
-		addonState = append(addonState, installedAddonState)
+		addonState = append(addonState, *installedAddonState)
 	}
 
 	return addonState, nil

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -237,7 +237,8 @@ func makeVpcConfig(subnets infrav1.Subnets, endpointAccess controlplanev1.Endpoi
 	}
 
 	subnetIds := make([]*string, 0)
-	for _, subnet := range subnets {
+	for i := range subnets {
+		subnet := subnets[i]
 		subnetIds = append(subnetIds, &subnet.ID)
 	}
 

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -156,7 +156,7 @@ func TestMakeVPCConfig(t *testing.T) {
 		{
 			name: "enough subnets",
 			input: input{
-				subnets: []*infrav1.SubnetSpec{
+				subnets: []infrav1.SubnetSpec{
 					{
 						ID:               idOne,
 						CidrBlock:        "10.0.10.0/24",
@@ -179,7 +179,7 @@ func TestMakeVPCConfig(t *testing.T) {
 		{
 			name: "security groups",
 			input: input{
-				subnets: []*infrav1.SubnetSpec{
+				subnets: []infrav1.SubnetSpec{
 					{
 						ID:               idOne,
 						CidrBlock:        "10.0.10.0/24",
@@ -208,7 +208,7 @@ func TestMakeVPCConfig(t *testing.T) {
 		{
 			name: "non canonical public access CIDR",
 			input: input{
-				subnets: []*infrav1.SubnetSpec{
+				subnets: []infrav1.SubnetSpec{
 					{
 						ID:               idOne,
 						CidrBlock:        "10.0.10.0/24",

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -319,7 +319,7 @@ func (s *Service) getAPIServerClassicELBSpec() (*infrav1.ClassicELB, error) {
 	res := &infrav1.ClassicELB{
 		Name:   elbName,
 		Scheme: s.scope.ControlPlaneLoadBalancerScheme(),
-		Listeners: []*infrav1.ClassicELBListener{
+		Listeners: []infrav1.ClassicELBListener{
 			{
 				Protocol:         infrav1.ClassicELBProtocolTCP,
 				Port:             int64(s.scope.APIServerPort()),

--- a/pkg/cloud/services/network/natgateways_test.go
+++ b/pkg/cloud/services/network/natgateways_test.go
@@ -42,12 +42,12 @@ func TestReconcileNatGateways(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		input  []*infrav1.SubnetSpec
+		input  []infrav1.SubnetSpec
 		expect func(m *mock_ec2iface.MockEC2APIMockRecorder)
 	}{
 		{
 			name: "single private subnet exists, should create no NAT gateway",
-			input: []*infrav1.SubnetSpec{
+			input: []infrav1.SubnetSpec{
 				{
 					ID:               "subnet-1",
 					AvailabilityZone: "us-east-1a",
@@ -61,7 +61,7 @@ func TestReconcileNatGateways(t *testing.T) {
 		},
 		{
 			name: "no private subnet exists, should create no NAT gateway",
-			input: []*infrav1.SubnetSpec{
+			input: []infrav1.SubnetSpec{
 				{
 					ID:               "subnet-1",
 					AvailabilityZone: "us-east-1a",
@@ -76,7 +76,7 @@ func TestReconcileNatGateways(t *testing.T) {
 		},
 		{
 			name: "public & private subnet exists, should create 1 NAT gateway",
-			input: []*infrav1.SubnetSpec{
+			input: []infrav1.SubnetSpec{
 				{
 					ID:               "subnet-1",
 					AvailabilityZone: "us-east-1a",
@@ -154,7 +154,7 @@ func TestReconcileNatGateways(t *testing.T) {
 		},
 		{
 			name: "two public & 1 private subnet, and one NAT gateway exists",
-			input: []*infrav1.SubnetSpec{
+			input: []infrav1.SubnetSpec{
 				{
 					ID:               "subnet-1",
 					AvailabilityZone: "us-east-1a",
@@ -243,7 +243,7 @@ func TestReconcileNatGateways(t *testing.T) {
 		},
 		{
 			name: "public & private subnet, and one NAT gateway exists",
-			input: []*infrav1.SubnetSpec{
+			input: []infrav1.SubnetSpec{
 				{
 					ID:               "subnet-1",
 					AvailabilityZone: "us-east-1a",
@@ -300,7 +300,7 @@ func TestReconcileNatGateways(t *testing.T) {
 		},
 		{
 			name: "public & private subnet declared, but don't exist yet",
-			input: []*infrav1.SubnetSpec{
+			input: []infrav1.SubnetSpec{
 				{
 					ID:               "",
 					AvailabilityZone: "us-east-1a",

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -50,17 +50,16 @@ func (s *Service) reconcileRouteTables() error {
 		return err
 	}
 
-	for i := range s.scope.Subnets() {
+	for _, sn := range s.scope.Subnets() {
 		// We need to compile the minimum routes for this subnet first, so we can compare it or create them.
 		var routes []*ec2.Route
-		sn := s.scope.Subnets()[i]
 		if sn.IsPublic {
 			if s.scope.VPC().InternetGatewayID == nil {
 				return errors.Errorf("failed to create routing tables: internet gateway for %q is nil", s.scope.VPC().ID)
 			}
 			routes = append(routes, s.getGatewayPublicRoute())
 		} else {
-			natGatewayID, err := s.getNatGatewayForSubnet(sn)
+			natGatewayID, err := s.getNatGatewayForSubnet(&sn)
 			if err != nil {
 				return err
 			}

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -50,7 +50,9 @@ func (s *Service) reconcileRouteTables() error {
 		return err
 	}
 
-	for _, sn := range s.scope.Subnets() {
+	subnets := s.scope.Subnets()
+	for i := range subnets {
+		sn := subnets[i]
 		// We need to compile the minimum routes for this subnet first, so we can compare it or create them.
 		var routes []*ec2.Route
 		if sn.IsPublic {

--- a/pkg/cloud/services/network/routetables_test.go
+++ b/pkg/cloud/services/network/routetables_test.go
@@ -56,12 +56,12 @@ func TestReconcileRouteTables(t *testing.T) {
 					},
 				},
 				Subnets: infrav1.Subnets{
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-routetables-private",
 						IsPublic:         false,
 						AvailabilityZone: "us-east-1a",
 					},
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-routetables-public",
 						IsPublic:         true,
 						NatGatewayID:     aws.String("nat-01"),
@@ -119,12 +119,12 @@ func TestReconcileRouteTables(t *testing.T) {
 					},
 				},
 				Subnets: infrav1.Subnets{
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-routetables-private",
 						IsPublic:         false,
 						AvailabilityZone: "us-east-1a",
 					},
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-routetables-public",
 						IsPublic:         true,
 						NatGatewayID:     aws.String("nat-01"),
@@ -149,12 +149,12 @@ func TestReconcileRouteTables(t *testing.T) {
 					},
 				},
 				Subnets: infrav1.Subnets{
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-routetables-private",
 						IsPublic:         false,
 						AvailabilityZone: "us-east-1a",
 					},
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-routetables-public",
 						IsPublic:         true,
 						NatGatewayID:     aws.String("nat-01"),

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -157,7 +157,8 @@ func (s *Service) reconcileSubnets() error {
 
 	// Proceed to create the rest of the subnets that don't have an ID.
 	if !unmanagedVPC {
-		for _, subnet := range subnets {
+		for i := range subnets {
+			subnet := subnets[i]
 			if subnet.ID != "" {
 				continue
 			}

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -51,7 +51,7 @@ func TestReconcileSubnets(t *testing.T) {
 				VPC: infrav1.VPCSpec{
 					ID: subnetsVPCID,
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						ID: "subnet-1",
 					},
@@ -134,7 +134,7 @@ func TestReconcileSubnets(t *testing.T) {
 				VPC: infrav1.VPCSpec{
 					ID: subnetsVPCID,
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						ID: "subnet-1",
 					},
@@ -201,7 +201,7 @@ func TestReconcileSubnets(t *testing.T) {
 				VPC: infrav1.VPCSpec{
 					ID: subnetsVPCID,
 				},
-				Subnets: []*infrav1.SubnetSpec{},
+				Subnets: []infrav1.SubnetSpec{},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
 				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
@@ -261,7 +261,7 @@ func TestReconcileSubnets(t *testing.T) {
 				VPC: infrav1.VPCSpec{
 					ID: subnetsVPCID,
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						AvailabilityZone: "us-east-1a",
 						CidrBlock:        "10.1.0.0/16",
@@ -315,7 +315,7 @@ func TestReconcileSubnets(t *testing.T) {
 				VPC: infrav1.VPCSpec{
 					ID: subnetsVPCID,
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						AvailabilityZone: "us-east-1a",
 						CidrBlock:        "10.0.10.0/24",
@@ -389,7 +389,7 @@ func TestReconcileSubnets(t *testing.T) {
 						infrav1.ClusterTagKey("test-cluster"): "owned",
 					},
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						AvailabilityZone: "us-east-1a",
 						CidrBlock:        "10.1.0.0/16",
@@ -546,7 +546,7 @@ func TestReconcileSubnets(t *testing.T) {
 						infrav1.ClusterTagKey("test-cluster"): "owned",
 					},
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						AvailabilityZone: "us-east-1a",
 						CidrBlock:        "10.1.0.0/16",
@@ -599,7 +599,7 @@ func TestReconcileSubnets(t *testing.T) {
 					},
 					CidrBlock: defaultVPCCidr,
 				},
-				Subnets: []*infrav1.SubnetSpec{},
+				Subnets: []infrav1.SubnetSpec{},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
 				m.DescribeAvailabilityZones(gomock.Any()).
@@ -755,7 +755,7 @@ func TestReconcileSubnets(t *testing.T) {
 					},
 					CidrBlock: defaultVPCCidr,
 				},
-				Subnets: []*infrav1.SubnetSpec{},
+				Subnets: []infrav1.SubnetSpec{},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
 				m.DescribeAvailabilityZones(gomock.Any()).
@@ -1019,7 +1019,7 @@ func TestReconcileSubnets(t *testing.T) {
 					AvailabilityZoneUsageLimit: aws.Int(1),
 					AvailabilityZoneSelection:  &infrav1.AZSelectionSchemeOrdered,
 				},
-				Subnets: []*infrav1.SubnetSpec{},
+				Subnets: []infrav1.SubnetSpec{},
 			},
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
 				m.DescribeAvailabilityZones(gomock.Any()).
@@ -1177,7 +1177,7 @@ func TestReconcileSubnets(t *testing.T) {
 						infrav1.ClusterTagKey("test-cluster"): "owned",
 					},
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						ID:               "subnet-1",
 						AvailabilityZone: "us-east-1a",
@@ -1347,7 +1347,7 @@ func TestDiscoverSubnets(t *testing.T) {
 		name   string
 		input  *infrav1.NetworkSpec
 		mocks  func(m *mock_ec2iface.MockEC2APIMockRecorder)
-		expect []*infrav1.SubnetSpec
+		expect []infrav1.SubnetSpec
 	}{
 		{
 			name: "provided VPC finds internet routes",
@@ -1355,7 +1355,7 @@ func TestDiscoverSubnets(t *testing.T) {
 				VPC: infrav1.VPCSpec{
 					ID: subnetsVPCID,
 				},
-				Subnets: []*infrav1.SubnetSpec{
+				Subnets: []infrav1.SubnetSpec{
 					{
 						ID:               "subnet-1",
 						AvailabilityZone: "us-east-1a",
@@ -1465,7 +1465,7 @@ func TestDiscoverSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 			},
-			expect: []*infrav1.SubnetSpec{
+			expect: []infrav1.SubnetSpec{
 				{
 					ID:               "subnet-1",
 					AvailabilityZone: "us-east-1a",
@@ -1524,7 +1524,7 @@ func TestDiscoverSubnets(t *testing.T) {
 			}
 
 			subnets := s.scope.Subnets()
-			out := make(map[string]*infrav1.SubnetSpec)
+			out := make(map[string]infrav1.SubnetSpec)
 			for _, sn := range subnets {
 				out[sn.ID] = sn
 			}

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -423,7 +423,8 @@ func (s *Service) createSecurityGroup(role infrav1.SecurityGroupRole, input *ec2
 
 func (s *Service) authorizeSecurityGroupIngressRules(id string, rules infrav1.IngressRules) error {
 	input := &ec2.AuthorizeSecurityGroupIngressInput{GroupId: aws.String(id)}
-	for _, rule := range rules {
+	for i := range rules {
+		rule := rules[i]
 		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(&rule))
 	}
 
@@ -438,7 +439,8 @@ func (s *Service) authorizeSecurityGroupIngressRules(id string, rules infrav1.In
 
 func (s *Service) revokeSecurityGroupIngressRules(id string, rules infrav1.IngressRules) error {
 	input := &ec2.RevokeSecurityGroupIngressInput{GroupId: aws.String(id)}
-	for _, rule := range rules {
+	for i := range rules {
+		rule := rules[i]
 		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(&rule))
 	}
 

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -424,7 +424,7 @@ func (s *Service) createSecurityGroup(role infrav1.SecurityGroupRole, input *ec2
 func (s *Service) authorizeSecurityGroupIngressRules(id string, rules infrav1.IngressRules) error {
 	input := &ec2.AuthorizeSecurityGroupIngressInput{GroupId: aws.String(id)}
 	for _, rule := range rules {
-		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(rule))
+		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(&rule))
 	}
 
 	if _, err := s.EC2Client.AuthorizeSecurityGroupIngress(input); err != nil {
@@ -439,7 +439,7 @@ func (s *Service) authorizeSecurityGroupIngressRules(id string, rules infrav1.In
 func (s *Service) revokeSecurityGroupIngressRules(id string, rules infrav1.IngressRules) error {
 	input := &ec2.RevokeSecurityGroupIngressInput{GroupId: aws.String(id)}
 	for _, rule := range rules {
-		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(rule))
+		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(&rule))
 	}
 
 	if _, err := s.EC2Client.RevokeSecurityGroupIngress(input); err != nil {
@@ -476,8 +476,8 @@ func (s *Service) revokeAllSecurityGroupIngressRules(id string) error {
 	return nil
 }
 
-func (s *Service) defaultSSHIngressRule(sourceSecurityGroupID string) *infrav1.IngressRule {
-	return &infrav1.IngressRule{
+func (s *Service) defaultSSHIngressRule(sourceSecurityGroupID string) infrav1.IngressRule {
+	return infrav1.IngressRule{
 		Description:            "SSH",
 		Protocol:               infrav1.SecurityGroupProtocolTCP,
 		FromPort:               22,
@@ -492,7 +492,7 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 
 	cniRules := make(infrav1.IngressRules, len(s.scope.CNIIngressRules()))
 	for i, r := range s.scope.CNIIngressRules() {
-		cniRules[i] = &infrav1.IngressRule{
+		cniRules[i] = infrav1.IngressRule{
 			Description: r.Description,
 			Protocol:    r.Protocol,
 			FromPort:    r.FromPort,
@@ -676,7 +676,7 @@ func ingressRuleToSDKType(i *infrav1.IngressRule) (res *ec2.IpPermission) {
 	return res
 }
 
-func ingressRuleFromSDKType(v *ec2.IpPermission) (res *infrav1.IngressRule) {
+func ingressRuleFromSDKType(v *ec2.IpPermission) (res infrav1.IngressRule) {
 	// Ports are only well-defined for TCP and UDP protocols, but EC2 overloads the port range
 	// in the case of ICMP(v6) traffic to indicate which codes are allowed. For all other protocols,
 	// including the custom "-1" All Traffic protcol, FromPort and ToPort are omitted from the response.
@@ -686,13 +686,13 @@ func ingressRuleFromSDKType(v *ec2.IpPermission) (res *infrav1.IngressRule) {
 		IPProtocolUDP,
 		IPProtocolICMP,
 		IPProtocolICMPv6:
-		res = &infrav1.IngressRule{
+		res = infrav1.IngressRule{
 			Protocol: infrav1.SecurityGroupProtocol(*v.IpProtocol),
 			FromPort: *v.FromPort,
 			ToPort:   *v.ToPort,
 		}
 	default:
-		res = &infrav1.IngressRule{
+		res = infrav1.IngressRule{
 			Protocol: infrav1.SecurityGroupProtocol(*v.IpProtocol),
 		}
 	}

--- a/pkg/cloud/services/securitygroup/securitygroups_test.go
+++ b/pkg/cloud/services/securitygroup/securitygroups_test.go
@@ -57,12 +57,12 @@ func TestReconcileSecurityGroups(t *testing.T) {
 					},
 				},
 				Subnets: infrav1.Subnets{
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-securitygroups-private",
 						IsPublic:         false,
 						AvailabilityZone: "us-east-1a",
 					},
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-securitygroups-public",
 						IsPublic:         true,
 						NatGatewayID:     aws.String("nat-01"),
@@ -241,12 +241,12 @@ func TestReconcileSecurityGroups(t *testing.T) {
 					InternetGatewayID: aws.String("igw-01"),
 				},
 				Subnets: infrav1.Subnets{
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-securitygroups-private",
 						IsPublic:         false,
 						AvailabilityZone: "us-east-1a",
 					},
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-securitygroups-public",
 						IsPublic:         true,
 						NatGatewayID:     aws.String("nat-01"),
@@ -285,12 +285,12 @@ func TestReconcileSecurityGroups(t *testing.T) {
 					},
 				},
 				Subnets: infrav1.Subnets{
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-securitygroups-private",
 						IsPublic:         false,
 						AvailabilityZone: "us-east-1a",
 					},
-					&infrav1.SubnetSpec{
+					infrav1.SubnetSpec{
 						ID:               "subnet-securitygroups-public",
 						IsPublic:         true,
 						NatGatewayID:     aws.String("nat-01"),


### PR DESCRIPTION
Signed-off-by: Richard Case <richard@weave.works>

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Due to a issue with conversion-gen and slices of struct pointers this changes our API to use slices of structs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2494 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
