### PR TITLE
Added unit test for pkg/cloud/services/autoscaling package

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -389,58 +389,6 @@ func createSDKMixedInstancesPolicy(name string, i *expinfrav1.MixedInstancesPoli
 	return mixedInstancesPolicy
 }
 
-// BuildTags takes the tag configuration from the resources and returns a slice of autoscaling Tags
-// usable in autoscaling API calls.
-func BuildTags(name string, params infrav1.BuildParams) []*autoscaling.Tag {
-	tags := make([]*autoscaling.Tag, 0)
-	resourceName := aws.String(name)
-	propagateAtLaunch := aws.Bool(false)
-	resourceType := aws.String("auto-scaling-group")
-	if params.Additional != nil {
-		for k, v := range params.Additional {
-			tags = append(tags, &autoscaling.Tag{
-				Key:   aws.String(k),
-				Value: aws.String(v),
-				// We set the instance tags in the LaunchTemplate, disabling propagation to prevent the two
-				// resources from clobbering each other's tags
-				PropagateAtLaunch: propagateAtLaunch,
-				ResourceId:        resourceName,
-				ResourceType:      resourceType,
-			})
-		}
-	}
-
-	tags = append(tags, &autoscaling.Tag{
-		Key:               aws.String(infrav1.ClusterTagKey(params.ClusterName)),
-		Value:             aws.String(string(params.Lifecycle)),
-		PropagateAtLaunch: propagateAtLaunch,
-		ResourceId:        resourceName,
-		ResourceType:      resourceType,
-	})
-
-	if params.Role != nil {
-		tags = append(tags, &autoscaling.Tag{
-			Key:               aws.String(infrav1.NameAWSClusterAPIRole),
-			Value:             params.Role,
-			PropagateAtLaunch: propagateAtLaunch,
-			ResourceId:        resourceName,
-			ResourceType:      resourceType,
-		})
-	}
-
-	if params.Name != nil {
-		tags = append(tags, &autoscaling.Tag{
-			Key:               aws.String("Name"),
-			Value:             params.Name,
-			PropagateAtLaunch: propagateAtLaunch,
-			ResourceId:        resourceName,
-			ResourceType:      resourceType,
-		})
-	}
-
-	return tags
-}
-
 // BuildTagsFromMap takes a map of keys and values and returns them as autoscaling group tags.
 func BuildTagsFromMap(asgName string, inTags map[string]string) []*autoscaling.Tag {
 	if inTags == nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/area testing
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR increases the unit tests coverage for `pkg/cloud/services/autoscaling` package.
Coverage increased from 13.7% to 94.2%
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2910

**Special notes for your reviewer**:
Please add missing test scenarios [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2910) for tracking.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add unit tests for `pkg/cloud/services/autoscaling` package
```
