### PR TITLE
Kustomize patch added for move-hierarchy label

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -41,6 +41,14 @@ patchesStrategicMerge:
 
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+# [LABEL] To enable label, uncomment all the sections with [LABEL] prefix.
+# patches here are for adding the label to each global identity CRDs
+- patches/label_in_awsclustercontrolleridentities.yaml
+- patches/label_in_awsclusterroleidentities.yaml
+- patches/label_in_awsclusterstaticidentities.yaml
+
+# +kubebuilder:scaffold:crdkustomizelabelpatch
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/patches/label_in_awsclustercontrolleridentities.yaml
+++ b/config/crd/patches/label_in_awsclustercontrolleridentities.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a label of move-hierarchy for global identity resources like AWSClusterControllerIdentity
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+  name: awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/label_in_awsclusterroleidentities.yaml
+++ b/config/crd/patches/label_in_awsclusterroleidentities.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a label of move-hierarchy for global identity resources like AWSClusterRoleIdentity
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+  name: awsclusterroleidentities.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/label_in_awsclusterstaticidentities.yaml
+++ b/config/crd/patches/label_in_awsclusterstaticidentities.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a label of move-hierarchy for global identity resources like AWSClusterStaticIdentity
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+  name: awsclusterstaticidentities.infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
added kustomize patch to add label of `clusterctl.cluster.x-k8s.io/move-hierarchy` to CRDs of global identity resources like AWSClusterControllerIdentity, AWSClusterRoleIdentity, AWSClusterStaticIdentity.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2533 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
None
```
