### PR TITLE
Add missing permissions for EKS OIDC provider configuration

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -375,6 +375,9 @@ func (t Template) ControllersPolicyEKS() *iamv1.PolicyDocument {
 				"eks:UpdateNodegroupConfig",
 				"eks:CreateNodegroup",
 				"eks:AssociateEncryptionConfig",
+				"eks:ListIdentityProviderConfigs",
+				"eks:AssociateIdentityProviderConfig",
+				"eks:DescribeIdentityProviderConfig",
 			},
 			Resource: iamv1.Resources{
 				"arn:*:eks:*:*:cluster/*",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -378,6 +378,7 @@ func (t Template) ControllersPolicyEKS() *iamv1.PolicyDocument {
 				"eks:ListIdentityProviderConfigs",
 				"eks:AssociateIdentityProviderConfig",
 				"eks:DescribeIdentityProviderConfig",
+				"eks:DisassociateIdentityProviderConfig",
 			},
 			Resource: iamv1.Resources{
 				"arn:*:eks:*:*:cluster/*",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -315,6 +315,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -318,6 +318,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -315,6 +315,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -318,6 +318,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -328,6 +328,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -331,6 +331,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -322,6 +322,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -325,6 +325,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -322,6 +322,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -325,6 +325,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -315,6 +315,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -318,6 +318,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -315,6 +315,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -318,6 +318,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -315,6 +315,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -318,6 +318,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -315,6 +315,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -318,6 +318,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -322,6 +322,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -325,6 +325,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -315,6 +315,9 @@ Resources:
           - eks:UpdateNodegroupConfig
           - eks:CreateNodegroup
           - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -318,6 +318,7 @@ Resources:
           - eks:ListIdentityProviderConfigs
           - eks:AssociateIdentityProviderConfig
           - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
           Effect: Allow
           Resource:
           - arn:*:eks:*:*:cluster/*


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR adds 3 missing permissions/actions for EKS cluster management, related to OIDC provider association/configuration. Without these, EKS reconciliation fails directly after cluster creation.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add missing permissions for EKS OIDC provider configuration
```
