### PR TITLE
Retry fetching managed vpc attributes when vpc is 'NotFound'

### DIFF
--- a/pkg/cloud/services/network/vpc.go
+++ b/pkg/cloud/services/network/vpc.go
@@ -117,6 +117,10 @@ func (s *Service) ensureManagedVPCAttributes(vpc *infrav1.VPCSpec) error {
 	}
 	vpcAttr, err := s.EC2Client.DescribeVpcAttribute(descAttrInput)
 	if err != nil {
+		// If the returned error is a 'NotFound' error it should trigger retry
+		if code, ok := awserrors.Code(errors.Cause(err)); ok && code == awserrors.VPCNotFound {
+			return err
+		}
 		errs = append(errs, errors.Wrap(err, "failed to describe enableDnsHostnames vpc attribute"))
 	} else if !aws.BoolValue(vpcAttr.EnableDnsHostnames.Value) {
 		attrInput := &ec2.ModifyVpcAttributeInput{
@@ -136,6 +140,10 @@ func (s *Service) ensureManagedVPCAttributes(vpc *infrav1.VPCSpec) error {
 	}
 	vpcAttr, err = s.EC2Client.DescribeVpcAttribute(descAttrInput)
 	if err != nil {
+		// If the returned error is a 'NotFound' error it should trigger retry
+		if code, ok := awserrors.Code(errors.Cause(err)); ok && code == awserrors.VPCNotFound {
+			return err
+		}
 		errs = append(errs, errors.Wrap(err, "failed to describe enableDnsSupport vpc attribute"))
 	} else if !aws.BoolValue(vpcAttr.EnableDnsSupport.Value) {
 		attrInput := &ec2.ModifyVpcAttributeInput{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The logic to retry when vpc is not found, already exists, but does not work as intended due to a minor bug.
This PR adds a fix to identify vpc 'NotFound' error and retry fetching vpc, instead of recreating an already existing vpc.


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2658 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Retry EC2::DescribeVpcAttribute when VPCs is temporarily not found instead of creating a duplicate
```
