### PR TITLE
Added clusterctl move label to global identity resources

### DIFF
--- a/api/v1alpha4/awsclustercontrolleridentity_webhook.go
+++ b/api/v1alpha4/awsclustercontrolleridentity_webhook.go
@@ -98,4 +98,5 @@ func (r *AWSClusterControllerIdentity) ValidateUpdate(old runtime.Object) error 
 
 // Default will set default values for the AWSClusterControllerIdentity.
 func (r *AWSClusterControllerIdentity) Default() {
+	SetDefaults_Labels(&r.ObjectMeta)
 }

--- a/api/v1alpha4/awsclusterroleidentity_webhook.go
+++ b/api/v1alpha4/awsclusterroleidentity_webhook.go
@@ -94,4 +94,5 @@ func (r *AWSClusterRoleIdentity) ValidateUpdate(old runtime.Object) error {
 
 // Default will set default values for the AWSClusterRoleIdentity.
 func (r *AWSClusterRoleIdentity) Default() {
+	SetDefaults_Labels(&r.ObjectMeta)
 }

--- a/api/v1alpha4/awsclusterstaticidentity_webhook.go
+++ b/api/v1alpha4/awsclusterstaticidentity_webhook.go
@@ -88,4 +88,5 @@ func (r *AWSClusterStaticIdentity) ValidateUpdate(old runtime.Object) error {
 
 // Default should return the default AWSClusterStaticIdentity.
 func (r *AWSClusterStaticIdentity) Default() {
+	SetDefaults_Labels(&r.ObjectMeta)
 }

--- a/api/v1alpha4/defaults.go
+++ b/api/v1alpha4/defaults.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package v1alpha4
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+)
+
 // TODO (richardcase): get this working with defaulter-gen
 
 // SetDefaults_Bastion is used by defaulter-gen.
@@ -46,5 +51,14 @@ func SetDefaults_NetworkSpec(obj *NetworkSpec) { //nolint:golint,stylecheck
 				},
 			},
 		}
+	}
+}
+
+// SetDefaults_Labels is used by defaulter-gen.
+func SetDefaults_Labels(obj *metav1.ObjectMeta) { //nolint:golint,stylecheck
+	// Defaults to set label if no labels have been set
+	if obj.Labels == nil {
+		obj.Labels = map[string]string{
+			clusterv1.ClusterctlMoveHierarchyLabelName: ""}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Add `clusterctl.cluster.x-k8s.io/move-hierarchy` label to global identity resources like AWSClusterControllerIdentity, AWSClusterRoleIdentity, AWSClusterStaticIdentity.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2415 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Apply clusterctl.cluster.x-k8s.io/move-hierarchy label on the infrastructure cluster global identity CRDs. 
```
