### PR TITLE
✨ Add shortnames to all resources

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -182,7 +182,7 @@ type AWSClusterStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclusters,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsclusters,scope=Namespaced,categories=cluster-api,shortName=awsc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSCluster belongs"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for EC2 instances"

--- a/api/v1alpha3/awsidentity_types.go
+++ b/api/v1alpha3/awsidentity_types.go
@@ -70,7 +70,7 @@ type AWSRoleSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclusterstaticidentities,scope=Cluster,categories=cluster-api
+// +kubebuilder:resource:path=awsclusterstaticidentities,scope=Cluster,categories=cluster-api,shortName=awssi
 
 // AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API
 // It represents a reference to an AWS access key ID and secret access key, stored in a secret.
@@ -102,7 +102,7 @@ type AWSClusterStaticIdentitySpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclusterroleidentities,scope=Cluster,categories=cluster-api
+// +kubebuilder:resource:path=awsclusterroleidentities,scope=Cluster,categories=cluster-api,shortName=awsri
 
 // AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API
 // It is used to assume a role using the provided sourceRef.
@@ -144,7 +144,7 @@ type AWSClusterRoleIdentitySpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclustercontrolleridentities,scope=Cluster,categories=cluster-api
+// +kubebuilder:resource:path=awsclustercontrolleridentities,scope=Cluster,categories=cluster-api,shortName=awsci
 
 // AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API
 // It is used to grant access to use Cluster API Provider AWS Controller credentials.

--- a/api/v1alpha3/awsmachine_types.go
+++ b/api/v1alpha3/awsmachine_types.go
@@ -238,7 +238,7 @@ type AWSMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmachines,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmachines,scope=Namespaced,categories=cluster-api,shortName=awsm
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSMachine belongs"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="EC2 instance state"

--- a/api/v1alpha3/awsmachinetemplate_types.go
+++ b/api/v1alpha3/awsmachinetemplate_types.go
@@ -26,7 +26,7 @@ type AWSMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmachinetemplates,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmachinetemplates,scope=Namespaced,categories=cluster-api,shortName=awsmt
 
 // AWSMachineTemplate is the Schema for the awsmachinetemplates API
 type AWSMachineTemplate struct {

--- a/api/v1alpha4/awscluster_types.go
+++ b/api/v1alpha4/awscluster_types.go
@@ -182,7 +182,7 @@ type AWSClusterStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclusters,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsclusters,scope=Namespaced,categories=cluster-api,shortName=awsc
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSCluster belongs"

--- a/api/v1alpha4/awsidentity_types.go
+++ b/api/v1alpha4/awsidentity_types.go
@@ -69,7 +69,7 @@ type AWSRoleSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclusterstaticidentities,scope=Cluster,categories=cluster-api
+// +kubebuilder:resource:path=awsclusterstaticidentities,scope=Cluster,categories=cluster-api,shortName=awssi
 // +kubebuilder:storageversion
 
 // AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API
@@ -102,7 +102,7 @@ type AWSClusterStaticIdentitySpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclusterroleidentities,scope=Cluster,categories=cluster-api
+// +kubebuilder:resource:path=awsclusterroleidentities,scope=Cluster,categories=cluster-api,shortName=awsri
 // +kubebuilder:storageversion
 
 // AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API
@@ -145,7 +145,7 @@ type AWSClusterRoleIdentitySpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsclustercontrolleridentities,scope=Cluster,categories=cluster-api
+// +kubebuilder:resource:path=awsclustercontrolleridentities,scope=Cluster,categories=cluster-api,shortName=awsci
 // +kubebuilder:storageversion
 
 // AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API

--- a/api/v1alpha4/awsmachine_types.go
+++ b/api/v1alpha4/awsmachine_types.go
@@ -238,7 +238,7 @@ type AWSMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmachines,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmachines,scope=Namespaced,categories=cluster-api,shortName=awsm
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSMachine belongs"

--- a/api/v1alpha4/awsmachinetemplate_types.go
+++ b/api/v1alpha4/awsmachinetemplate_types.go
@@ -26,7 +26,7 @@ type AWSMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmachinetemplates,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmachinetemplates,scope=Namespaced,categories=cluster-api,shortName=awsmt
 // +kubebuilder:storageversion
 
 // AWSMachineTemplate is the Schema for the awsmachinetemplates API

--- a/bootstrap/eks/api/v1alpha3/eksconfig_types.go
+++ b/bootstrap/eks/api/v1alpha3/eksconfig_types.go
@@ -58,7 +58,7 @@ type EKSConfigStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=eksconfigs,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=eksconfigs,scope=Namespaced,categories=cluster-api,shortName=eksc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Bootstrap configuration is ready"
 // +kubebuilder:printcolumn:name="DataSecretName",type="string",JSONPath=".status.dataSecretName",description="Name of Secret containing bootstrap data"

--- a/bootstrap/eks/api/v1alpha3/eksconfigtemplate_types.go
+++ b/bootstrap/eks/api/v1alpha3/eksconfigtemplate_types.go
@@ -31,7 +31,7 @@ type EKSConfigTemplateResource struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=eksconfigtemplates,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=eksconfigtemplates,scope=Namespaced,categories=cluster-api,shortName=eksct
 
 // EKSConfigTemplate is the Schema for the eksconfigtemplates API
 type EKSConfigTemplate struct {

--- a/bootstrap/eks/api/v1alpha4/eksconfig_types.go
+++ b/bootstrap/eks/api/v1alpha4/eksconfig_types.go
@@ -58,7 +58,7 @@ type EKSConfigStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=eksconfigs,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=eksconfigs,scope=Namespaced,categories=cluster-api,shortName=eksc
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Bootstrap configuration is ready"

--- a/bootstrap/eks/api/v1alpha4/eksconfigtemplate_types.go
+++ b/bootstrap/eks/api/v1alpha4/eksconfigtemplate_types.go
@@ -31,7 +31,7 @@ type EKSConfigTemplateResource struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=eksconfigtemplates,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=eksconfigtemplates,scope=Namespaced,categories=cluster-api,shortName=eksct
 // +kubebuilder:storageversion
 
 // EKSConfigTemplate is the Schema for the eksconfigtemplates API

--- a/bootstrap/eks/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigs.yaml
+++ b/bootstrap/eks/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigs.yaml
@@ -15,6 +15,8 @@ spec:
     kind: EKSConfig
     listKind: EKSConfigList
     plural: eksconfigs
+    shortNames:
+    - eksc
     singular: eksconfig
   scope: Namespaced
   versions:

--- a/bootstrap/eks/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigtemplates.yaml
+++ b/bootstrap/eks/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigtemplates.yaml
@@ -15,6 +15,8 @@ spec:
     kind: EKSConfigTemplate
     listKind: EKSConfigTemplateList
     plural: eksconfigtemplates
+    shortNames:
+    - eksct
     singular: eksconfigtemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSClusterControllerIdentity
     listKind: AWSClusterControllerIdentityList
     plural: awsclustercontrolleridentities
+    shortNames:
+    - awsci
     singular: awsclustercontrolleridentity
   scope: Cluster
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSClusterRoleIdentity
     listKind: AWSClusterRoleIdentityList
     plural: awsclusterroleidentities
+    shortNames:
+    - awsri
     singular: awsclusterroleidentity
   scope: Cluster
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSCluster
     listKind: AWSClusterList
     plural: awsclusters
+    shortNames:
+    - awsc
     singular: awscluster
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSClusterStaticIdentity
     listKind: AWSClusterStaticIdentityList
     plural: awsclusterstaticidentities
+    shortNames:
+    - awssi
     singular: awsclusterstaticidentity
   scope: Cluster
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsfargateprofiles.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsfargateprofiles.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSFargateProfile
     listKind: AWSFargateProfileList
     plural: awsfargateprofiles
+    shortNames:
+    - awsfp
     singular: awsfargateprofile
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSMachinePool
     listKind: AWSMachinePoolList
     plural: awsmachinepools
+    shortNames:
+    - awsmp
     singular: awsmachinepool
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSMachine
     listKind: AWSMachineList
     plural: awsmachines
+    shortNames:
+    - awsm
     singular: awsmachine
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSMachineTemplate
     listKind: AWSMachineTemplateList
     plural: awsmachinetemplates
+    shortNames:
+    - awsmt
     singular: awsmachinetemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AWSManagedMachinePool
     listKind: AWSManagedMachinePoolList
     plural: awsmanagedmachinepools
+    shortNames:
+    - awsmmp
     singular: awsmanagedmachinepool
   scope: Namespaced
   versions:

--- a/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
@@ -230,7 +230,7 @@ type AWSManagedControlPlaneStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmanagedcontrolplanes,shortName=awsmcp,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmanagedcontrolplanes,shortName=awsmcp,scope=Namespaced,categories=cluster-api,shortName=awsmcp
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSManagedControl belongs"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Control plane infrastructure is ready for worker nodes"

--- a/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_types.go
@@ -230,7 +230,7 @@ type AWSManagedControlPlaneStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmanagedcontrolplanes,shortName=awsmcp,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmanagedcontrolplanes,shortName=awsmcp,scope=Namespaced,categories=cluster-api,shortName=awsmcp
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSManagedControl belongs"

--- a/exp/api/v1alpha3/awsfargateprofile_types.go
+++ b/exp/api/v1alpha3/awsfargateprofile_types.go
@@ -128,7 +128,7 @@ type FargateProfileStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsfargateprofiles,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsfargateprofiles,scope=Namespaced,categories=cluster-api,shortName=awsfp
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="AWSFargateProfile ready status"
 // +kubebuilder:printcolumn:name="ProfileName",type="string",JSONPath=".spec.profileName",description="EKS Fargate profile name"

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -175,7 +175,7 @@ type AWSMachinePoolInstanceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=awsmachinepools,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmachinepools,scope=Namespaced,categories=cluster-api,shortName=awsmp
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Machine ready status"
 // +kubebuilder:printcolumn:name="MinSize",type="integer",JSONPath=".spec.minSize",description="Minimum instanes in ASG"

--- a/exp/api/v1alpha3/awsmanagedmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmanagedmachinepool_types.go
@@ -193,7 +193,7 @@ type AWSManagedMachinePoolStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmanagedmachinepools,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmanagedmachinepools,scope=Namespaced,categories=cluster-api,shortName=awsmmp
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="MachinePool ready status"
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Number of replicas"

--- a/exp/api/v1alpha4/awsfargateprofile_types.go
+++ b/exp/api/v1alpha4/awsfargateprofile_types.go
@@ -128,7 +128,7 @@ type FargateProfileStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsfargateprofiles,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsfargateprofiles,scope=Namespaced,categories=cluster-api,shortName=awsfp
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="AWSFargateProfile ready status"

--- a/exp/api/v1alpha4/awsmachinepool_types.go
+++ b/exp/api/v1alpha4/awsmachinepool_types.go
@@ -176,7 +176,7 @@ type AWSMachinePoolInstanceStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:resource:path=awsmachinepools,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmachinepools,scope=Namespaced,categories=cluster-api,shortName=awsmp
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Machine ready status"
 // +kubebuilder:printcolumn:name="MinSize",type="integer",JSONPath=".spec.minSize",description="Minimum instanes in ASG"

--- a/exp/api/v1alpha4/awsmanagedmachinepool_types.go
+++ b/exp/api/v1alpha4/awsmanagedmachinepool_types.go
@@ -197,7 +197,7 @@ type AWSManagedMachinePoolStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmanagedmachinepools,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=awsmanagedmachinepools,scope=Namespaced,categories=cluster-api,shortName=awsmmp
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="MachinePool ready status"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds short names to all resources. Below are the short names for each resource added as part of this PR:
- eksc : EKSConfig
- eksct: EKSConfigTemplate
- awsci: AWSClusterControllerIdentity
- awsri: AWSClusterRoleIdentity
- awsc: AWSCluster
- awssi: AWSClusterStaticIdentity
- awsfp: AWSFargateProfile
- awsmp: AWSMachinePool
- awsm: AWSMachine
- awsmt: AWSMachineTemplate
- awsmmp: AWSManagedMachinePool

**Which issue(s) this PR fixes** :
Fixes #2491 

```release-note
            NONE
```

/sig scheduling
