### PR TITLE
Fix reconciliation of AWS ingress rules of same port

### DIFF
--- a/api/v1alpha4/types_test.go
+++ b/api/v1alpha4/types_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSG_Difference(t *testing.T) {
+	tests := []struct {
+		name     string
+		self     IngressRules
+		input    IngressRules
+		expected IngressRules
+	}{
+		{
+			name:     "self and input are nil",
+			self:     nil,
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "input is nil",
+			self: IngressRules{
+				{
+					Description:            "SSH",
+					Protocol:               SecurityGroupProtocolTCP,
+					FromPort:               22,
+					ToPort:                 22,
+					SourceSecurityGroupIDs: []string{"sg-source-1"},
+				},
+			},
+			input: nil,
+			expected: IngressRules{
+				{
+					Description:            "SSH",
+					Protocol:               SecurityGroupProtocolTCP,
+					FromPort:               22,
+					ToPort:                 22,
+					SourceSecurityGroupIDs: []string{"sg-source-1"},
+				},
+			},
+		},
+		{
+			name: "self has more rules",
+			self: IngressRules{
+				{
+					Description:            "SSH",
+					Protocol:               SecurityGroupProtocolTCP,
+					FromPort:               22,
+					ToPort:                 22,
+					SourceSecurityGroupIDs: []string{"sg-source-1"},
+				},
+				{
+					Description: "MY-SSH",
+					Protocol:    SecurityGroupProtocolTCP,
+					FromPort:    22,
+					ToPort:      22,
+					CidrBlocks:  []string{"0.0.0.0/0"},
+				},
+			},
+			input: IngressRules{
+				{
+					Description:            "SSH",
+					Protocol:               SecurityGroupProtocolTCP,
+					FromPort:               22,
+					ToPort:                 22,
+					SourceSecurityGroupIDs: []string{"sg-source-1"},
+				},
+			},
+			expected: IngressRules{
+				{
+					Description: "MY-SSH",
+					Protocol:    SecurityGroupProtocolTCP,
+					FromPort:    22,
+					ToPort:      22,
+					CidrBlocks:  []string{"0.0.0.0/0"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			out := tc.self.Difference(tc.input)
+
+			g.Expect(out).To(Equal(tc.expected))
+		})
+	}
+}

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -652,45 +652,54 @@ func ingressRuleToSDKType(i *infrav1.IngressRule) (res *ec2.IpPermission) {
 	return res
 }
 
-func ingressRuleFromSDKType(v *ec2.IpPermission) (res infrav1.IngressRule) {
+func ingressRulesFromSDKType(v *ec2.IpPermission) (res infrav1.IngressRules) {
 	// Ports are only well-defined for TCP and UDP protocols, but EC2 overloads the port range
 	// in the case of ICMP(v6) traffic to indicate which codes are allowed. For all other protocols,
-	// including the custom "-1" All Traffic protcol, FromPort and ToPort are omitted from the response.
+	// including the custom "-1" All Traffic protocol, FromPort and ToPort are omitted from the response.
 	// See: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html
+	var ir infrav1.IngressRule
 	switch *v.IpProtocol {
 	case IPProtocolTCP,
 		IPProtocolUDP,
 		IPProtocolICMP,
 		IPProtocolICMPv6:
-		res = infrav1.IngressRule{
+		ir = infrav1.IngressRule{
 			Protocol: infrav1.SecurityGroupProtocol(*v.IpProtocol),
 			FromPort: *v.FromPort,
 			ToPort:   *v.ToPort,
 		}
 	default:
-		res = infrav1.IngressRule{
+		ir = infrav1.IngressRule{
 			Protocol: infrav1.SecurityGroupProtocol(*v.IpProtocol),
 		}
 	}
 
-	for _, ec2range := range v.IpRanges {
-		if ec2range.Description != nil && *ec2range.Description != "" {
-			res.Description = *ec2range.Description
-		}
+	if len(v.IpRanges) > 0 {
+		r1 := ir
+		for _, ec2range := range v.IpRanges {
+			if ec2range.Description != nil && *ec2range.Description != "" {
+				r1.Description = *ec2range.Description
+			}
 
-		res.CidrBlocks = append(res.CidrBlocks, *ec2range.CidrIp)
+			r1.CidrBlocks = append(r1.CidrBlocks, *ec2range.CidrIp)
+		}
+		res = append(res, r1)
 	}
 
-	for _, pair := range v.UserIdGroupPairs {
-		if pair.GroupId == nil {
-			continue
-		}
+	if len(v.UserIdGroupPairs) > 0 {
+		r2 := ir
+		for _, pair := range v.UserIdGroupPairs {
+			if pair.GroupId == nil {
+				continue
+			}
 
-		if pair.Description != nil && *pair.Description != "" {
-			res.Description = *pair.Description
-		}
+			if pair.Description != nil && *pair.Description != "" {
+				r2.Description = *pair.Description
+			}
 
-		res.SourceSecurityGroupIDs = append(res.SourceSecurityGroupIDs, *pair.GroupId)
+			r2.SourceSecurityGroupIDs = append(r2.SourceSecurityGroupIDs, *pair.GroupId)
+		}
+		res = append(res, r2)
 	}
 
 	return res

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -252,14 +252,10 @@ func (s *Service) describeSecurityGroupOverridesByID() (map[infrav1.SecurityGrou
 }
 
 func (s *Service) ec2SecurityGroupToSecurityGroup(ec2SecurityGroup *ec2.SecurityGroup) infrav1.SecurityGroup {
-	sg := infrav1.SecurityGroup{
-		ID:   *ec2SecurityGroup.GroupId,
-		Name: *ec2SecurityGroup.GroupName,
-		Tags: converters.TagsToMap(ec2SecurityGroup.Tags),
-	}
+	sg := makeInfraSecurityGroup(ec2SecurityGroup)
 
 	for _, ec2rule := range ec2SecurityGroup.IpPermissions {
-		sg.IngressRules = append(sg.IngressRules, ingressRuleFromSDKType(ec2rule))
+		sg.IngressRules = append(sg.IngressRules, ingressRulesFromSDKType(ec2rule)...)
 	}
 	return sg
 }
@@ -361,12 +357,7 @@ func (s *Service) describeSecurityGroupsByName() (map[string]infrav1.SecurityGro
 
 	res := make(map[string]infrav1.SecurityGroup, len(out.SecurityGroups))
 	for _, ec2sg := range out.SecurityGroups {
-		sg := makeInfraSecurityGroup(ec2sg)
-
-		for _, ec2rule := range ec2sg.IpPermissions {
-			sg.IngressRules = append(sg.IngressRules, ingressRuleFromSDKType(ec2rule))
-		}
-
+		sg := s.ec2SecurityGroupToSecurityGroup(ec2sg)
 		res[sg.Name] = sg
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix `ingressRulesFromSDKType` function.
Changed the logic to generate separate Ingress rules for userIdGroupPairs and IPRanges from EC2 IpPermission API Response.
An IngressRule cannot have SourceSecurityGroupIDs and CidrBlocks at the same time and combining them into a single IngressRule was the cause of the reported bug.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2795

**Special notes for your reviewer**:
There are three commits in this PR, which I plan to keep separate.
* The first commit refactors duplicate codes.
* The second commit back-fills unit tests for Difference function.
* The third commit is an actual fix for the issue.

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Fix reconciliation of AWS ingress rules of same port
```
