### PR TITLE
chore: updated header verify to support go 1.17 build contraints

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -97,6 +97,8 @@ def file_passes(filename, refs, regexs):
 
     # remove extra content from the top of files
     if extension == "go" or extension == "generatego":
+        p = regexs["go_build_constraints_old"]
+        (data, found) = p.subn("", data, 1)
         p = regexs["go_build_constraints"]
         (data, found) = p.subn("", data, 1)
     elif extension == "sh":
@@ -204,7 +206,9 @@ def get_regexs():
     # company holder names can be anything
     regexs["date"] = re.compile(get_dates())
     # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
+    regexs["go_build_constraints_old"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
+    # strip // +build \n\n build constraints
+    regexs["go_build_constraints"] = re.compile(r"^(//go.build.*\n)", re.MULTILINE)
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     # Search for generated files


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
Go 1.17 introduces a new format for build constrants, see the following:

https://golang.org/doc/go1.17
https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md

And files formatted using `go fmt` will be changed to use the new
format. For example in our e2e test files:

```go
//go:build e2e
// +build e2e
```

This change updates the header verification to strip out the new build
constraint tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
