### PR TITLE
Skip AWSMMP reconciliation if the owning Cluster or AWSMMP itself is paused

### DIFF
--- a/exp/controlleridentitycreator/awscontrolleridentity_controller.go
+++ b/exp/controlleridentitycreator/awscontrolleridentity_controller.go
@@ -91,7 +91,7 @@ func (r *AWSControllerIdentityReconciler) Reconcile(ctx context.Context, req ctr
 	// If identity type is not AWSClusterControllerIdentity, then no need to create AWSClusterControllerIdentity singleton.
 	if identityRef.Kind == infrav1.ClusterRoleIdentityKind ||
 		identityRef.Kind == infrav1.ClusterStaticIdentityKind {
-		log.Info("Cluster does not use AWSClusterControllerIdentity as identityRef, skipping new instance creation")
+		log.V(4).Info("Cluster does not use AWSClusterControllerIdentity as identityRef, skipping new instance creation")
 		return ctrl.Result{}, nil
 	}
 

--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -42,6 +42,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -114,6 +115,11 @@ func (r *AWSManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctr
 	if err != nil {
 		log.Info("Failed to retrieve Cluster from MachinePool")
 		return reconcile.Result{}, nil
+	}
+
+	if annotations.IsPaused(cluster, awsPool) {
+		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
 	}
 
 	log = log.WithValues("Cluster", cluster.Name)

--- a/pkg/cloud/services/instancestate/rule_test.go
+++ b/pkg/cloud/services/instancestate/rule_test.go
@@ -322,7 +322,10 @@ func TestRemoveInstanceStateFromEventPattern(t *testing.T) {
 			InstanceIDs: []string{"instance-a", "instance-b", "instance-c"},
 		},
 	}
-	patternData, _ := json.Marshal(pattern) //nolint
+	patternData, err := json.Marshal(pattern)
+	if err != nil {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
 
 	testCases := []struct {
 		name              string
@@ -345,7 +348,10 @@ func TestRemoveInstanceStateFromEventPattern(t *testing.T) {
 				}, nil)
 				expectedPattern := pattern
 				expectedPattern.EventDetail.InstanceIDs = []string{}
-				expectedData, _ := json.Marshal(expectedPattern) //nolint
+				expectedData, err := json.Marshal(expectedPattern)
+				if err != nil {
+					t.Fatalf("got an unexpected error: %v", err)
+				}
 
 				m.PutRule(&eventbridge.PutRuleInput{
 					Name:         aws.String("test-cluster-ec2-rule"),

--- a/test/e2e/shared/resource.go
+++ b/test/e2e/shared/resource.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -71,7 +72,7 @@ func (r *TestResource) WriteRequestedResources(e2eCtx *E2EContext, testName stri
 	requestedResourceFilePath := path.Join(e2eCtx.Settings.ArtifactFolder, "requested-resources.yaml")
 	if _, err := os.Stat(ResourceQuotaFilePath); err != nil {
 		// If requested-resources file does not exist, create it
-		f, err := os.Create(requestedResourceFilePath) //nolint:gosec
+		f, err := os.Create(filepath.Clean(requestedResourceFilePath))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We skip AWSMCP reconciliation when the owning Cluster or the AWSMCP itself is paused (https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go#L137). We should add the same logic for AWSMMP.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3155

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Skip AWSMMP reconciliation if the owning Cluster or AWSMMP itself is paused
```
