### PR TITLE
fix: api/v1beta1: Make AWSCluster ControlPlaneLoadBalancer name immutable

### DIFF
--- a/api/v1beta1/awscluster_webhook.go
+++ b/api/v1beta1/awscluster_webhook.go
@@ -104,8 +104,10 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 				)
 			}
 		}
-		// If old name was not nil, the new name should be the same.
-		if existingLoadBalancer.Name != nil && !reflect.DeepEqual(existingLoadBalancer.Name, newLoadBalancer.Name) {
+		// The name must be defined when the AWSCluster is created. If it is not defined,
+		// then the controller generates a default name at runtime, but does not store it,
+		// so the name remains nil. In either case, the name cannot be changed.
+		if !reflect.DeepEqual(existingLoadBalancer.Name, newLoadBalancer.Name) {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "name"),
 					r.Spec.ControlPlaneLoadBalancer.Name, "field is immutable"),

--- a/api/v1beta1/awscluster_webhook_test.go
+++ b/api/v1beta1/awscluster_webhook_test.go
@@ -139,7 +139,7 @@ func TestAWSCluster_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "controlPlaneLoadBalancer name is immutable once set",
+			name: "controlPlaneLoadBalancer name is immutable",
 			oldCluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
@@ -157,7 +157,7 @@ func TestAWSCluster_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "controlPlaneLoadBalancer name can be set if undefined",
+			name: "controlPlaneLoadBalancer name is immutable, even if it is nil",
 			oldCluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
@@ -172,7 +172,7 @@ func TestAWSCluster_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "controlPlaneLoadBalancer scheme is immutable",


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Prior to commit 2cd2f4900e77a3f8de5a67f8740a44c7e2493117, the name was
immutable, unless it was nil, in which case it could be updated. Now,
the name must be immutable, even if it is nil, since the default name is
generated at runtime and not written to the AWSCluster resource.

This change should have been included as part of #3004.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3003

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
