### PR TITLE
Download the e2e restart scripts outside the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,6 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
 # Copy the sources
 COPY ./ ./
 
-RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
-  wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \
-  chmod +x /start.sh && chmod +x /restart.sh
-
 # Build
 ARG package=.
 ARG ARCH

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ test-e2e-eks: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks 
 	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" --source-template="$(EKS_SOURCE_TEMPLATE)" $(E2E_ARGS) $(EKS_E2E_ARGS)
 
 .PHONY: e2e-image
-e2e-image: docker-pull-prerequisites
+e2e-image: docker-pull-prerequisites $(TOOLS_BIN_DIR)/start.sh $(TOOLS_BIN_DIR)/restart.sh
 	docker build -f Dockerfile --tag="gcr.io/k8s-staging-cluster-api/capa-manager:e2e" .
 
 CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -58,6 +58,11 @@ $(SHARE_DIR):
 $(GTAR):
 	@$(GTAR) --version > /dev/null || (echo Install GNU Tar with brew install gnu-tar && exit -1)
 
+$(BIN_DIR)/start.sh:
+	curl https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh -o $@
+
+$(BIN_DIR)/restart.sh:
+	curl https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh -o $@
 
 GO_APIDIFF := $(BIN_DIR)/go-apidiff
 $(GO_APIDIFF): $(BIN_DIR) go.mod go.sum


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
There is some network issues in downloading the start.sh and restart.sh scripts in dockerfile, which is causing e2e test runs to fail. This PR fetches those scripts outside the dockerfile to fix the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
None
```
