### PR TITLE
[backport 0.7] Remove os.Exit calls from TestMain

### DIFF
--- a/api/v1alpha3/webhook_suite_test.go
+++ b/api/v1alpha3/webhook_suite_test.go
@@ -18,7 +18,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -52,11 +51,9 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {

--- a/api/v1alpha4/suite_test.go
+++ b/api/v1alpha4/suite_test.go
@@ -18,7 +18,6 @@ package v1alpha4
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -47,9 +46,8 @@ func TestAPIs(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	setup()
-	code := m.Run()
-	teardown()
-	os.Exit(code)
+	defer teardown()
+	m.Run()
 }
 
 func setup() {

--- a/bootstrap/eks/api/v1alpha3/webhook_suite_test.go
+++ b/bootstrap/eks/api/v1alpha3/webhook_suite_test.go
@@ -18,7 +18,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -36,11 +35,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {
@@ -48,9 +45,9 @@ func setup() {
 	utilruntime.Must(bootstrapv1alpha4.AddToScheme(scheme.Scheme))
 
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
-		path.Join("bootstrap", "eks", "config", "crd", "bases"),
+		path.Join("config", "crd", "bases"),
 	},
-	).WithWebhookConfiguration("unmanaged", path.Join("bootstrap", "eks", "config", "webhook", "manifests.yaml"))
+	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
 	var err error
 	testEnv, err = testEnvConfig.Build()
 	if err != nil {

--- a/bootstrap/eks/controllers/suite_test.go
+++ b/bootstrap/eks/controllers/suite_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -37,11 +36,8 @@ var (
 
 func TestMain(m *testing.M) {
 	setup()
-	defer func() {
-		teardown()
-	}()
-	code := m.Run()
-	os.Exit(code) // nolint:gocritic
+	defer teardown()
+	m.Run()
 }
 
 func setup() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -37,11 +36,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {

--- a/controlplane/eks/api/v1alpha3/webhook_suite_test.go
+++ b/controlplane/eks/api/v1alpha3/webhook_suite_test.go
@@ -18,7 +18,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -36,11 +35,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {
@@ -48,7 +45,7 @@ func setup() {
 	utilruntime.Must(controlplanev1alpha4.AddToScheme(scheme.Scheme))
 
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
-		path.Join("..", "config", "crd", "bases"),
+		path.Join("config", "crd", "bases"),
 	},
 	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
 	var err error

--- a/controlplane/eks/api/v1alpha4/suite_test.go
+++ b/controlplane/eks/api/v1alpha4/suite_test.go
@@ -18,7 +18,6 @@ package v1alpha4
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -35,9 +34,8 @@ var (
 
 func TestMain(m *testing.M) {
 	setup()
-	code := m.Run()
-	teardown()
-	os.Exit(code)
+	defer teardown()
+	m.Run()
 }
 
 func setup() {

--- a/exp/api/v1alpha3/webhook_suite_test.go
+++ b/exp/api/v1alpha3/webhook_suite_test.go
@@ -18,7 +18,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -51,11 +50,9 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {

--- a/exp/controlleridentitycreator/suite_test.go
+++ b/exp/controlleridentitycreator/suite_test.go
@@ -18,7 +18,6 @@ package controlleridentitycreator
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -43,11 +42,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {
@@ -57,7 +54,6 @@ func setup() {
 
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
 		path.Join("config", "crd", "bases"),
-		path.Join("controlplane", "eks", "config", "crd", "bases"),
 	},
 	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
 	var err error

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -42,11 +41,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {

--- a/exp/instancestate/suite_test.go
+++ b/exp/instancestate/suite_test.go
@@ -18,7 +18,6 @@ package instancestate
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -47,11 +46,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	code := 0
-	defer func() { os.Exit(code) }()
 	setup()
 	defer teardown()
-	code = m.Run()
+	m.Run()
 }
 
 func setup() {


### PR DESCRIPTION
[go#34129]: https://github.com/golang/go/issues/34129

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

As described in [go#34129], `os.Exit()` in the way we have in multiple
tests in this project make panics to fail silently. That was first
described in #3032.

Since go 1.15 the `os.Exit(code)` calls are not required, therefore,
let's make panics visible and just run `m.Run()`.

**Which issue(s) this PR fixes**:
Fixes #3032

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Refactor TestMain functions across the project to stop using os.Exit swallowing errors
```