### PR TITLE
Add lint-fix to Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,11 @@ clusterawsadm: ## Build clusterawsadm binary.
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint codebase
-	$(GOLANGCI_LINT) run -v --fast=false
+	$(GOLANGCI_LINT) run -v --fast=false $(GOLANGCI_LINT_EXTRA_ARGS)
+
+.PHONY: lint-fix
+lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
+	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
 
 ## --------------------------------------
 ## Generate


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:
Add lint-fix to Makefile target.
When a linter supports `--fix` option, running `make lint-fix` will fix linter errors. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
```release-note
NONE
```
