### PR TITLE
Add check for invalid memory address or nil pointer dereference

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -747,6 +747,18 @@ func (s *Service) getImageSnapshotSize(imageID string) (*int64, error) {
 		return nil, errors.Errorf("no images returned when looking up ID %q", imageID)
 	}
 
+	if len(output.Images[0].BlockDeviceMappings) == 0 {
+		return nil, errors.Errorf("no block device mappings returned when looking up ID %q", imageID)
+	}
+
+	if output.Images[0].BlockDeviceMappings[0].Ebs == nil {
+		return nil, errors.Errorf("no EBS returned when looking up ID %q", imageID)
+	}
+
+	if output.Images[0].BlockDeviceMappings[0].Ebs.VolumeSize == nil {
+		return nil, errors.Errorf("no EBS volume size returned when looking up ID %q", imageID)
+	}
+
 	return output.Images[0].BlockDeviceMappings[0].Ebs.VolumeSize, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Not totally sure why we saw a panic here https://github.com/openshift/hypershift/pull/486 / https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/486/pull-ci-openshift-hypershift-main-e2e-aws-pooled/1445408206435127296/artifacts/e2e-aws-pooled/test-e2e/artifacts/namespaces/e2e-clusters-slgzn-example-f748r/core/pods/logs/capa-controller-manager-f66fd8977-knt6h-manager-previous.log

But this seems a safe check to do nevertheless.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note

```
