### PR TITLE
chore: Remove unnecessary conversion code

### DIFF
--- a/api/v1alpha3/conversion.go
+++ b/api/v1alpha3/conversion.go
@@ -42,10 +42,6 @@ func (r *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	restoreInstance(restored.Status.Bastion, dst.Status.Bastion)
-	if restored.Status.Bastion != nil && dst.Status.Bastion != nil {
-		RestoreRootVolume(restored.Status.Bastion.RootVolume, dst.Status.Bastion.RootVolume)
-		restoreNonRootVolumes(restored.Status.Bastion.NonRootVolumes, dst.Status.Bastion.NonRootVolumes)
-	}
 	return nil
 }
 
@@ -146,7 +142,6 @@ func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 
 // ConvertFrom converts the v1alpha4 AWSMachineTemplate receiver to a v1alpha3 AWSMachineTemplate.
 func (r *AWSMachineTemplate) ConvertFrom(srcRaw conversion.Hub) error {
-
 	src := srcRaw.(*v1alpha4.AWSMachineTemplate)
 
 	if err := Convert_v1alpha4_AWSMachineTemplate_To_v1alpha3_AWSMachineTemplate(src, r, nil); err != nil {
@@ -357,8 +352,8 @@ func restoreNonRootVolumes(restoredVolumes, dstVolumes []v1alpha4.Volume) {
 	if dstVolumes == nil {
 		dstVolumes = make([]v1alpha4.Volume, 0)
 	}
-	//restoring the nonrootvolumes which are missing in dstVolumes
-	//restoring dstVolumes[i].Encrypted to nil in order to avoid v1alpha4 --> v1alpha3 --> v1alpha4 round trip errors
+	// restoring the nonrootvolumes which are missing in dstVolumes
+	// restoring dstVolumes[i].Encrypted to nil in order to avoid v1alpha4 --> v1alpha3 --> v1alpha4 round trip errors
 	for i := range restoredVolumes {
 		if restoredVolumes[i].Encrypted == nil {
 			if len(dstVolumes) <= i {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The removed code, introduced in #2556, became unnecessary when
equivalent code was added to the restoreInstance() function in #2468.

This code handles a subset of the cases that restoreInstances() does;
namely, when both the restored and dst pointers are non-nil. The
conversion tests fail if the restoreInstance() call is removed, but this
code is left.  They pass if this code is removed.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
