### PR TITLE
EKS: Support tagging node group's underlying ASG

### DIFF
--- a/pkg/cloud/scope/managednodegroup.go
+++ b/pkg/cloud/scope/managednodegroup.go
@@ -138,7 +138,7 @@ func (s *ManagedMachinePoolScope) ServiceLimiter(service string) *throttle.Servi
 
 // ClusterName returns the cluster name.
 func (s *ManagedMachinePoolScope) ClusterName() string {
-	return s.Cluster.Name
+	return s.ControlPlane.Spec.EKSClusterName
 }
 
 // EnableIAM indicates that reconciliation should create IAM roles.

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -33,6 +33,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
@@ -62,6 +63,34 @@ func (s *NodegroupService) describeNodegroup() (*eks.Nodegroup, error) {
 	}
 
 	return out.Nodegroup, nil
+}
+
+func (s *NodegroupService) describeASGs(ng *eks.Nodegroup) (*autoscaling.Group, error) {
+	eksClusterName := s.scope.KubernetesClusterName()
+	nodegroupName := s.scope.NodegroupName()
+	s.scope.V(2).Info("describing node group ASG", "cluster", eksClusterName, "nodegroup", nodegroupName)
+
+	if len(ng.Resources.AutoScalingGroups) == 0 {
+		return nil, nil
+	}
+
+	input := &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{
+			ng.Resources.AutoScalingGroups[0].Name,
+		},
+	}
+
+	out, err := s.AutoscalingClient.DescribeAutoScalingGroups(input)
+	switch {
+	case awserrors.IsNotFound(err):
+		return nil, nil
+	case err != nil:
+		return nil, errors.Wrap(err, "failed to describe ASGs")
+	case len(out.AutoScalingGroups) == 0:
+		return nil, errors.Wrap(err, "no ASG found")
+	}
+
+	return out.AutoScalingGroups[0], nil
 }
 
 func (s *NodegroupService) scalingConfig() *eks.NodegroupScalingConfig {
@@ -486,6 +515,10 @@ func (s *NodegroupService) reconcileNodegroup() error {
 
 	if err := s.reconcileTags(ng); err != nil {
 		return errors.Wrapf(err, "failed to reconcile nodegroup tags")
+	}
+
+	if err := s.reconcileASGTags(ng); err != nil {
+		return errors.Wrapf(err, "failed to reconcile asg tags")
 	}
 
 	return nil

--- a/pkg/cloud/services/eks/tags.go
+++ b/pkg/cloud/services/eks/tags.go
@@ -83,7 +83,7 @@ func getASGTagUpdates(clusterName string, currentTags map[string]string, tags ma
 		eksNodeGroupNameTag,
 		fmt.Sprintf("k8s.io/cluster-autoscaler/%s", clusterName),
 		eksClusterAutoscalerEnabledTag,
-		fmt.Sprintf("kubernetes.io/cluster/%s", clusterName),
+		infrav1.ClusterAWSCloudProviderTagKey(clusterName),
 	}
 	tagsToDelete = make(map[string]string)
 	tagsToAdd = make(map[string]string)

--- a/test/e2e/suites/managed/helpers.go
+++ b/test/e2e/suites/managed/helpers.go
@@ -132,7 +132,7 @@ func verifyRoleExistsAndOwned(roleName string, clusterName string, checkOwned bo
 	}
 }
 
-func verifyManagedNodeGroup(clusterName, eksClusterName, nodeGroupName string, checkOwned bool, sess client.ConfigProvider) {
+func verifyManagedNodeGroup(eksClusterName, nodeGroupName string, checkOwned bool, sess client.ConfigProvider) {
 	eksClient := eks.New(sess)
 	input := &eks.DescribeNodegroupInput{
 		ClusterName:   aws.String(eksClusterName),
@@ -143,7 +143,7 @@ func verifyManagedNodeGroup(clusterName, eksClusterName, nodeGroupName string, c
 	Expect(*result.Nodegroup.Status).To(BeEquivalentTo(eks.NodegroupStatusActive))
 
 	if checkOwned {
-		tagName := infrav1.ClusterAWSCloudProviderTagKey(clusterName)
+		tagName := infrav1.ClusterAWSCloudProviderTagKey(eksClusterName)
 		tagValue, ok := result.Nodegroup.Tags[tagName]
 		Expect(ok).To(BeTrue(), "expecting the cluster owned tag to exist")
 		Expect(*tagValue).To(BeEquivalentTo(string(infrav1.ResourceLifecycleOwned)))

--- a/test/e2e/suites/managed/machine_pool.go
+++ b/test/e2e/suites/managed/machine_pool.go
@@ -83,7 +83,7 @@ func ManagedMachinePoolSpec(ctx context.Context, inputGetter func() ManagedMachi
 	shared.Byf("Check the status of the node group")
 	nodeGroupName := getEKSNodegroupName(input.Namespace.Name, input.ClusterName)
 	eksClusterName := getEKSClusterName(input.Namespace.Name, input.ClusterName)
-	verifyManagedNodeGroup(input.ClusterName, eksClusterName, nodeGroupName, true, input.AWSSession)
+	verifyManagedNodeGroup(eksClusterName, nodeGroupName, true, input.AWSSession)
 
 	if input.IncludeScaling { // TODO (richardcase): should this be a separate spec?
 		ginkgo.By("Scaling the machine pool up")


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
There is an [open issue](https://github.com/aws/containers-roadmap/issues/1541) on EKS where EKS doesn’t support tagging the underlying ASGs, however it’s quite important for many organizations for compliance, cost. This PR adds such support in CAPA, where user can specify an optional `AdditionalAsgTags` field in `AWSManagedMachinePool` and the node group controller will reconcile the underlying ASG tags.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2881

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Support tagging EKS node group's underlying ASG
```
