### PR TITLE
Enable predeclared and unused golang linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
   - typecheck
   - unconvert
   - unparam
+  - unused
   - varcheck
   - whitespace
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
   - noctx
   - nolintlint
   - prealloc
+  - predeclared
   - revive
   - rowserrcheck
   - staticcheck

--- a/cmd/clusterawsadm/cmd/ami/ami.go
+++ b/cmd/clusterawsadm/cmd/ami/ami.go
@@ -19,7 +19,7 @@ package ami
 import (
 	"github.com/spf13/cobra"
 
-	cp "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/copy"
+	cm "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/common"
 	ls "sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/cmd/ami/list"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 )
@@ -41,8 +41,8 @@ func RootCmd() *cobra.Command {
 		},
 	}
 
-	newCmd.AddCommand(cp.CopyAMICmd())
-	newCmd.AddCommand(cp.EncryptedCopyAMICmd())
+	newCmd.AddCommand(cm.CopyAMICmd())
+	newCmd.AddCommand(cm.EncryptedCopyAMICmd())
 	newCmd.AddCommand(ls.ListAMICmd())
 
 	return newCmd

--- a/cmd/clusterawsadm/cmd/ami/common/common.go
+++ b/cmd/clusterawsadm/cmd/ami/common/common.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package copy
+package common
 
 import (
 	"fmt"

--- a/cmd/clusterawsadm/cmd/ami/common/encryptedcopy.go
+++ b/cmd/clusterawsadm/cmd/ami/common/encryptedcopy.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package copy
+package common
 
 import (
 	"fmt"
@@ -29,25 +29,42 @@ import (
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
-// CopyAMICmd will copy AMIs from an AWS account to the AWS account which credentials are provided.
-func CopyAMICmd() *cobra.Command {
+var (
+	kmsKeyID string
+)
+
+// EncryptedCopyAMICmd is a command to encrypt and copy AMI snapshots, then create an AMI with that snapshot.
+func EncryptedCopyAMICmd() *cobra.Command {
 	newCmd := &cobra.Command{
-		Use:   "copy",
-		Short: "Copy AMIs from an AWS account to the AWS account which credentials are provided",
+		Use:   "encrypted-copy",
+		Short: "Encrypt and copy AMI snapshot, then create an AMI with that snapshot",
 		Long: cmd.LongDesc(`
-			Copy AMIs based on Kubernetes version, OS, region from an AWS account where AMIs are stored
-            to the current AWS account (use case: air-gapped deployments)
+			Find the AMI based on Kubernetes version, OS, region in the AWS account where AMIs are stored.
+			Encrypt and copy the snapshot of the AMI to the current AWS account.
+			Create an AMI with that snapshot.
 		`),
 		Example: cmd.Examples(`
-		# Copy AMI from the default AWS account where AMIs are stored.
+		# Create an encrypted AMI:
 		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2
-		clusterawsadm ami copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
+		clusterawsadm ami encrypted-copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
 
 		# owner-id and dry-run flags are optional. region can be set via flag or env
-		clusterawsadm ami copy --os centos-7 --kubernetes-version=v1.19.4 --owner-id=111111111111 --dry-run
+		clusterawsadm ami encrypted-copy --os centos-7 --kubernetes-version=v1.19.4 --owner-id=111111111111 --dry-run
 
 		# copy from us-east-1 to us-east-2
-		clusterawsadm ami copy --os centos-7 --kubernetes-version=v1.19.4 --region us-east-2 --source-region us-east-1
+		clusterawsadm ami encrypted-copy --os centos-7 --kubernetes-version=v1.19.4 --owner-id=111111111111 --region us-east-2 --source-region us-east-1
+
+		# Encrypt using a non-default KmsKeyId specified using Key ID:
+		clusterawsadm ami encrypted-copy --os centos-7 --kubernetes-version=v1.19.4 --kms-key-id=key/1234abcd-12ab-34cd-56ef-1234567890ab
+
+		# Encrypt using a non-default KmsKeyId specified using Key alias:
+		clusterawsadm ami encrypted-copy --os centos-7 --kubernetes-version=v1.19.4 --kms-key-id=alias/ExampleAlias
+
+		# Encrypt using a non-default KmsKeyId specified using Key ARN:
+		clusterawsadm ami encrypted-copy --os centos-7 --kubernetes-version=v1.19.4 --kms-key-id=arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef
+
+		# Encrypt using a non-default KmsKeyId specified using Alias ARN:
+		clusterawsadm ami encrypted-copy --os centos-7 --kubernetes-version=v1.19.4 --kms-key-id=arn:aws:kms:us-east-1:012345678910:alias/ExampleAlias
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,6 +91,8 @@ func CopyAMICmd() *cobra.Command {
 			ami, err := ami.Copy(ami.CopyInput{
 				DestinationRegion: region,
 				DryRun:            dryRun,
+				Encrypted:         true,
+				KmsKeyID:          kmsKeyID,
 				KubernetesVersion: kubernetesVersion,
 				Log:               log,
 				OperatingSystem:   opSystem,
@@ -89,7 +108,6 @@ func CopyAMICmd() *cobra.Command {
 
 			printer.Print(ami)
 
-			// klog.V(0).Infof("Completed copying %v\n", *image.ImageId)
 			return nil
 		},
 	}
@@ -99,6 +117,11 @@ func CopyAMICmd() *cobra.Command {
 	addKubernetesVersionFlag(newCmd)
 	addDryRunFlag(newCmd)
 	addOwnerIDFlag(newCmd)
+	addKmsKeyIDFlag(newCmd)
 	addSourceRegion(newCmd)
 	return newCmd
+}
+
+func addKmsKeyIDFlag(c *cobra.Command) {
+	c.Flags().StringVar(&kmsKeyID, "kms-key-id", "", "The ID of the KMS key for Amazon EBS encryption")
 }

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package copy
+package list
 
 import (
 	"fmt"

--- a/pkg/hash/base36.go
+++ b/pkg/hash/base36.go
@@ -29,8 +29,8 @@ const base36set = "0123456789abcdefghijklmnopqrstuvwxyz"
 // Base36TruncatedHash returns a consistent hash using blake2b
 // and truncating the byte values to alphanumeric only
 // of a fixed length specified by the consumer.
-func Base36TruncatedHash(str string, len int) (string, error) {
-	hasher, err := blake2b.New(len, nil)
+func Base36TruncatedHash(str string, length int) (string, error) {
+	hasher, err := blake2b.New(length, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to create hash function")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Enabled two more linters
* predeclared linter finds code that shadows one of Go's predeclared identifiers.
* unused linter checks Go code for unused constants, variables, functions and types

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3077 

**Special notes for your reviewer**:
Will keep two commits separately as one is for `unused` linter and another is for `predeclared` linter.

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Enable predeclared and unused golang linters
```
