### PR TITLE
Makefile fix for pr blocking e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ generate-test-flavors: $(KUSTOMIZE)  ## Generate test template flavors
 
 .PHONY: test-e2e ## Run e2e tests using clusterctl
 test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run e2e tests
-	time $(GINKGO) -trace -stream -progress -v -tags=e2e -focus=$(E2E_UNMANAGED_FOCUS) $(GINKGO_ARGS) -nodes=$(GINKGO_NODES) ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" $(E2E_ARGS) -use-existing-cluster=$(USE_EXISTING_CLUSTER)
+	time $(GINKGO) -trace -stream -progress -v -tags=e2e -focus="$(E2E_UNMANAGED_FOCUS)" $(GINKGO_ARGS) -nodes=$(GINKGO_NODES) ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" $(E2E_ARGS) -use-existing-cluster=$(USE_EXISTING_CLUSTER)
 
 .PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
 test-e2e-eks: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests

--- a/test/e2e/shared/resource.go
+++ b/test/e2e/shared/resource.go
@@ -228,7 +228,3 @@ func ReleaseResources(request *TestResource, nodeNum int, fileLock *flock.Flock)
 	}
 	return errors.New("giving up on releasing resource due to timeout")
 }
-
-func DeleteResourceQuotaFile()  {
-	Expect(os.Remove(ResourceQuotaFilePath)).To(Succeed())
-}

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -242,8 +242,6 @@ func AllNodesBeforeSuite(e2eCtx *E2EContext, data []byte) {
 
 // Node1AfterSuite is cleanup that runs on the first ginkgo node after the test suite finishes
 func Node1AfterSuite(e2eCtx *E2EContext) {
-	DeleteResourceQuotaFile()
-
 	if e2eCtx.Environment.ResourceTickerDone != nil {
 		e2eCtx.Environment.ResourceTickerDone <- true
 	}

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_quick_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_quick_test.go
@@ -1,0 +1,80 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unmanaged
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gofrs/flock"
+	"github.com/onsi/ginkgo/config"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+
+var _ = Describe("Cluster API E2E tests - unmanaged [PR-Blocking]", func() {
+	var (
+		namespace *corev1.Namespace
+		ctx       context.Context
+		specName  = "capi-tests-pr-blocking"
+	)
+
+	BeforeEach(func() {
+		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
+		ctx = context.TODO()
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
+		shared.CreateAWSClusterControllerIdentity(e2eCtx.Environment.BootstrapClusterProxy.GetClient())
+		time.Sleep(5 * time.Second)
+	})
+
+	SetDefaultEventuallyTimeout(20 * time.Minute)
+	SetDefaultEventuallyPollingInterval(10 * time.Second)
+	Context("Running the quick-start spec", func() {
+		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
+		BeforeEach(func() {
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-quick-start-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
+		capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
+			return capi_e2e.QuickStartSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
+				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			}
+		})
+		AfterEach(func() {
+			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+		})
+	})
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+	})
+})

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -72,28 +72,29 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 			}
 		})
 	})
-	Context("Running the KCP upgrade spec - HA cluster", func() {
-		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
-		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
-		BeforeEach(func() {
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-kcp-ha-upgrade-test")
-			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
-		})
-		capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
-			return capi_e2e.KCPUpgradeSpecInput{
-				E2EConfig:                e2eCtx.E2EConfig,
-				ClusterctlConfigPath:     e2eCtx.Environment.ClusterctlConfigPath,
-				BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
-				Flavor:                   clusterctl.DefaultFlavor,
-				ControlPlaneMachineCount: 3,
-				ArtifactFolder:           e2eCtx.Settings.ArtifactFolder,
-				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
-			}
-		})
-		AfterEach(func() {
-			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
-		})
-	})
+	// TODO: Enable when there are more resources in the test infra
+	//Context("Running the KCP upgrade spec - HA cluster", func() {
+	//	// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+	//	requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
+	//	BeforeEach(func() {
+	//		requiredResources.WriteRequestedResources(e2eCtx, "capi-kcp-ha-upgrade-test")
+	//		Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+	//	})
+	//	capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
+	//		return capi_e2e.KCPUpgradeSpecInput{
+	//			E2EConfig:                e2eCtx.E2EConfig,
+	//			ClusterctlConfigPath:     e2eCtx.Environment.ClusterctlConfigPath,
+	//			BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
+	//			Flavor:                   clusterctl.DefaultFlavor,
+	//			ControlPlaneMachineCount: 3,
+	//			ArtifactFolder:           e2eCtx.Settings.ArtifactFolder,
+	//			SkipCleanup:              e2eCtx.Settings.SkipCleanup,
+	//		}
+	//	})
+	//	AfterEach(func() {
+	//		shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+	//	})
+	//})
 	Context("Running the KCP upgrade spec - HA cluster using scale in rollout", func() {
 		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1}

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -53,26 +53,6 @@ var _ = Describe("Cluster API E2E tests - unmanaged", func() {
 
 	SetDefaultEventuallyTimeout(20 * time.Minute)
 	SetDefaultEventuallyPollingInterval(10 * time.Second)
-	Context("Running the quick-start spec [PR-Blocking]", func() {
-		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
-		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}
-		BeforeEach(func() {
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-quick-start-test")
-			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
-		})
-		capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
-			return capi_e2e.QuickStartSpecInput{
-				E2EConfig:             e2eCtx.E2EConfig,
-				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
-				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-				ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
-				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
-			}
-		})
-		AfterEach(func() {
-			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
-		})
-	})
 	Context("Running the KCP upgrade spec - a single control plane cluster", func() {
 		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 3, VPC: 1, ClassicLB: 1, EIP: 3}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
The new PR blocking test was failing due regex problem. This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
