### PR TITLE
Update EKS clusters to enable encryption

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -342,6 +342,7 @@ func (t Template) ControllersPolicy() *infrav1.PolicyDocument {
 					"eks:DeleteNodegroup",
 					"eks:UpdateNodegroupConfig",
 					"eks:CreateNodegroup",
+					"eks:AssociateEncryptionConfig",
 				},
 				Resource: infrav1.Resources{
 					"arn:*:eks:*:*:cluster/*",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -304,6 +304,7 @@ Resources:
           - eks:DeleteNodegroup
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
+          - eks:AssociateEncryptionConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_enable.yaml
@@ -304,6 +304,7 @@ Resources:
           - eks:DeleteNodegroup
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
+          - eks:AssociateEncryptionConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -304,6 +304,7 @@ Resources:
           - eks:DeleteNodegroup
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
+          - eks:AssociateEncryptionConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook.go
@@ -131,6 +131,20 @@ func (r *AWSManagedControlPlane) ValidateUpdate(old runtime.Object) error {
 		)
 	}
 
+	// If encryptionConfig is already set, do not allow removal of it.
+	if oldAWSManagedControlplane.Spec.EncryptionConfig != nil && r.Spec.EncryptionConfig == nil {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "encryptionConfig"), r.Spec.EncryptionConfig, "disabling EKS encryption is not allowed after it has been enabled"),
+		)
+	}
+
+	// If encryptionConfig is already set, do not allow change in provider
+	if r.Spec.EncryptionConfig != nil && oldAWSManagedControlplane.Spec.EncryptionConfig != nil && *r.Spec.EncryptionConfig.Provider != *oldAWSManagedControlplane.Spec.EncryptionConfig.Provider {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "encryptionConfig", "provider"), r.Spec.EncryptionConfig.Provider, "changing EKS encryption is not allowed after it has been enabled"),
+		)
+	}
+
 	// If a identityRef is already set, do not allow removal of it.
 	if oldAWSManagedControlplane.Spec.IdentityRef != nil && r.Spec.IdentityRef == nil {
 		allErrs = append(allErrs,

--- a/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/utils/pointer"
+
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -354,6 +356,68 @@ func TestWebhookUpdate(t *testing.T) {
 			newClusterSpec: AWSManagedControlPlaneSpec{
 				EKSClusterName: "default_cluster1",
 				Version:        &vV1_17,
+			},
+			expectError: false,
+		},
+		{
+			name: "change in encryption config to nil",
+			oldClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+				EncryptionConfig: &EncryptionConfig{
+					Provider:  pointer.String("provider"),
+					Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+				},
+			},
+			newClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+			},
+			expectError: true,
+		},
+		{
+			name: "change in encryption config from nil to valid encryption-config",
+			oldClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+			},
+			newClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+				EncryptionConfig: &EncryptionConfig{
+					Provider:  pointer.String("provider"),
+					Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "change in provider of encryption config",
+			oldClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+				EncryptionConfig: &EncryptionConfig{
+					Provider:  pointer.String("provider"),
+					Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+				},
+			},
+			newClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+				EncryptionConfig: &EncryptionConfig{
+					Provider:  pointer.String("new-provider"),
+					Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "no change in provider of encryption config",
+			oldClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+				EncryptionConfig: &EncryptionConfig{
+					Provider: pointer.String("provider"),
+				},
+			},
+			newClusterSpec: AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+				EncryptionConfig: &EncryptionConfig{
+					Provider: pointer.String("provider"),
+				},
 			},
 			expectError: false,
 		},

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"reflect"
 	"time"
+
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/internal/cmp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -219,15 +220,25 @@ func (s *Service) deleteClusterAndWait(cluster *eks.Cluster) error {
 }
 
 func makeEksEncryptionConfigs(encryptionConfig *controlplanev1.EncryptionConfig) []*eks.EncryptionConfig {
+	cfg := []*eks.EncryptionConfig{}
+
 	if encryptionConfig == nil {
-		return []*eks.EncryptionConfig{}
+		return cfg
 	}
-	return []*eks.EncryptionConfig{{
+	//TODO: change EncryptionConfig so that provider and resources are required  if encruptionConfig is specified
+	if encryptionConfig.Provider == nil || len(*encryptionConfig.Provider) == 0 {
+		return cfg
+	}
+	if len(encryptionConfig.Resources) == 0 {
+		return cfg
+	}
+
+	return append(cfg, &eks.EncryptionConfig{
 		Provider: &eks.Provider{
 			KeyArn: encryptionConfig.Provider,
 		},
 		Resources: encryptionConfig.Resources,
-	}}
+	})
 }
 
 func makeVpcConfig(subnets infrav1.Subnets, endpointAccess controlplanev1.EndpointAccess, securityGroups map[infrav1.SecurityGroupRole]infrav1.SecurityGroup) (*eks.VpcConfigRequest, error) {
@@ -481,16 +492,23 @@ func (s *Service) reconcileVpcConfig(vpcConfig *eks.VpcConfigResponse) (*eks.Vpc
 	return nil, nil
 }
 
-func (s *Service) reconcileEKSEncryptionConfig(encryptionConfig []*eks.EncryptionConfig) error {
+func (s *Service) reconcileEKSEncryptionConfig(currentClusterConfig []*eks.EncryptionConfig) error {
+	s.Info("reconciling encryption configuration")
+	if currentClusterConfig == nil {
+		currentClusterConfig = []*eks.EncryptionConfig{}
+	}
+
 	encryptionConfigs := s.scope.ControlPlane.Spec.EncryptionConfig
 	updatedEncryptionConfigs := makeEksEncryptionConfigs(encryptionConfigs)
 
 	switch {
-	case reflect.DeepEqual(encryptionConfig, updatedEncryptionConfigs):
+	case compareEncryptionConfig(currentClusterConfig, updatedEncryptionConfigs):
+		s.V(2).Info("encryption configuration unchanged, no action")
 		return nil
-	case encryptionConfig == nil || len(encryptionConfig) == 0 && updatedEncryptionConfigs != nil:
+	case len(currentClusterConfig) == 0 && len(updatedEncryptionConfigs) > 0:
+		s.V(2).Info("enabling encryption for eks cluster", "cluster", s.scope.KubernetesClusterName())
 		if err := s.updateEncryptionConfig(updatedEncryptionConfigs); err != nil {
-			record.Warnf(s.scope.ControlPlane, "FailedUpdateEKSControlPlane", "failed to update the EKS control plane: %v", err)
+			record.Warnf(s.scope.ControlPlane, "FailedUpdateEKSControlPlane", "failed to update the EKS control plane encryption configuration: %v", err)
 			return errors.Wrapf(err, "failed to update EKS cluster")
 		}
 	default:
@@ -658,4 +676,19 @@ func (c EKSClient) WaitUntilClusterUpdating(input *eks.DescribeClusterInput, opt
 	w.ApplyOptions(opts...)
 
 	return w.WaitWithContext(ctx)
+}
+
+func compareEncryptionConfig(updatedEncryptionConfig, existingEncryptionConfig []*eks.EncryptionConfig) bool {
+	if len(updatedEncryptionConfig) != len(existingEncryptionConfig) {
+		return false
+	}
+	for index, encryptionConfig := range updatedEncryptionConfig {
+		if encryptionConfig.Provider != existingEncryptionConfig[index].Provider {
+			return false
+		}
+		if cmp.Equals(encryptionConfig.Resources, existingEncryptionConfig[index].Resources) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/internal/cmp/slice.go
+++ b/pkg/internal/cmp/slice.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmp
+
+import (
+	"sort"
+
+	"k8s.io/utils/pointer"
+)
+
+type ByPtrValue []*string
+
+func (s ByPtrValue) Len() int {
+	return len(s)
+}
+
+func (s ByPtrValue) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByPtrValue) Less(i, j int) bool {
+	return *s[i] < *s[j]
+}
+
+func Equals(slice1, slice2 []*string) bool {
+	sort.Sort(ByPtrValue(slice1))
+	sort.Sort(ByPtrValue(slice2))
+
+	if len(slice1) == len(slice2) {
+		for i, v := range slice1 {
+			if pointer.StringEqual(v, slice2[i]) {
+				return false
+			}
+		}
+	} else {
+		return false
+	}
+	return true
+}

--- a/pkg/internal/cmp/slice_test.go
+++ b/pkg/internal/cmp/slice_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmp
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+)
+
+func TestCompareSlices(t *testing.T) {
+	g := NewWithT(t)
+
+	slice1 := []*string{pointer.String("foo"), pointer.String("bar")}
+	slice2 := []*string{pointer.String("bar"), pointer.String("foo")}
+
+	expected := Equals(slice1, slice2)
+	g.Expect(expected, true)
+
+	slice2 = append(slice2, pointer.String("test"))
+	expected = Equals(slice1, slice2)
+	g.Expect(expected, false)
+}

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -34,7 +34,7 @@
       "context": "controlplane/eks",
       "image": "gcr.io/k8s-staging-cluster-api-aws/eks-controlplane-controller",
       "live_reload_deps": [
-        "main.go", "api", "controllers"
+        "main.go", "api", "controllers", "../../pkg"
       ]
     }
   }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables to add encryption config in update path if it was nil at the time of cluster creation. It also disallows any modifications in further update if the config was already defined at the time of creation

**Which issue(s) this PR fixes**:
Fixes #2452

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
* Add encryption-config in update if missed in cluster creation
* Add webhook validation checks for encryption-config
Action required
Controllers policy updated with missing IAM permissions required to enable EKS encryption, if you are planning to enable EKS encryption then you will need to update your controllers policy by running `clusterawsadm bootstrap iam create-cloudformation-stack` again.
```
