### PR TITLE
Docs: fix create-cloudformation-stack command

### DIFF
--- a/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
+++ b/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
@@ -50,7 +50,7 @@ spec:
 and passing it to clusterawsadm as follows
 
 ```bash
-clusterawsadm bootstrap iam create-stack --config bootstrap-config.yaml
+clusterawsadm bootstrap iam create-cloudformation-stack --config bootstrap-config.yaml
 ```
 
 These will be added to the control plane and node roles respectively when they are created.


### PR DESCRIPTION
fixes typo in docs create-stack -> create-cloudformation-stack

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Fixes incorrect bootstrap iam command. `create-stack` to `create-cloudformation-stack`

```release-note
NONE
```


