### PR TITLE
Upgrade to CAPI v0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,9 +180,9 @@ test-conformance-fast: ## Run clusterctl based conformance test on workload clus
 
 .PHONY: test-cover
 test-cover: ## Run tests with code coverage and code generate  reports
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -coverprofile=out/coverage.out ./... $(TEST_ARGS)
-	go tool cover -func=out/coverage.out -o out/coverage.txt
-	go tool cover -html=out/coverage.out -o out/coverage.html
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -coverprofile=coverage.out ./... $(TEST_ARGS)
+	go tool cover -func=coverage.out -o coverage.txt
+	go tool cover -html=coverage.out -o coverage.html
 ## --------------------------------------
 ## Binaries
 ## --------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-aws
 
 go 1.16
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v0.4.0-rc.0
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v0.4.0
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
@@ -36,8 +36,8 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
 	sigs.k8s.io/aws-iam-authenticator v0.5.3
-	sigs.k8s.io/cluster-api v0.4.0-rc.0
-	sigs.k8s.io/cluster-api/test v0.4.0-rc.0
+	sigs.k8s.io/cluster-api v0.4.0
+	sigs.k8s.io/cluster-api/test v0.4.0
 	sigs.k8s.io/controller-runtime v0.9.1
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1583,10 +1583,10 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/aws-iam-authenticator v0.5.3 h1:EyqQ/uxzbe2mDETZZmuMnv0xHITnyLhZfPlGb6Mma20=
 sigs.k8s.io/aws-iam-authenticator v0.5.3/go.mod h1:DIq7gy0lvnyaG88AgFyJzUVeix+ia5msHEp4RL0102I=
-sigs.k8s.io/cluster-api v0.4.0-rc.0 h1:E52O4W62snVvlGneSUtsvPM/+sfR4+TwcVMbhrkc5No=
-sigs.k8s.io/cluster-api v0.4.0-rc.0/go.mod h1:9ALETQ/6KGZ/kYiqvQGfjOx0CfVGE39d4VP3UrS5B24=
-sigs.k8s.io/cluster-api/test v0.4.0-rc.0 h1:M0TOVHbbz88ZM//LmQbxVnaQyWqJVy57lmm/FP8omSw=
-sigs.k8s.io/cluster-api/test v0.4.0-rc.0/go.mod h1:Smn0J1FPtwLmd4ipXLb42RSXhKW+ur46qHWXoOAfpgw=
+sigs.k8s.io/cluster-api v0.4.0 h1:y9MxtU1uW9r9JtDyOQ/9BRXZEau2PGl2yOIozaxXO0E=
+sigs.k8s.io/cluster-api v0.4.0/go.mod h1:9ALETQ/6KGZ/kYiqvQGfjOx0CfVGE39d4VP3UrS5B24=
+sigs.k8s.io/cluster-api/test v0.4.0 h1:iD9WWGPQWCk85xRWNIdLYKvaZvk3wYD+rTzyqFg7yAg=
+sigs.k8s.io/cluster-api/test v0.4.0/go.mod h1:Smn0J1FPtwLmd4ipXLb42RSXhKW+ur46qHWXoOAfpgw=
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-runtime v0.9.1 h1:+LAqHAhkVW4lt/jLlrKmnGPA7OORMw/xEUH3Ey1h1Bs=
 sigs.k8s.io/controller-runtime v0.9.1/go.mod h1:cTqsgnwSOsYS03XwySYZj8k6vf0+eC4FJRcCgQ9elb4=

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -31,7 +31,7 @@ providers:
     versions:
       - name: v0.4.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0-rc.0/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0/core-components.yaml"
         type: "url"
         files:
           - sourcePath: "./shared/v1alpha4/metadata.yaml"
@@ -50,7 +50,7 @@ providers:
     versions:
       - name: v0.4.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0-rc.0/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0/bootstrap-components.yaml"
         type: "url"
         replacements:
           - old: "imagePullPolicy: Always"
@@ -67,7 +67,7 @@ providers:
     versions:
       - name: v0.4.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0-rc.0/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0/control-plane-components.yaml"
         type: "url"
         replacements:
           - old: "imagePullPolicy: Always"

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -37,7 +37,7 @@ providers:
     versions:
       - name: v0.4.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0-rc.0/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.0/core-components.yaml"
         type: "url"
         files:
           - sourcePath: "./shared/v1alpha4/metadata.yaml"

--- a/test/e2e/shared/resource.go
+++ b/test/e2e/shared/resource.go
@@ -147,7 +147,7 @@ func (r *TestResource) release(request *TestResource) {
 }
 
 func AcquireResources(request *TestResource, nodeNum int, fileLock *flock.Flock) error {
-	timeoutInSec := 60 * 60
+	timeoutInSec := 60 * 60 * 4
 	defer func() error {
 		if err := fileLock.Unlock(); err != nil {
 			return err
@@ -191,7 +191,7 @@ func AcquireResources(request *TestResource, nodeNum int, fileLock *flock.Flock)
 			return err
 		}
 	}
-	return errors.New("giving up on releasing resource due to timeout")
+	return errors.New("giving up on acquiring resource due to timeout")
 }
 
 func ReleaseResources(request *TestResource, nodeNum int, fileLock *flock.Flock) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Upgrades CAPI to v0.4.0 release
- Fixes an issue with coverage tests

**Release note**:
```release-note
NONE
```
