### PR TITLE
Automated cherry pick of #2587: Cleanup ReconcileVPC() and set id early in reconciliation.

### DIFF
--- a/api/v1alpha3/awscluster_webhook_test.go
+++ b/api/v1alpha3/awscluster_webhook_test.go
@@ -143,6 +143,38 @@ func TestAWSCluster_ValidateUpdate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "VPC id is immutable cannot be emptied once set",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					NetworkSpec: NetworkSpec{
+						VPC: VPCSpec{ID: "managed-or-unmanaged-vpc"},
+					},
+				},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "VPC id is immutable, cannot be set to a different value once set",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					NetworkSpec: NetworkSpec{
+						VPC: VPCSpec{ID: "managed-or-unmanaged-vpc"},
+					},
+				},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					NetworkSpec: NetworkSpec{
+						VPC: VPCSpec{ID: "a-new-vpc"},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #2587 on release-0.6.

#2587: Cleanup ReconcileVPC() and set id early in reconciliation.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.