### PR TITLE
Fix kube-context usage in clusterawsadm

### DIFF
--- a/cmd/clusterawsadm/controller/helper.go
+++ b/cmd/clusterawsadm/controller/helper.go
@@ -45,7 +45,7 @@ func GetClient(kubeconfigPath string, kubeconfigContext string) (*kubernetes.Cli
 	}
 
 	configOverrides := &clientcmd.ConfigOverrides{}
-	if kubeconfigContext == "" {
+	if kubeconfigContext != "" {
 		configOverrides.CurrentContext = kubeconfigContext
 	}
 


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:
`clusterawsadm` was disregarding the KubeConfig context passed via arguments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Fix for using kubeconfig context in clusterawsadm.
```
