### PR TITLE
Update ClusterUpgradeConformanceSpec to skip conformance test

### DIFF
--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onsi/ginkgo/config"
 	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
-	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
 
 var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
@@ -40,28 +39,7 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
 	})
 
-	// DEPRECATED. Should be replaced with the conformance upgrade spec
-	ginkgo.PDescribe("[Deprecated] KCP Upgrade Spec - Single Control Plane Cluster", func() {
-		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
-		requiredResources := &shared.TestResource{EC2: 2, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3}
-		ginkgo.BeforeEach(func() {
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-kcp-single-cp-upgrade-test")
-			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
-		})
-		capi_e2e.KCPUpgradeSpec(ctx, func() capi_e2e.KCPUpgradeSpecInput {
-			return capi_e2e.KCPUpgradeSpecInput{
-				E2EConfig:                e2eCtx.E2EConfig,
-				ClusterctlConfigPath:     e2eCtx.Environment.ClusterctlConfigPath,
-				BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
-				Flavor:                   clusterctl.DefaultFlavor,
-				ControlPlaneMachineCount: 1,
-				ArtifactFolder:           e2eCtx.Settings.ArtifactFolder,
-				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
-			}
-		})
-	})
-
-	// DEPRECATED. Should be replaced with the conformance upgrade spec
+	// DEPRECATED. Should be replaced with the conformance upgrade spec when ClusterUpgradeConformanceSpec supports different ControlPlaneMachineCount
 	ginkgo.PDescribe("[Deprecated] KCP Upgrade Spec - HA Control Plane Cluster using Scale-In", func() {
 		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 4, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3}
@@ -202,11 +180,11 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 		})
 	})
 
-	ginkgo.Describe("Running the workload cluster upgrade spec and testing K8S conformance [Conformance] [K8s-Upgrade]", func() {
+	ginkgo.Describe("Cluster Upgrade spec - Single Control Plane Cluster", func() {
 		// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 		requiredResources := &shared.TestResource{EC2: 5, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2}
 		ginkgo.BeforeEach(func() {
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-cluster-upgrade-conformance-test")
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-cluster-upgrade-test")
 			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
 		})
 
@@ -217,6 +195,7 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
 				ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
 				SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+				SkipConformanceTests:  true,
 			}
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updated ClusterUpgradeConformanceSpec in unmanaged suite to skip conformance test for now to reduce testing time.
Also, removed `KCP Upgrade Spec - Single Control Plane Cluster` test as the test case is covered by the `ClusterUpgradeConformanceSpec`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

This is a part of #2993. 

**Special notes for your reviewer**:
[KCP Upgrade Spec - HA Control Plane Cluster using Scale-In](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go#L65) will be replaced with ClusterUpgradeConformanceSpec when we consume the next version of CAPI. The [PR](https://github.com/kubernetes-sigs/cluster-api/pull/5763) to make the test configurable was merged.

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
