### PR TITLE
fix: node affinity rules indentation in external CCM CRDs

### DIFF
--- a/test/e2e/data/infrastructure-aws/cluster-template-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template-external-cloud-provider.yaml
@@ -195,8 +195,6 @@ data:
               effect: NoSchedule
             - key: node-role.kubernetes.io/master
               effect: NoSchedule
-            - key: node-role.kubernetes.io/master
-                effect: NoSchedule
             - effect: NoSchedule
               key: node-role.kubernetes.io/control-plane
           affinity:

--- a/test/e2e/data/infrastructure-aws/external-cloud-provider/aws-ccm-external.yaml
+++ b/test/e2e/data/infrastructure-aws/external-cloud-provider/aws-ccm-external.yaml
@@ -25,8 +25,6 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-        - key: node-role.kubernetes.io/master
-            effect: NoSchedule
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
       affinity:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix for failing e2e test in https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2722

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
