### PR TITLE
Allow setting ELB scheme when previously not set

### DIFF
--- a/api/v1alpha4/awscluster_webhook_test.go
+++ b/api/v1alpha4/awscluster_webhook_test.go
@@ -98,6 +98,34 @@ func TestAWSCluster_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "controlPlaneLoadBalancer scheme is immutable when left empty",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						Scheme: &ClassicELBSchemeInternal,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "controlPlaneLoadBalancer scheme can be set to default when left empty",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						Scheme: &ClassicELBSchemeInternetFacing,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "controlPlaneLoadBalancer crossZoneLoadBalancer is mutable",
 			oldCluster: &AWSCluster{
 				Spec: AWSClusterSpec{

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -96,6 +96,10 @@ var (
 	ClassicELBSchemeInternal = ClassicELBScheme("internal")
 )
 
+func (e ClassicELBScheme) String() string {
+	return string(e)
+}
+
 // ClassicELBProtocol defines listener protocols for a classic load balancer.
 type ClassicELBProtocol string
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When controlPlaneEndpoint is not set, it is defaulted to `Internet-facing` and validation webhook does not allow setting it to `Internet-facing` due to immutability. For better UX, this PR allows user to set the ELB scheme to the defaulted value when initially `scheme` is left empty. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2534

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
