### PR TITLE
Fix timeout due to delay in bringing up control plane in e2e tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -14,22 +14,20 @@
 # For more details, run `go run ./cmd/clusterawsadm bootstrap credentials`
 
 images:
+  - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.3.12
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v0.3.12
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v0.3.12
+    loadBehavior: tryLoad
   # Use local dev images built source tree;
   - name: gcr.io/k8s-staging-cluster-api/capa-manager:e2e
     loadBehavior: mustLoad
-
-## PLEASE KEEP THESE UP TO DATE WITH THE COMPONENTS
-  - name: quay.io/jetstack/cert-manager-cainjector:v1.1.0
+  - name: quay.io/jetstack/cert-manager-cainjector:v0.16.1
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-webhook:v1.1.0
+  - name: quay.io/jetstack/cert-manager-webhook:v0.16.1
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-controller:v1.1.0
-    loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v0.4.1
-    loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v0.4.1
-    loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v0.4.1
+  - name: quay.io/jetstack/cert-manager-controller:v0.16.1
     loadBehavior: tryLoad
 
 providers:
@@ -37,77 +35,67 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v0.4.1
+      - name: v0.3.12
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.1/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.12/core-components.yaml"
         type: "url"
-        files:
-          - sourcePath: "./shared/v1alpha4/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-          - old: "--leader-elect"
-            new: "--leader-elect=false"
-          - old: --metrics-bind-addr=127.0.0.1:8080
-            new: --metrics-bind-addr=:8080
+          - old: "--enable-leader-election"
+            new: "--enable-leader-election=false"
+          - old: --metrics-addr=127.0.0.1:8080
+            new: --metrics-addr=:8080
 
   - name: kubeadm
     type: BootstrapProvider
-    files:
-      - sourcePath: "./shared/v1alpha4/metadata.yaml"
     versions:
-      - name: v0.4.1
+      - name: v0.3.12
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.1/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.12/bootstrap-components.yaml"
         type: "url"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-          - old: "--leader-elect"
-            new: "--leader-elect=false"
-          - old: --metrics-bind-addr=127.0.0.1:8080
-            new: --metrics-bind-addr=:8080
+          - old: "--enable-leader-election"
+            new: "--enable-leader-election=false"
+          - old: --metrics-addr=127.0.0.1:8080
+            new: --metrics-addr=:8080
 
   - name: kubeadm
     type: ControlPlaneProvider
-    files:
-      - sourcePath: "./shared/v1alpha4/metadata.yaml"
     versions:
-      - name: v0.4.1
+      - name: v0.3.12
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.1/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.12/control-plane-components.yaml"
         type: "url"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-          - old: "--leader-elect"
-            new: "--leader-elect=false"
-          - old: --metrics-bind-addr=127.0.0.1:8080
-            new: --metrics-bind-addr=:8080
+          - old: "--enable-leader-election"
+            new: "--enable-leader-election=false"
+          - old: --metrics-addr=127.0.0.1:8080
+            new: --metrics-addr=:8080
 
   - name: aws
     type: InfrastructureProvider
     versions:
-      - name: v0.7.0
+      - name: v0.5.0
         # Use manifest from source files
-        value: ../../../config/default
-        files:
-          - sourcePath: "./shared/v1alpha4_provider/metadata.yaml"
+        value: ../../../config
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-          - old: "--leader-elect"
-            new: "--leader-elect=false"
-          - old: --metrics-bind-addr=127.0.0.1:8080
-            new: --metrics-bind-addr=:8080
+          - old: "--enable-leader-election"
+            new: "--enable-leader-election=false"
+          - old: --metrics-addr=127.0.0.1:8080
+            new: --metrics-addr=:8080
           - old: gcr.io/k8s-staging-cluster-api/cluster-api-aws-controller-amd64:dev
             new: gcr.io/k8s-staging-cluster-api/capa-manager:e2e
           - old: gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller:latest
             new: gcr.io/k8s-staging-cluster-api/capa-manager:e2e
     files:
       # Add a cluster template
-      - sourcePath: "./shared/v1alpha4/metadata.yaml"
-        targetName: "metadata.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template-ssm.yaml"
         targetName: "cluster-template-ssm.yaml"
@@ -117,53 +105,26 @@ providers:
         targetName: "cluster-template-limit-az.yaml"
       - sourcePath: "./infrastructure-aws/cluster-template-spot-instances.yaml"
         targetName: "cluster-template-spot-instances.yaml"
-      - sourcePath: "./infrastructure-aws/cluster-template-md-remediation.yaml"
-        targetName: "cluster-template-md-remediation.yaml"
-      - sourcePath: "./infrastructure-aws/cluster-template-kcp-remediation.yaml"
-        targetName: "cluster-template-kcp-remediation.yaml"
-      - sourcePath: "./infrastructure-aws/cluster-template-kcp-scale-in.yaml"
-        targetName: "cluster-template-kcp-scale-in.yaml"
-      - sourcePath: "./infrastructure-aws/cluster-template-machine-pool.yaml"
-        targetName: "cluster-template-machine-pool.yaml"
-      - sourcePath: "./infrastructure-aws/cluster-template-upgrade-to-main.yaml"
-        targetName: "cluster-template-upgrade-to-main.yaml"
-      - sourcePath: "./infrastructure-aws/cluster-template-simple-multitenancy.yaml"
-        targetName: "cluster-template-simple-multitenancy.yaml"
-      - sourcePath: "./infrastructure-aws/cluster-template-nested-multitenancy.yaml"
-        targetName: "cluster-template-nested-multitenancy.yaml"
 
 variables:
+  KUBERNETES_VERSION: "v1.19.4"
   CNI: "../../data/cni/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
-  EVENT_BRIDGE_INSTANCE_STATE: "true"
   AWS_CONTROL_PLANE_MACHINE_TYPE: t3.large
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.21.2"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.19.4"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
-  EXP_MACHINE_POOL: "true"
-  ETCD_VERSION_UPGRADE_TO: "3.4.13-2"
-  COREDNS_VERSION_UPGRADE_TO: "v1.8.4"
-  KUBERNETES_VERSION: "v1.21.2"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.21.2"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.20.8"
-  MULTI_TENANCY_ROLE_NAME: "multi-tenancy-role"
-  MULTI_TENANCY_NESTED_ROLE_NAME: "multi-tenancy-nested-role"
-  IP_FAMILY: "IPv4"
 
 intervals:
   default/wait-cluster: ["25m", "10s"]
-  default/wait-control-plane: ["10m", "10s"]
+  default/wait-control-plane: ["20m", "10s"]
   default/wait-worker-nodes: ["10m", "10s"]
   conformance/wait-control-plane: ["30m", "10s"]
   conformance/wait-worker-nodes: ["30m", "10s"]
   default/wait-controllers: ["3m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
-  default/wait-machine-upgrade: ["30m", "10s"]
+  default/wait-machine-upgrade: ["20m", "10s"]
   default/wait-machine-status: ["20m", "10s"]
-  default/wait-failed-machine-status: ["2m", "10s"]
   default/wait-infra-subnets: ["5m", "30s"]
-  default/wait-machine-pool-nodes: ["40m", "10s"]
-  default/wait-machine-pool-upgrade: [ "50m", "10s" ]
-  default/wait-create-identity: ["1m", "10s"]


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind regression

**What this PR does / why we need it**:
The control plane node wait interval is set to 10m in e2e conf, but sometimes the control plane takes more than 10m to come up. This PR updates the wait interval for control plane to fix the flaky tests in testgrid. Related to #2763

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
None
```
