### PR TITLE
Fetch ASGs by tag instead of name

### DIFF
--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -159,6 +159,9 @@ const (
 
 	// MachineNameTagKey is the key for machine name.
 	MachineNameTagKey = "MachineName"
+
+	// NodeRoleTagValue describes the value for the node role.
+	NodeRoleTagValue = "node"
 )
 
 // ClusterTagKey generates the key for resources associated with a cluster.

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -158,7 +158,6 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			reterr = err
 		}
 	}()
-
 	switch infraScope := infraCluster.(type) {
 	case *scope.ManagedControlPlaneScope:
 		if !awsMachinePool.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -372,7 +371,7 @@ func (r *AWSMachinePoolReconciler) createPool(machinePoolScope *scope.MachinePoo
 
 func (r *AWSMachinePoolReconciler) findASG(machinePoolScope *scope.MachinePoolScope, asgsvc services.ASGInterface) (*expinfrav1.AutoScalingGroup, error) {
 	// Query the instance using tags.
-	asg, err := asgsvc.GetASGByName(machinePoolScope)
+	asg, err := asgsvc.GetASGByTags(machinePoolScope)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to query AWSMachinePool by name")
 	}

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -163,7 +163,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 				t.Helper()
 
 				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", expectedErr).AnyTimes()
-				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+				asgSvc.EXPECT().GetASGByTags(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 			}
 			t.Run("should exit immediately on an error state", func(t *testing.T) {
 				g := NewWithT(t)
@@ -280,7 +280,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 			finalizer(t, g)
 
 			expectedErr := errors.New("no connection available ")
-			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+			asgSvc.EXPECT().GetASGByTags(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 
 			_, err := reconciler.reconcileDelete(ms, cs, cs)
 			g.Expect(errors.Cause(err)).To(MatchError(expectedErr))
@@ -291,7 +291,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 			defer teardown(t, g)
 			finalizer(t, g)
 
-			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil)
+			asgSvc.EXPECT().GetASGByTags(gomock.Any()).Return(nil, nil)
 			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 
 			buf := new(bytes.Buffer)
@@ -313,7 +313,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 				Name:   "an-asg-that-is-currently-being-deleted",
 				Status: expinfrav1.ASGStatusDeleteInProgress,
 			}
-			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(&inProgressASG, nil)
+			asgSvc.EXPECT().GetASGByTags(gomock.Any()).Return(&inProgressASG, nil)
 			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", nil).AnyTimes()
 
 			buf := new(bytes.Buffer)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-vpc-cni-k8s v1.10.2
 	github.com/aws/aws-lambda-go v1.28.0
-	github.com/aws/aws-sdk-go v1.40.56
+	github.com/aws/aws-sdk-go v1.41.3
 	github.com/awslabs/goformation/v4 v4.19.5
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/aws/aws-sdk-go v1.8.39/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoM
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.6/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.40.56 h1:FM2yjR0UUYFzDTMx+mH9Vyw1k1EUUxsAFzk+BjkzANA=
-github.com/aws/aws-sdk-go v1.40.56/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.41.3 h1:deglLZ1jjHdhkd6Rbad1MZM4gL+1pfnTfjuFk6CGJFM=
+github.com/aws/aws-sdk-go v1.41.3/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/awslabs/goformation/v4 v4.19.5 h1:Y+Tzh01tWg8gf//AgGKUamaja7Wx9NPiJf1FpZu4/iU=
 github.com/awslabs/goformation/v4 v4.19.5/go.mod h1:JoNpnVCBOUtEz9bFxc9sjy8uBUCLF5c4D1L7RhRTVM8=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/pkg/cloud/filter/asg.go
+++ b/pkg/cloud/filter/asg.go
@@ -1,0 +1,48 @@
+package filter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+)
+
+// ASG exposes the autoscaling sdk related filters.
+var ASG = new(asgFilters)
+
+type asgFilters struct{}
+
+// Name returns a filter based on the resource name.
+func (asgFilters) Name(name string) *autoscaling.Filter {
+	return &autoscaling.Filter{
+		Name:   aws.String("tag:Name"),
+		Values: aws.StringSlice([]string{name}),
+	}
+}
+
+// ClusterOwned returns a filter using the Cluster API per-cluster tag where
+// the resource is owned.
+func (asgFilters) ClusterOwned(clusterName string) *autoscaling.Filter {
+	return &autoscaling.Filter{
+		Name:   aws.String(fmt.Sprintf("tag:%s", infrav1.ClusterTagKey(clusterName))),
+		Values: aws.StringSlice([]string{string(infrav1.ResourceLifecycleOwned)}),
+	}
+}
+
+// ProviderRole returns a filter using cluster-api-provider-aws role tag.
+func (asgFilters) ProviderRole(role string) *autoscaling.Filter {
+	return &autoscaling.Filter{
+		Name:   aws.String(fmt.Sprintf("tag:%s", infrav1.NameAWSClusterAPIRole)),
+		Values: aws.StringSlice([]string{role}),
+	}
+}
+
+// ProviderOwned returns a filter using the cloud provider tag where the resource is owned.
+func (asgFilters) ProviderOwned(clusterName string) *autoscaling.Filter {
+	return &autoscaling.Filter{
+		Name:   aws.String(fmt.Sprintf("tag:%s", infrav1.ClusterAWSCloudProviderTagKey(clusterName))),
+		Values: aws.StringSlice([]string{string(infrav1.ResourceLifecycleOwned)}),
+	}
+}

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -122,6 +122,14 @@ func (m *MachinePoolScope) Namespace() string {
 	return m.AWSMachinePool.Namespace
 }
 
+// ClusterName returns the Cluster name.
+func (m *MachinePoolScope) ClusterName() string {
+	if m.Cluster != nil {
+		return m.Cluster.Name
+	}
+	return ""
+}
+
 // GetRawBootstrapData returns the bootstrap data from the secret in the Machine's bootstrap.dataSecretName.
 // todo(rudoi): stolen from MachinePool - any way to reuse?
 func (m *MachinePoolScope) GetRawBootstrapData() ([]byte, error) {

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -39,7 +39,7 @@ import (
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
-func TestService_GetASGByName(t *testing.T) {
+func TestService_GetASGByTags(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	tests := []struct {
@@ -55,11 +55,7 @@ func TestService_GetASGByName(t *testing.T) {
 			wantErr:         false,
 			wantASG:         false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
-					AutoScalingGroupNames: []*string{
-						aws.String("test-asg-is-not-present"),
-					},
-				})).
+				m.DescribeAutoScalingGroups(gomock.AssignableToTypeOf(&autoscaling.DescribeAutoScalingGroupsInput{})).
 					Return(nil, awserrors.NewNotFound("not found"))
 			},
 		},
@@ -69,11 +65,7 @@ func TestService_GetASGByName(t *testing.T) {
 			wantErr:         true,
 			wantASG:         false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
-					AutoScalingGroupNames: []*string{
-						aws.String("dependency-failure-occurred"),
-					},
-				})).
+				m.DescribeAutoScalingGroups(gomock.AssignableToTypeOf(&autoscaling.DescribeAutoScalingGroupsInput{})).
 					Return(nil, awserrors.NewFailedDependency("unknown error occurred"))
 			},
 		},
@@ -83,11 +75,7 @@ func TestService_GetASGByName(t *testing.T) {
 			wantErr:         false,
 			wantASG:         true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
-					AutoScalingGroupNames: []*string{
-						aws.String("test-group-is-present"),
-					},
-				})).
+				m.DescribeAutoScalingGroups(gomock.AssignableToTypeOf(&autoscaling.DescribeAutoScalingGroupsInput{})).
 					Return(&autoscaling.DescribeAutoScalingGroupsOutput{
 						AutoScalingGroups: []*autoscaling.Group{
 							{
@@ -119,7 +107,7 @@ func TestService_GetASGByName(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			mps.AWSMachinePool.Name = tt.machinePoolName
 
-			asg, err := s.GetASGByName(mps)
+			asg, err := s.GetASGByTags(mps)
 			checkErr(tt.wantErr, err, g)
 			checkASG(tt.wantASG, asg, g)
 		})

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -33,13 +33,13 @@ const (
 // actuator.
 type ASGInterface interface {
 	ASGIfExists(id *string) (*expinfrav1.AutoScalingGroup, error)
-	GetASGByName(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error)
 	CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error)
 	UpdateASG(scope *scope.MachinePoolScope) error
 	StartASGInstanceRefresh(scope *scope.MachinePoolScope) error
 	CanStartASGInstanceRefresh(scope *scope.MachinePoolScope) (bool, error)
 	UpdateResourceTags(resourceID *string, create, remove map[string]string) error
 	DeleteASGAndWait(id string) error
+	GetASGByTags(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error)
 }
 
 // EC2MachineInterface encapsulates the methods exposed to the machine

--- a/pkg/cloud/services/mock_services/autoscaling_interface_mock.go
+++ b/pkg/cloud/services/mock_services/autoscaling_interface_mock.go
@@ -110,19 +110,19 @@ func (mr *MockASGInterfaceMockRecorder) DeleteASGAndWait(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteASGAndWait", reflect.TypeOf((*MockASGInterface)(nil).DeleteASGAndWait), arg0)
 }
 
-// GetASGByName mocks base method.
-func (m *MockASGInterface) GetASGByName(arg0 *scope.MachinePoolScope) (*v1beta1.AutoScalingGroup, error) {
+// GetASGByTags mocks base method.
+func (m *MockASGInterface) GetASGByTags(arg0 *scope.MachinePoolScope) (*v1beta1.AutoScalingGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetASGByName", arg0)
+	ret := m.ctrl.Call(m, "GetASGByTags", arg0)
 	ret0, _ := ret[0].(*v1beta1.AutoScalingGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetASGByName indicates an expected call of GetASGByName.
-func (mr *MockASGInterfaceMockRecorder) GetASGByName(arg0 interface{}) *gomock.Call {
+// GetASGByTags indicates an expected call of GetASGByTags.
+func (mr *MockASGInterfaceMockRecorder) GetASGByTags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetASGByName", reflect.TypeOf((*MockASGInterface)(nil).GetASGByName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetASGByTags", reflect.TypeOf((*MockASGInterface)(nil).GetASGByTags), arg0)
 }
 
 // StartASGInstanceRefresh mocks base method.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The[ autoscaling API now supports lookups by tag](https://github.com/aws/aws-sdk-go/blob/main/CHANGELOG.md#release-v1413-2021-10-14), so the AWS MachinePool controller could be made more robust by only matching tagged ASGs, using the same rules as the other services. So now, ASGs are fetched using Tags instead of name.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2857 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fetching Autoscaling groups by tags instead of name
```
