### PR TITLE
Fix for internet-facing ELB scheme

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -148,7 +148,7 @@ type Bastion struct {
 type AWSLoadBalancerSpec struct {
 	// Scheme sets the scheme of the load balancer (defaults to internet-facing)
 	// +kubebuilder:default=internet-facing
-	// +kubebuilder:validation:Enum=internet-facing;internal
+	// +kubebuilder:validation:Enum=internet-facing;Internet-facing;internal
 	// +optional
 	Scheme *ClassicELBScheme `json:"scheme,omitempty"`
 

--- a/api/v1alpha3/conversion.go
+++ b/api/v1alpha3/conversion.go
@@ -47,7 +47,6 @@ func (r *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 		}
 		restoreInstance(restored.Status.Bastion, dst.Status.Bastion)
 	}
-
 	return nil
 }
 
@@ -58,7 +57,6 @@ func (r *AWSCluster) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := Convert_v1alpha4_AWSCluster_To_v1alpha3_AWSCluster(src, r, nil); err != nil {
 		return err
 	}
-
 	// Preserve Hub data on down-conversion.
 	if err := utilconversion.MarshalData(src, r); err != nil {
 		return err

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -96,6 +96,10 @@ var (
 	ClassicELBSchemeInternal = ClassicELBScheme("internal")
 )
 
+func (e ClassicELBScheme) String() string {
+	return string(e)
+}
+
 // ClassicELBProtocol defines listener protocols for a classic load balancer.
 type ClassicELBProtocol string
 

--- a/api/v1alpha4/awscluster_webhook_test.go
+++ b/api/v1alpha4/awscluster_webhook_test.go
@@ -19,12 +19,14 @@ package v1alpha4
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestAWSClusterDefault(t *testing.T) {
@@ -36,12 +38,50 @@ func TestAWSClusterDefault(t *testing.T) {
 }
 
 func TestAWSCluster_ValidateCreate(t *testing.T) {
+	unsupportedIncorrectScheme := ClassicELBScheme("any-other-scheme")
+
 	tests := []struct {
 		name    string
 		cluster *AWSCluster
 		wantErr bool
+		expect  func(t *testing.T, res *AWSLoadBalancerSpec)
 	}{
 		// The SSHKeyName tests were moved to sshkeyname_test.go
+		{
+			name: "Default nil scheme to `internet-facing`",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{},
+			},
+			expect: func(t *testing.T, res *AWSLoadBalancerSpec) {
+				if res.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
+					t.Error("Expected internet-facing defaulting for nil loadbalancer schemes")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "Internet-facing ELB scheme is defaulted to internet-facing during creation",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{Scheme: &ClassicELBSchemeIncorrectInternetFacing},
+				},
+			},
+			expect: func(t *testing.T, res *AWSLoadBalancerSpec) {
+				if res.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
+					t.Error("Expected internet-facing defaulting for supported incorrect scheme: Internet-facing")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "Supported schemes are 'internet-facing, Internet-facing, internal, or nil', rest will be rejected",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{Scheme: &unsupportedIncorrectScheme},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -54,6 +94,23 @@ func TestAWSCluster_ValidateCreate(t *testing.T) {
 			if err := testEnv.Create(ctx, cluster); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateCreate() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if tt.wantErr {
+				return
+			}
+
+			c := &AWSCluster{}
+			key := client.ObjectKey{
+				Name:      cluster.Name,
+				Namespace: "default",
+			}
+
+			g := NewWithT(t)
+			g.Eventually(func() bool {
+				err := testEnv.Get(ctx, key, c)
+				return err == nil
+			}, 10*time.Second).Should(Equal(true))
+
+			tt.expect(t, c.Spec.ControlPlaneLoadBalancer)
 		})
 	}
 }

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -105,6 +105,9 @@ var (
 	// accessible AWS Classic ELB scheme.
 	ClassicELBSchemeInternetFacing = ClassicELBScheme("internet-facing")
 
+	// ClassicELBSchemeIncorrectInternetFacing was inaccurately used to define an internet-facing LB in v0.6 releases > v0.6.6 and v0.7.0 release
+	ClassicELBSchemeIncorrectInternetFacing = ClassicELBScheme("Internet-facing")
+
 	// ClassicELBSchemeInternal defines an internal-only facing
 	// load balancer internal to an ELB.
 	ClassicELBSchemeInternal = ClassicELBScheme("internal")
@@ -140,7 +143,7 @@ type ClassicELB struct {
 	// DNSName is the dns name of the load balancer.
 	DNSName string `json:"dnsName,omitempty"`
 
-	// Scheme is the load balancer scheme, either internet-facing or private.
+	// Scheme is the load balancer scheme, either internet-facing or internal.
 	Scheme ClassicELBScheme `json:"scheme,omitempty"`
 
 	// AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2026,7 +2026,7 @@ spec:
                         type: string
                       scheme:
                         description: Scheme is the load balancer scheme, either internet-facing
-                          or private.
+                          or internal.
                         type: string
                       securityGroupIds:
                         description: SecurityGroupIDs is an array of security groups

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -143,6 +143,7 @@ spec:
                       to internet-facing)
                     enum:
                     - internet-facing
+                    - Internet-facing
                     - internal
                     type: string
                   subnets:
@@ -1437,7 +1438,7 @@ spec:
                         type: string
                       scheme:
                         description: Scheme is the load balancer scheme, either internet-facing
-                          or private.
+                          or internal.
                         type: string
                       securityGroupIds:
                         description: SecurityGroupIDs is an array of security groups


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
1) Adds `Internet-facing` to `internet-facing` change to defaulter. 
2) Adds logic in AWSCluster reconciler to patch `Internet-facing` schemes with `internet-facing`. To do this, needed to add an exception in the update validation so that immutable field could be changed.

We do not need to add any conversion webhook because there is not OpenAPI check during conversion, so a value that is valid for a version is not valid in the other version, things still work.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Intended backport of #2832

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
For v1alpha4 and upgraded v1alpha3 clusters, having "Internet-facing" scheme in the load balancer spec will work exactly as "internet-facing" scheme. In v1beta1, only "internet-facing" scheme will be used. 
```
/priority critical-urgent
/area api
/kind release-blocking
/milestone v1.0.0

