### PR TITLE
EKS: allow updating roleName in fargate, if not already configured

### DIFF
--- a/exp/api/v1beta1/awsfargateprofile_webhook.go
+++ b/exp/api/v1beta1/awsfargateprofile_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -31,6 +32,7 @@ import (
 
 const (
 	maxProfileNameLength = 100
+	maxIAMRoleNameLength = 64
 )
 
 // SetupWebhookWithManager will setup the webhooks for the AWSFargateProfile.
@@ -75,6 +77,23 @@ func (r *AWSFargateProfile) ValidateUpdate(oldObj runtime.Object) error {
 	}
 
 	var allErrs field.ErrorList
+
+	// Spec is immutable, but if the new RoleName is the generated one(or default if EnableIAM is disabled) and
+	// the old RoleName is nil, then ignore checking that field.
+	if old.Spec.RoleName == "" {
+		roleName, err := eks.GenerateEKSName(
+			"fargate",
+			fmt.Sprintf("%s-%s", r.Spec.ClusterName, r.Spec.ProfileName),
+			maxIAMRoleNameLength,
+		)
+		if err != nil {
+			mmpLog.Error(err, "failed to create EKS fargate role name")
+		}
+
+		if r.Spec.RoleName == roleName || r.Spec.RoleName == DefaultEKSFargateRole {
+			r.Spec.RoleName = ""
+		}
+	}
 
 	// Spec is immutable, but if the new ProfileName is the defaulted one and
 	// the old ProfileName is nil, then ignore checking that field.

--- a/exp/api/v1beta1/awsfargateprofile_webhook_test.go
+++ b/exp/api/v1beta1/awsfargateprofile_webhook_test.go
@@ -41,3 +41,73 @@ func TestAWSFargateProfileDefault(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(fargate.Spec.ProfileName).To(BeEquivalentTo(name))
 }
+
+func TestAWSFargateProfileValidateRoleNameUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	before := &AWSFargateProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: FargateProfileSpec{
+			ClusterName: "clustername",
+			ProfileName: "profilename",
+		},
+	}
+
+	invalidRoleNameUpdate := before.DeepCopy()
+	invalidRoleNameUpdate.Spec.RoleName = "invalid-role-name"
+
+	defaultRoleNameUpdate := before.DeepCopy()
+	defaultRoleNameUpdate.Spec.RoleName = DefaultEKSFargateRole
+
+	validRoleNameUpdate := before.DeepCopy()
+	validRoleNameUpdate.Spec.RoleName = "clustername-profilename_fargate"
+
+	beforeWithDifferentRoleName := before.DeepCopy()
+	beforeWithDifferentRoleName.Spec.RoleName = "different-role-name"
+
+	tests := []struct {
+		name           string
+		expectErr      bool
+		before         *AWSFargateProfile
+		fargateProfile *AWSFargateProfile
+	}{
+		{
+			name:           "update roleName should fail when existing roleName is empty and the new roleName is not the generated name",
+			expectErr:      true,
+			before:         before,
+			fargateProfile: invalidRoleNameUpdate,
+		},
+		{
+			name:           "update roleName should succeed when existing roleName is empty and the new roleName is the default name",
+			expectErr:      false,
+			before:         before,
+			fargateProfile: defaultRoleNameUpdate,
+		},
+		{
+			name:           "update roleName should succeed when existing roleName is empty and the new roleName is the generated name",
+			expectErr:      false,
+			before:         before,
+			fargateProfile: validRoleNameUpdate,
+		},
+		{
+			name:           "update roleName should fail when existing roleName is different from the new roleName",
+			expectErr:      true,
+			before:         beforeWithDifferentRoleName,
+			fargateProfile: validRoleNameUpdate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fargateProfile.ValidateUpdate(tt.before.DeepCopy())
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).To(Succeed())
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR allows updating AWSFargateProfile roleName when the existing roleName is empty. This resolves the error from the fargate webhook validation.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3051 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
[EKS] Fix to allow updating roleName in fargate, if not already configured
```
