### PR TITLE
[cloud/network] Fix panic on RouteTables reconcile.

### DIFF
--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -80,7 +80,8 @@ func (s *Service) reconcileRouteTables() error {
 					// Routes destination cidr blocks must be unique within a routing table.
 					// If there is a mistmatch, we replace the routing association.
 					specRoute := routes[i]
-					if *currentRoute.DestinationCidrBlock == *specRoute.DestinationCidrBlock &&
+					if (currentRoute.DestinationCidrBlock != nil && // Manually-created routes can have .DestinationIpv6CidrBlock or .DestinationPrefixListId set instead.
+						*currentRoute.DestinationCidrBlock == *specRoute.DestinationCidrBlock) &&
 						((currentRoute.GatewayId != nil && *currentRoute.GatewayId != *specRoute.GatewayId) ||
 							(currentRoute.NatGatewayId != nil && *currentRoute.NatGatewayId != *specRoute.NatGatewayId)) {
 						if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a panic when there are extra routes with non-CIDR destinations (IPv6 CIDR, Prefix List) present in the managed routing table.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: N/A

**Special notes for your reviewer**: N/A

**Checklist**:

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
BUGFIX: Fixes a panic when there are extra routes with non-CIDR destinations (IPv6 CIDR, Prefix List) present in the managed routing table.
```
