### PR TITLE
Always add controllers role to IAMAuthenticator config

### DIFF
--- a/pkg/cloud/services/iamauth/iamauth.go
+++ b/pkg/cloud/services/iamauth/iamauth.go
@@ -25,11 +25,15 @@ import (
 const (
 	// EC2NodeUserName is the username required for EC2 nodes.
 	EC2NodeUserName = "system:node:{{EC2PrivateDNSName}}"
+	// ControllersUserName is the username used for access from controllers.
+	ControllersUserName = "system:capa:controllers"
 )
 
 var (
 	// NodeGroups is the groups that are required for a node.
 	NodeGroups = []string{"system:bootstrappers", "system:nodes"}
+	// ControllersGroups is the groups that are required for access from controllers.
+	ControllersGroups = []string{"system:masters"}
 )
 
 // AuthenticatorBackend is the interface that represents an aws-iam-authenticator backend.

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -48,9 +48,9 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 		return fmt.Errorf("getting aws-iam-authenticator backend: %w", err)
 	}
 
-	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/nodes%s", accountID, iamv1.DefaultNameSuffix)
+	nodesRoleARN := fmt.Sprintf("arn:aws:iam::%s:role/nodes%s", accountID, iamv1.DefaultNameSuffix)
 	nodesRoleMapping := ekscontrolplanev1.RoleMapping{
-		RoleARN: roleARN,
+		RoleARN: nodesRoleARN,
 		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 			UserName: EC2NodeUserName,
 			Groups:   NodeGroups,
@@ -59,6 +59,19 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	s.scope.V(2).Info("Mapping node IAM role", "iam-role", nodesRoleMapping.RoleARN, "user", nodesRoleMapping.UserName)
 	if err := authBackend.MapRole(nodesRoleMapping); err != nil {
 		return fmt.Errorf("mapping iam node role: %w", err)
+	}
+
+	controllersRoleARN := fmt.Sprintf("arn:aws:iam::%s:role/controllers%s", accountID, iamv1.DefaultNameSuffix)
+	controllersRoleMapping := ekscontrolplanev1.RoleMapping{
+		RoleARN: controllersRoleARN,
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: ControllersUserName,
+			Groups:   ControllersGroups,
+		},
+	}
+	s.scope.V(2).Info("Mapping controllers IAM role", "iam-role", controllersRoleMapping.RoleARN, "user", controllersRoleMapping.UserName)
+	if err := authBackend.MapRole(controllersRoleMapping); err != nil {
+		return fmt.Errorf("mapping iam controllers role: %w", err)
 	}
 
 	s.scope.V(2).Info("Mapping additional IAM roles and users")


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This ensures that access to clusters is never lost by CAPA controllers,
which might have happened in different situations, e.g. when creating
a management cluster from a temporary bootstrap cluster and then moving
the management cluster to an EKS managed cluster (probably to itself).

In that case, the initial bootstrapping of the EKS cluster used the users
IAM identity to create the cluster, which gives it admin access to the
whole cluster. When the cluster is then moved to itself, and at the same
time the creator forgot to add the controllers role to the clusters
"iamAuthenticatorConfig", access to the cluster is lost by the controller.

From that point on, it can not generate valid admin kubeconfigs anymore
and also fails to update resources on the cluster (e.g. via CRS) from that
point on. Also, IAM authenticator reconcilation itself will fail as this
requires a valid kubeconfig.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Always add controllers role to IAMAuthenticator config
```
