### PR TITLE
Fix EKS encryption config value comparisons

### DIFF
--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
@@ -139,7 +139,11 @@ func (r *AWSManagedControlPlane) ValidateUpdate(old runtime.Object) error {
 	}
 
 	// If encryptionConfig is already set, do not allow change in provider
-	if r.Spec.EncryptionConfig != nil && oldAWSManagedControlplane.Spec.EncryptionConfig != nil && *r.Spec.EncryptionConfig.Provider != *oldAWSManagedControlplane.Spec.EncryptionConfig.Provider {
+	if r.Spec.EncryptionConfig != nil &&
+		r.Spec.EncryptionConfig.Provider != nil &&
+		oldAWSManagedControlplane.Spec.EncryptionConfig != nil &&
+		oldAWSManagedControlplane.Spec.EncryptionConfig.Provider != nil &&
+		*r.Spec.EncryptionConfig.Provider != *oldAWSManagedControlplane.Spec.EncryptionConfig.Provider {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "encryptionConfig", "provider"), r.Spec.EncryptionConfig.Provider, "changing EKS encryption is not allowed after it has been enabled"),
 		)

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -707,12 +707,19 @@ func compareEncryptionConfig(updatedEncryptionConfig, existingEncryptionConfig [
 		return false
 	}
 	for index, encryptionConfig := range updatedEncryptionConfig {
-		if encryptionConfig.Provider != existingEncryptionConfig[index].Provider {
+		if getKeyArn(encryptionConfig) != getKeyArn(existingEncryptionConfig[index]) {
 			return false
 		}
-		if cmp.Equals(encryptionConfig.Resources, existingEncryptionConfig[index].Resources) {
+		if !cmp.Equals(encryptionConfig.Resources, existingEncryptionConfig[index].Resources) {
 			return false
 		}
 	}
 	return true
+}
+
+func getKeyArn(encryptionConfig *eks.EncryptionConfig) string {
+	if encryptionConfig.Provider != nil {
+		return aws.StringValue(encryptionConfig.Provider.KeyArn)
+	}
+	return ""
 }

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -441,11 +441,24 @@ func TestReconcileEKSEncryptionConfig(t *testing.T) {
 		expectError         bool
 	}{
 		{
-			name:                "no upgrade necessary",
+			name:                "no upgrade necessary - encryption disabled",
 			oldEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{},
 			newEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{},
 			expect:              func(m *mock_eksiface.MockEKSAPIMockRecorder) {},
 			expectError:         false,
+		},
+		{
+			name: "no upgrade necessary - encryption config unchanged",
+			oldEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{
+				Provider:  pointer.String("provider"),
+				Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+			},
+			newEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{
+				Provider:  pointer.String("provider"),
+				Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+			},
+			expect:      func(m *mock_eksiface.MockEKSAPIMockRecorder) {},
+			expectError: false,
 		},
 		{
 			name:                "needs upgrade",

--- a/pkg/internal/cmp/slice.go
+++ b/pkg/internal/cmp/slice.go
@@ -42,7 +42,7 @@ func Equals(slice1, slice2 []*string) bool {
 
 	if len(slice1) == len(slice2) {
 		for i, v := range slice1 {
-			if pointer.StringEqual(v, slice2[i]) {
+			if !pointer.StringEqual(v, slice2[i]) {
 				return false
 			}
 		}

--- a/pkg/internal/cmp/slice_test.go
+++ b/pkg/internal/cmp/slice_test.go
@@ -30,9 +30,9 @@ func TestCompareSlices(t *testing.T) {
 	slice2 := []*string{pointer.String("bar"), pointer.String("foo")}
 
 	expected := Equals(slice1, slice2)
-	g.Expect(expected, true)
+	g.Expect(expected).To(BeTrue())
 
 	slice2 = append(slice2, pointer.String("test"))
 	expected = Equals(slice1, slice2)
-	g.Expect(expected, false)
+	g.Expect(expected).To(BeFalse())
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR addresses a couple of issues that are preventing EKS-managed clusters from fully reconciling when encryption is enabled:
- Update EncryptionConfig.Provider comparison to dereference pointers and compare KeyARN
- Fix a couple of other equality comparisons that were flipped (checking true vs false)
- Add assertions to TestCompareSlices (`g.Expect(...)` vs `g.Expect(...).To(...)`)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2908 

**Special notes for your reviewer**:
This PR does not address the refactor work [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2540), but I am happy to add that if it's still wanted.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix EKS encryption configuration comparison issues that blocked building a new cluster with encryption enabled
```
