### PR TITLE
[backport] fix: added may resync check for EKS

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,12 @@ var (
 	healthAddr               string
 	serviceEndpoints         string
 
-	errEKSInvalidFlags = errors.New("invalid EKS flag combination")
+	// maxEKSSyncPeriod is the maximum allowed duration for the sync-period flag when using EKS. It is set to 10 minutes
+	// because during resync it will create a new AWS auth token which can a maximum life of 15 minutes and this ensures
+	// the token (and kubeconfig secret) is refreshed before token expiration.
+	maxEKSSyncPeriod         = time.Minute * 10
+	errMaxSyncPeriodExceeded = errors.New("sync period greater than maximum allowed")
+	errEKSInvalidFlags       = errors.New("invalid EKS flag combination")
 )
 
 func main() {
@@ -282,6 +287,11 @@ func enableGates(ctx context.Context, mgr ctrl.Manager, awsServiceEndpoints []sc
 	if feature.Gates.Enabled(feature.EKS) {
 		setupLog.Info("enabling EKS controllers")
 
+		if syncPeriod > maxEKSSyncPeriod {
+			setupLog.Error(errMaxSyncPeriodExceeded, "failed to enable EKS", "max-sync-period", maxEKSSyncPeriod, "syn-period", syncPeriod)
+			os.Exit(1)
+		}
+
 		enableIAM := feature.Gates.Enabled(feature.EKSEnableIAM)
 		allowAddRoles := feature.Gates.Enabled(feature.EKSAllowAddRoles)
 		setupLog.V(2).Info("EKS IAM role creation", "enabled", enableIAM)
@@ -432,7 +442,7 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&syncPeriod,
 		"sync-period",
 		10*time.Minute,
-		"The minimum interval at which watched resources are reconciled (e.g. 15m)",
+		fmt.Sprintf("The minimum interval at which watched resources are reconciled. If EKS is enabled the maximum allowed is %s", maxEKSSyncPeriod),
 	)
 
 	fs.IntVar(&webhookPort,


### PR DESCRIPTION
**What type of PR is this?**

/kind regression


**What this PR does / why we need it**:

When EKS was graduated the check to make sure that the
max sync time wasn't greater than 10 mins was missed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #2845 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Reinstating the check for the maximum allowed resync period when EKS is enabled.
```
