### PR TITLE
Fix AWSMachine controller trying to update rootVolume device name

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -115,7 +115,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 	input := &infrav1.Instance{
 		Type:              scope.AWSMachine.Spec.InstanceType,
 		IAMProfile:        scope.AWSMachine.Spec.IAMInstanceProfile,
-		RootVolume:        scope.AWSMachine.Spec.RootVolume,
+		RootVolume:        scope.AWSMachine.Spec.RootVolume.DeepCopy(),
 		NonRootVolumes:    scope.AWSMachine.Spec.NonRootVolumes,
 		NetworkInterfaces: scope.AWSMachine.Spec.NetworkInterfaces,
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes the issue of AWSMachine controller trying to update an immutable field, `spec.rootVolume.deviceName`, and getting an webhook error while trying to update it.
```
"error"="admission webhook \"validation.awsmachine.infrastructure.cluster.x-k8s.io\" denied the request: AWSMachine.infrastructure.cluster.x-k8s.io \"mgmt-control-plane-cvc28\" is invalid: spec: Forbidden: cannot be modified"
```

This was caused by rootVolumes of AWSMachine and an instance sharing the same pointer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3000 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Fix the issue of AWSMachine controller trying to update an immutable field, rootVolume deviceName
```
