### PR TITLE
Version locking comment cleanup from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,6 @@ go 1.17
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.0.1-0.20211111175208-4cc2fce2111a
 
-// Versions to be held for v1beta1
-// sigs.k8s.io/controller-runtime on v0.10.x
-// k8s.io/* on v0.22.x
-// github.com/go-logr/logr on v0.4.x
-// k8s.io/klog/v2 on v2.10.x
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-vpc-cni-k8s v1.9.3


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
This PR deletes version locking comment for v1beta1 in go.mod since v1beta1 will span multiple minor releases.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note

```
