### PR TITLE
Validate additionalTags

### DIFF
--- a/api/v1beta1/awscluster_webhook.go
+++ b/api/v1beta1/awscluster_webhook.go
@@ -54,6 +54,7 @@ func (r *AWSCluster) ValidateCreate() error {
 
 	allErrs = append(allErrs, r.Spec.Bastion.Validate()...)
 	allErrs = append(allErrs, r.validateSSHKeyName()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
@@ -152,6 +153,7 @@ func (r *AWSCluster) ValidateUpdate(old runtime.Object) error {
 	}
 
 	allErrs = append(allErrs, r.Spec.Bastion.Validate()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }

--- a/api/v1beta1/awscluster_webhook_test.go
+++ b/api/v1beta1/awscluster_webhook_test.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,6 +84,20 @@ func TestAWSCluster_ValidateCreate(t *testing.T) {
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{Scheme: &unsupportedIncorrectScheme},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid tags are rejected",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					AdditionalTags: Tags{
+						"key-1":                    "value-1",
+						"":                         "value-2",
+						strings.Repeat("CAPI", 33): "value-3",
+						"key-4":                    strings.Repeat("CAPI", 65),
+					},
 				},
 			},
 			wantErr: true,
@@ -326,6 +341,28 @@ func TestAWSCluster_ValidateUpdate(t *testing.T) {
 				Spec: AWSClusterSpec{
 					NetworkSpec: NetworkSpec{
 						VPC: VPCSpec{ID: "a-new-vpc"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid keys are not accepted during update",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					AdditionalTags: Tags{
+						"key-1": "value-1",
+						"key-2": "value-2",
+					},
+				},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					AdditionalTags: Tags{
+						"key-1":                    "value-1",
+						"":                         "value-2",
+						strings.Repeat("CAPI", 33): "value-3",
+						"key-4":                    strings.Repeat("CAPI", 65),
 					},
 				},
 			},

--- a/api/v1beta1/awsmachine_webhook.go
+++ b/api/v1beta1/awsmachine_webhook.go
@@ -54,6 +54,7 @@ func (r *AWSMachine) ValidateCreate() error {
 	allErrs = append(allErrs, r.validateNonRootVolumes()...)
 	allErrs = append(allErrs, r.validateSSHKeyName()...)
 	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
@@ -76,6 +77,7 @@ func (r *AWSMachine) ValidateUpdate(old runtime.Object) error {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, r.validateCloudInitSecret()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	newAWSMachineSpec := newAWSMachine["spec"].(map[string]interface{})
 	oldAWSMachineSpec := oldAWSMachine["spec"].(map[string]interface{})

--- a/api/v1beta1/awsmachine_webhook_test.go
+++ b/api/v1beta1/awsmachine_webhook_test.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -200,6 +201,19 @@ func TestAWSMachine_Create(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "valid additional tags are accepted",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					AdditionalTags: Tags{
+						"key-1": "value-1",
+						"key-2": "value-2",
+					},
+					InstanceType: "test",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "empty instance type not allowed",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
@@ -213,6 +227,21 @@ func TestAWSMachine_Create(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "t",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid tags return error",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					AdditionalTags: Tags{
+						"key-1":                    "value-1",
+						"":                         "value-2",
+						strings.Repeat("CAPI", 33): "value-3",
+						"key-4":                    strings.Repeat("CAPI", 65),
+					},
+					InstanceType: "test",
 				},
 			},
 			wantErr: true,
@@ -294,6 +323,33 @@ func TestAWSMachine_Update(t *testing.T) {
 							ID: pointer.StringPtr("ID"),
 						},
 					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "change in tags adding invalid ones",
+			oldMachine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					ProviderID: nil,
+					AdditionalTags: Tags{
+						"key-1": "value-1",
+					},
+					AdditionalSecurityGroups: nil,
+					InstanceType:             "test",
+				},
+			},
+			newMachine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					ProviderID: nil,
+					AdditionalTags: Tags{
+						"key-1":                    "value-1",
+						"":                         "value-2",
+						strings.Repeat("CAPI", 33): "value-3",
+						"key-4":                    strings.Repeat("CAPI", 65),
+					},
+					AdditionalSecurityGroups: nil,
+					InstanceType:             "test",
 				},
 			},
 			wantErr: true,

--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -70,6 +71,32 @@ func (t Tags) Merge(other Tags) {
 	for k, v := range other {
 		t[k] = v
 	}
+}
+
+// Validate checks if tags are valid for the AWS API. Keys must have at
+// least 1 character and max 128. Values must be max 256 characters long.
+func (t Tags) Validate() []*field.Error {
+	var errs field.ErrorList
+
+	for k, v := range t {
+		if len(k) < 1 {
+			errs = append(errs,
+				field.Invalid(field.NewPath("spec", "additionalTags"), k, "key cannot be empty"),
+			)
+		}
+		if len(k) > 128 {
+			errs = append(errs,
+				field.Invalid(field.NewPath("spec", "additionalTags"), k, "key cannot be longer than 128 characters"),
+			)
+		}
+		if len(v) > 256 {
+			errs = append(errs,
+				field.Invalid(field.NewPath("spec", "additionalTags"), v, "value cannot be longer than 256 characters"),
+			)
+		}
+	}
+
+	return errs
 }
 
 // ResourceLifecycle configures the lifecycle of a resource.

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
@@ -94,6 +94,7 @@ func (r *AWSManagedControlPlane) ValidateCreate() error {
 	allErrs = append(allErrs, r.validateSecondaryCIDR()...)
 	allErrs = append(allErrs, r.validateEKSAddons()...)
 	allErrs = append(allErrs, r.validateDisableVPCCNI()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	if len(allErrs) == 0 {
 		return nil
@@ -125,6 +126,7 @@ func (r *AWSManagedControlPlane) ValidateUpdate(old runtime.Object) error {
 	allErrs = append(allErrs, r.validateSecondaryCIDR()...)
 	allErrs = append(allErrs, r.validateEKSAddons()...)
 	allErrs = append(allErrs, r.validateDisableVPCCNI()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	if r.Spec.Region != oldAWSManagedControlplane.Spec.Region {
 		allErrs = append(allErrs,

--- a/exp/api/v1beta1/awsfargateprofile_webhook.go
+++ b/exp/api/v1beta1/awsfargateprofile_webhook.go
@@ -108,7 +108,8 @@ func (r *AWSFargateProfile) ValidateUpdate(oldObj runtime.Object) error {
 		}
 	}
 
-	// ignore checking additionalTags since they are mutable
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
+	// remove additionalTags from equal check since they are mutable
 	old.Spec.AdditionalTags = nil
 	r.Spec.AdditionalTags = nil
 
@@ -132,7 +133,18 @@ func (r *AWSFargateProfile) ValidateUpdate(oldObj runtime.Object) error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSFargateProfile) ValidateCreate() error {
-	return nil
+	var allErrs field.ErrorList
+
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		r.GroupVersionKind().GroupKind(),
+		r.Name,
+		allErrs,
+	)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/exp/api/v1beta1/awsmachinepool_webhook.go
+++ b/exp/api/v1beta1/awsmachinepool_webhook.go
@@ -89,6 +89,7 @@ func (r *AWSMachinePool) ValidateCreate() error {
 
 	allErrs = append(allErrs, r.validateDefaultCoolDown()...)
 	allErrs = append(allErrs, r.validateRootVolume()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	if len(allErrs) == 0 {
 		return nil
@@ -106,6 +107,7 @@ func (r *AWSMachinePool) ValidateUpdate(old runtime.Object) error {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, r.validateDefaultCoolDown()...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	if len(allErrs) == 0 {
 		return nil

--- a/exp/api/v1beta1/awsmanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/awsmanagedmachinepool_webhook.go
@@ -110,6 +110,8 @@ func (r *AWSManagedMachinePool) ValidateCreate() error {
 		allErrs = append(allErrs, errs...)
 	}
 
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
+
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -133,6 +135,7 @@ func (r *AWSManagedMachinePool) ValidateUpdate(old runtime.Object) error {
 
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, r.validateImmutable(oldPool)...)
+	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	if errs := r.validateScaling(); errs != nil || len(errs) == 0 {
 		allErrs = append(allErrs, errs...)


### PR DESCRIPTION
**What type of PR is this?**


/kind bug

**What this PR does / why we need it**:

As described in https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3102, tags keys currently can be empty or do not
respect other AWS rules for tagging, resulting in errors during
resources provisioning.

This commit adds validation to the tags in the webhook, for all the
resource where `additionalTags` is present, during creation and update.

Validation is done in the webhook instead of OpenAPI schema due to
limitations in the current `additionalTags` field type, as better
described in #3102.

**Which issue(s) this PR fixes**:
Part of #3102

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
additionalTags are now validated to comply with AWS API requirements
```