### PR TITLE
fix: ensure updates to subnet are persisted to the scope

### DIFF
--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -127,6 +127,7 @@ func (s *Service) reconcileRouteTables() error {
 
 		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
 			if err := s.associateRouteTable(rt, sn.ID); err != nil {
+				s.scope.Error(err, "trying to associate route table", "subnet_id", sn.ID)
 				return false, err
 			}
 			return true, nil


### PR DESCRIPTION
Signed-off-by: Richard Case <richard@weave.works>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Due to a recent change to remove slices of pointers the subnet reconcilation logic was not correctly saving the subnet ID of the newly created subnets to the AWSCluster/AWSmanagedControlPlane. This then cause the routetable reconcilation to fail because of the missing subnet ids:

```bash
[manager] E0709 13:25:30.608802       8 routetables.go:131]  "msg"="trying to associate route table" "error"="failed to associate route table \"rtb-07d2c36ff9ab81afc\" to subnet \"\": MissingParameter: The request must contain the parameter SubnetId or GatewayId\n\tstatus code: 400, request id: f3fc1704-18cd-436e-9036-a32963045218"  "subnet_id"=""
``` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2546 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
