### PR TITLE
Make EKS conversion tests run and fix failing conversion tests

### DIFF
--- a/bootstrap/eks/api/v1alpha3/webhook_suite_test.go
+++ b/bootstrap/eks/api/v1alpha3/webhook_suite_test.go
@@ -48,9 +48,9 @@ func setup() {
 	utilruntime.Must(eksbootstrapv1.AddToScheme(scheme.Scheme))
 
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
-		path.Join("bootstrap", "eks", "config", "crd", "bases"),
+		path.Join("config", "crd", "bases"),
 	},
-	).WithWebhookConfiguration("unmanaged", path.Join("bootstrap", "eks", "config", "webhook", "manifests.yaml"))
+	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
 	var err error
 	testEnv, err = testEnvConfig.Build()
 	if err != nil {

--- a/bootstrap/eks/api/v1alpha4/conversion.go
+++ b/bootstrap/eks/api/v1alpha4/conversion.go
@@ -27,6 +27,7 @@ import (
 // ConvertTo converts the v1alpha4 EKSConfig receiver to a v1beta1 EKSConfig.
 func (r *EKSConfig) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1beta1.EKSConfig)
+
 	if err := Convert_v1alpha4_EKSConfig_To_v1beta1_EKSConfig(r, dst, nil); err != nil {
 		return err
 	}
@@ -36,17 +37,23 @@ func (r *EKSConfig) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
-	dst.Spec.ContainerRuntime = restored.Spec.ContainerRuntime
-	dst.Spec.DNSClusterIP = restored.Spec.DNSClusterIP
-	dst.Spec.DockerConfigJSON = restored.Spec.DockerConfigJSON
-	dst.Spec.APIRetryAttempts = restored.Spec.APIRetryAttempts
-	if restored.Spec.PauseContainer != nil {
-		dst.Spec.PauseContainer.AccountNumber = restored.Spec.PauseContainer.AccountNumber
-		dst.Spec.PauseContainer.Version = restored.Spec.PauseContainer.Version
-	}
-	dst.Spec.UseMaxPods = restored.Spec.UseMaxPods
+	restoreSpec(&restored.Spec, &dst.Spec)
 
 	return nil
+}
+
+func restoreSpec(rSpec, dSpec *v1beta1.EKSConfigSpec) {
+	dSpec.ContainerRuntime = rSpec.ContainerRuntime
+	dSpec.DNSClusterIP = rSpec.DNSClusterIP
+	dSpec.DockerConfigJSON = rSpec.DockerConfigJSON
+	dSpec.APIRetryAttempts = rSpec.APIRetryAttempts
+	if rSpec.PauseContainer != nil {
+		dSpec.PauseContainer = &v1beta1.PauseContainer{
+			AccountNumber: rSpec.PauseContainer.AccountNumber,
+			Version:       rSpec.PauseContainer.Version,
+		}
+	}
+	dSpec.UseMaxPods = rSpec.UseMaxPods
 }
 
 // ConvertFrom converts the v1beta1 EKSConfig receiver to a v1alpha4 EKSConfig.
@@ -82,14 +89,33 @@ func (r *EKSConfigList) ConvertFrom(srcRaw conversion.Hub) error {
 func (r *EKSConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1beta1.EKSConfigTemplate)
 
-	return Convert_v1alpha4_EKSConfigTemplate_To_v1beta1_EKSConfigTemplate(r, dst, nil)
+	if err := Convert_v1alpha4_EKSConfigTemplate_To_v1beta1_EKSConfigTemplate(r, dst, nil); err != nil {
+		return err
+	}
+
+	restored := &v1beta1.EKSConfigTemplate{}
+	if ok, err := utilconversion.UnmarshalData(r, restored); err != nil || !ok {
+		return err
+	}
+
+	restoreSpec(&restored.Spec.Template.Spec, &dst.Spec.Template.Spec)
+
+	return nil
 }
 
 // ConvertFrom converts the v1beta1 EKSConfigTemplate receiver to a v1alpha4 EKSConfigTemplate.
 func (r *EKSConfigTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1beta1.EKSConfigTemplate)
 
-	return Convert_v1beta1_EKSConfigTemplate_To_v1alpha4_EKSConfigTemplate(src, r, nil)
+	if err := Convert_v1beta1_EKSConfigTemplate_To_v1alpha4_EKSConfigTemplate(src, r, nil); err != nil {
+		return err
+	}
+
+	if err := utilconversion.MarshalData(src, r); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConvertTo converts the v1alpha4 EKSConfigTemplateList receiver to a v1beta1 EKSConfigTemplateList.

--- a/bootstrap/eks/api/v1alpha4/webhook_suite_test.go
+++ b/bootstrap/eks/api/v1alpha4/webhook_suite_test.go
@@ -48,9 +48,9 @@ func setup() {
 	utilruntime.Must(eksbootstrapv1.AddToScheme(scheme.Scheme))
 
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
-		path.Join("bootstrap", "eks", "config", "crd", "bases"),
+		path.Join("config", "crd", "bases"),
 	},
-	).WithWebhookConfiguration("unmanaged", path.Join("bootstrap", "eks", "config", "webhook", "manifests.yaml"))
+	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
 	var err error
 	testEnv, err = testEnvConfig.Build()
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
EKS API conversion tests were silently exiting with panic due to an incorrect webhook config path.

This PR enables the tests and fixed failing conversion tests in v1alpha3 and v1alpha4.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3023

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Make EKS conversion tests run and fix failing conversions
```
