### PR TITLE
Bump cluster-api in e2e tests + fix K8s version

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -27,11 +27,11 @@ images:
     loadBehavior: tryLoad
   - name: quay.io/jetstack/cert-manager-controller:v1.5.3
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.0.0
+  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.0.1
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.0.1
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.0.1
     loadBehavior: tryLoad
 
 providers:
@@ -60,8 +60,8 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.0.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/core-components.yaml"
+      - name: v1.0.1
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.1/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -96,8 +96,8 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.0.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/bootstrap-components.yaml"
+      - name: v1.0.1
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.1/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -134,8 +134,8 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.0.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/control-plane-components.yaml"
+      - name: v1.0.1
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.1/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -162,7 +162,7 @@ providers:
         files:
           - sourcePath: "./shared/v1alpha4_provider/metadata.yaml"
           - sourcePath: "./infrastructure-aws/capi-upgrades/v1alpha4/cluster-template.yaml"
-      - name: v1.0.0
+      - name: v1.0.1
         # Use manifest from source files
         value: ../../../config/default
         contract: v1beta1
@@ -202,8 +202,8 @@ variables:
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
   KUBERNETES_VERSION_MANAGEMENT: "v1.22.2"
-  KUBERNETES_VERSION: "v1.22.3"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.22.3"
+  KUBERNETES_VERSION: "v1.22.2"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.22.2"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.21.6"
   CNI: "../../data/cni/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
@@ -211,7 +211,7 @@ variables:
   AWS_CONTROL_PLANE_MACHINE_TYPE: t3.large
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.22.3"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.22.2"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
   EXP_MACHINE_POOL: "true"
@@ -224,7 +224,7 @@ variables:
   INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-{OS}-{ARCH}"
     # INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_KUBERNETES_VERSION: "v1.22.3"
+  INIT_WITH_KUBERNETES_VERSION: "v1.22.2"
 
 intervals:
   default/wait-cluster: ["25m", "10s"]

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -25,11 +25,11 @@ images:
     loadBehavior: tryLoad
   - name: quay.io/jetstack/cert-manager-controller:v1.5.0
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.0.1
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.0.1
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.0.0
+  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.0.1
     loadBehavior: tryLoad
 
 providers:
@@ -58,8 +58,8 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.0.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/core-components.yaml"
+      - name: v1.0.1
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.1/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -94,8 +94,8 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.0.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/bootstrap-components.yaml"
+      - name: v1.0.1
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.1/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -131,8 +131,8 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.0.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/control-plane-components.yaml"
+      - name: v1.0.1
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.1/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:


### PR DESCRIPTION
/kind failing-test

Downgrade K8s version to the latest kind node 1.22.2




```release-note
NONE
```
