### PR TITLE
Fix AWSManagedControlPlane conversion

### DIFF
--- a/controlplane/eks/api/v1alpha3/conversion.go
+++ b/controlplane/eks/api/v1alpha3/conversion.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
 	clusterapiapiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterapiapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
@@ -30,14 +31,35 @@ import (
 func (r *AWSManagedControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1beta1.AWSManagedControlPlane)
 
-	return Convert_v1alpha3_AWSManagedControlPlane_To_v1beta1_AWSManagedControlPlane(r, dst, nil)
+	if err := Convert_v1alpha3_AWSManagedControlPlane_To_v1beta1_AWSManagedControlPlane(r, dst, nil); err != nil {
+		return err
+	}
+
+	restored := &v1beta1.AWSManagedControlPlane{}
+	if ok, err := utilconversion.UnmarshalData(r, restored); err != nil || !ok {
+		return err
+	}
+
+	dst.Status.IdentityProviderStatus = restored.Status.IdentityProviderStatus
+	dst.Status.Bastion = restored.Status.Bastion
+	dst.Spec.OIDCIdentityProviderConfig = restored.Spec.OIDCIdentityProviderConfig
+
+	return nil
 }
 
 // ConvertFrom converts the v1beta1 AWSManagedControlPlane receiver to a v1alpha3 AWSManagedControlPlane.
 func (r *AWSManagedControlPlane) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1beta1.AWSManagedControlPlane)
 
-	return Convert_v1beta1_AWSManagedControlPlane_To_v1alpha3_AWSManagedControlPlane(src, r, nil)
+	if err := Convert_v1beta1_AWSManagedControlPlane_To_v1alpha3_AWSManagedControlPlane(src, r, nil); err != nil {
+		return err
+	}
+
+	if err := utilconversion.MarshalData(src, r); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConvertTo converts the v1alpha3 AWSManagedControlPlaneList receiver to a v1beta1 AWSManagedControlPlaneList.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The `AWSManagedControlPlane` object conversion from `v1alpha3` to
`v1beta1` were not considering new fields in status and spec. The bug
is covered by tests, but these are failing silently at the moment as
described in #3032.

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Bugfix in  `AWSManagedControlPlane` object conversion from v1alpha3 to v1beta1. Some fields in Status and Spec were not being considered during conversion
```
