### PR TITLE
[wip] Fix timeout due to delay in bringing up control plane in e2e tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -119,7 +119,7 @@ variables:
 
 intervals:
   default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["10m", "10s"]
+  default/wait-control-plane: ["20m", "10s"]
   default/wait-worker-nodes: ["10m", "10s"]
   conformance/wait-control-plane: ["30m", "10s"]
   conformance/wait-worker-nodes: ["30m", "10s"]


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind regression

**What this PR does / why we need it**:
The control plane node wait interval is set to 10m in e2e conf, but sometimes the control plane takes more than 10m to come up. This PR updates the wait interval for control plane to fix the flaky tests in testgrid. Related to #2763

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
None
```
