### PR TITLE
Add AWS cloud provider tags to pre-existing infrastructure

### DIFF
--- a/api/v1alpha4/tags.go
+++ b/api/v1alpha4/tags.go
@@ -188,7 +188,9 @@ func Build(params BuildParams) Tags {
 		tags[k] = v
 	}
 
-	tags[ClusterTagKey(params.ClusterName)] = string(params.Lifecycle)
+	if params.ClusterName != "" {
+		tags[ClusterTagKey(params.ClusterName)] = string(params.Lifecycle)
+	}
 	if params.Role != nil {
 		tags[NameAWSClusterAPIRole] = *params.Role
 	}

--- a/pkg/cloud/tags/tags.go
+++ b/pkg/cloud/tags/tags.go
@@ -90,12 +90,19 @@ func WithEC2(ec2client ec2iface.EC2API) BuilderOption {
 	return func(b *Builder) {
 		b.applyFunc = func(params *infrav1.BuildParams) error {
 			tags := infrav1.Build(*params)
-
 			awsTags := make([]*ec2.Tag, 0, len(tags))
-			for k, v := range tags {
+
+			// For testing, we need sorted keys
+			sortedKeys := make([]string, 0, len(tags))
+			for k := range tags {
+				sortedKeys = append(sortedKeys, k)
+			}
+			sort.Strings(sortedKeys)
+
+			for _, key := range sortedKeys {
 				tag := &ec2.Tag{
-					Key:   aws.String(k),
-					Value: aws.String(v),
+					Key:   aws.String(key),
+					Value: aws.String(tags[key]),
 				}
 				awsTags = append(awsTags, tag)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Support writing AWS cloud provider tags on pre-existing infrastructure

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2584

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note:**
```release-note
Support adding AWS cloud provider tags to pre-existing infrastructure
`kubernetes.io/cluster/<name> = shared` and `kubernetes.io/role/elb = 1` for public subnets
`kubernetes.io/cluster/<name> = shared` and`kubernetes.io/role/internal-elb = 1` for private subnets
```