### PR TITLE
Update tilt-provider.json to add CAPA label in Tilt

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -14,7 +14,9 @@
         "pkg",
         "controlplane/eks",
         "bootstrap/eks"
-      ]
+      ],
+      "label": "CAPA",
+      "manager_name": "capa-controller-manager"
     }
   }
 ]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update tilt-provider.json to add CAPA label in Tilt UX. This grouping feature is supported in tilt version >= v0.22.2.
See [cluster-api issue](https://github.com/kubernetes-sigs/cluster-api/pull/5217) for grouping resources in Tilt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
```release-note
Add CAPA label in Tilt
```
