### PR TITLE
Add e2e test for provisioning a cluster with a specific AMI

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -224,6 +224,7 @@ providers:
           - sourcePath: "./infrastructure-aws/generated/cluster-template.yaml"
           - sourcePath: "./infrastructure-aws/generated/cluster-template-gpu.yaml"
           - sourcePath: "./infrastructure-aws/generated/cluster-template-upgrades.yaml"
+          - sourcePath: "./infrastructure-aws/generated/cluster-template-custom-ami.yaml"
           - sourcePath: "./infrastructure-aws/kustomize_sources/topology/clusterclass-quick-start.yaml"
           - sourcePath: "./shared/v1beta1_provider/metadata.yaml"
         replacements:

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/custom-ami/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/custom-ami/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../default
+patchesStrategicMerge:
+  - patches/awsmachinetemplate.yaml

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/custom-ami/patches/awsmachinetemplate.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/custom-ami/patches/awsmachinetemplate.yaml
@@ -1,0 +1,19 @@
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      ami:
+        id: "${IMAGE_ID}"
+---
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      ami:
+        id: "${IMAGE_ID}"

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -56,6 +56,7 @@ const (
 	KCPScaleInFlavor             = "kcp-scale-in"
 	StorageClassOutTreeZoneLabel = "topology.ebs.csi.aws.com/zone"
 	GPUFlavor                    = "gpu"
+	CustomAMI                    = "custom-ami"
 	InstanceVcpu                 = "AWS_MACHINE_TYPE_VCPU_USAGE"
 )
 

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -528,4 +528,36 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 			Expect(len(controlPlaneMachines)).To(Equal(1))
 		})
 	})
+
+	ginkgo.Describe("Create a cluster using a custom AMI", func() {
+		ginkgo.It("should provision a machine using a custom AMI", func() {
+			specName := "functional-test-custom-ami"
+			requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3}
+			requiredResources.WriteRequestedResources(e2eCtx, specName)
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			defer shared.ReleaseResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))
+			namespace := shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+			defer shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+			ginkgo.By("Creating a cluster")
+			clusterName := fmt.Sprintf("cluster-%s", util.RandomString(6))
+			configCluster := defaultConfigCluster(clusterName, namespace.Name)
+			configCluster.WorkerMachineCount = pointer.Int64Ptr(1)
+			configCluster.Flavor = shared.CustomAMI
+			_, md, _ := createCluster(ctx, configCluster, result)
+
+			workerMachines := framework.GetMachinesByMachineDeployments(ctx, framework.GetMachinesByMachineDeploymentsInput{
+				Lister:            e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+				ClusterName:       clusterName,
+				Namespace:         namespace.Name,
+				MachineDeployment: *md[0],
+			})
+			controlPlaneMachines := framework.GetControlPlaneMachinesByCluster(ctx, framework.GetControlPlaneMachinesByClusterInput{
+				Lister:      e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+				ClusterName: clusterName,
+				Namespace:   namespace.Name,
+			})
+			Expect(len(workerMachines)).To(Equal(1))
+			Expect(len(controlPlaneMachines)).To(Equal(1))
+		})
+	})
 })


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Adds an E2E test to create a cluster with the AMI ID set in AWSMachineTemplate. This validates the provisioning machines with a custom AMI use case.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3183 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Adds an E2E test to validate clusters can be provisioned with custom AMIs specified.
```
