### PR TITLE
Downgrade k8s version for clusterctl upgrade spec

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -224,7 +224,7 @@ variables:
   INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-{OS}-{ARCH}"
     # INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_KUBERNETES_VERSION: "v1.22.2"
+  INIT_WITH_KUBERNETES_VERSION: "v1.21.6"
 
 intervals:
   default/wait-cluster: ["25m", "10s"]


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
clusterctl v1alpha3 upgrade spec on main is failing with the following message. See [failing test](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-e2e/1461346822172708864)

```
[6] • Failure [847.960 seconds]
[6] [unmanaged] [Cluster API Framework]
[6] /home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go:34
[6]   Clusterctl Upgrade Spec [from v1alpha3]
[6]   /home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go:155
[6]     Should create a management cluster and then upgrade all the providers [It]
[6]     /home/prow/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.0.1-0.20211111175208-4cc2fce2111a/e2e/clusterctl_upgrade.go:145
[6] 
[6]     failed to run clusterctl init:
      
[6]     Error: unsupported management cluster server version: v1.22.2 - versions greater or equal than v1.22.0 are not supported
```

Downgrading k8s version to 1.21.6 to fix the failing test and unblock main.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
An issue is raised in CAPI for a long term solution by @sedefsavas  - https://github.com/kubernetes-sigs/cluster-api/issues/5704

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
None
```
