### PR TITLE
[backport 0.6] Remove os.Exit calls from TestMain

### DIFF
--- a/api/v1alpha3/suite_test.go
+++ b/api/v1alpha3/suite_test.go
@@ -44,10 +44,15 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	// testMain wrapper is needed to support defers and panics.
+	// os.Exit will ignore those and exit silently.
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
 	setup()
-	code := m.Run()
-	teardown()
-	os.Exit(code)
+	defer teardown()
+	return m.Run()
 }
 
 func setup() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -50,12 +50,15 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	// testMain wrapper is needed to support defers and panics.
+	// os.Exit will ignore those and exit silently.
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
 	setup()
-	defer func() {
-		teardown()
-	}()
-	code := m.Run()
-	os.Exit(code)
+	defer teardown()
+	return m.Run()
 }
 
 func setup() {

--- a/controlplane/eks/api/v1alpha3/suite_test.go
+++ b/controlplane/eks/api/v1alpha3/suite_test.go
@@ -32,10 +32,15 @@ import (
 var testEnv *helpers.TestEnvironment
 
 func TestMain(m *testing.M) {
+	// testMain wrapper is needed to support defers and panics.
+	// os.Exit will ignore those and exit silently.
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
 	setup()
-	code := m.Run()
-	teardown()
-	os.Exit(code)
+	defer teardown()
+	return m.Run()
 }
 
 func setup() {

--- a/exp/controlleridentitycreator/suite_test.go
+++ b/exp/controlleridentitycreator/suite_test.go
@@ -53,12 +53,15 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	// testMain wrapper is needed to support defers and panics.
+	// os.Exit will ignore those and exit silently.
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
 	setup()
-	defer func() {
-		teardown()
-	}()
-	code := m.Run()
-	os.Exit(code)
+	defer teardown()
+	return m.Run()
 }
 
 func setup() {
@@ -68,7 +71,6 @@ func setup() {
 
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
 		path.Join("config", "crd", "bases"),
-		path.Join("controlplane", "eks", "config", "crd", "bases"),
 	},
 	).WithWebhookConfiguration("unmanaged", path.Join("config", "webhook", "manifests.yaml"))
 	var err error

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -58,12 +58,15 @@ func TestAPIs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	// testMain wrapper is needed to support defers and panics.
+	// os.Exit will ignore those and exit silently.
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
 	setup()
-	defer func() {
-		teardown()
-	}()
-	code := m.Run()
-	os.Exit(code)
+	defer teardown()
+	return m.Run()
 }
 
 func setup() {


### PR DESCRIPTION
[go#34129]: https://github.com/golang/go/issues/34129

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

As described in [go#34129], `os.Exit()` in the way we have in multiple
tests in this project make panics to fail silently. That was first
described in #3032.

Since go 1.15 the `os.Exit(code)` calls are not required, therefore,
let's make panics visible and just run `m.Run()`.

**Which issue(s) this PR fixes**:
Fixes #3032

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Refactor TestMain functions across the project to stop using os.Exit swallowing errors
```