### PR TITLE
Enable thelper golang linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
   - staticcheck
   - structcheck
   - stylecheck
+  - thelper
   - typecheck
   - unconvert
   - unparam

--- a/api/v1beta1/awscluster_webhook_test.go
+++ b/api/v1beta1/awscluster_webhook_test.go
@@ -54,6 +54,8 @@ func TestAWSCluster_ValidateCreate(t *testing.T) {
 				Spec: AWSClusterSpec{},
 			},
 			expect: func(t *testing.T, res *AWSLoadBalancerSpec) {
+				t.Helper()
+
 				if res.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
 					t.Error("Expected internet-facing defaulting for nil loadbalancer schemes")
 				}
@@ -68,6 +70,8 @@ func TestAWSCluster_ValidateCreate(t *testing.T) {
 				},
 			},
 			expect: func(t *testing.T, res *AWSLoadBalancerSpec) {
+				t.Helper()
+
 				if res.Scheme.String() != ClassicELBSchemeInternetFacing.String() {
 					t.Error("Expected internet-facing defaulting for supported incorrect scheme: Internet-facing")
 				}

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -58,9 +58,11 @@ func TestAWSMachineReconciler(t *testing.T) {
 		recorder   *record.FakeRecorder
 	)
 
-	setup := func(awsMachine *infrav1.AWSMachine, t *testing.T, g *WithT) {
+	setup := func(t *testing.T, g *WithT, awsMachine *infrav1.AWSMachine) {
 		// https://github.com/kubernetes/klog/issues/87#issuecomment-540153080
 		// TODO: Replace with LogToOutput when https://github.com/kubernetes/klog/pull/99 merges
+		t.Helper()
+
 		var err error
 
 		if err := flag.Set("logtostderr", "false"); err != nil {
@@ -157,6 +159,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 		}
 	}
 	teardown := func(t *testing.T, g *WithT) {
+		t.Helper()
 		mockCtrl.Finish()
 	}
 
@@ -164,13 +167,14 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("when can't reach amazon", func(t *testing.T) {
 			expectedErr := errors.New("no connection available ")
 			runningInstance := func(t *testing.T, g *WithT) {
+				t.Helper()
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 			}
 
 			t.Run("should exit immediately on an error state", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				runningInstance(t, g)
 				er := capierrors.CreateMachineError
@@ -187,7 +191,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should exit immediately if cluster infra isn't ready", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				runningInstance(t, g)
 				ms.Cluster.Status.InfrastructureReady = false
@@ -204,7 +208,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should exit immediately if bootstrap data secret reference isn't available", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				runningInstance(t, g)
 				ms.Machine.Spec.Bootstrap.DataSecretName = nil
@@ -222,7 +226,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should return an error when we can't list instances by tags", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				runningInstance(t, g)
 				_, err := reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
@@ -232,7 +236,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("shouldn't add our finalizer to the machine", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				runningInstance(t, g)
 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs)
@@ -244,6 +248,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("when there's a provider ID", func(t *testing.T) {
 			id := "aws:////myMachine"
 			providerID := func(t *testing.T, g *WithT) {
+				t.Helper()
 				_, err := noderefutil.NewProviderID(id)
 				g.Expect(err).To(BeNil())
 
@@ -253,7 +258,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should look up by provider ID when one exists", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 
 				providerID(t, g)
@@ -267,7 +272,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should try to create a new machine if none exists and add finalizers", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 
 				providerID(t, g)
@@ -287,6 +292,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 			var instance *infrav1.Instance
 
 			instanceCreate := func(t *testing.T, g *WithT) {
+				t.Helper()
+
 				instance = &infrav1.Instance{
 					ID:        "myMachine",
 					VolumeIDs: []string{"volume-1", "volume-2"},
@@ -301,6 +308,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("instance security group errors", func(t *testing.T) {
 				var buf *bytes.Buffer
 				getInstanceSecurityGroups := func(t *testing.T, g *WithT) {
+					t.Helper()
+
 					buf = new(bytes.Buffer)
 					klog.SetOutput(buf)
 					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(nil, errors.New("stop here"))
@@ -309,7 +318,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should set attributes after creating an instance", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getInstanceSecurityGroups(t, g)
@@ -322,7 +331,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should set instance to pending", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getInstanceSecurityGroups(t, g)
@@ -340,7 +349,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should set instance to running", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 
 					instanceCreate(t, g)
@@ -360,7 +369,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("new EC2 instance state: should error when the instance state is a new unseen one", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				instanceCreate(t, g)
 
@@ -378,6 +387,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 			})
 			t.Run("security Groups succeed", func(t *testing.T) {
 				getCoreSecurityGroups := func(t *testing.T, g *WithT) {
+					t.Helper()
+
 					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
 						Return(map[string][]string{"eid": {}}, nil)
 					secretSvc.EXPECT().UserData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
@@ -386,7 +397,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should reconcile security groups", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getCoreSecurityGroups(t, g)
@@ -405,7 +416,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should not tag anything if there's not tags", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getCoreSecurityGroups(t, g)
@@ -419,7 +430,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should tag instances from machine and cluster tags", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getCoreSecurityGroups(t, g)
@@ -450,7 +461,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should tag instances volume tags", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachineWithAdditionalTags()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getCoreSecurityGroups(t, g)
@@ -474,6 +485,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("temporarily stopping then starting the AWSMachine", func(t *testing.T) {
 				var buf *bytes.Buffer
 				getCoreSecurityGroups := func(t *testing.T, g *WithT) {
+					t.Helper()
+
 					buf = new(bytes.Buffer)
 					klog.SetOutput(buf)
 					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
@@ -485,7 +498,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should set instance to stopping and unready", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getCoreSecurityGroups(t, g)
@@ -501,7 +514,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should then set instance to stopped and unready", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getCoreSecurityGroups(t, g)
@@ -517,7 +530,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should then set instance to running and ready once it is restarted", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					getCoreSecurityGroups(t, g)
@@ -532,6 +545,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("deleting the AWSMachine outside of Kubernetes", func(t *testing.T) {
 				var buf *bytes.Buffer
 				deleteMachine := func(t *testing.T, g *WithT) {
+					t.Helper()
+
 					buf = new(bytes.Buffer)
 					klog.SetOutput(buf)
 					secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
@@ -541,7 +556,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should warn if an instance is shutting-down", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					deleteMachine(t, g)
@@ -555,7 +570,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should error when the instance is seen as terminated", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					instanceCreate(t, g)
 					deleteMachine(t, g)
@@ -580,7 +595,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should leverage AWS Secrets Manager", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 
 				instance = &infrav1.Instance{
@@ -605,6 +620,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("Secrets management lifecycle when there's a node ref and a secret ARN", func(t *testing.T) {
 			var instance *infrav1.Instance
 			setNodeRef := func(t *testing.T, g *WithT) {
+				t.Helper()
+
 				instance = &infrav1.Instance{
 					ID: "myMachine",
 				}
@@ -626,7 +643,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should delete the secret if the instance is running", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setNodeRef(t, g)
 
@@ -641,7 +658,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should delete the secret if the instance is terminated", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setNodeRef(t, g)
 
@@ -653,7 +670,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should delete the secret if the AWSMachine is deleted", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setNodeRef(t, g)
 
@@ -666,7 +683,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should delete the secret if the AWSMachine is in a failure condition", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setNodeRef(t, g)
 
@@ -680,6 +697,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("Secrets management lifecycle when there's only a secret ARN and no node ref", func(t *testing.T) {
 			var instance *infrav1.Instance
 			setSSM := func(t *testing.T, g *WithT) {
+				t.Helper()
+
 				instance = &infrav1.Instance{
 					ID: "myMachine",
 				}
@@ -695,7 +714,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should not delete the secret if the instance is running", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setSSM(t, g)
 
@@ -710,7 +729,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should delete the secret if the instance is terminated", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setSSM(t, g)
 
@@ -722,7 +741,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should delete the secret if the AWSMachine is deleted", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setSSM(t, g)
 
@@ -735,7 +754,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should delete the secret if the AWSMachine is in a failure condition", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				setSSM(t, g)
 
@@ -751,13 +770,14 @@ func TestAWSMachineReconciler(t *testing.T) {
 			secretPrefix := "test/secret"
 
 			getInstances := func(t *testing.T, g *WithT) {
+				t.Helper()
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
 			}
 
 			t.Run("should error if secret could not be created", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				getInstances(t, g)
 
@@ -771,7 +791,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("should update prefix and count on successful creation", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				getInstances(t, g)
 
@@ -796,6 +816,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 	t.Run("Deleting an AWSMachine", func(t *testing.T) {
 		finalizer := func(t *testing.T, g *WithT) {
+			t.Helper()
+
 			ms.AWSMachine.Finalizers = []string{
 				infrav1.MachineFinalizer,
 				metav1.FinalizerDeleteDependents,
@@ -804,7 +826,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("should exit immediately on an error state", func(t *testing.T) {
 			g := NewWithT(t)
 			awsMachine := getAWSMachine()
-			setup(awsMachine, t, g)
+			setup(t, g, awsMachine)
 			defer teardown(t, g)
 			finalizer(t, g)
 
@@ -817,7 +839,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("should log and remove finalizer when no machine exists", func(t *testing.T) {
 			g := NewWithT(t)
 			awsMachine := getAWSMachine()
-			setup(awsMachine, t, g)
+			setup(t, g, awsMachine)
 			defer teardown(t, g)
 			finalizer(t, g)
 
@@ -835,7 +857,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("should ignore instances in shutting down state", func(t *testing.T) {
 			g := NewWithT(t)
 			awsMachine := getAWSMachine()
-			setup(awsMachine, t, g)
+			setup(t, g, awsMachine)
 			defer teardown(t, g)
 			finalizer(t, g)
 
@@ -854,7 +876,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("should ignore instances in terminated down state", func(t *testing.T) {
 			g := NewWithT(t)
 			awsMachine := getAWSMachine()
-			setup(awsMachine, t, g)
+			setup(t, g, awsMachine)
 			defer teardown(t, g)
 			finalizer(t, g)
 
@@ -873,12 +895,13 @@ func TestAWSMachineReconciler(t *testing.T) {
 		t.Run("instance not shutting down yet", func(t *testing.T) {
 			id := "aws:////myid"
 			getRunningInstance := func(t *testing.T, g *WithT) {
+				t.Helper()
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{ID: id}, nil)
 			}
 			t.Run("should return an error when the instance can't be terminated", func(t *testing.T) {
 				g := NewWithT(t)
 				awsMachine := getAWSMachine()
-				setup(awsMachine, t, g)
+				setup(t, g, awsMachine)
 				defer teardown(t, g)
 				finalizer(t, g)
 				getRunningInstance(t, g)
@@ -896,13 +919,14 @@ func TestAWSMachineReconciler(t *testing.T) {
 			})
 			t.Run("when instance can be shut down", func(t *testing.T) {
 				terminateInstance := func(t *testing.T, g *WithT) {
+					t.Helper()
 					ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil)
 				}
 
 				t.Run("should error when it can't retrieve security groups if there are network interfaces", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					finalizer(t, g)
 					getRunningInstance(t, g)
@@ -922,7 +946,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should error when it can't detach a security group from an interface", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					finalizer(t, g)
 					getRunningInstance(t, g)
@@ -943,7 +967,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should detach all combinations of network interfaces", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					finalizer(t, g)
 					getRunningInstance(t, g)
@@ -965,7 +989,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				t.Run("should remove security groups", func(t *testing.T) {
 					g := NewWithT(t)
 					awsMachine := getAWSMachine()
-					setup(awsMachine, t, g)
+					setup(t, g, awsMachine)
 					defer teardown(t, g)
 					finalizer(t, g)
 					getRunningInstance(t, g)

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -63,6 +63,8 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 		secret         *corev1.Secret
 	)
 	setup := func(t *testing.T, g *WithT) {
+		t.Helper()
+
 		var err error
 
 		if err := flag.Set("logtostderr", "false"); err != nil {
@@ -144,6 +146,8 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 	}
 
 	teardown := func(t *testing.T, g *WithT) {
+		t.Helper()
+
 		ctx := context.TODO()
 		mpPh, err := patch.NewHelper(awsMachinePool, testEnv)
 		g.Expect(err).ShouldNot(HaveOccurred())
@@ -158,6 +162,8 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 		t.Run("when can't reach amazon", func(t *testing.T) {
 			expectedErr := errors.New("no connection available ")
 			getASG := func(t *testing.T, g *WithT) {
+				t.Helper()
+
 				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, "", expectedErr).AnyTimes()
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 			}
@@ -223,6 +229,8 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 		t.Run("there's a provider ID", func(t *testing.T) {
 			id := "<cloudProvider>://<optional>/<segments>/<providerid>"
 			setProviderID := func(t *testing.T, g *WithT) {
+				t.Helper()
+
 				_, err := noderefutil.NewProviderID(id)
 				g.Expect(err).To(BeNil())
 
@@ -260,6 +268,8 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 
 	t.Run("Deleting an AWSMachinePool", func(t *testing.T) {
 		finalizer := func(t *testing.T, g *WithT) {
+			t.Helper()
+
 			ms.AWSMachinePool.Finalizers = []string{
 				expinfrav1.MachinePoolFinalizer,
 				metav1.FinalizerDeleteDependents,

--- a/pkg/cloud/scope/session_test.go
+++ b/pkg/cloud/scope/session_test.go
@@ -41,7 +41,7 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 		name             string
 		clusterNamespace string
 		allowedNs        *infrav1.AllowedNamespaces
-		setup            func(client.Client, *testing.T)
+		setup            func(*testing.T, client.Client)
 		expectedResult   bool
 		expectErr        bool
 	}{
@@ -66,7 +66,9 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 				NamespaceList: []string{"match"},
 				Selector:      metav1.LabelSelector{},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				ns := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "match",
@@ -88,7 +90,9 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 				NamespaceList: []string{"nomatch"},
 				Selector:      metav1.LabelSelector{},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				ns := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
@@ -112,7 +116,9 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 					MatchLabels: map[string]string{"ns": "nomatchlabel"},
 				},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				ns := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "match",
@@ -136,7 +142,9 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 					MatchLabels: map[string]string{"ns": "nomatchlabel"},
 				},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				ns := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
@@ -160,7 +168,9 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 					MatchLabels: map[string]string{"ns": "matchlabel"},
 				},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				ns := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "default",
@@ -188,7 +198,7 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 			}
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			if tc.setup != nil {
-				tc.setup(k8sClient, t)
+				tc.setup(t, k8sClient)
 			}
 			result, err := isClusterPermittedToUsePrincipal(k8sClient, tc.allowedNs, tc.clusterNamespace)
 			if tc.expectErr {
@@ -226,7 +236,7 @@ func TestPrincipalParsing(t *testing.T) {
 		awsCluster  infrav1.AWSCluster
 		identityRef *corev1.ObjectReference
 		identity    runtime.Object
-		setup       func(client.Client, *testing.T)
+		setup       func(*testing.T, client.Client)
 		expect      func([]identity.AWSPrincipalTypeProvider)
 		expectError bool
 	}{
@@ -243,7 +253,8 @@ func TestPrincipalParsing(t *testing.T) {
 				},
 				Spec: infrav1.AWSClusterSpec{},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
 			},
 			expect: func(providers []identity.AWSPrincipalTypeProvider) {
 				if len(providers) != 0 {
@@ -269,7 +280,9 @@ func TestPrincipalParsing(t *testing.T) {
 					},
 				},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				identity := &infrav1.AWSClusterStaticIdentity{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "static-identity",
@@ -342,7 +355,9 @@ func TestPrincipalParsing(t *testing.T) {
 					},
 				},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				staticPrincipal := &infrav1.AWSClusterStaticIdentity{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "static-identity",
@@ -425,7 +440,9 @@ func TestPrincipalParsing(t *testing.T) {
 					},
 				},
 			},
-			setup: func(c client.Client, t *testing.T) {
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+
 				identity := &infrav1.AWSClusterRoleIdentity{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "role-identity",
@@ -469,7 +486,7 @@ func TestPrincipalParsing(t *testing.T) {
 				t.Fatal(err)
 			}
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-			tc.setup(k8sClient, t)
+			tc.setup(t, k8sClient)
 			clusterScope.AWSCluster = &tc.awsCluster
 			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope, klogr.New())
 			if tc.expectError {

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -161,6 +161,7 @@ func TestGetAPIServerClassicELBSpec_ControlPlaneLoadBalancer(t *testing.T) {
 			lb:    nil,
 			mocks: func(m *mock_ec2iface.MockEC2APIMockRecorder) {},
 			expect: func(t *testing.T, res *infrav1.ClassicELB) {
+				t.Helper()
 				if res.Attributes.CrossZoneLoadBalancing {
 					t.Error("Expected load balancer not to have cross-zone load balancing enabled")
 				}
@@ -173,6 +174,7 @@ func TestGetAPIServerClassicELBSpec_ControlPlaneLoadBalancer(t *testing.T) {
 			},
 			mocks: func(m *mock_ec2iface.MockEC2APIMockRecorder) {},
 			expect: func(t *testing.T, res *infrav1.ClassicELB) {
+				t.Helper()
 				if !res.Attributes.CrossZoneLoadBalancing {
 					t.Error("Expected load balancer to have cross-zone load balancing enabled")
 				}
@@ -204,6 +206,7 @@ func TestGetAPIServerClassicELBSpec_ControlPlaneLoadBalancer(t *testing.T) {
 					}, nil)
 			},
 			expect: func(t *testing.T, res *infrav1.ClassicELB) {
+				t.Helper()
 				if len(res.SubnetIDs) != 2 {
 					t.Errorf("Expected load balancer to be configured for 2 subnets, got %v", len(res.SubnetIDs))
 				}
@@ -219,6 +222,7 @@ func TestGetAPIServerClassicELBSpec_ControlPlaneLoadBalancer(t *testing.T) {
 			},
 			mocks: func(m *mock_ec2iface.MockEC2APIMockRecorder) {},
 			expect: func(t *testing.T, res *infrav1.ClassicELB) {
+				t.Helper()
 				if len(res.SecurityGroupIDs) != 3 {
 					t.Errorf("Expected load balancer to be configured for 3 security groups, got %v", len(res.SecurityGroupIDs))
 				}
@@ -352,6 +356,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 			},
 			ec2Mocks: func(m *mock_ec2iface.MockEC2APIMockRecorder) {},
 			check: func(t *testing.T, err error) {
+				t.Helper()
 				if err != nil {
 					t.Fatalf("did not expect error: %v", err)
 				}
@@ -434,6 +439,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 					}, nil)
 			},
 			check: func(t *testing.T, err error) {
+				t.Helper()
 				if err != nil {
 					t.Fatalf("did not expect error: %v", err)
 				}
@@ -508,6 +514,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 					}, nil)
 			},
 			check: func(t *testing.T, err error) {
+				t.Helper()
 				expectedErrMsg := "failed to register instance with APIServer ELB \"bar-apiserver\": instance is in availability zone \"us-west-1a\", no public subnets attached to the ELB in the same zone"
 				if err == nil {
 					t.Fatalf("Expected error, but got nil")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
See https://github.com/kulti/thelper for more information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Part of #3077 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Enable thelper golang linter 
```
