### PR TITLE
Add webhook to ensure that only ID references AMI

### DIFF
--- a/api/v1alpha4/awsmachinetemplate_webhook.go
+++ b/api/v1alpha4/awsmachinetemplate_webhook.go
@@ -55,6 +55,14 @@ func (r *AWSMachineTemplate) ValidateCreate() error {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "template", "spec", "providerID"), "cannot be set in templates"))
 	}
 
+	if spec.AMI.ARN != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "template", "spec", "ami", "arn"), spec.AMI.ARN, "only ID can be used to reference AMI"))
+	}
+
+	if spec.AMI.Filters != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "template", "spec", "filters"), spec.AMI.Filters, "only ID can be used to reference AMI"))
+	}
+
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 

--- a/api/v1alpha4/awsmachinetemplate_webhook_test.go
+++ b/api/v1alpha4/awsmachinetemplate_webhook_test.go
@@ -60,6 +60,38 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			name: "don't allow to reference AMI using ARN",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							AMI: AWSResourceReference{
+								ARN: pointer.String("arn"),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "don't allow to reference AMI using Filters",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							AMI: AWSResourceReference{
+								Filters: []Filter{{Name: "filter"}},
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Currently, only ID is used to reference an AMI https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/pkg/cloud/services/ec2/instances.go#L132 however we expose two other API fields - ARN and Filters. This PR adds a webhook to prevent users from using unsupported values.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add webhook to ensure that only ID references AMI 
```
