### PR TITLE
Add flatcar-stable to supported OS list for clusterawsadm

### DIFF
--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -38,7 +38,7 @@ const (
 )
 
 func getSupportedOsList() []string {
-	return []string{"centos-7", "ubuntu-18.04", "ubuntu-20.04", "amazon-2"}
+	return []string{"centos-7", "ubuntu-18.04", "ubuntu-20.04", "amazon-2", "flatcar-stable"}
 }
 
 func getimageRegionList() []string {

--- a/cmd/clusterawsadm/cmd/ami/common/copy.go
+++ b/cmd/clusterawsadm/cmd/ami/common/copy.go
@@ -40,7 +40,7 @@ func CopyAMICmd() *cobra.Command {
 		`),
 		Example: cmd.Examples(`
 		# Copy AMI from the default AWS account where AMIs are stored.
-		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2
+		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2, flatcar-stable
 		clusterawsadm ami copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
 
 		# owner-id and dry-run flags are optional. region can be set via flag or env

--- a/cmd/clusterawsadm/cmd/ami/common/encryptedcopy.go
+++ b/cmd/clusterawsadm/cmd/ami/common/encryptedcopy.go
@@ -45,7 +45,7 @@ func EncryptedCopyAMICmd() *cobra.Command {
 		`),
 		Example: cmd.Examples(`
 		# Create an encrypted AMI:
-		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2
+		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2, flatcar-stable
 		clusterawsadm ami encrypted-copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
 
 		# owner-id and dry-run flags are optional. region can be set via flag or env

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -49,7 +49,7 @@ func ListAMICmd() *cobra.Command {
 		`),
 		Example: cmd.Examples(`
 		# List AMIs from the default AWS account where AMIs are stored.
-		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2
+		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2, flatcar-stable
 		clusterawsadm ami list --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
 		# To list all supported AMIs in all supported Kubernetes versions, regions, and linux distributions:
 		clusterawsadm ami list

--- a/docs/book/src/topics/images/built-amis.md
+++ b/docs/book/src/topics/images/built-amis.md
@@ -11,6 +11,7 @@ See [clusterawsadm ami list](../clusterawsadm/clusterawsadm_ami_list.md) for det
 - Amazon Linux 2 (amazon-2)
 - Ubuntu (ubuntu-20.04, ubuntu-18.04)
 - Centos (centos-7)
+- Flatcar (flatcar-stable)
 
 ## Supported AWS Regions
 - ap-northeast-1


### PR DESCRIPTION
**What this PR does / why we need it**:
To automatically list pre-built `flatcar-stable` in the book, added it to supported OS list.

Also, images can be listed with clusterawsadm.
`clusterawsadm ami list --kubernetes-version=1.23.3 --os=flatcar-stable`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3107

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add flatcar-stable os to supported OS list, will publish reference AMIs with each new K8s release.
```
