### PR TITLE
Add support for custom protocol for ELB health checks

### DIFF
--- a/api/v1alpha3/awscluster_conversion.go
+++ b/api/v1alpha3/awscluster_conversion.go
@@ -61,6 +61,7 @@ func (r *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 // Assumes restored and dst are non-nil.
 func restoreControlPlaneLoadBalancer(restored, dst *infrav1.AWSLoadBalancerSpec) {
 	dst.Name = restored.Name
+	dst.HealthCheckProtocol = restored.HealthCheckProtocol
 }
 
 // ConvertFrom converts the v1beta1 AWSCluster receiver to a v1alpha3 AWSCluster.

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1056,6 +1056,7 @@ func autoConvert_v1beta1_AWSLoadBalancerSpec_To_v1alpha3_AWSLoadBalancerSpec(in 
 	out.Scheme = (*ClassicELBScheme)(unsafe.Pointer(in.Scheme))
 	out.CrossZoneLoadBalancing = in.CrossZoneLoadBalancing
 	out.Subnets = *(*[]string)(unsafe.Pointer(&in.Subnets))
+	// WARNING: in.HealthCheckProtocol requires manual conversion: does not exist in peer-type
 	out.AdditionalSecurityGroups = *(*[]string)(unsafe.Pointer(&in.AdditionalSecurityGroups))
 	return nil
 }

--- a/api/v1alpha4/awscluster_conversion.go
+++ b/api/v1alpha4/awscluster_conversion.go
@@ -52,6 +52,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 // Assumes restored and dst are non-nil.
 func restoreControlPlaneLoadBalancer(restored, dst *infrav1.AWSLoadBalancerSpec) {
 	dst.Name = restored.Name
+	dst.HealthCheckProtocol = restored.HealthCheckProtocol
 }
 
 // ConvertFrom converts the v1beta1 AWSCluster receiver to a v1alpha4 AWSCluster.

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1219,6 +1219,7 @@ func autoConvert_v1beta1_AWSLoadBalancerSpec_To_v1alpha4_AWSLoadBalancerSpec(in 
 	out.Scheme = (*ClassicELBScheme)(unsafe.Pointer(in.Scheme))
 	out.CrossZoneLoadBalancing = in.CrossZoneLoadBalancing
 	out.Subnets = *(*[]string)(unsafe.Pointer(&in.Subnets))
+	// WARNING: in.HealthCheckProtocol requires manual conversion: does not exist in peer-type
 	out.AdditionalSecurityGroups = *(*[]string)(unsafe.Pointer(&in.AdditionalSecurityGroups))
 	return nil
 }

--- a/api/v1beta1/awscluster_types.go
+++ b/api/v1beta1/awscluster_types.go
@@ -177,6 +177,11 @@ type AWSLoadBalancerSpec struct {
 	// +optional
 	Subnets []string `json:"subnets,omitempty"`
 
+	// HealthCheckProtocol sets the protocol type for classic ELB health check target
+	// default value is ClassicELBProtocolSSL
+	// +optional
+	HealthCheckProtocol *ClassicELBProtocol `json:"healthCheckProtocol,omitempty"`
+
 	// AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs
 	// This is optional - if not provided new security groups will be created for the load balancer
 	// +optional

--- a/api/v1beta1/awscluster_webhook.go
+++ b/api/v1beta1/awscluster_webhook.go
@@ -115,6 +115,16 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 					r.Spec.ControlPlaneLoadBalancer.Name, "field is immutable"),
 			)
 		}
+
+		// Block the update for HealthCheckProtocol :
+		// - if it was not set in old spec but added in new spec
+		// - if it was set in old spec but changed in new spec
+		if !reflect.DeepEqual(newLoadBalancer.HealthCheckProtocol, existingLoadBalancer.HealthCheckProtocol) {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "healthCheckProtocol"),
+					newLoadBalancer.HealthCheckProtocol, "field is immutable once set"),
+			)
+		}
 	}
 
 	if !reflect.DeepEqual(oldC.Spec.ControlPlaneEndpoint, clusterv1.APIEndpoint{}) &&

--- a/api/v1beta1/network_types.go
+++ b/api/v1beta1/network_types.go
@@ -54,6 +54,10 @@ func (e ClassicELBScheme) String() string {
 // ClassicELBProtocol defines listener protocols for a classic load balancer.
 type ClassicELBProtocol string
 
+func (e ClassicELBProtocol) String() string {
+	return string(e)
+}
+
 var (
 	// ClassicELBProtocolTCP defines the ELB API string representing the TCP protocol.
 	ClassicELBProtocolTCP = ClassicELBProtocol("TCP")

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -558,6 +558,11 @@ func (in *AWSLoadBalancerSpec) DeepCopyInto(out *AWSLoadBalancerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.HealthCheckProtocol != nil {
+		in, out := &in.HealthCheckProtocol, &out.HealthCheckProtocol
+		*out = new(ClassicELBProtocol)
+		**out = **in
+	}
 	if in.AdditionalSecurityGroups != nil {
 		in, out := &in.AdditionalSecurityGroups, &out.AdditionalSecurityGroups
 		*out = make([]string, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1651,6 +1651,10 @@ spec:
                       registered instances in its Availability Zone only. \n Defaults
                       to false."
                     type: boolean
+                  healthCheckProtocol:
+                    description: HealthCheckProtocol sets the protocol type for classic
+                      ELB health check target default value is ClassicELBProtocolSSL
+                    type: string
                   name:
                     description: Name sets the name of the classic ELB load balancer.
                       As per AWS, the name must be unique within your set of load

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -474,6 +474,11 @@ spec:
                               registered instances in its Availability Zone only.
                               \n Defaults to false."
                             type: boolean
+                          healthCheckProtocol:
+                            description: HealthCheckProtocol sets the protocol type
+                              for classic ELB health check target default value is
+                              ClassicELBProtocolSSL
+                            type: string
                           name:
                             description: Name sets the name of the classic ELB load
                               balancer. As per AWS, the name must be unique within

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -431,7 +431,7 @@ func (s *Service) getAPIServerClassicELBSpec(elbName string) (*infrav1.ClassicEL
 			},
 		},
 		HealthCheck: &infrav1.ClassicELBHealthCheck{
-			Target:             fmt.Sprintf("%v:%d", infrav1.ClassicELBProtocolSSL, 6443),
+			Target:             fmt.Sprintf("%v:%d", s.getHealthCheckELBProtocol(), 6443),
 			Interval:           10 * time.Second,
 			Timeout:            5 * time.Second,
 			HealthyThreshold:   5,
@@ -779,6 +779,14 @@ func (s *Service) reconcileELBTags(lb *infrav1.ClassicELB, desiredTags map[strin
 	}
 
 	return nil
+}
+
+func (s *Service) getHealthCheckELBProtocol() *infrav1.ClassicELBProtocol {
+	controlPlaneELB := s.scope.ControlPlaneLoadBalancer()
+	if controlPlaneELB != nil && controlPlaneELB.HealthCheckProtocol != nil {
+		return controlPlaneELB.HealthCheckProtocol
+	}
+	return &infrav1.ClassicELBProtocolSSL
 }
 
 func fromSDKTypeToClassicELB(v *elb.LoadBalancerDescription, attrs *elb.LoadBalancerAttributes, tags []*elb.Tag) *infrav1.ClassicELB {

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/limit-az/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/limit-az/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - ../default
 patchesStrategicMerge:
   - patches/limit-az.yaml
+  - patches/elb-health-check-protocol.yaml

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/limit-az/patches/elb-health-check-protocol.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/limit-az/patches/elb-health-check-protocol.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  controlPlaneLoadBalancer:
+    healthCheckProtocol: "TCP"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds support for providing the custom protocol for Classic ELB health checks so as to support different ciphers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1657 

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Add support for custom protocol for ELB health checks
```
