### PR TITLE
🌱 use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Related:
  - Part of: https://github.com/kubernetes/k8s.io/issues/1523
  - Followup of: https://github.com/kubernetes/test-infra/pull/23656

Use a version of gcb-docker-gcloud that is hosted in a community repo
instead of a google.com-owned repo.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

```release-notes
NONE
```
