### PR TITLE
Update bastion status after deleting it

### DIFF
--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -118,6 +118,9 @@ func (s *Service) DeleteBastion() error {
 		record.Warnf(s.scope.InfraCluster(), "FailedTerminateBastion", "Failed to terminate bastion instance %q: %v", instance.ID, err)
 		return errors.Wrap(err, "unable to delete bastion instance")
 	}
+
+	s.scope.SetBastionInstance(nil)
+
 	conditions.MarkFalse(s.scope.InfraCluster(), infrav1.BastionHostReadyCondition, clusterv1.DeletedReason, clusterv1.ConditionSeverityInfo, "")
 	record.Eventf(s.scope.InfraCluster(), "SuccessfulTerminateBastion", "Terminated bastion instance %q", instance.ID)
 

--- a/pkg/cloud/services/ec2/bastion_test.go
+++ b/pkg/cloud/services/ec2/bastion_test.go
@@ -71,9 +71,10 @@ func TestDeleteBastion(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		expect      func(m *mock_ec2iface.MockEC2APIMockRecorder)
-		expectError bool
+		name          string
+		expect        func(m *mock_ec2iface.MockEC2APIMockRecorder)
+		expectError   bool
+		bastionStatus *infrav1.Instance
 	}{
 		{
 			name: "instance not found",
@@ -153,7 +154,8 @@ func TestDeleteBastion(t *testing.T) {
 					).
 					Return(nil)
 			},
-			expectError: false,
+			expectError:   false,
+			bastionStatus: nil,
 		},
 	}
 
@@ -217,6 +219,8 @@ func TestDeleteBastion(t *testing.T) {
 				}
 
 				g.Expect(err).To(BeNil())
+
+				g.Expect(scope.AWSCluster.Status.Bastion).To(BeEquivalentTo(tc.bastionStatus))
 			})
 		}
 	}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This PR updates bastion instance in `AWSCluster` status upon its deletion.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3089

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
