### PR TITLE
fix: reconcile Secret when userdata changes

### DIFF
--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -245,37 +246,32 @@ func (r *EKSConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 // sets the reference in the configuration status and ready to true.
 func (r *EKSConfigReconciler) storeBootstrapData(ctx context.Context, cluster *clusterv1.Cluster, config *bootstrapv1.EKSConfig, data []byte) error {
 	log := ctrl.LoggerFrom(ctx)
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name,
-			Namespace: config.Namespace,
-			Labels: map[string]string{
-				clusterv1.ClusterLabelName: cluster.Name,
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: bootstrapv1.GroupVersion.String(),
-					Kind:       "EKSConfig",
-					Name:       config.Name,
-					UID:        config.UID,
-					Controller: pointer.BoolPtr(true),
-				},
-			},
-		},
-		Data: map[string][]byte{
-			"value": data,
-		},
-		Type: clusterv1.ClusterSecretType,
-	}
 
 	// as secret creation and scope.Config status patch are not atomic operations
 	// it is possible that secret creation happens but the config.Status patches are not applied
-	if err := r.Client.Create(ctx, secret); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return errors.Wrap(err, "failed to create bootstrap data secret for EKSConfig")
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Name:      config.Name,
+		Namespace: config.Namespace,
+	}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			if err := r.createBootstrapSecret(ctx, cluster, config, data); err != nil {
+				return errors.Wrap(err, "failed to create bootstrap data secret for EKSConfig")
+			}
+			log.Info("created bootstrap data secret for EKSConfig", "secret", secret.Name)
+		} else {
+			return errors.Wrap(err, "failed to get data secret for EKSConfig")
 		}
-		log.Info("bootstrap data secret for EKSConfig already exists", "secret", secret.Name)
+	} else {
+		updated, err := r.updateBootstrapSecret(ctx, secret, data)
+		if err != nil {
+			return errors.Wrap(err, "failed to update data secret for EKSConfig")
+		}
+		if updated {
+			log.Info("updated bootstrap data secret for EKSConfig", "secret", secret.Name)
+		}
 	}
+
 	config.Status.DataSecretName = pointer.StringPtr(secret.Name)
 	config.Status.Ready = true
 	conditions.MarkTrue(config, bootstrapv1.DataSecretAvailableCondition)
@@ -347,4 +343,40 @@ func (r *EKSConfigReconciler) ClusterToEKSConfigs(o client.Object) []ctrl.Reques
 	}
 
 	return result
+}
+
+// Create the Secret containing bootstrap userdata.
+func (r *EKSConfigReconciler) createBootstrapSecret(ctx context.Context, cluster *clusterv1.Cluster, config *bootstrapv1.EKSConfig, data []byte) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: cluster.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: bootstrapv1.GroupVersion.String(),
+					Kind:       "EKSConfig",
+					Name:       config.Name,
+					UID:        config.UID,
+					Controller: pointer.BoolPtr(true),
+				},
+			},
+		},
+		Data: map[string][]byte{
+			"value": data,
+		},
+		Type: clusterv1.ClusterSecretType,
+	}
+	return r.Client.Create(ctx, secret)
+}
+
+// Update the userdata in the bootstrap Secret.
+func (r *EKSConfigReconciler) updateBootstrapSecret(ctx context.Context, secret *corev1.Secret, data []byte) (bool, error) {
+	if !bytes.Equal(secret.Data["value"], data) {
+		secret.Data["value"] = data
+		return true, r.Client.Update(ctx, secret)
+	}
+	return false, nil
 }

--- a/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
+++ b/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -27,39 +28,84 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	bootstrapv1 "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/internal/userdata"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
 func TestEKSConfigReconciler(t *testing.T) {
-	t.Run("Should reconcile an EKSConfig and wait until infrastructure is ready", func(t *testing.T) {
+	t.Run("Should reconcile an EKSConfig and create data Secret", func(t *testing.T) {
 		g := NewWithT(t)
 		cluster := newCluster("test-cluster")
 		machine := newMachine(cluster, "test-machine")
 		config := newEKSConfig(machine, "test-config")
+		expectedUserData, err := newUserData("test-cluster", map[string]string{"test-arg": "test-value"})
+		g.Expect(err).To(BeNil())
+		g.Expect(testEnv.Client.Create(ctx, newAMCP("test-cluster"))).To(Succeed())
 
-		bytes, err := yaml.Marshal(machine)
+		machineBytes, err := yaml.Marshal(machine)
 		g.Expect(err).To(BeNil())
 
 		owner := &unstructured.Unstructured{}
-		err = yaml.Unmarshal(bytes, owner)
+		err = yaml.Unmarshal(machineBytes, owner)
 		g.Expect(err).To(BeNil())
 
 		reconciler := EKSConfigReconciler{
 			Client: testEnv.Client,
 		}
-
 		t.Log("Calling reconcile should requeue")
 		result, err := reconciler.joinWorker(context.Background(), cluster, config)
 		g.Expect(err).To(Succeed())
 		g.Expect(result.Requeue).To(BeFalse())
+
+		t.Log("Secret should exist and be correct")
+		secret := &corev1.Secret{}
+		g.Expect(testEnv.Client.Get(ctx, client.ObjectKey{
+			Name:      "test-config",
+			Namespace: "default",
+		}, secret)).To(Succeed())
+		g.Expect(bytes.Equal(secret.Data["value"], expectedUserData)).To(BeTrue())
+	})
+
+	t.Run("Should reconcile an EKSConfig and update data Secret", func(t *testing.T) {
+		g := NewWithT(t)
+		cluster := newCluster("test-cluster")
+		machine := newMachine(cluster, "test-machine")
+		config := newEKSConfig(machine, "test-config")
+		oldUserData, err := newUserData("test-cluster", map[string]string{"old-test-arg": "old-test-value"})
+		g.Expect(err).To(BeNil())
+		expectedUserData, err := newUserData("test-cluster", map[string]string{"test-arg": "test-value"})
+		g.Expect(err).To(BeNil())
+
+		// Secret already exists in testEnv so we update it
+		g.Expect(testEnv.Client.Update(ctx, newSecret(cluster, config, oldUserData))).To(Succeed())
+
+		reconciler := EKSConfigReconciler{
+			Client: testEnv.Client,
+		}
+		t.Log("Calling reconcile should requeue")
+		result, err := reconciler.joinWorker(context.Background(), cluster, config)
+		g.Expect(err).To(Succeed())
+		g.Expect(result.Requeue).To(BeFalse())
+
+		t.Log("Secret should exist and be up to date")
+		secret := &corev1.Secret{}
+		g.Expect(testEnv.Client.Get(ctx, client.ObjectKey{
+			Name:      "test-config",
+			Namespace: "default",
+		}, secret)).To(Succeed())
+		g.Expect(bytes.Equal(secret.Data["value"], expectedUserData)).To(BeTrue())
 	})
 }
 
 // newCluster return a CAPI cluster object.
 func newCluster(name string) *clusterv1.Cluster {
-	return &clusterv1.Cluster{
+	cluster := &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Cluster",
 			APIVersion: clusterv1.GroupVersion.String(),
@@ -75,7 +121,12 @@ func newCluster(name string) *clusterv1.Cluster {
 				Namespace: "default",
 			},
 		},
+		Status: clusterv1.ClusterStatus{
+			InfrastructureReady: true,
+		},
 	}
+	conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)
+	return cluster
 }
 
 // newMachine return a CAPI machine object; if cluster is not nil, the machine is linked to the cluster as well.
@@ -119,6 +170,11 @@ func newEKSConfig(machine *clusterv1.Machine, name string) *bootstrapv1.EKSConfi
 			Name:      name,
 			UID:       types.UID(fmt.Sprintf("%s uid", name)),
 		},
+		Spec: bootstrapv1.EKSConfigSpec{
+			KubeletExtraArgs: map[string]string{
+				"test-arg": "test-value",
+			},
+		},
 	}
 	if machine != nil {
 		config.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
@@ -133,4 +189,51 @@ func newEKSConfig(machine *clusterv1.Machine, name string) *bootstrapv1.EKSConfi
 		machine.Spec.Bootstrap.ConfigRef.Namespace = config.Namespace
 	}
 	return config
+}
+
+// newUserData generates user data ready to be passed to r.storeBootstrapData.
+func newUserData(clusterName string, kubeletExtraArgs map[string]string) ([]byte, error) {
+	return userdata.NewNode(&userdata.NodeInput{
+		ClusterName:      clusterName,
+		KubeletExtraArgs: kubeletExtraArgs,
+	})
+}
+
+// newAMCP returns an EKS AWSManagedControlPlane object.
+func newAMCP(name string) *ekscontrolplanev1.AWSManagedControlPlane {
+	return &ekscontrolplanev1.AWSManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+			EKSClusterName: "test-cluster",
+		},
+	}
+}
+
+// newSecret returns a secret containing the given user data for the given Cluster and EKSConfig.
+func newSecret(cluster *clusterv1.Cluster, config *bootstrapv1.EKSConfig, data []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: cluster.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: bootstrapv1.GroupVersion.String(),
+					Kind:       "EKSConfig",
+					Name:       config.Name,
+					UID:        config.UID,
+					Controller: pointer.BoolPtr(true),
+				},
+			},
+		},
+		Data: map[string][]byte{
+			"value": data,
+		},
+		Type: clusterv1.ClusterSecretType,
+	}
 }

--- a/bootstrap/eks/controllers/suite_test.go
+++ b/bootstrap/eks/controllers/suite_test.go
@@ -22,6 +22,9 @@ import (
 	"path"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
 	ctrl "sigs.k8s.io/controller-runtime"
 	// +kubebuilder:scaffold:imports
@@ -44,8 +47,10 @@ func TestMain(m *testing.M) {
 func setup() {
 	// utilruntime.Must(bootstrapv1.AddToScheme(scheme.Scheme))
 	// utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(ekscontrolplanev1.AddToScheme(scheme.Scheme))
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
 		path.Join("config", "crd", "bases"),
+		path.Join("controlplane", "eks", "config", "crd", "bases"),
 	},
 	)
 	var err error


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Whenever the `EKSConfig` `.spec.kubeletExtraArgs` field is updated, the eksconfig controller will reconcile the resulting userdata `Secret` and refresh its `.data.value` field value. Otherwise the `Secret` needs to be manually deleted to trigger a LaunchTemplate update.

I'm also improving the unit tests. Currently, since `cluster.Status.InfrastructureReady == false` all tests end [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/bootstrap/eks/controllers/eksconfig_controller.go#L171). With my changes, the `Secret` is effectively created and checked after reconciliation, thus ensuring the entire reconciliation loop was run.

**Which issue(s) this PR fixes** 

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2578

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Update userdata Secret when EKSConfig kubeletExtraArgs are changed
```
