### PR TITLE
chore: rely on cluster deletion in eks e2e tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -155,3 +155,4 @@ intervals:
   default/wait-infra-subnets: ["5m", "30s"]
   default/wait-machine-pool-nodes: ["40m", "10s"]
   default/wait-machine-pool-upgrade: [ "50m", "10s" ]
+  default/wait-create-identity: ["1m", "10s"]

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -131,13 +131,14 @@ variables:
   EXP_EKS_ADD_ROLES: "false"
   VPC_ADDON_VERSION: "v1.6.3-eksbuild.1"
   CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.19.8"
+  AUTO_CONTROLLER_IDENTITY_CREATOR: "false"
 
 intervals:
   default/wait-cluster: ["30m", "10s"]
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-controllers: ["3m", "10s"]
-  default/wait-delete-cluster: ["35m", "10s"]
+  default/wait-delete-cluster: ["35m", "30s"]
   default/wait-delete-machine: ["10m", "10s"]
   default/wait-delete-machine-deployment: ["10m", "10s"]
   default/wait-delete-machine-pool: ["20m", "10s"]
@@ -146,3 +147,4 @@ intervals:
   default/wait-infra-subnets: ["5m", "30s"]
   default/wait-control-plane-upgrade: ["35m", "30s"]
   default/wait-addon-status: ["10m", "30s"]
+  default/wait-create-identity: ["1m", "10s"]

--- a/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
@@ -28,3 +28,6 @@ spec:
     - name: "vpc-cni"
       version: "${VPC_ADDON_VERSION}"
       conflictResolution: "overwrite"
+  identityRef:
+    kind: AWSClusterStaticIdentity
+    name: e2e-account

--- a/test/e2e/data/eks/cluster-template-eks-control-plane-only.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-control-plane-only.yaml
@@ -24,3 +24,6 @@ spec:
   region: "${AWS_REGION}"
   sshKeyName: "${AWS_SSH_KEY_NAME}"
   version: "${KUBERNETES_VERSION}"
+  identityRef:
+    kind: AWSClusterStaticIdentity
+    name: e2e-account

--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -60,10 +60,12 @@ func DumpSpecResourcesAndCleanup(ctx context.Context, specName string, namespace
 	Byf("Dumping all EC2 instances in the %q namespace", namespace.Name)
 	DumpMachines(ctx, e2eCtx, namespace)
 	if !e2eCtx.Settings.SkipCleanup {
+		intervals := e2eCtx.E2EConfig.GetIntervals(specName, "wait-delete-cluster")
+		Byf("Deleting all clusters in the %q namespace with intervals %q", namespace.Name, intervals)
 		framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
 			Client:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
 			Namespace: namespace.Name,
-		}, e2eCtx.E2EConfig.GetIntervals(specName, "wait-delete-cluster")...)
+		}, intervals...)
 
 		Byf("Deleting namespace used for hosting the %q test spec", specName)
 		framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{

--- a/test/e2e/shared/identity.go
+++ b/test/e2e/shared/identity.go
@@ -1,0 +1,120 @@
+// +build e2e
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
+)
+
+const (
+	credsSecretName = "e2e-account-creds"
+	capaNamespace   = "capa-system"
+	eksNamespace    = "capa-eks-control-plane-system"
+	idName          = "e2e-account"
+)
+
+func SetupStaticCredentials(ctx context.Context, namespace *corev1.Namespace, e2eCtx *E2EContext) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for SetupStaticCredentials")
+	Expect(namespace).NotTo(BeNil(), "namespace is required for SetupStaticCredentials")
+	Expect(e2eCtx).NotTo(BeNil(), "e2eCtx is required for SetupStaticCredentials")
+	Expect(e2eCtx.Environment.BootstrapAccessKey).NotTo(BeNil(), "e2eCtx.Environment.BootstrapAccessKey is required for SetupStaticCredentials")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      credsSecretName,
+			Namespace: capaNamespace,
+		},
+		StringData: map[string]string{
+			"AccessKeyID":     *e2eCtx.Environment.BootstrapAccessKey.AccessKeyId,
+			"SecretAccessKey": *e2eCtx.Environment.BootstrapAccessKey.SecretAccessKey,
+		},
+	}
+
+	client := e2eCtx.Environment.BootstrapClusterProxy.GetClient()
+	Byf("Creating credentials secret %s in namespace %s", secret.Name, secret.Namespace)
+	Eventually(func() error {
+		return client.Create(ctx, secret)
+	}, e2eCtx.E2EConfig.GetIntervals("", "wait-create-identity")...).Should(Succeed())
+
+	if e2eCtx.IsManaged {
+		//TODO: this doesn't feel right to be creating the secret in 2 places.
+		cpSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      credsSecretName,
+				Namespace: eksNamespace,
+			},
+			StringData: map[string]string{
+				"AccessKeyID":     *e2eCtx.Environment.BootstrapAccessKey.AccessKeyId,
+				"SecretAccessKey": *e2eCtx.Environment.BootstrapAccessKey.SecretAccessKey,
+			},
+		}
+		Byf("Creating credentials secret %s in namespace %s", cpSecret.Name, cpSecret.Namespace)
+		Eventually(func() error {
+			return client.Create(ctx, cpSecret)
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-create-identity")...).Should(Succeed())
+	}
+
+	id := &infrav1.AWSClusterStaticIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      idName,
+			Namespace: namespace.Name,
+		},
+		Spec: infrav1.AWSClusterStaticIdentitySpec{
+			SecretRef: credsSecretName,
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{
+					NamespaceList: []string{namespace.Name},
+				},
+			},
+		},
+	}
+
+	Byf("Creating AWSClusterStaticIdentity %s in namespace %s", id.Name, namespace.Name)
+	Eventually(func() error {
+		return client.Create(ctx, id)
+	}, e2eCtx.E2EConfig.GetIntervals("", "wait-create-identity")...).Should(Succeed())
+}
+
+func CleanupStaticCredentials(ctx context.Context, namespace *corev1.Namespace, e2eCtx *E2EContext) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for SetupStaticCredentials")
+	Expect(namespace).NotTo(BeNil(), "namespace is required for SetupStaticCredentials")
+	Expect(e2eCtx).NotTo(BeNil(), "e2eCtx is required for SetupStaticCredentials")
+
+	id := &infrav1.AWSClusterStaticIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      idName,
+			Namespace: namespace.Name,
+		},
+	}
+
+	Byf("Deleting AWSClusterStaticIdentity %s in namespace %s", idName, namespace.Name)
+	client := e2eCtx.Environment.BootstrapClusterProxy.GetClient()
+	Eventually(func() error {
+		return client.Delete(ctx, id)
+	}, e2eCtx.E2EConfig.GetIntervals("", "wait-create-identity")...).Should(Succeed())
+
+	//NOTE: secrets should be cleared up when the namespaces are deleted
+}

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -21,13 +21,14 @@ package shared
 import (
 	"context"
 	"flag"
-	"github.com/gofrs/flock"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"time"
+
+	"github.com/gofrs/flock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -137,7 +138,9 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 	e2eCtx.BootstratpUserAWSSession = NewAWSSessionWithKey(e2eCtx.Environment.BootstrapAccessKey)
 
 	// Image ID is needed when using a CI Kubernetes version. This is used in conformance test and upgrade to main test.
-	e2eCtx.E2EConfig.Variables["IMAGE_ID"] = conformanceImageID(e2eCtx)
+	if !e2eCtx.IsManaged {
+		e2eCtx.E2EConfig.Variables["IMAGE_ID"] = conformanceImageID(e2eCtx)
+	}
 
 	Byf("Creating a clusterctl local repository into %q", e2eCtx.Settings.ArtifactFolder)
 	e2eCtx.Environment.ClusterctlConfigPath = createClusterctlLocalRepository(e2eCtx.E2EConfig, filepath.Join(e2eCtx.Settings.ArtifactFolder, "repository"))


### PR DESCRIPTION
Signed-off-by: Richard Case <richard@weave.works>

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:
The EKS e2e tests are timing out and are getting stuck in the `WaitForClusterDeleted` in the test cleanup. Removed the EKS cluster deletion from the test and now relying on the Cluster deletion and the ownership chain.

Also,  changed templates used by the tests to use AWSClusterStaticIdentity
and added shared functions to create an instance of this CR and also the
associated secrets

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
