### PR TITLE
fix: add the doc for using external CCM with CSI driver to summary_prefix.md

### DIFF
--- a/docs/book/src/SUMMARY_PREFIX.md
+++ b/docs/book/src/SUMMARY_PREFIX.md
@@ -20,6 +20,7 @@
   - [Consuming Existing AWS Infrastructure](./topics/consuming-existing-aws-infrastructure.md)
   - [Specifying the IAM Role to use for Management Components](./topics/specify-management-iam-role.md)
   - [Multi-AZ Control Planes](./topics/multi-az-control-planes.md)
+  - [Using external cloud provider with EBS CSI driver](./topics/external-cloud-provider-with-ebs-csi-driver.md)
   - [Restricting Cluster API to certain namespaces](./topics/restricting-cluster-api-to-certain-namespaces.md)
   - [Using Cluster API with cross-account role assumption](./topics/using-cluster-api-with-cross-account-role-assumption.md)
   - [Userdata Privacy](./topics/userdata-privacy.md)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
The doc which was added for [using external cloud provider with EBS CSI driver](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2718) was not added to `SUMMARY_PREFIX.md`, which is added in this PR

**Checklist**:
- [ ] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
