### PR TITLE
Fix e2e config CAPA version

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -195,7 +195,7 @@ providers:
         files:
           - sourcePath: "./shared/v1alpha4_provider/metadata.yaml"
           - sourcePath: "./infrastructure-aws/capi-upgrades/v1alpha4/cluster-template.yaml"
-      - name: v1.2.0
+      - name: v1.0.99
         # Use manifest from source files
         value: ../../../config/default
         contract: v1beta1

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -179,7 +179,7 @@ providers:
   - name: aws
     type: InfrastructureProvider
     versions:
-      - name: v1.0.2
+      - name: v1.0.99
         # Use manifest from source files
         value: ../../../config/default
         contract: v1beta1


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:
`clusterctl init` fails with the error below when CAPA version is set > v1.0:


```
[1]   [91mfailed to run clusterctl init
[1]   Unexpected error:
[1]       <*errors.withStack | 0xc000c14e40>: {
[1]           error: <*errors.withMessage | 0xc000498e60>{
[1]               cause: <*errors.withStack | 0xc000c14e10>{
[1]                   error: <*errors.withMessage | 0xc000498e40>{
[1]                       cause: <*errors.withStack | 0xc000c14de0>{
[1]                           error: <*errors.withMessage | 0xc000498e20>{
[1]                               cause: <*errors.withStack | 0xc000c14db0>{
[1]                                   error: <*errors.withMessage | 0xc000498e00>{
[1]                                       cause: <*errors.fundamental | 0xc000c14d80>{
[1]                                           msg: "failed to find releases tagged with a valid semantic version number",
[1]                                           stack: [..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ...],
[1]                                       },
[1]                                       msg: "failed to get latest version",
[1]                                   },
[1]                                   stack: [0x1c69d89, 0x1c616fe, 0x1c61465, 0x1cb97f5, 0x1cb97c6, 0x1cbac0d, 0x1cbecae, 0x1cbe834, 0x1cbddf0, 0x1cc4a1c, 0x1d30987, 0x1d29b70, 0x1d2f078, 0x1d32d45, 0x4d1874, 0x4d0e25, 0x73563a, 0x73357a, 0x732f45, 0x73483e, 0x734472, 0x758c87, 0x758833, 0x75aaf2, 0x766c25, 0x766a3e, 0x1d32ccf, 0x514dc2, 0x46af21],
[1]                               },
[1]                               msg: "error creating the local filesystem repository client",
[1]                           },
[1]                           stack: [0x1c6171c, 0x1c61465, 0x1cb97f5, 0x1cb97c6, 0x1cbac0d, 0x1cbecae, 0x1cbe834, 0x1cbddf0, 0x1cc4a1c, 0x1d30987, 0x1d29b70, 0x1d2f078, 0x1d32d45, 0x4d1874, 0x4d0e25, 0x73563a, 0x73357a, 0x732f45, 0x73483e, 0x734472, 0x758c87, 0x758833, 0x75aaf2, 0x766c25, 0x766a3e, 0x1d32ccf, 0x514dc2, 0x46af21],
[1]                       },
[1]                       msg: "failed to get repository client for the InfrastructureProvider with name aws",
[1]                   },
[1]                   stack: [0x1c6156a, 0x1cb97f5, 0x1cb97c6, 0x1cbac0d, 0x1cbecae, 0x1cbe834, 0x1cbddf0, 0x1cc4a1c, 0x1d30987, 0x1d29b70, 0x1d2f078, 0x1d32d45, 0x4d1874, 0x4d0e25, 0x73563a, 0x73357a, 0x732f45, 0x73483e, 0x734472, 0x758c87, 0x758833, 0x75aaf2, 0x766c25, 0x766a3e, 0x1d32ccf, 0x514dc2, 0x46af21],
[1]               },
[1]               msg: "failed to get provider components for the \"aws\" provider",
[1]           },
[1]           stack: [0x1cbef28, 0x1cbe834, 0x1cbddf0, 0x1cc4a1c, 0x1d30987, 0x1d29b70, 0x1d2f078, 0x1d32d45, 0x4d1874, 0x4d0e25, 0x73563a, 0x73357a, 0x732f45, 0x73483e, 0x734472, 0x758c87, 0x758833, 0x75aaf2, 0x766c25, 0x766a3e, 0x1d32ccf, 0x514dc2, 0x46af21],
[1]       }
[1]       failed to get provider components for the "aws" provider: failed to get repository client for the InfrastructureProvider with name aws: error creating the local filesystem repository client: failed to get latest version: failed to find releases tagged with a valid semantic version number
[1]   occurred[0m
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note

```
