### PR TITLE
Replace ioutil with os/io packages

### DIFF
--- a/api/v1alpha3/awscluster_conversion.go
+++ b/api/v1alpha3/awscluster_conversion.go
@@ -80,7 +80,6 @@ func (r *AWSClusterList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AWSClusterList_To_v1alpha3_AWSClusterList(src, r, nil)
 }
 
-
 // Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint .
 func Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint(in *clusterv1alpha3.APIEndpoint, out *clusterv1.APIEndpoint, s apiconversion.Scope) error {
 	return clusterv1alpha3.Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint(in, out, s)

--- a/api/v1alpha3/awsidentity_conversion.go
+++ b/api/v1alpha3/awsidentity_conversion.go
@@ -115,7 +115,6 @@ func (r *AWSClusterControllerIdentityList) ConvertFrom(srcRaw conversion.Hub) er
 	return Convert_v1beta1_AWSClusterControllerIdentityList_To_v1alpha3_AWSClusterControllerIdentityList(src, r, nil)
 }
 
-
 // Convert_v1alpha3_AWSClusterStaticIdentitySpec_To_v1beta1_AWSClusterStaticIdentitySpec .
 func Convert_v1alpha3_AWSClusterStaticIdentitySpec_To_v1beta1_AWSClusterStaticIdentitySpec(in *AWSClusterStaticIdentitySpec, out *infrav1.AWSClusterStaticIdentitySpec, s apiconversion.Scope) error {
 	return autoConvert_v1alpha3_AWSClusterStaticIdentitySpec_To_v1beta1_AWSClusterStaticIdentitySpec(in, out, s)

--- a/api/v1alpha3/awsmachine_conversion.go
+++ b/api/v1alpha3/awsmachine_conversion.go
@@ -134,7 +134,6 @@ func (r *AWSMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AWSMachineTemplateList_To_v1alpha3_AWSMachineTemplateList(src, r, nil)
 }
 
-
 // Convert_v1beta1_Volume_To_v1alpha3_Volume .
 func Convert_v1beta1_Volume_To_v1alpha3_Volume(in *infrav1.Volume, out *Volume, s apiconversion.Scope) error {
 	return autoConvert_v1beta1_Volume_To_v1alpha3_Volume(in, out, s)

--- a/api/v1alpha4/awscluster_conversion.go
+++ b/api/v1alpha4/awscluster_conversion.go
@@ -39,7 +39,6 @@ func (r *AWSCluster) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta1_AWSCluster_To_v1alpha4_AWSCluster(src, r, nil)
 }
 
-
 // ConvertTo converts the v1alpha3 AWSCluster receiver to a v1beta1 AWSCluster.
 func (r *AWSClusterTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*infrav1.AWSClusterTemplate)
@@ -88,7 +87,6 @@ func Convert_v1alpha4_APIEndpoint_To_v1beta1_APIEndpoint(in *clusterv1alpha4.API
 func Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint(in *clusterv1.APIEndpoint, out *clusterv1alpha4.APIEndpoint, s apiconversion.Scope) error {
 	return clusterv1alpha4.Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint(in, out, s)
 }
-
 
 // ConvertTo converts the v1alpha4 AWSClusterList receiver to a v1beta1 AWSClusterList.
 func (src *AWSClusterList) ConvertTo(dstRaw conversion.Hub) error {

--- a/api/v1alpha4/awsidentity_conversion.go
+++ b/api/v1alpha4/awsidentity_conversion.go
@@ -28,7 +28,7 @@ func (src *AWSClusterControllerIdentity) ConvertTo(dstRaw conversion.Hub) error 
 }
 
 // ConvertFrom converts the v1beta1 AWSClusterControllerIdentity to a v1alpha4 AWSClusterControllerIdentity.
-func (dst *AWSClusterControllerIdentity) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSClusterControllerIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSClusterControllerIdentity)
 
 	return Convert_v1beta1_AWSClusterControllerIdentity_To_v1alpha4_AWSClusterControllerIdentity(src, dst, nil)
@@ -41,7 +41,7 @@ func (src *AWSClusterControllerIdentityList) ConvertTo(dstRaw conversion.Hub) er
 }
 
 // ConvertFrom converts the v1beta1 AWSClusterControllerIdentityList to a v1alpha4 AWSClusterControllerIdentityList.
-func (dst *AWSClusterControllerIdentityList) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSClusterControllerIdentityList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSClusterControllerIdentityList)
 
 	return Convert_v1beta1_AWSClusterControllerIdentityList_To_v1alpha4_AWSClusterControllerIdentityList(src, dst, nil)
@@ -54,7 +54,7 @@ func (src *AWSClusterRoleIdentity) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 AWSClusterRoleIdentity to a v1alpha4 AWSClusterRoleIdentity.
-func (dst *AWSClusterRoleIdentity) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSClusterRoleIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSClusterRoleIdentity)
 
 	return Convert_v1beta1_AWSClusterRoleIdentity_To_v1alpha4_AWSClusterRoleIdentity(src, dst, nil)
@@ -67,12 +67,11 @@ func (src *AWSClusterRoleIdentityList) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 AWSClusterRoleIdentityList to a v1alpha4 AWSClusterRoleIdentityList.
-func (dst *AWSClusterRoleIdentityList) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSClusterRoleIdentityList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSClusterRoleIdentityList)
 
 	return Convert_v1beta1_AWSClusterRoleIdentityList_To_v1alpha4_AWSClusterRoleIdentityList(src, dst, nil)
 }
-
 
 // ConvertTo converts the v1alpha4 AWSClusterStaticIdentity receiver to a v1beta1 AWSClusterStaticIdentity.
 func (src *AWSClusterStaticIdentity) ConvertTo(dstRaw conversion.Hub) error {
@@ -81,7 +80,7 @@ func (src *AWSClusterStaticIdentity) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 AWSClusterStaticIdentity to a v1alpha4 AWSClusterStaticIdentity.
-func (dst *AWSClusterStaticIdentity) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSClusterStaticIdentity) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSClusterStaticIdentity)
 
 	return Convert_v1beta1_AWSClusterStaticIdentity_To_v1alpha4_AWSClusterStaticIdentity(src, dst, nil)
@@ -94,7 +93,7 @@ func (src *AWSClusterStaticIdentityList) ConvertTo(dstRaw conversion.Hub) error 
 }
 
 // ConvertFrom converts the v1beta1 AWSClusterStaticIdentityList to a v1alpha4 AWSClusterStaticIdentityList.
-func (dst *AWSClusterStaticIdentityList) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSClusterStaticIdentityList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSClusterStaticIdentityList)
 
 	return Convert_v1beta1_AWSClusterStaticIdentityList_To_v1alpha4_AWSClusterStaticIdentityList(src, dst, nil)

--- a/api/v1alpha4/awsmachine_conversion.go
+++ b/api/v1alpha4/awsmachine_conversion.go
@@ -30,7 +30,7 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 AWSMachine to a v1alpha4 AWSMachine.
-func (dst *AWSMachine) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSMachine) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSMachine)
 
 	return Convert_v1beta1_AWSMachine_To_v1alpha4_AWSMachine(src, dst, nil)
@@ -43,7 +43,7 @@ func (src *AWSMachineList) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 AWSMachineList to a v1alpha4 AWSMachineList.
-func (dst *AWSMachineList) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSMachineList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSMachineList)
 
 	return Convert_v1beta1_AWSMachineList_To_v1alpha4_AWSMachineList(src, dst, nil)
@@ -57,13 +57,13 @@ func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
-		// Manually restore data.
-		restored := &infrav1.AWSMachineTemplate{}
-		if ok, err := utilconversion.UnmarshalData(r, restored); err != nil || !ok {
-			return err
-		}
+	// Manually restore data.
+	restored := &infrav1.AWSMachineTemplate{}
+	if ok, err := utilconversion.UnmarshalData(r, restored); err != nil || !ok {
+		return err
+	}
 
-		dst.Spec.Template.ObjectMeta = restored.Spec.Template.ObjectMeta
+	dst.Spec.Template.ObjectMeta = restored.Spec.Template.ObjectMeta
 
 	return nil
 }
@@ -91,12 +91,11 @@ func (src *AWSMachineTemplateList) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 AWSMachineTemplateList to a v1alpha4 AWSMachineTemplateList.
-func (dst *AWSMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error{
+func (dst *AWSMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1.AWSMachineTemplateList)
 
 	return Convert_v1beta1_AWSMachineTemplateList_To_v1alpha4_AWSMachineTemplateList(src, dst, nil)
 }
-
 
 func Convert_v1beta1_AWSMachineTemplateResource_To_v1alpha4_AWSMachineTemplateResource(in *infrav1.AWSMachineTemplateResource, out *AWSMachineTemplateResource, s apiconversion.Scope) error {
 	return autoConvert_v1beta1_AWSMachineTemplateResource_To_v1alpha4_AWSMachineTemplateResource(in, out, s)

--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -18,7 +18,7 @@ package ami
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -88,11 +88,11 @@ func latestStableRelease() (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
-
 	latestVersion := strings.TrimSpace(string(b))
 	tagPrefix := "v"
 	latestVersionSemVer, err := semver.Make(strings.TrimPrefix(latestVersion, tagPrefix))
@@ -110,7 +110,7 @@ func latestStableRelease() (string, error) {
 			return "", err
 		}
 		defer resp.Body.Close()
-		b, err = ioutil.ReadAll(resp.Body)
+		b, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
@@ -18,7 +18,7 @@ package bootstrap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/converters"
@@ -53,7 +53,7 @@ func (t Template) GenerateManagedIAMPolicyDocuments(policyDocDir string) error {
 		}
 
 		fn := path.Join(policyDocDir, fmt.Sprintf("%s.json", pn))
-		err = ioutil.WriteFile(fn, []byte(pds), 0o600)
+		err = os.WriteFile(fn, []byte(pds), 0o600)
 		if err != nil {
 			return fmt.Errorf("failed to generate policy document for ManagedIAMPolicy %q: %w", pn, err)
 		}

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
@@ -18,7 +18,7 @@ package bootstrap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -171,7 +171,7 @@ func Test_RenderCloudformation(t *testing.T) {
 
 	for _, c := range cases {
 		cfn := cloudformation.Template{}
-		data, err := ioutil.ReadFile(path.Join("fixtures", c.fixture+".yaml"))
+		data, err := os.ReadFile(path.Join("fixtures", c.fixture+".yaml"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -184,7 +184,7 @@ func Test_RenderCloudformation(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ioutil.WriteFile("/tmp/tmp1", tData, 0600) // nolint:gosec
+		os.WriteFile("/tmp/tmp1", tData, 0600)
 
 		if string(tData) != string(data) {
 			dmp := diffmatchpatch.New()

--- a/cmd/clusterawsadm/configreader/configreader.go
+++ b/cmd/clusterawsadm/configreader/configreader.go
@@ -18,7 +18,7 @@ package configreader
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -66,7 +66,7 @@ type fsLoader struct {
 
 // ReadFile reads a file.
 func (fsLoader) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filepath.Clean(filename))
+	return os.ReadFile(filepath.Clean(filename))
 }
 
 // NewFsLoader returns a Loader that loads a AWSIAMConfiguration from the `config file`.

--- a/exp/api/v1alpha4/conversion_test.go
+++ b/exp/api/v1alpha4/conversion_test.go
@@ -33,9 +33,9 @@ func TestFuzzyConversion(t *testing.T) {
 	g.Expect(v1beta1.AddToScheme(scheme)).To(Succeed())
 
 	t.Run("for AWSMachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme:      scheme,
-		Hub:         &v1beta1.AWSMachinePool{},
-		Spoke:       &AWSMachinePool{},
+		Scheme: scheme,
+		Hub:    &v1beta1.AWSMachinePool{},
+		Spoke:  &AWSMachinePool{},
 	}))
 
 	t.Run("for AWSManagedMachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -20,20 +20,20 @@ limitations under the License.
 package tools
 
 import (
+	_ "embed"
 	_ "github.com/a8m/envsubst"
 	_ "github.com/ahmetb/gen-crd-api-reference-docs"
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/itchyny/gojq/cmd/gojq"
 	_ "github.com/onsi/ginkgo/ginkgo"
+	_ "k8s.io/apimachinery/pkg/util/intstr"
 	_ "k8s.io/code-generator"
+	_ "k8s.io/code-generator/cmd/conversion-gen"
 	_ "k8s.io/release/cmd/release-notes"
 	_ "sigs.k8s.io/cluster-api/hack/tools/mdbook/embed"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kind"
 	_ "sigs.k8s.io/kustomize/kustomize/v4"
 	_ "sigs.k8s.io/testing_frameworks/integration"
-	_ "k8s.io/apimachinery/pkg/util/intstr"
-	_ "embed"
-	_ "k8s.io/code-generator/cmd/conversion-gen"
 )

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -24,7 +24,6 @@ import (
 	b64 "encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -415,7 +414,7 @@ func DumpCloudTrailEvents(e2eCtx *E2EContext) {
 	}
 	logPath := filepath.Join(e2eCtx.Settings.ArtifactFolder, "cloudtrail-events.yaml")
 	dat, err := yaml.Marshal(events)
-	if err := ioutil.WriteFile(logPath, dat, 0600); err != nil {
+	if err := os.WriteFile(logPath, dat, 0600); err != nil {
 		fmt.Fprintf(GinkgoWriter, "couldn't write cloudtrail events to file: file=%s err=%s", logPath, err)
 		return
 	}
@@ -574,7 +573,7 @@ func dumpEKSCluster(cluster *eks.Cluster, logPath string) {
 	}
 	defer f.Close()
 
-	if err := ioutil.WriteFile(f.Name(), clusterYAML, 0600); err != nil {
+	if err := os.WriteFile(f.Name(), clusterYAML, 0600); err != nil {
 		fmt.Fprintf(GinkgoWriter, "couldn't write cluster yaml to file: name=%s file=%s err=%s", *cluster.Name, f.Name(), err)
 		return
 	}

--- a/test/e2e/shared/exec.go
+++ b/test/e2e/shared/exec.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -120,7 +119,7 @@ func commandsForMachine(ctx context.Context, e2eCtx *E2EContext, f *os.File, ins
 			return
 		}
 		result, _, err := e.Expect(shellStart, 20*time.Second)
-		if err := ioutil.WriteFile(logFile, []byte(result), os.ModePerm); err != nil {
+		if err := os.WriteFile(logFile, []byte(result), os.ModePerm); err != nil {
 			fmt.Fprintf(f, "error writing log file: err=%s", err)
 			return
 		}

--- a/test/e2e/shared/resource.go
+++ b/test/e2e/shared/resource.go
@@ -21,7 +21,6 @@ package shared
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -58,7 +57,7 @@ func WriteResourceQuotesToFile(logPath string, serviceQuotas map[string]*Service
 	data, err := yaml.Marshal(resources)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = ioutil.WriteFile(logPath, data, 0644)
+	err = os.WriteFile(logPath, data, 0644)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -86,7 +85,7 @@ func (r *TestResource) WriteRequestedResources(e2eCtx *E2EContext, testName stri
 	err := fileLock.Lock()
 	Expect(err).NotTo(HaveOccurred())
 
-	requestedResources, err := ioutil.ReadFile(requestedResourceFilePath)
+	requestedResources, err := os.ReadFile(requestedResourceFilePath)
 	Expect(err).NotTo(HaveOccurred())
 
 	resources := struct {
@@ -101,7 +100,7 @@ func (r *TestResource) WriteRequestedResources(e2eCtx *E2EContext, testName stri
 	resources.TestResourceMap[testName] = *r
 	str, err := yaml.Marshal(resources)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(ioutil.WriteFile(requestedResourceFilePath, str, 0644)).To(Succeed())
+	Expect(os.WriteFile(requestedResourceFilePath, str, 0644)).To(Succeed())
 }
 
 func (r *TestResource) doesSatisfy(request *TestResource) bool {
@@ -164,7 +163,7 @@ func AcquireResources(request *TestResource, nodeNum int, fileLock *flock.Flock)
 		if err != nil {
 			continue
 		}
-		resourceText, err := ioutil.ReadFile(ResourceQuotaFilePath)
+		resourceText, err := os.ReadFile(ResourceQuotaFilePath)
 		if err != nil {
 			return err
 		}
@@ -180,7 +179,7 @@ func AcquireResources(request *TestResource, nodeNum int, fileLock *flock.Flock)
 			if err != nil {
 				return err
 			}
-			if err := ioutil.WriteFile(ResourceQuotaFilePath, data, 0644); err != nil {
+			if err := os.WriteFile(ResourceQuotaFilePath, data, 0644); err != nil {
 				return err
 			}
 			Byf("Node %d acquired resources: %s", nodeNum, request.String())
@@ -213,7 +212,7 @@ func ReleaseResources(request *TestResource, nodeNum int, fileLock *flock.Flock)
 		if err := fileLock.Lock(); err != nil {
 			continue
 		}
-		resourceText, err := ioutil.ReadFile(ResourceQuotaFilePath)
+		resourceText, err := os.ReadFile(ResourceQuotaFilePath)
 		if err != nil {
 			return err
 		}
@@ -226,7 +225,7 @@ func ReleaseResources(request *TestResource, nodeNum int, fileLock *flock.Flock)
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(ResourceQuotaFilePath, data, 0644); err != nil {
+		if err := os.WriteFile(ResourceQuotaFilePath, data, 0644); err != nil {
 			return err
 		}
 		Byf("Node %d released resources: %s", nodeNum, request.String())

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -21,7 +21,6 @@ package shared
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -62,16 +61,16 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 	Expect(os.MkdirAll(e2eCtx.Settings.ArtifactFolder, 0o750)).To(Succeed(), "Invalid test suite argument. Can't create artifacts-folder %q", e2eCtx.Settings.ArtifactFolder)
 	Byf("Loading the e2e test configuration from %q", e2eCtx.Settings.ConfigPath)
 	e2eCtx.E2EConfig = LoadE2EConfig(e2eCtx.Settings.ConfigPath)
-	sourceTemplate, err := ioutil.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, e2eCtx.Settings.SourceTemplate))
+	sourceTemplate, err := os.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, e2eCtx.Settings.SourceTemplate))
 	Expect(err).NotTo(HaveOccurred())
 	e2eCtx.StartOfSuite = time.Now()
 
 	var clusterctlCITemplate clusterctl.Files
 	if !e2eCtx.IsManaged {
 		// Create CI manifest for upgrading to Kubernetes main test
-		platformKustomization, err := ioutil.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, "ci-artifacts-platform-kustomization-for-upgrade.yaml"))
+		platformKustomization, err := os.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, "ci-artifacts-platform-kustomization-for-upgrade.yaml"))
 		Expect(err).NotTo(HaveOccurred())
-		sourceTemplateForUpgrade, err := ioutil.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, "infrastructure-aws/generated/cluster-template-upgrade-to-main.yaml"))
+		sourceTemplateForUpgrade, err := os.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, "infrastructure-aws/generated/cluster-template-upgrade-to-main.yaml"))
 		Expect(err).NotTo(HaveOccurred())
 
 		ciTemplateForUpgradePath, err := kubernetesversions.GenerateCIArtifactsInjectedTemplateForDebian(
@@ -96,7 +95,7 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 		}
 
 		// Create CI manifest for conformance test
-		platformKustomization, err = ioutil.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, "ci-artifacts-platform-kustomization.yaml"))
+		platformKustomization, err = os.ReadFile(filepath.Join(e2eCtx.Settings.DataFolder, "ci-artifacts-platform-kustomization.yaml"))
 		Expect(err).NotTo(HaveOccurred())
 		ciTemplatePath, err := kubernetesversions.GenerateCIArtifactsInjectedTemplateForDebian(
 			kubernetesversions.GenerateCIArtifactsInjectedTemplateForDebianInput{

--- a/test/e2e/shared/temp.go
+++ b/test/e2e/shared/temp.go
@@ -20,7 +20,6 @@ package shared
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -107,7 +106,7 @@ func InitManagementClusterAndWatchControllerLogs(ctx context.Context, input Init
 }
 
 func localLoadE2EConfig(configPath string) *clusterctl.E2EConfig {
-	configData, err := ioutil.ReadFile(configPath)
+	configData, err := os.ReadFile(configPath)
 	Expect(err).ToNot(HaveOccurred(), "Failed to read the e2e test config file")
 	Expect(configData).ToNot(BeEmpty(), "The e2e test config file should not be empty")
 

--- a/test/e2e/shared/template.go
+++ b/test/e2e/shared/template.go
@@ -20,7 +20,7 @@ package shared
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/awslabs/goformation/v4/cloudformation"
@@ -106,11 +106,11 @@ func newBootstrapTemplate(e2eCtx *E2EContext) *cfn_bootstrap.Template {
 	t.Spec.EKS.ManagedMachinePool.Disable = false
 	str, err := yaml.Marshal(t.Spec)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(ioutil.WriteFile(path.Join(e2eCtx.Settings.ArtifactFolder, "awsiamconfiguration.yaml"), str, 0644)).To(Succeed())
+	Expect(os.WriteFile(path.Join(e2eCtx.Settings.ArtifactFolder, "awsiamconfiguration.yaml"), str, 0644)).To(Succeed())
 	cloudformationTemplate := renderCustomCloudFormation(&t)
 	cfnData, err := cloudformationTemplate.YAML()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(ioutil.WriteFile(path.Join(e2eCtx.Settings.ArtifactFolder, "cloudformation.yaml"), cfnData, 0644)).To(Succeed())
+	Expect(os.WriteFile(path.Join(e2eCtx.Settings.ArtifactFolder, "cloudformation.yaml"), cfnData, 0644)).To(Succeed())
 	return &t
 }
 

--- a/test/e2e/suites/managed/cluster.go
+++ b/test/e2e/suites/managed/cluster.go
@@ -21,7 +21,7 @@ package managed
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -114,7 +114,7 @@ func ManagedClusterSpec(ctx context.Context, inputGetter func() ManagedClusterSp
 
 	if input.CNIManifestPath != "" {
 		shared.Byf("Installing a CNI plugin to the workload cluster: %s", input.CNIManifestPath)
-		cniYaml, err := ioutil.ReadFile(input.CNIManifestPath)
+		cniYaml, err := os.ReadFile(input.CNIManifestPath)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		Expect(workloadClusterProxy.Apply(ctx, cniYaml)).ShouldNot(HaveOccurred())

--- a/test/e2e/suites/unmanaged/helpers_test.go
+++ b/test/e2e/suites/unmanaged/helpers_test.go
@@ -21,9 +21,9 @@ package unmanaged
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -679,7 +679,7 @@ func LatestCIReleaseForVersion(searchVersion string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -19,8 +19,8 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"path/filepath"
 	goruntime "runtime"
@@ -215,7 +215,7 @@ func (t *TestEnvironmentConfiguration) Build() (*TestEnvironment, error) {
 func buildModifiedWebhook(tag string, relativeFilePath string) (admissionv1.MutatingWebhookConfiguration, admissionv1.ValidatingWebhookConfiguration, error) {
 	var mutatingWebhook admissionv1.MutatingWebhookConfiguration
 	var validatingWebhook admissionv1.ValidatingWebhookConfiguration
-	data, err := ioutil.ReadFile(filepath.Clean(filepath.Join(root, relativeFilePath)))
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(root, relativeFilePath)))
 	if err != nil {
 		return mutatingWebhook, validatingWebhook, errors.Wrap(err, "failed to read webhook configuration file")
 	}

--- a/util/system/util.go
+++ b/util/system/util.go
@@ -18,7 +18,6 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -63,7 +62,7 @@ func GetNamespaceFromFile(nsFilePath string) (string, error) {
 	}
 
 	// Load the namespace file and return its content
-	namespace, err := ioutil.ReadFile(filepath.Clean(nsFilePath))
+	namespace, err := os.ReadFile(filepath.Clean(nsFilePath))
 	if err != nil {
 		return "", fmt.Errorf("error reading namespace file: %w", err)
 	}

--- a/util/system/util_test.go
+++ b/util/system/util_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -66,7 +65,7 @@ func TestGetNamespaceFromFile(t *testing.T) {
 	_, err = os.OpenFile(filepath.Clean(nsPath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	g.Expect(err).NotTo(HaveOccurred())
 	ns := []byte("different-ns")
-	g.Expect(ioutil.WriteFile(nsPath, ns, 0644)).NotTo(HaveOccurred()) //nolint:gosec
+	g.Expect(os.WriteFile(nsPath, ns, 0644)).NotTo(HaveOccurred()) //nolint:gosec
 	g.Expect(GetNamespaceFromFile(nsPath)).To(Equal("different-ns"))
 	g.Expect(os.Remove(nsPath)).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we need to replace all the ioutil with os and io.


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Replace ioutil deprecated package with os/io for golang 1.16
```
