### PR TITLE
Fix unzip command while running e2e tests locally

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -183,7 +183,7 @@ ifeq ($(UNAME), Linux)
 endif
 ifeq ($(UNAME), Darwin)
 	$(MAKE) $(SSM_SHARE)/sessionmanager-bundle.zip
-	cd $(BIN_DIR) && unzip -j ../share/ssm/sessionmanager-bundle.zip sessionmanager-bundle/bin/session-manager-plugin
+	cd $(BIN_DIR) && unzip -o -j ../share/ssm/sessionmanager-bundle.zip sessionmanager-bundle/bin/session-manager-plugin
 endif
 
 .PHONY: clean


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR updates the unzip command in Makefile such that session manager plugin installation is not asked everytime e2e test runs in macOS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2674

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
None
```
