### PR TITLE
[e2e] Fix GPU test cuda vector pod creation timeout

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -236,4 +236,4 @@ intervals:
   default/wait-machine-pool-nodes: ["40m", "10s"]
   default/wait-machine-pool-upgrade: [ "50m", "10s" ]
   default/wait-create-identity: ["1m", "10s"]
-  default/wait-job: ["5m", "10s"]
+  default/wait-job: ["10m", "10s"]


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
This PR increases the timeout interval for wait-job creation in e2e config which is causing GPU tests to be flaky.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2905 

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
None
```
