### PR TITLE
Remove unused capd helper functions

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -25,12 +25,3 @@ cd_root_path() {
     cd "$(get_root_path)" || exit
 }
 
-# get_capd_root_path returns the root path of CAPD source tree
-get_capd_root_path() {
-    echo "$(get_root_path)"/test/infrastructure/docker
-}
-
-# cd_capd_root_path cds to the root path of the CAPD source tree
-cd_capd_root_path() {
-    cd "$(get_capd_root_path)" || exit
-}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Recently merged https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3178 brought capd helper functions from CAPI that are not needed in CAPA. Cleaning up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
