### PR TITLE
eksconfig_controller_reconciler_test: Eventually test for updated secret

### DIFF
--- a/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
+++ b/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
@@ -116,9 +116,8 @@ func TestEKSConfigReconciler(t *testing.T) {
 				Name:      config.Name,
 				Namespace: "default",
 			}, secret)).To(Succeed())
+			g.Expect(string(secret.Data["value"])).To(Equal(string(oldUserData)))
 		}).Should(Succeed())
-
-		g.Expect(string(secret.Data["value"])).To(Equal(string(oldUserData)))
 
 		// Secret already exists in testEnv so we update it
 		config.Spec.KubeletExtraArgs = map[string]string{
@@ -140,8 +139,8 @@ func TestEKSConfigReconciler(t *testing.T) {
 				Name:      config.Name,
 				Namespace: "default",
 			}, secret)).To(Succeed())
+			g.Expect(string(secret.Data["value"])).To(Equal(string(expectedUserData)))
 		}).Should(Succeed())
-		g.Expect(string(secret.Data["value"])).To(Equal(string(expectedUserData)))
 	})
 }
 


### PR DESCRIPTION
Moves the check for the value of the modified secret into the
Eventually, since the new secret value is eventually consistent.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**


/kind failing-test



**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```

/assign @richardcase 
