### PR TITLE
[Backport-v1alpha4] Correct the casing of internet-facing ELB scheme

### DIFF
--- a/api/v1alpha3/awscluster_types.go
+++ b/api/v1alpha3/awscluster_types.go
@@ -146,9 +146,9 @@ type Bastion struct {
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer.
 type AWSLoadBalancerSpec struct {
-	// Scheme sets the scheme of the load balancer (defaults to Internet-facing)
-	// +kubebuilder:default=Internet-facing
-	// +kubebuilder:validation:Enum=Internet-facing;internal
+	// Scheme sets the scheme of the load balancer (defaults to internet-facing)
+	// +kubebuilder:default=internet-facing
+	// +kubebuilder:validation:Enum=internet-facing;Internet-facing;internal
 	// +optional
 	Scheme *ClassicELBScheme `json:"scheme,omitempty"`
 

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -89,12 +89,16 @@ type ClassicELBScheme string
 var (
 	// ClassicELBSchemeInternetFacing defines an internet-facing, publicly
 	// accessible AWS Classic ELB scheme.
-	ClassicELBSchemeInternetFacing = ClassicELBScheme("Internet-facing")
+	ClassicELBSchemeInternetFacing = ClassicELBScheme("internet-facing")
 
 	// ClassicELBSchemeInternal defines an internal-only facing
 	// load balancer internal to an ELB.
 	ClassicELBSchemeInternal = ClassicELBScheme("internal")
 )
+
+func (e ClassicELBScheme) String() string {
+	return string(e)
+}
 
 // ClassicELBProtocol defines listener protocols for a classic load balancer.
 type ClassicELBProtocol string

--- a/api/v1alpha4/awscluster_types.go
+++ b/api/v1alpha4/awscluster_types.go
@@ -146,9 +146,9 @@ type Bastion struct {
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer.
 type AWSLoadBalancerSpec struct {
-	// Scheme sets the scheme of the load balancer (defaults to Internet-facing)
-	// +kubebuilder:default=Internet-facing
-	// +kubebuilder:validation:Enum=Internet-facing;internal
+	// Scheme sets the scheme of the load balancer (defaults to internet-facing)
+	// +kubebuilder:default=internet-facing
+	// +kubebuilder:validation:Enum=internet-facing;Internet-facing;internal
 	// +optional
 	Scheme *ClassicELBScheme `json:"scheme,omitempty"`
 

--- a/api/v1alpha4/awscluster_webhook.go
+++ b/api/v1alpha4/awscluster_webhook.go
@@ -84,7 +84,7 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if oldC.Spec.ControlPlaneLoadBalancer == nil {
-		// If old scheme was nil, the only value accepted here is the default value: Internet-facing
+		// If old scheme was nil, the only value accepted here is the default value: internet-facing
 		if newLoadBalancer.Scheme != nil && newLoadBalancer.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "scheme"),
@@ -95,10 +95,14 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 		// If old scheme was not nil, the new scheme should be the same.
 		existingLoadBalancer := oldC.Spec.ControlPlaneLoadBalancer.DeepCopy()
 		if !reflect.DeepEqual(existingLoadBalancer.Scheme, newLoadBalancer.Scheme) {
-			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "scheme"),
-					r.Spec.ControlPlaneLoadBalancer.Scheme, "field is immutable"),
-			)
+			// Only allow changes from Internet-facing scheme to internet-facing.
+			if newLoadBalancer.Scheme == nil || !(existingLoadBalancer.Scheme.String() == ClassicELBSchemeIncorrectInternetFacing.String() &&
+				newLoadBalancer.Scheme.String() == ClassicELBSchemeInternetFacing.String()) {
+				allErrs = append(allErrs,
+					field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "scheme"),
+						r.Spec.ControlPlaneLoadBalancer.Scheme, "field is immutable"),
+				)
+			}
 		}
 	}
 
@@ -154,6 +158,13 @@ func (r *AWSCluster) validateSSHKeyName() field.ErrorList {
 func SetDefaultsAWSClusterSpec(s *AWSClusterSpec) {
 	SetDefaults_Bastion(&s.Bastion)
 	SetDefaults_NetworkSpec(&s.NetworkSpec)
+
+	// 	If ELB scheme is set to Internet-facing due to an API bug in versions > v0.6.6 and v0.7.0, default it to internet-facing.
+	if s.ControlPlaneLoadBalancer == nil {
+		s.ControlPlaneLoadBalancer = &AWSLoadBalancerSpec{Scheme: &ClassicELBSchemeInternetFacing}
+	} else if s.ControlPlaneLoadBalancer.Scheme != nil && s.ControlPlaneLoadBalancer.Scheme.String() == ClassicELBSchemeIncorrectInternetFacing.String() {
+		s.ControlPlaneLoadBalancer.Scheme = &ClassicELBSchemeInternetFacing
+	}
 
 	if s.IdentityRef == nil {
 		s.IdentityRef = &AWSIdentityReference{

--- a/api/v1alpha4/awscluster_webhook_test.go
+++ b/api/v1alpha4/awscluster_webhook_test.go
@@ -19,12 +19,14 @@ package v1alpha4
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestAWSClusterDefault(t *testing.T) {
@@ -36,12 +38,51 @@ func TestAWSClusterDefault(t *testing.T) {
 }
 
 func TestAWSCluster_ValidateCreate(t *testing.T) {
+	unsupportedIncorrectScheme := ClassicELBScheme("any-other-scheme")
+
 	tests := []struct {
 		name    string
 		cluster *AWSCluster
 		wantErr bool
+		expect  func(t *testing.T, res *AWSLoadBalancerSpec)
 	}{
 		// The SSHKeyName tests were moved to sshkeyname_test.go
+
+		{
+			name: "Default nil scheme to `internet-facing`",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{},
+			},
+			expect: func(t *testing.T, res *AWSLoadBalancerSpec) {
+				if res.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
+					t.Error("Expected internet-facing defaulting for nil loadbalancer schemes")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "Internet-facing ELB scheme is defaulted to internet-facing during creation",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{Scheme: &ClassicELBSchemeIncorrectInternetFacing},
+				},
+			},
+			expect: func(t *testing.T, res *AWSLoadBalancerSpec) {
+				if res.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
+					t.Error("Expected internet-facing defaulting for supported incorrect scheme: Internet-facing")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "Supported schemes are 'internet-facing, Internet-facing, internal, or nil', rest will be rejected",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{Scheme: &unsupportedIncorrectScheme},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -54,6 +95,24 @@ func TestAWSCluster_ValidateCreate(t *testing.T) {
 			if err := testEnv.Create(ctx, cluster); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateCreate() error = %v, wantErr %v", err, tt.wantErr)
 			}
+
+			if tt.wantErr {
+				return
+			}
+
+			c := &AWSCluster{}
+			key := client.ObjectKey{
+				Name:      cluster.Name,
+				Namespace: "default",
+			}
+
+			g := NewWithT(t)
+			g.Eventually(func() bool {
+				err := testEnv.Get(ctx, key, c)
+				return err == nil
+			}, 10*time.Second).Should(Equal(true))
+
+			tt.expect(t, c.Spec.ControlPlaneLoadBalancer)
 		})
 	}
 }

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -103,11 +103,14 @@ type ClassicELBScheme string
 var (
 	// ClassicELBSchemeInternetFacing defines an internet-facing, publicly
 	// accessible AWS Classic ELB scheme.
-	ClassicELBSchemeInternetFacing = ClassicELBScheme("Internet-facing")
+	ClassicELBSchemeInternetFacing = ClassicELBScheme("internet-facing")
 
 	// ClassicELBSchemeInternal defines an internal-only facing
 	// load balancer internal to an ELB.
 	ClassicELBSchemeInternal = ClassicELBScheme("internal")
+
+	// ClassicELBSchemeIncorrectInternetFacing was inaccurately used to define an internet-facing LB in v0.6 releases > v0.6.6 and v0.7.0 release.
+	ClassicELBSchemeIncorrectInternetFacing = ClassicELBScheme("Internet-facing")
 )
 
 func (e ClassicELBScheme) String() string {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -138,10 +138,11 @@ spec:
                       to false."
                     type: boolean
                   scheme:
-                    default: Internet-facing
+                    default: internet-facing
                     description: Scheme sets the scheme of the load balancer (defaults
-                      to Internet-facing)
+                      to internet-facing)
                     enum:
+                    - internet-facing
                     - Internet-facing
                     - internal
                     type: string
@@ -886,10 +887,11 @@ spec:
                       to false."
                     type: boolean
                   scheme:
-                    default: Internet-facing
+                    default: internet-facing
                     description: Scheme sets the scheme of the load balancer (defaults
-                      to Internet-facing)
+                      to internet-facing)
                     enum:
+                    - internet-facing
                     - Internet-facing
                     - internal
                     type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -126,10 +126,11 @@ spec:
                               \n Defaults to false."
                             type: boolean
                           scheme:
-                            default: Internet-facing
+                            default: internet-facing
                             description: Scheme sets the scheme of the load balancer
-                              (defaults to Internet-facing)
+                              (defaults to internet-facing)
                             enum:
+                            - internet-facing
                             - Internet-facing
                             - internal
                             type: string


### PR DESCRIPTION
/kind backport

**What this PR does / why we need it**:
Backport of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2832
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Correct the casing of the ELB load balancer scheme from `Internet-facing` to `internet-facing`, allowing the ELB to be correctly continuously reconciled
```
