### PR TITLE
Add v1alpha3 to v1alpha4 upgrade e2e test

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -50,6 +50,17 @@ providers:
             new: "--leader-elect=false"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
+      - name: v0.3.16 # latest published release
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/core-components.yaml"
+        type: "url"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+          - old: "--leader-elect"
+            new: "--leader-elect=false"
+          - old: --metrics-bind-addr=127.0.0.1:8080
+            new: --metrics-bind-addr=:8080
+
 
   - name: kubeadm
     type: BootstrapProvider

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -126,4 +126,26 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
 		})
 	})
+
+	ginkgo.Describe("Running the Clusterctl Upgrade Spec", func() {
+		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1}
+		ginkgo.BeforeEach(func() {
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-clusterctl-upgrade-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
+
+		capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {
+			return capi_e2e.ClusterctlUpgradeSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
+				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			}
+		})
+		ginkgo.AfterEach(func() {
+			shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind regression

**What this PR does / why we need it**:
The upgrade path from v1alpha3 to v1alpha4 has to be tested in E2E, hence this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2388 

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
```release-note
Add v1alpha3 to v1alpha4 upgrade test
```
