### PR TITLE
fix kubebuilder pointing to changed api-endpoint

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -30,7 +30,7 @@ const (
 	AWSClusterControllerIdentityName = "default"
 )
 
-// AWSClusterSpec defines the desired state of AWSCluster
+// AWSClusterSpec defines the desired state of AWSCluster.
 type AWSClusterSpec struct {
 	// NetworkSpec encapsulates all things related to AWS network.
 	NetworkSpec NetworkSpec `json:"networkSpec,omitempty"`
@@ -91,7 +91,7 @@ type AWSClusterSpec struct {
 	IdentityRef *AWSIdentityReference `json:"identityRef,omitempty"`
 }
 
-// AWSIdentityKind defines allowed AWS identity types
+// AWSIdentityKind defines allowed AWS identity types.
 type AWSIdentityKind string
 
 var (
@@ -173,7 +173,7 @@ type AWSLoadBalancerSpec struct {
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 }
 
-// AWSClusterStatus defines the observed state of AWSCluster
+// AWSClusterStatus defines the observed state of AWSCluster.
 type AWSClusterStatus struct {
 	// +kubebuilder:default=false
 	Ready          bool                     `json:"ready"`
@@ -189,10 +189,10 @@ type AWSClusterStatus struct {
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSCluster belongs"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for EC2 instances"
 // +kubebuilder:printcolumn:name="VPC",type="string",JSONPath=".spec.networkSpec.vpc.id",description="AWS VPC the cluster is using"
-// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.apiEndpoints[0]",description="API Endpoint",priority=1
+// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Bastion IP",type="string",JSONPath=".status.bastion.publicIp",description="Bastion IP address for breakglass access"
 
-// AWSCluster is the Schema for the awsclusters API
+// AWSCluster is the Schema for the awsclusters API.
 type AWSCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/awscluster_types.go
+++ b/api/v1alpha4/awscluster_types.go
@@ -190,10 +190,10 @@ type AWSClusterStatus struct {
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSCluster belongs"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for EC2 instances"
 // +kubebuilder:printcolumn:name="VPC",type="string",JSONPath=".spec.networkSpec.vpc.id",description="AWS VPC the cluster is using"
-// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.apiEndpoints[0]",description="API Endpoint",priority=1
+// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Bastion IP",type="string",JSONPath=".status.bastion.publicIp",description="Bastion IP address for breakglass access"
 
-// AWSCluster is the Schema for the awsclusters API
+// AWSCluster is the Schema for the awsclusters API.
 type AWSCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -34,7 +34,7 @@ spec:
       name: VPC
       type: string
     - description: API Endpoint
-      jsonPath: .status.apiEndpoints[0]
+      jsonPath: .spec.controlPlaneEndpoint
       name: Endpoint
       priority: 1
       type: string
@@ -45,7 +45,7 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AWSCluster is the Schema for the awsclusters API
+        description: AWSCluster is the Schema for the awsclusters API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -60,7 +60,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AWSClusterSpec defines the desired state of AWSCluster
+            description: AWSClusterSpec defines the desired state of AWSCluster.
             properties:
               additionalTags:
                 additionalProperties:
@@ -335,7 +335,7 @@ spec:
                 type: string
             type: object
           status:
-            description: AWSClusterStatus defines the observed state of AWSCluster
+            description: AWSClusterStatus defines the observed state of AWSCluster.
             properties:
               bastion:
                 description: Instance describes an AWS instance.
@@ -782,7 +782,7 @@ spec:
       name: VPC
       type: string
     - description: API Endpoint
-      jsonPath: .status.apiEndpoints[0]
+      jsonPath: .spec.controlPlaneEndpoint
       name: Endpoint
       priority: 1
       type: string
@@ -793,7 +793,7 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AWSCluster is the Schema for the awsclusters API
+        description: AWSCluster is the Schema for the awsclusters API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

We identified kubebuilder print column is still pointing to the old status field which was merged in PR https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1372. By changing `Status.APIEndpoints` to `Spec.ControlPlaneEndpoint` it should empty column in `kubectl get awscluster` for endpoints.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Correct field being used for endpoint column on `kubectl get AWSCluster`
```
