### PR TITLE
bug: Add bastion-sg to managedMachinePool remoteAccess source-sgs when bastion is enabled

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -127,13 +127,13 @@ func (s *NodegroupService) remoteAccess() (*eks.RemoteAccessConfig, error) {
 		sSGs = append(sSGs, clusterSG.ID)
 
 		if controlPlane.Spec.Bastion.Enabled {
-			additionalSG, ok := controlPlane.Status.Network.SecurityGroups[infrav1.SecurityGroupEKSNodeAdditional]
+			bastionSG, ok := controlPlane.Status.Network.SecurityGroups[infrav1.SecurityGroupBastion]
 			if !ok {
-				return nil, errors.Errorf("%s security group not found on control plane", infrav1.SecurityGroupEKSNodeAdditional)
+				return nil, errors.Errorf("%s security group not found on control plane", infrav1.SecurityGroupBastion)
 			}
 			sSGs = append(
 				sSGs,
-				additionalSG.ID,
+				bastionSG.ID,
 			)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When bastion is enabled for an EKS cluster, this PR ensures SSH access via bastion, to the worker nodes/instances associated with the NodeGroup. 

Currently, when bastion is enabled and SSH key is configured in a ManagedMachinePool, SSH access fails when attempted from the bastion node using the private IP of the worker node.
This is because worker node security-group(sg) "eks-remoteAccess-" has an inbound rule with "-node-eks-additional" sg as source, which in turn has an inbound rule with "-bastion" sg as source.  But adding a security group as a source does not add rules from the source security group.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2442 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
