### PR TITLE
fix: node affinity rules in external CCM CRDs

### DIFF
--- a/test/e2e/data/infrastructure-aws/cluster-template-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template-external-cloud-provider.yaml
@@ -195,6 +195,20 @@ data:
               effect: NoSchedule
             - key: node-role.kubernetes.io/master
               effect: NoSchedule
+            - key: node-role.kubernetes.io/master
+                effect: NoSchedule
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager

--- a/test/e2e/data/infrastructure-aws/external-cloud-provider/aws-ccm-external.yaml
+++ b/test/e2e/data/infrastructure-aws/external-cloud-provider/aws-ccm-external.yaml
@@ -25,6 +25,20 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Follow up of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2647
Added node affinity rules for external cloud provider as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
