### PR TITLE
Ensure destination pointer is non-nil before calling restore functions

### DIFF
--- a/exp/api/v1alpha3/conversion.go
+++ b/exp/api/v1alpha3/conversion.go
@@ -42,13 +42,17 @@ func (r *AWSMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	infrav1alpha3.RestoreAMIReference(&restored.Spec.AWSLaunchTemplate.AMI, &dst.Spec.AWSLaunchTemplate.AMI)
-	infrav1alpha3.RestoreRootVolume(restored.Spec.AWSLaunchTemplate.RootVolume, dst.Spec.AWSLaunchTemplate.RootVolume)
+	if restored.Spec.AWSLaunchTemplate.RootVolume != nil {
+		if dst.Spec.AWSLaunchTemplate.RootVolume == nil {
+			dst.Spec.AWSLaunchTemplate.RootVolume = &infrav1alpha4.Volume{}
+		}
+		infrav1alpha3.RestoreRootVolume(restored.Spec.AWSLaunchTemplate.RootVolume, dst.Spec.AWSLaunchTemplate.RootVolume)
+	}
 	return nil
 }
 
 // ConvertFrom converts the v1alpha4 AWSMachinePool receiver to a v1alpha3 AWSMachinePool.
 func (r *AWSMachinePool) ConvertFrom(srcRaw conversion.Hub) error {
-
 	src := srcRaw.(*v1alpha4.AWSMachinePool)
 
 	if err := Convert_v1alpha4_AWSMachinePool_To_v1alpha3_AWSMachinePool(src, r, nil); err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Previously, the functions were reassigning the destination pointer, which had no effect outside the function scope, because pointers are passed by value.

(The bug had no effect on the conversion tests, but that appears to be a happy accident.)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Another approach is to return errors if either the `dst` pointer is nil. However, the caller _wants_ to end up with a non-nil `dst`, and that's only possible if the caller initializes it. Likewise, the caller does not need to call the function if `restored` is nil, so we ask the caller to make that decision, rather than adding a nil check in the function.

In summary, if either `restored` or `dst` is nil, the caller is implemented incorrectly.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note

```
