### PR TITLE
Unsurface error when getting the remote client

### DIFF
--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"time"
 
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
 	"github.com/go-logr/logr"
@@ -130,10 +131,11 @@ func (s *ManagedControlPlaneScope) RemoteClient() (client.Client, error) {
 		Namespace: s.Namespace(),
 	}
 
-	restConfig, err := remote.RESTConfig(context.Background(), s.controllerName, s.Client, clusterKey)
+	restConfig, err := remote.RESTConfig(context.Background(), s.ControlPlane.Name, s.Client, clusterKey)
 	if err != nil {
-		return nil, fmt.Errorf("getting remote client for %s/%s: %w", s.Namespace(), s.Name(), err)
+		return nil, fmt.Errorf("getting remote rest config for %s/%s: %w", s.Namespace(), s.Name(), err)
 	}
+	restConfig.Timeout = 1 * time.Minute
 
 	return client.New(restConfig, client.Options{Scheme: scheme})
 }

--- a/pkg/cloud/services/awsnode/service.go
+++ b/pkg/cloud/services/awsnode/service.go
@@ -41,15 +41,12 @@ type Scope interface {
 
 // Service defines the spec for a service.
 type Service struct {
-	scope  Scope
-	client client.Client
+	scope Scope
 }
 
 // NewService will create a new service.
 func NewService(awsnodeScope Scope) *Service {
-	client, _ := awsnodeScope.RemoteClient()
 	return &Service{
-		scope:  awsnodeScope,
-		client: client,
+		scope: awsnodeScope,
 	}
 }

--- a/pkg/cloud/services/iamauth/service.go
+++ b/pkg/cloud/services/iamauth/service.go
@@ -30,6 +30,8 @@ import (
 type Scope interface {
 	cloud.ClusterScoper
 
+	// RemoteClient returns the Kubernetes client for connecting to the workload cluster.
+	RemoteClient() (client.Client, error)
 	// IAMAuthConfig returns the IAM authenticator config
 	IAMAuthConfig() *ekscontrolplanev1.IAMAuthenticatorConfig
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
When a new EKS cluster comes up, remote client may not be retrieved right away (until apiserver comes up). We forgot to do error handling during CNI reconciliation as pointed in the issue.

We need to backport this fix for v1alpha4 and v1alpha3.

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2859


```release-note
Adds missing error handling for getting a remote client during EKS CNI reconciliation.
```
