### PR TITLE
fix: break down DescribeTags requests by 20 LoadBalancers at a time

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -18,6 +18,7 @@ package elb
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -296,7 +297,7 @@ func TestDeleteLoadbalancers(t *testing.T) {
 
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec: infrav1.AWSClusterSpec{},
+				Spec:       infrav1.AWSClusterSpec{},
 			}
 
 			client := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -405,6 +406,37 @@ func TestDescribeLoadbalancers(t *testing.T) {
 			_, err = s.describeClassicELB(tc.lbName)
 			if err == nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestChunkELBs(t *testing.T) {
+	base := "loadbalancer"
+	var names []string
+	for i := 0; i < 25; i++ {
+		names = append(names, fmt.Sprintf("%s+%d", base, i))
+	}
+	tests := []struct {
+		testName              string
+		names                 []string
+		expectedChunkArrayLen int
+	}{
+		{
+			testName:              "When the user has more the 20 ELBs",
+			names:                 names,
+			expectedChunkArrayLen: 2,
+		}, {
+			testName:              "When the user has less than 20 ELBs",
+			names:                 []string{"loadBalancer-00"},
+			expectedChunkArrayLen: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			ans := chunkELBs(tc.names)
+			if len(ans) != tc.expectedChunkArrayLen {
+				t.Errorf("got %d, want %d", len(ans), tc.expectedChunkArrayLen)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug 
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This allows users with more than 20 LoadBalancers in their account to delete them in an airgapped environment 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2497

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
bug: fixes bug in elb.DescribeTags when the user has more than 20 load balancers in an account
```
