### PR TITLE
Separate EKS-related IAM resources

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -250,6 +250,17 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.custom-suffix.com
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -250,6 +250,17 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -263,6 +263,17 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:ssm:*:*:parameter/cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -255,6 +255,19 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      Groups:
+      - Ref: AWSIAMGroupBootstrapper
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -255,6 +255,19 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      Groups:
+      - Ref: AWSIAMGroupBootstrapper
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -250,6 +250,17 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -250,6 +250,17 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -250,6 +250,17 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -255,6 +255,19 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      Groups:
+      - Ref: AWSIAMGroupBootstrapper
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -250,6 +250,17 @@ Resources:
           Effect: Allow
           Resource:
           - arn:*:ssm:*:*:parameter/cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
         - Action:
           - ssm:GetParameter
           Effect: Allow

--- a/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
@@ -29,7 +29,7 @@ import (
 type PolicyName string
 
 // ManagedIAMPolicyNames slice of managed IAM policies.
-var ManagedIAMPolicyNames = [4]PolicyName{ControllersPolicy, ControlPlanePolicy, NodePolicy, CSIPolicy}
+var ManagedIAMPolicyNames = [5]PolicyName{ControllersPolicy, ControllersPolicyEKS, ControlPlanePolicy, NodePolicy, CSIPolicy}
 
 // IsValid will check if a given policy name is valid. That is, it will check if the given policy name is
 // one of the ManagedIAMPolicyNames.
@@ -63,10 +63,11 @@ func (t Template) GenerateManagedIAMPolicyDocuments(policyDocDir string) error {
 
 func (t Template) policyFunctionMap() map[PolicyName]func() *v1alpha4.PolicyDocument {
 	return map[PolicyName]func() *v1alpha4.PolicyDocument{
-		ControlPlanePolicy: t.cloudProviderControlPlaneAwsPolicy,
-		ControllersPolicy:  t.ControllersPolicy,
-		NodePolicy:         t.cloudProviderNodeAwsPolicy,
-		CSIPolicy:          t.csiControllerPolicy,
+		ControlPlanePolicy:   t.cloudProviderControlPlaneAwsPolicy,
+		ControllersPolicy:    t.ControllersPolicy,
+		ControllersPolicyEKS: t.ControllersPolicyEKS,
+		NodePolicy:           t.cloudProviderNodeAwsPolicy,
+		CSIPolicy:            t.csiControllerPolicy,
 	}
 }
 

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template.go
@@ -45,6 +45,7 @@ const (
 	AWSIAMRoleEKSFargate                         = "AWSIAMRoleEKSFargate"
 	AWSIAMUserBootstrapper                       = "AWSIAMUserBootstrapper"
 	ControllersPolicy                 PolicyName = "AWSIAMManagedPolicyControllers"
+	ControllersPolicyEKS              PolicyName = "AWSIAMManagedPolicyControllersEKS"
 	ControlPlanePolicy                PolicyName = "AWSIAMManagedPolicyCloudProviderControlPlane"
 	NodePolicy                        PolicyName = "AWSIAMManagedPolicyCloudProviderNodes"
 	CSIPolicy                         PolicyName = "AWSEBSCSIPolicyController"
@@ -94,6 +95,16 @@ func (t Template) RenderCloudFormation() *cloudformation.Template {
 		PolicyDocument:    t.ControllersPolicy(),
 		Groups:            t.controllersPolicyGroups(),
 		Roles:             t.controllersPolicyRoleAttachments(),
+	}
+
+	if !t.Spec.EKS.Disable {
+		template.Resources[string(ControllersPolicyEKS)] = &cfn_iam.ManagedPolicy{
+			ManagedPolicyName: t.NewManagedName("controllers-eks"),
+			Description:       `For the Kubernetes Cluster API Provider AWS Controllers`,
+			PolicyDocument:    t.ControllersPolicyEKS(),
+			Groups:            t.controllersPolicyGroups(),
+			Roles:             t.controllersPolicyRoleAttachments(),
+		}
 	}
 
 	if !t.Spec.ControlPlane.DisableCloudProviderPolicy {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR works around the AWS character limit for managed policies. In the e2e tests the `AWSIAMManagedPolicyControllers` policy is currently very close to the AWS limit, which means that the next time a feature adds a few lines to this policy, the CloudFormation template would error out (I've already hit this limit while working on #2271, hence this issue + PR). More info and repro instructions in #2642.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2642

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Move EKS-related resources from `AWSIAMManagedPolicyControllers` to a separate policy to work around AWS size limit for managed policies.
```
