### PR TITLE
docs: fix extra policies field name

### DIFF
--- a/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
+++ b/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
@@ -39,11 +39,11 @@ apiVersion: bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSIAMConfiguration
 spec:
   controlPlane:
-    ExtraPolicyAttachments:
+    extraPolicyAttachments:
       - arn:aws:iam::<AWS_ACCOUNT>:policy/my-policy
       - arn:aws:iam::aws:policy/AmazonEC2FullAccess
   nodes:
-    ExtraPolicyAttachments:
+    extraPolicyAttachments:
       - arn:aws:iam::<AWS_ACCOUNT>:policy/my-other-policy
 ```
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The example of how to add extra policies to nodes and the control plane use a capitalised name of `extraPolicyAttachments`. This field is just ignored this way and since this field is ignored when null, the exported config (`clusterawsadm bootstrap iam show-config`) does not have these fields.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [x] includes documentation

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
