### PR TITLE
fix: replace string literal in AWSFargateProfile

### DIFF
--- a/templates/cluster-template-eks-fargate.yaml
+++ b/templates/cluster-template-eks-fargate.yaml
@@ -35,6 +35,6 @@ kind: AWSFargateProfile
 metadata:
   name: "${CLUSTER_NAME}-fargate-0"
 spec:
-  clusterName: mb-test-1
+  clusterName: "${CLUSTER_NAME}"
   selectors:
     - namespace: default


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
There is a string literal in a template for the cluster name. This will render an invalid kubeyaml doc for kind: AWSFargateProfile.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2983 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
fix: Replace string literal in template for AWSFargateProfile.
```
