### PR TITLE
Remove elasticloadbalancing:AddTags duplicate entries.

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cloud_provider_integration_control_plane.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cloud_provider_integration_control_plane.go
@@ -78,7 +78,6 @@ func (t Template) cloudProviderControlPlaneAwsPolicy() *v1alpha4.PolicyDocument 
 					"elasticloadbalancing:ModifyLoadBalancerAttributes",
 					"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
 					"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
-					"elasticloadbalancing:AddTags",
 					"elasticloadbalancing:CreateListener",
 					"elasticloadbalancing:CreateTargetGroup",
 					"elasticloadbalancing:DeleteListener",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -68,7 +68,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -68,7 +68,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -68,7 +68,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -65,7 +65,6 @@ Resources:
           - elasticloadbalancing:ModifyLoadBalancerAttributes
           - elasticloadbalancing:RegisterInstancesWithLoadBalancer
           - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-          - elasticloadbalancing:AddTags
           - elasticloadbalancing:CreateListener
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener


### PR DESCRIPTION
This PR removes all the duplicate `elasticloadbalancing:AddTags` entries from the policies that `clusterawsadm` generates.

Signed-off-by: Rayan Das <rayandas91@gmail.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**:
Fixes #2683 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits

**Release note**:
```
Removed elasticloadbalancing:AddTags duplicate entries.
```

