### PR TITLE
Fix ssm parameter

### DIFF
--- a/pkg/cloud/services/ssm/secret.go
+++ b/pkg/cloud/services/ssm/secret.go
@@ -93,11 +93,10 @@ func (s *Service) Create(m *scope.MachineScope, data []byte) (string, int32, err
 // retryableCreateSecret is a function to be passed into a waiter. In a separate function for ease of reading.
 func (s *Service) retryableCreateSecret(name string, chunk []byte, tags infrav1.Tags) (bool, error) {
 	_, err := s.SSMClient.PutParameter(&ssm.PutParameterInput{
-		Name:     aws.String(name),
-		DataType: aws.String("text"),
-		Value:    aws.String(string(chunk)),
-		Tags:     converters.MapToSSMTags(tags),
-		Type:     aws.String("SecureString"),
+		Name:  aws.String(name),
+		Value: aws.String(string(chunk)),
+		Tags:  converters.MapToSSMTags(tags),
+		Type:  aws.String("SecureString"),
 	})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
/kind bug


**What this PR does / why we need it**:
Removes the data type to make ssm work with govcloud.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2636

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix for supporting SecureString as a parameter type in SSM on GovCloud
```
