### PR TITLE
Refactor identity management

### DIFF
--- a/api/v1beta1/awsidentity_types.go
+++ b/api/v1beta1/awsidentity_types.go
@@ -148,7 +148,7 @@ type AWSClusterRoleIdentitySpec struct {
 
 	// SourceIdentityRef is a reference to another identity which will be chained to do
 	// role assumption. All identity types are accepted.
-	SourceIdentityRef *AWSIdentityReference `json:"sourceIdentityRef,omitempty"`
+	SourceIdentityRef *AWSIdentityReference `json:"sourceIdentityRef"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
@@ -460,6 +460,7 @@ spec:
                 type: object
             required:
             - roleARN
+            - sourceIdentityRef
             type: object
         type: object
     served: true

--- a/pkg/cloud/identity/identity.go
+++ b/pkg/cloud/identity/identity.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 )
@@ -78,13 +77,12 @@ func GetAssumeRoleCredentials(roleIdentityProvider *AWSRolePrincipalTypeProvider
 }
 
 // NewAWSRolePrincipalTypeProvider will create a new AWSRolePrincipalTypeProvider from an AWSClusterRoleIdentity.
-func NewAWSRolePrincipalTypeProvider(identity *infrav1.AWSClusterRoleIdentity, sourceProvider *AWSPrincipalTypeProvider, log logr.Logger) *AWSRolePrincipalTypeProvider {
+func NewAWSRolePrincipalTypeProvider(identity *infrav1.AWSClusterRoleIdentity, sourceProvider *AWSPrincipalTypeProvider) *AWSRolePrincipalTypeProvider {
 	return &AWSRolePrincipalTypeProvider{
 		credentials:    nil,
 		stsClient:      nil,
 		Principal:      identity,
 		sourceProvider: sourceProvider,
-		log:            log.WithName("AWSRolePrincipalTypeProvider"),
 	}
 }
 
@@ -129,7 +127,6 @@ type AWSRolePrincipalTypeProvider struct {
 	Principal      *infrav1.AWSClusterRoleIdentity
 	credentials    *credentials.Credentials
 	sourceProvider *AWSPrincipalTypeProvider
-	log            logr.Logger
 	stsClient      stsiface.STSAPI
 }
 

--- a/pkg/cloud/scope/session_test.go
+++ b/pkg/cloud/scope/session_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2/klogr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/identity"
 	"sigs.k8s.io/cluster-api-provider-aws/util/system"
@@ -227,7 +226,7 @@ func TestPrincipalParsing(t *testing.T) {
 		identityRef *corev1.ObjectReference
 		identity    runtime.Object
 		setup       func(client.Client, *testing.T)
-		expect      func([]identity.AWSPrincipalTypeProvider)
+		expect      func(identity.AWSPrincipalTypeProvider)
 		expectError bool
 	}{
 		{
@@ -245,9 +244,9 @@ func TestPrincipalParsing(t *testing.T) {
 			},
 			setup: func(c client.Client, t *testing.T) {
 			},
-			expect: func(providers []identity.AWSPrincipalTypeProvider) {
-				if len(providers) != 0 {
-					t.Fatalf("Expected 0 providers, got %v", len(providers))
+			expect: func(provider identity.AWSPrincipalTypeProvider) {
+				if provider != nil {
+					t.Fatalf("Provider should not be nil")
 				}
 			},
 		},
@@ -304,11 +303,11 @@ func TestPrincipalParsing(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			expect: func(providers []identity.AWSPrincipalTypeProvider) {
-				if len(providers) != 1 {
-					t.Fatalf("Expected 1 provider, got %v", len(providers))
+			expect: func(provider identity.AWSPrincipalTypeProvider) {
+				if provider == nil {
+					t.Fatalf("provider should not be nil")
 				}
-				provider := providers[0]
+
 				p, ok := provider.(*identity.AWSStaticPrincipalTypeProvider)
 				if !ok {
 					t.Fatal("Expected providers to be of type AWSStaticPrincipalTypeProvider")
@@ -401,9 +400,9 @@ func TestPrincipalParsing(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			expect: func(providers []identity.AWSPrincipalTypeProvider) {
-				if len(providers) != 1 {
-					t.Fatalf("Expected 1 providers, got %v", len(providers))
+			expect: func(provider identity.AWSPrincipalTypeProvider) {
+				if provider == nil {
+					t.Fatalf("Provider should not be nil")
 				}
 			},
 		},
@@ -445,11 +444,10 @@ func TestPrincipalParsing(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			expect: func(providers []identity.AWSPrincipalTypeProvider) {
-				if len(providers) != 1 {
-					t.Fatalf("Expected 1 providers, got %v", len(providers))
+			expect: func(provider identity.AWSPrincipalTypeProvider) {
+				if provider == nil {
+					t.Fatalf("Provider should not be nil")
 				}
-				provider := providers[0]
 				p, ok := provider.(*identity.AWSRolePrincipalTypeProvider)
 				if !ok {
 					t.Fatal("Expected providers to be of type AWSRolePrincipalTypeProvider")
@@ -471,7 +469,7 @@ func TestPrincipalParsing(t *testing.T) {
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			tc.setup(k8sClient, t)
 			clusterScope.AWSCluster = &tc.awsCluster
-			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope, klogr.New())
+			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected an error but didn't get one")


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
This PR does the initial refactoring for https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2936

Before, `buildProvidersForRef()` was returning an array of providers but this never is the case as for each identity there must be exactly 1 provider. This is not a bug because in the logic, we were never ending up returning multiple providers.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
