### PR TITLE
fix: eks encryption logic fix

### DIFF
--- a/docs/book/src/topics/eks/encryption.md
+++ b/docs/book/src/topics/eks/encryption.md
@@ -4,7 +4,7 @@ To enable encryption when creating a cluster you need to create a new KMS key th
 
 For example, `arn:aws:kms:eu-north-1:12345678901:alias/cluster-api-provider-aws-key1`.
 
-You then need to specify this alias in the `encryptionConfig` of the `AWSManagedControlPlane`:
+You then need to specify the **key ARN**  in the `encryptionConfig` of the `AWSManagedControlPlane`:
 
 ```yaml
 kind: AWSManagedControlPlane
@@ -14,10 +14,12 @@ metadata:
 spec:
   ...
   encryptionConfig:
-    provider: "arn:aws:kms:eu-north-1:12345678901:alias/cluster-api-provider-aws-key1"
+    provider: "arn:aws:kms:eu-north-1:12345678901:key/351f5544-6130-42e4-8786-2c85e546fc2d"
     resources:
     - "secrets"
 ```
+
+> You must use the ARN of the key and not the ARN of the alias.
 
 ## Custom KMS Alias Prefix
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The logic for when to update the EKS encryption had issues. This
refactors the logic to be more explicit.

Also updated the docs to say that the KMS key ARN needs to be used and
not the alias ARN.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3092 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Update to EKS encryption logic to stop it reporting a chnage when one hasn't occured.
```
