### PR TITLE
Fix the timeout for conformance test due to prolonged log collection

### DIFF
--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -131,7 +131,7 @@ func DumpMachine(ctx context.Context, e2eCtx *E2EContext, machine infrav1.AWSMac
 		[]command{
 			{
 				title: "systemd",
-				cmd:   "journalctl --no-pager --output=short-precise",
+				cmd:   "journalctl --no-pager --output=short-precise | grep -v  'audit:\\|audit\\['",
 			},
 			{
 				title: "kern",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
This PR fixes the timeout errors in the conformance tests because log collection takes longer time than expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2746 

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
