### PR TITLE
Enable v1alpha3/v1alpha4 to v1beta1 upgrade test

### DIFF
--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -150,7 +150,7 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 		})
 	})
 
-	ginkgo.PDescribe("Clusterctl Upgrade Spec [from v1alpha3]", func() {
+	ginkgo.Describe("Clusterctl Upgrade Spec [from v1alpha3]", func() {
 		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 5, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2}
 		ginkgo.BeforeEach(func() {
@@ -175,7 +175,7 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 		})
 	})
 
-	ginkgo.PDescribe("Clusterctl Upgrade Spec [from v1alpha4]", func() {
+	ginkgo.Describe("Clusterctl Upgrade Spec [from v1alpha4]", func() {
 		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 5, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2}
 		ginkgo.BeforeEach(func() {


### PR DESCRIPTION
Enable v1alpha4 to v1beta1 upgrade test

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2788
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2833

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Enable v1alpha3/v1alpha4 to v1beta1 upgrade e2e test 
```
