### PR TITLE
Increase ec2 quota to 128

### DIFF
--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -138,7 +138,7 @@ func getLimitedResources() map[string]*ServiceQuota {
 		ServiceCode:         "ec2",
 		QuotaName:           "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances",
 		QuotaCode:           "L-1216C47A",
-		DesiredMinimumValue: 20,
+		DesiredMinimumValue: 128,
 	}
 
 	serviceQuotas["eip"] = &ServiceQuota{


### PR DESCRIPTION

**What this PR does / why we need it**:
e2e tests are failing due to hitting ec2 quota when it is set to 32.
Testing if this will fix

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
