### PR TITLE
feat: Support running with public subnets only

### DIFF
--- a/pkg/cloud/scope/shared_test.go
+++ b/pkg/cloud/scope/shared_test.go
@@ -108,7 +108,7 @@ func TestSubnetPlacement(t *testing.T) {
 			expectError:       false,
 		},
 		{
-			name:          "use control plane subnets",
+			name:          "use control plane private subnets",
 			specSubnetIDs: []string{},
 			specAZs:       []string{},
 			parentAZs:     []string{},
@@ -131,6 +131,32 @@ func TestSubnetPlacement(t *testing.T) {
 			},
 			logger:            klogr.New(),
 			expectedSubnetIDs: []string{"az1", "az2"},
+			expectError:       false,
+		},
+		{
+			name:          "use control plane public subnets if no private subnets",
+			specSubnetIDs: []string{},
+			specAZs:       []string{},
+			parentAZs:     []string{},
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+			},
+			logger:            klogr.New(),
+			expectedSubnetIDs: []string{"az1", "az2", "az3"},
 			expectError:       false,
 		},
 		{

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -144,14 +144,10 @@ func (s *Service) reconcileSubnets() error {
 	}
 
 	if !unmanagedVPC {
-		// Check that we need at least 1 private and 1 public subnet after we have updated the metadata
-		if len(subnets.FilterPrivate()) < 1 {
-			record.Warnf(s.scope.InfraCluster(), "FailedNoPrivateSubnet", "Expected at least 1 private subnet but got 0")
-			return errors.New("expected at least 1 private subnet but got 0")
-		}
-		if len(subnets.FilterPublic()) < 1 {
-			record.Warnf(s.scope.InfraCluster(), "FailedNoPublicSubnet", "Expected at least 1 public subnet but got 0")
-			return errors.New("expected at least 1 public subnet but got 0")
+		// Check that we need at least 2 subnets
+		if len(subnets) < 2 {
+			record.Warnf(s.scope.InfraCluster(), "FailedNotEnoughSubnet", "Expected at least 2 subnets")
+			return errors.New("expected at least 2 subnets")
 		}
 	} else if unmanagedVPC {
 		if len(subnets) < 1 {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
We have an usecase to create an EKS cluster with only public subnets.
We need to maintain 1 to 1 tcp connection mapping between our pods and clients like:
```
pod 1 <--- tcp port 30000 over internet ----> client 1
pod 2 <--- tcp port 30001 over internet ----> client 2
...
```
A nodeport service is created for each pod to expose the pod publicly over internet.
With that requirement, the worker ec2 instances have to run in public subnets and we don't need private subnets (and natgw) at all.

This PR allows:
- creating VPC with only public subnets
- place the managed nodes group to those public subnets if no private subnets defined in the cluster spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2997 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note

```
