### PR TITLE
Fix AMI publishing failure for patch versions in book

### DIFF
--- a/cmd/clusterawsadm/ami/helper_test.go
+++ b/cmd/clusterawsadm/ami/helper_test.go
@@ -1,0 +1,36 @@
+package ami
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAllPatchVersions(t *testing.T) {
+	tests := []struct {
+		name          string
+		latestVersion string
+		want          []string
+	}{
+		{
+			name:          "Should return 3 different patch versions for v1.23.3",
+			latestVersion: "v1.23.3",
+			want:          []string{"v1.23.2", "v1.23.1", "v1.23.0"},
+		},
+		{
+			name:          "Should return empty patch versions for v1.23.0",
+			latestVersion: "v1.23.0",
+			want:          []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := allPatchesForVersion(tt.latestVersion)
+			if err != nil {
+				t.Fatalf("error while fetching patch versions %+v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("allPatchesForVersion() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/clusterawsadm/ami/list.go
+++ b/cmd/clusterawsadm/ami/list.go
@@ -35,6 +35,8 @@ type ListInput struct {
 	OperatingSystem   string
 }
 
+const lastNReleases = 3
+
 // List will create an AWSAMIList from a given ListInput.
 func List(input ListInput) (*amiv1.AWSAMIList, error) {
 	supportedOsList := []string{}
@@ -53,7 +55,7 @@ func List(input ListInput) (*amiv1.AWSAMIList, error) {
 	supportedVersions := []string{}
 	if input.KubernetesVersion == "" {
 		var err error
-		supportedVersions, err = getSupportedKubernetesVersions()
+		supportedVersions, err = getSupportedKubernetesVersions(lastNReleases)
 		if err != nil {
 			fmt.Println("Failed to calculate supported Kubernetes versions")
 			return nil, err
@@ -96,6 +98,9 @@ func List(input ListInput) (*amiv1.AWSAMIList, error) {
 				image, err := findAMI(imageMap, os, version)
 				if err != nil {
 					return nil, err
+				}
+				if image == nil {
+					continue
 				}
 				creationTimestamp, err := time.Parse(time.RFC3339, aws.StringValue(image.CreationDate))
 				if err != nil {

--- a/docs/book/src/topics/images/built-amis.md
+++ b/docs/book/src/topics/images/built-amis.md
@@ -105,3 +105,7 @@ See [clusterawsadm ami list](../clusterawsadm/clusterawsadm_ami_list.md) for det
   .catch((error) => console.error('Error:', error));
 </script>
 
+If you want to query any other AMI which is not listed in the table, then use below command
+```
+clusterawsadm ami list --kubernetes-version <some-k8s-version> --region <supported-aws-region> --os <supported-os-name>
+```

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -278,5 +278,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace sigs.k8s.io/cluster-api/hack/tools => github.com/sbueringer/cluster-api/hack/tools v0.0.0-20211111153850-3b4953a9021d

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -1345,8 +1345,6 @@ github.com/saschagrunert/ccli v1.0.2-0.20200423111659-b68f755cc0f5/go.mod h1:nF6
 github.com/saschagrunert/go-modiff v1.3.0 h1:K/CJGaWH8poLrg/NpNQzHU60T/FiFtgZl2w8JhZequA=
 github.com/saschagrunert/go-modiff v1.3.0/go.mod h1:SSVmjiafeH2c1ITdPSmVDJ4/plhYJteb2VytMaD5/ZE=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/sbueringer/cluster-api/hack/tools v0.0.0-20211111153850-3b4953a9021d h1:X4Jq69BedTGvRAQkpKi3H5SLQm+oWen8EESr1q3kocc=
-github.com/sbueringer/cluster-api/hack/tools v0.0.0-20211111153850-3b4953a9021d/go.mod h1:Bib3nYZoRjwPdZ1+X1MVRWcQL18dJ4q2U+Ok603lcAE=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
@@ -2405,6 +2403,8 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.23/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20211111175208-4cc2fce2111a h1:VrYPmq0nN1VQuhid22yD9Z5Hn+M6p/N0f0dCkuM5C2s=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20211111175208-4cc2fce2111a/go.mod h1:Bib3nYZoRjwPdZ1+X1MVRWcQL18dJ4q2U+Ok603lcAE=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20211110210527-619e6b92dab9/go.mod h1:+sJcI1F0QI0Cv+8fp5rH5B2fK1LxzrAQqYnaPx9nY8I=
 sigs.k8s.io/controller-tools v0.7.1-0.20211110210727-ab52f76cc7d1 h1:fsnXNyvliKAKkcOZ5l9gGinGqjGM8eKKT+4TW/LoI7A=
 sigs.k8s.io/controller-tools v0.7.1-0.20211110210727-ab52f76cc7d1/go.mod h1:h59umkqeBKj3TNpLmLoqDCwXDcbN+mkhQzlNjoUDJ3I=


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR helps in publishing AMI images for last 4 Kubernetes releases in [book](https://cluster-api-aws.sigs.k8s.io/topics/images/built-amis.html).
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3061 

**Special notes for your reviewer**:
To find out all Patch versions for a given kubernetes release, we are taking all versions from vx.x.0 to vx.x.latest_stable_patch. And during finding images I am ignoring those patches for which image is not found

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Publish CAPA AMI images for last 4 k8s releases in CAPA book. 
```
