### PR TITLE
feat: expose eks service network configuration.

### DIFF
--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -365,3 +365,16 @@ func (s *ManagedControlPlaneScope) DisableVPCCNI() bool {
 func (s *ManagedControlPlaneScope) OIDCIdentityProviderConfig() *ekscontrolplanev1.OIDCIdentityProviderConfig {
 	return s.ControlPlane.Spec.OIDCIdentityProviderConfig
 }
+
+// ServiceCidrs returns the CIDR blocks used for services.
+func (s *ManagedControlPlaneScope) ServiceCidrs() *clusterv1.NetworkRanges {
+	if s.Cluster.Spec.ClusterNetwork != nil {
+		if s.Cluster.Spec.ClusterNetwork.Services != nil {
+			if len(s.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks) > 0 {
+				return s.Cluster.Spec.ClusterNetwork.Services
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/internal/cidr"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/internal/cmp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -240,6 +241,25 @@ func makeEksEncryptionConfigs(encryptionConfig *ekscontrolplanev1.EncryptionConf
 	})
 }
 
+func makeKubernetesNetworkConfig(serviceCidrs *clusterv1.NetworkRanges) (*eks.KubernetesNetworkConfigRequest, error) {
+	if serviceCidrs == nil || len(serviceCidrs.CIDRBlocks) == 0 {
+		return nil, nil
+	}
+
+	ipv4cidrs, err := cidr.GetIPv4Cidrs(serviceCidrs.CIDRBlocks)
+	if err != nil {
+		return nil, fmt.Errorf("filtering service cidr blocks to IPv4: %w", err)
+	}
+
+	if len(ipv4cidrs) == 0 {
+		return nil, nil
+	}
+
+	return &eks.KubernetesNetworkConfigRequest{
+		ServiceIpv4Cidr: &ipv4cidrs[0],
+	}, nil
+}
+
 func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.EndpointAccess, securityGroups map[infrav1.SecurityGroupRole]infrav1.SecurityGroup) (*eks.VpcConfigRequest, error) {
 	// TODO: Do we need to just add the private subnets?
 	if len(subnets) < 2 {
@@ -336,6 +356,10 @@ func (s *Service) createCluster(eksClusterName string) (*eks.Cluster, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't create vpc config for cluster")
 	}
+	netConfig, err := makeKubernetesNetworkConfig(s.scope.ServiceCidrs())
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create Kubernetes network config for cluster")
+	}
 
 	// Make sure to use the MachineScope here to get the merger of AWSCluster and AWSMachine tags
 	additionalTags := s.scope.AdditionalTags()
@@ -355,13 +379,14 @@ func (s *Service) createCluster(eksClusterName string) (*eks.Cluster, error) {
 
 	v := versionToEKS(parseEKSVersion(*s.scope.ControlPlane.Spec.Version))
 	input := &eks.CreateClusterInput{
-		Name:               aws.String(eksClusterName),
-		Version:            aws.String(v),
-		Logging:            logging,
-		EncryptionConfig:   encryptionConfigs,
-		ResourcesVpcConfig: vpcConfig,
-		RoleArn:            role.Arn,
-		Tags:               tags,
+		Name:                    aws.String(eksClusterName),
+		Version:                 aws.String(v),
+		Logging:                 logging,
+		EncryptionConfig:        encryptionConfigs,
+		ResourcesVpcConfig:      vpcConfig,
+		RoleArn:                 role.Arn,
+		Tags:                    tags,
+		KubernetesNetworkConfig: netConfig,
 	}
 
 	var out *eks.CreateClusterOutput

--- a/pkg/internal/cidr/cidr.go
+++ b/pkg/internal/cidr/cidr.go
@@ -18,6 +18,7 @@ package cidr
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"net"
 
@@ -62,4 +63,46 @@ func SplitIntoSubnetsIPv4(cidrBlock string, numSubnets int) ([]*net.IPNet, error
 	}
 
 	return subnets, nil
+}
+
+// GetIPv4Cidrs gets the IPv4 CIDRs from a string slice.
+func GetIPv4Cidrs(cidrs []string) ([]string, error) {
+	found := []string{}
+
+	for i := range cidrs {
+		cidr := cidrs[i]
+
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return found, fmt.Errorf("parsing %s as cidr: %w", cidr, err)
+		}
+
+		ipv4 := ip.To4()
+		if ipv4 != nil {
+			found = append(found, cidr)
+		}
+	}
+
+	return found, nil
+}
+
+// GetIPv6Cidrs gets the IPv6 CIDRs from a string slice.
+func GetIPv6Cidrs(cidrs []string) ([]string, error) {
+	found := []string{}
+
+	for i := range cidrs {
+		cidr := cidrs[i]
+
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return found, fmt.Errorf("parsing %s as cidr: %w", cidr, err)
+		}
+
+		ipv4 := ip.To4()
+		if ipv4 == nil {
+			found = append(found, cidr)
+		}
+	}
+
+	return found, nil
 }

--- a/pkg/internal/cidr/cidr_test.go
+++ b/pkg/internal/cidr/cidr_test.go
@@ -1,0 +1,37 @@
+package cidr_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/internal/cidr"
+)
+
+func TestParseIPv4CIDR(t *testing.T) {
+	RegisterTestingT(t)
+
+	input := []string{
+		"2001:0db8:85a3:0000:0000:8a2e:0370:7334/64",
+		"2001:db8::/32",
+		"193.168.3.20/7",
+	}
+
+	output, err := cidr.GetIPv4Cidrs(input)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(output).To(HaveLen(1))
+}
+
+func TestParseIPv6CIDR(t *testing.T) {
+	RegisterTestingT(t)
+
+	input := []string{
+		"2001:0db8:85a3:0000:0000:8a2e:0370:7334/64",
+		"2001:db8::/32",
+		"193.168.3.20/7",
+	}
+
+	output, err := cidr.GetIPv6Cidrs(input)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(output).To(HaveLen(2))
+}


### PR DESCRIPTION


Signed-off-by: Richard Case <richard@weave.works>

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

If an IPv4 CIDR is specified in `ClusterNetwork.Services.CIDRBlocks` then we will use this for configuring the ipv4 services cidr when creating the eks cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2891 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Allow configuring services cidr when creating an EKS cluster.
```
