### PR TITLE
Add new condition (EKSNodegroupUpdateSucceededCondition) to the AWSManagedMachinePool resource

### DIFF
--- a/exp/api/v1beta1/conditions_consts.go
+++ b/exp/api/v1beta1/conditions_consts.go
@@ -45,13 +45,23 @@ const (
 )
 
 const (
-	// EKSNodegroupReadyCondition condition reports on the successful reconciliation of eks control plane.
+	// EKSNodegroupReadyCondition reports on the successful reconciliation of EKS node group.
 	EKSNodegroupReadyCondition clusterv1.ConditionType = "EKSNodegroupReady"
-	// EKSNodegroupReconciliationFailedReason used to report failures while reconciling EKS control plane.
+	// EKSNodegroupUpdateSucceededCondition reports on whether the EKS node group update has succeeded.
+	EKSNodegroupUpdateSucceededCondition clusterv1.ConditionType = "EKSNodegroupUpdateSucceeded"
+	// EKSNodegroupReconciliationFailedReason used to report failures while reconciling EKS node group.
 	EKSNodegroupReconciliationFailedReason = "EKSNodegroupReconciliationFailed"
 	// WaitingForEKSControlPlaneReason used when the machine pool is waiting for
 	// EKS control plane infrastructure to be ready before proceeding.
 	WaitingForEKSControlPlaneReason = "WaitingForEKSControlPlane"
+	// EKSNodegroupCreatingReason is used to report that the EKS node group is currently being created.
+	EKSNodegroupCreatingReason = "Creating"
+	// EKSNodegroupUpdatingReason is used to report that the EKS node group is currently being updated.
+	EKSNodegroupUpdatingReason = "Updating"
+	// EKSNodegroupFailedToCreateReason is used to report that the EKS node group has failed to create.
+	EKSNodegroupFailedToCreateReason = "FailedToCreate"
+	// EKSNodegroupFailedToUpdateReason is used to report that the EKS node group has failed to update.
+	EKSNodegroupFailedToUpdateReason = "FailedToUpdate"
 )
 
 const (

--- a/pkg/cloud/scope/managednodegroup.go
+++ b/pkg/cloud/scope/managednodegroup.go
@@ -242,6 +242,7 @@ func (s *ManagedMachinePoolScope) PatchObject() error {
 		s.ManagedMachinePool,
 		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
 			expinfrav1.EKSNodegroupReadyCondition,
+			expinfrav1.EKSNodegroupUpdateSucceededCondition,
 			expinfrav1.IAMNodegroupRolesReadyCondition,
 		}})
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR adds a new condition (`EKSNodegroupUpdateSucceededCondition`) to the `AWSManagedMachinePool` resource, as well as related reasons (`Creating`, `Updating`, `FailedToCreate`, `FailedToUpdate`). See issue link below as well as the discussion in this PR.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #2966 

**Special notes for your reviewer**:
 I haven't found any places in the documentation that would need manual updating as a result of this change, but please let me know if I missed something. Thanks in advance for the review.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add new condition (EKSNodegroupUpdateSucceededCondition) to the AWSManagedMachinePool resource.
```
