### PR TITLE
[backport] Rename the ELB scheme from Internet-facing to internet-facing

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -146,9 +146,9 @@ type Bastion struct {
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer.
 type AWSLoadBalancerSpec struct {
-	// Scheme sets the scheme of the load balancer (defaults to Internet-facing)
-	// +kubebuilder:default=Internet-facing
-	// +kubebuilder:validation:Enum=Internet-facing;internal
+	// Scheme sets the scheme of the load balancer (defaults to internet-facing)
+	// +kubebuilder:default=internet-facing
+	// +kubebuilder:validation:Enum=internet-facing;internal
 	// +optional
 	Scheme *ClassicELBScheme `json:"scheme,omitempty"`
 

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -89,7 +89,7 @@ type ClassicELBScheme string
 var (
 	// ClassicELBSchemeInternetFacing defines an internet-facing, publicly
 	// accessible AWS Classic ELB scheme.
-	ClassicELBSchemeInternetFacing = ClassicELBScheme("Internet-facing")
+	ClassicELBSchemeInternetFacing = ClassicELBScheme("internet-facing")
 
 	// ClassicELBSchemeInternal defines an internal-only facing
 	// load balancer internal to an ELB.

--- a/api/v1alpha4/awscluster_types.go
+++ b/api/v1alpha4/awscluster_types.go
@@ -146,9 +146,9 @@ type Bastion struct {
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer.
 type AWSLoadBalancerSpec struct {
-	// Scheme sets the scheme of the load balancer (defaults to Internet-facing)
-	// +kubebuilder:default=Internet-facing
-	// +kubebuilder:validation:Enum=Internet-facing;internal
+	// Scheme sets the scheme of the load balancer (defaults to internet-facing)
+	// +kubebuilder:default=internet-facing
+	// +kubebuilder:validation:Enum=internet-facing;internal
 	// +optional
 	Scheme *ClassicELBScheme `json:"scheme,omitempty"`
 

--- a/api/v1alpha4/awscluster_webhook.go
+++ b/api/v1alpha4/awscluster_webhook.go
@@ -84,11 +84,11 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if oldC.Spec.ControlPlaneLoadBalancer == nil {
-		// If old scheme was nil, the only value accepted here is the default value: Internet-facing
+		// If old scheme was nil, the only value accepted here is the default value: internet-facing
 		if newLoadBalancer.Scheme != nil && newLoadBalancer.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "scheme"),
-					r.Spec.ControlPlaneLoadBalancer.Scheme, "field is immutable, default value was set to Internet-facing"),
+					r.Spec.ControlPlaneLoadBalancer.Scheme, "field is immutable, default value was set to internet-facing"),
 			)
 		}
 	} else {

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -103,7 +103,7 @@ type ClassicELBScheme string
 var (
 	// ClassicELBSchemeInternetFacing defines an internet-facing, publicly
 	// accessible AWS Classic ELB scheme.
-	ClassicELBSchemeInternetFacing = ClassicELBScheme("Internet-facing")
+	ClassicELBSchemeInternetFacing = ClassicELBScheme("internet-facing")
 
 	// ClassicELBSchemeInternal defines an internal-only facing
 	// load balancer internal to an ELB.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -138,11 +138,11 @@ spec:
                       to false."
                     type: boolean
                   scheme:
-                    default: Internet-facing
+                    default: internet-facing
                     description: Scheme sets the scheme of the load balancer (defaults
-                      to Internet-facing)
+                      to internet-facing)
                     enum:
-                    - Internet-facing
+                    - internet-facing
                     - internal
                     type: string
                   subnets:
@@ -886,11 +886,11 @@ spec:
                       to false."
                     type: boolean
                   scheme:
-                    default: Internet-facing
+                    default: internet-facing
                     description: Scheme sets the scheme of the load balancer (defaults
-                      to Internet-facing)
+                      to internet-facing)
                     enum:
-                    - Internet-facing
+                    - internet-facing
                     - internal
                     type: string
                   subnets:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -126,11 +126,11 @@ spec:
                               \n Defaults to false."
                             type: boolean
                           scheme:
-                            default: Internet-facing
+                            default: internet-facing
                             description: Scheme sets the scheme of the load balancer
-                              (defaults to Internet-facing)
+                              (defaults to internet-facing)
                             enum:
-                            - Internet-facing
+                            - internet-facing
                             - internal
                             type: string
                           subnets:


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
Backport of #2768. According to AWS documentation, the scheme is lowercase. If the field is explicitly set to Internet-facing, CAPA fails to recognize the ELB it has created, because the ELB's scheme is lowercase, i.e., internet-facing.

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2534 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Changes the accepted ELB scheme from "Internet-facing" to "internet-facing." Although this is a breaking API change, it should not impact any user, because cluster create always fails with the previous value.
```
