### PR TITLE
:bug: AWSMachinePool: Prune old Launch Template versions

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -456,7 +456,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID || launchTemplateUserDataHash != bootstrapDataHash {
 		machinePoolScope.Info("creating new version for launch template", "existing", launchTemplate, "incoming", machinePoolScope.AWSMachinePool.Spec.AWSLaunchTemplate)
 		// There is a limit to the number of Launch Template Versions.
-		// We ensure that the number of versions does not grow without bound by following a simple rule: For each version we create, we delete one old version.
+		// We ensure that the number of versions does not grow without bound by following a simple rule: Before we create a new version, we delete one old version, if there is at least one old version that is not in use.
 		if err := ec2svc.PruneLaunchTemplateVersions(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID); err != nil {
 			return err
 		}

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -455,6 +455,11 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 	// userdata, OR we've discovered a new AMI ID.
 	if needsUpdate || tagsChanged || *imageID != *launchTemplate.AMI.ID || launchTemplateUserDataHash != bootstrapDataHash {
 		machinePoolScope.Info("creating new version for launch template", "existing", launchTemplate, "incoming", machinePoolScope.AWSMachinePool.Spec.AWSLaunchTemplate)
+		// There is a limit to the number of Launch Template Versions.
+		// We ensure that the number of versions does not grow without bound by following a simple rule: For each version we create, we delete one old version.
+		if err := ec2svc.PruneLaunchTemplateVersions(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID); err != nil {
+			return err
+		}
 		if err := ec2svc.CreateLaunchTemplateVersion(machinePoolScope, imageID, bootstrapData); err != nil {
 			return err
 		}

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -242,6 +243,63 @@ func (s *Service) DeleteLaunchTemplate(id string) error {
 	}
 
 	s.scope.V(2).Info("Deleted launch template", "id", id)
+	return nil
+}
+
+// PruneLaunchTemplateVersions deletes one old launch template version.
+// It does not delete the "latest" version, because that version may still be in use.
+// It does not delete the "default" version, because that version cannot be deleted.
+// It does not assume that versions are sequential. Versions may be deleted out of band.
+func (s *Service) PruneLaunchTemplateVersions(id string) error {
+	// When there is one version available, it is the default and the latest.
+	// When there are two versions available, one the is the default, the other is the latest.
+	// Therefore we only prune when there are at least 3 versions available.
+	const minCountToAllowPrune = 3
+
+	input := &ec2.DescribeLaunchTemplateVersionsInput{
+		LaunchTemplateId: aws.String(id),
+		MinVersion:       aws.String("0"),
+		MaxVersion:       aws.String(expinfrav1.LaunchTemplateLatestVersion),
+		MaxResults:       aws.Int64(minCountToAllowPrune),
+	}
+
+	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
+	if err != nil {
+		s.scope.Info("", "aerr", err.Error())
+		return err
+	}
+
+	// len(out.LaunchTemplateVersions)	|	items
+	// -------------------------------- + -----------------------
+	// 								1	|	[default/latest]
+	// 								2	|	[default, latest]
+	// 								3	| 	[default, versionToPrune, latest]
+	if len(out.LaunchTemplateVersions) < minCountToAllowPrune {
+		return nil
+	}
+	versionToPrune := out.LaunchTemplateVersions[1].VersionNumber
+	return s.deleteLaunchTemplateVersion(id, versionToPrune)
+}
+
+func (s *Service) deleteLaunchTemplateVersion(id string, version *int64) error {
+	s.scope.V(2).Info("Deleting launch template version", "id", id)
+
+	if version == nil {
+		return errors.New("version is a nil pointer")
+	}
+	versions := []string{strconv.FormatInt(*version, 10)}
+
+	input := &ec2.DeleteLaunchTemplateVersionsInput{
+		LaunchTemplateId: aws.String(id),
+		Versions:         aws.StringSlice(versions),
+	}
+
+	_, err := s.EC2Client.DeleteLaunchTemplateVersions(input)
+	if err != nil {
+		return err
+	}
+
+	s.scope.V(2).Info("Deleted launch template", "id", id, "version", *version)
 	return nil
 }
 

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -64,6 +64,7 @@ type EC2MachineInterface interface {
 	GetLaunchTemplateID(id string) (string, error)
 	CreateLaunchTemplate(scope *scope.MachinePoolScope, imageID *string, userData []byte) (string, error)
 	CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, imageID *string, userData []byte) error
+	PruneLaunchTemplateVersions(id string) error
 	DeleteLaunchTemplate(id string) error
 	LaunchTemplateNeedsUpdate(scope *scope.MachinePoolScope, incoming *expinfrav1.AWSLaunchTemplate, existing *expinfrav1.AWSLaunchTemplate) (bool, error)
 }

--- a/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_machine_interface_mock.go
@@ -260,6 +260,20 @@ func (mr *MockEC2MachineInterfaceMockRecorder) LaunchTemplateNeedsUpdate(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LaunchTemplateNeedsUpdate", reflect.TypeOf((*MockEC2MachineInterface)(nil).LaunchTemplateNeedsUpdate), arg0, arg1, arg2)
 }
 
+// PruneLaunchTemplateVersions mocks base method.
+func (m *MockEC2MachineInterface) PruneLaunchTemplateVersions(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PruneLaunchTemplateVersions", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PruneLaunchTemplateVersions indicates an expected call of PruneLaunchTemplateVersions.
+func (mr *MockEC2MachineInterfaceMockRecorder) PruneLaunchTemplateVersions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneLaunchTemplateVersions", reflect.TypeOf((*MockEC2MachineInterface)(nil).PruneLaunchTemplateVersions), arg0)
+}
+
 // TerminateInstance mocks base method.
 func (m *MockEC2MachineInterface) TerminateInstance(arg0 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Remove one old version before creating a new version.

Fixes #2368


**Special notes for your reviewer**:
I'm not sure what sort of unit test we want to see.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
AWSMachinePool controller removes one old LaunchTemplate version before creating a new version, preventing the number of versions from growing without bound, and reaching the maximum limit. 
```
