### PR TITLE
Return error if providerID is set and instance cannot be found

### DIFF
--- a/pkg/cloud/services/ec2/errors.go
+++ b/pkg/cloud/services/ec2/errors.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ec2
+
+import "errors"
+
+var (
+	// ErrInstanceNotFoundByID defines an error for when the instance with the provided provider ID is missing.
+	ErrInstanceNotFoundByID = errors.New("failed to find instance by id")
+
+	// ErrDescribeInstance defines an error for when AWS SDK returns error when describing instances.
+	ErrDescribeInstance = errors.New("failed to describe instance by id")
+)

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -61,8 +61,8 @@ func TestInstanceIfExists(t *testing.T) {
 					Return(nil, awserrors.NewNotFound("not found"))
 			},
 			check: func(instance *infrav1.Instance, err error) {
-				if err != nil {
-					t.Fatalf("did not expect error: %v", err)
+				if err == nil {
+					t.Fatalf("expects error when instance could not be found: %v", err)
 				}
 
 				if instance != nil {
@@ -80,8 +80,8 @@ func TestInstanceIfExists(t *testing.T) {
 					Return(nil, awserr.New(awserrors.InvalidInstanceID, "does not exist", nil))
 			},
 			check: func(instance *infrav1.Instance, err error) {
-				if err != nil {
-					t.Fatalf("did not expect error: %v", err)
+				if err == nil {
+					t.Fatalf("expects error when DescribeInstances returns error: %v", err)
 				}
 
 				if instance != nil {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
If providerID is set for an `AWSMachine`, we should never create a new instance for it again. Because the new instance id does not propagate to `Machine.status.nodeRef`.

This PR has some reorg for better readability. The main change is to return error (instead of nil instance and nil error), when the instance could not be found in `InstanceIfExists()`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2915, more investigation needed.

```release-note
Do not create a new instance if AWSMachine already has ProviderID field set.
```
