### PR TITLE
[WIP] Adding a grep-able logger interface

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -38,6 +38,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/feature"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
@@ -46,13 +53,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/instancestate"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/network"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/securitygroup"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/logger"
 	infrautilconditions "sigs.k8s.io/cluster-api-provider-aws/util/conditions"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/annotations"
-	"sigs.k8s.io/cluster-api/util/conditions"
-	"sigs.k8s.io/cluster-api/util/patch"
-	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 var (
@@ -80,7 +82,7 @@ type AWSClusterReconciler struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclustercontrolleridentities,verbs=get;list;watch;create;
 
 func (r *AWSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	log := ctrl.LoggerFrom(ctx)
+	log := logger.LoggerFrom(ctx)
 
 	// Fetch the AWSCluster instance
 	awsCluster := &infrav1.AWSCluster{}
@@ -130,7 +132,7 @@ func (r *AWSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Create the scope.
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		Client:         r.Client,
-		Logger:         &log,
+		Logger:         log,
 		Cluster:        cluster,
 		AWSCluster:     awsCluster,
 		ControllerName: "awscluster",

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -49,6 +49,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/secretsmanager"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ssm"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/userdata"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/logger"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -119,7 +121,7 @@ func (r *AWSMachineReconciler) getSecretService(machineScope *scope.MachineScope
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
 func (r *AWSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	log := ctrl.LoggerFrom(ctx)
+	log := logger.FromContext(ctx)
 
 	// Fetch the AWSMachine instance.
 	awsMachine := &infrav1.AWSMachine{}
@@ -157,7 +159,7 @@ func (r *AWSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	log = log.WithValues("cluster", cluster.Name)
 
-	infraCluster, err := r.getInfraCluster(ctx, log, cluster, awsMachine)
+	infraCluster, err := r.getInfraCluster(ctx, *log, cluster, awsMachine)
 	if err != nil {
 		return ctrl.Result{}, errors.New("error getting infra provider cluster or control plane object")
 	}
@@ -804,7 +806,7 @@ func (r *AWSMachineReconciler) requestsForCluster(log logr.Logger, namespace, na
 	return result
 }
 
-func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log logr.Logger, cluster *clusterv1.Cluster, awsMachine *infrav1.AWSMachine) (scope.EC2Scope, error) {
+func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log logger.Logger, cluster *clusterv1.Cluster, awsMachine *infrav1.AWSMachine) (scope.EC2Scope, error) {
 	var clusterScope *scope.ClusterScope
 	var managedControlPlaneScope *scope.ManagedControlPlaneScope
 	var err error

--- a/pkg/cloud/identity/identity.go
+++ b/pkg/cloud/identity/identity.go
@@ -27,10 +27,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/logger"
 )
 
 // AWSPrincipalTypeProvider defines the interface for AWS Principal Type Provider.
@@ -79,13 +79,13 @@ func GetAssumeRoleCredentials(roleIdentityProvider *AWSRolePrincipalTypeProvider
 }
 
 // NewAWSRolePrincipalTypeProvider will create a new AWSRolePrincipalTypeProvider from an AWSClusterRoleIdentity.
-func NewAWSRolePrincipalTypeProvider(identity *infrav1.AWSClusterRoleIdentity, sourceProvider *AWSPrincipalTypeProvider, log logr.Logger) *AWSRolePrincipalTypeProvider {
+func NewAWSRolePrincipalTypeProvider(identity *infrav1.AWSClusterRoleIdentity, sourceProvider *AWSPrincipalTypeProvider, log logger.Logger) *AWSRolePrincipalTypeProvider {
 	return &AWSRolePrincipalTypeProvider{
 		credentials:    nil,
 		stsClient:      nil,
 		Principal:      identity,
 		sourceProvider: sourceProvider,
-		log:            log.WithName("AWSRolePrincipalTypeProvider"),
+		log:            *log.WithName("AWSRolePrincipalTypeProvider"),
 	}
 }
 
@@ -130,7 +130,7 @@ type AWSRolePrincipalTypeProvider struct {
 	Principal      *infrav1.AWSClusterRoleIdentity
 	credentials    *credentials.Credentials
 	sourceProvider *AWSPrincipalTypeProvider
-	log            logr.Logger
+	log            logger.Logger
 	stsClient      stsiface.STSAPI
 }
 

--- a/pkg/cloud/interfaces.go
+++ b/pkg/cloud/interfaces.go
@@ -18,11 +18,12 @@ package cloud
 
 import (
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/logger"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
@@ -69,22 +70,52 @@ type Logger interface {
 	// triggered this log line, if present.
 	Error(err error, msg string, keysAndValues ...interface{})
 
-	// V returns a Logger value for a specific verbosity level, relative to
-	// this Logger.  In other words, V values are additive.  V higher verbosity
-	// level means a log message is less important.  It's illegal to pass a log
-	// level less than zero.
-	V(level int) logr.Logger
+	// Warning logs a warning, with the given message and key/value pairs as context.
+	//
+	// The msg argument should be used to add some constant description to
+	// the log line. The key/value pairs can then be used to add additional
+	// variable information.  The key/value pairs should alternate string
+	// keys and arbitrary values.
+	Warning(msg string, keysAndValues ...interface{})
+
+	// Fatal logs a fatal, unrecoverable error, with the given message and key/value
+	// pairs as context.
+	//
+	// The msg argument should be used to add some constant description to
+	// the log line.The key/value pairs can then be used to add additional
+	// variable information. The key/value pairs should alternate string
+	// keys and arbitrary values.
+	Fatal(msg string, keysAndValues ...interface{})
+
+	// Debug logs a debug message. Additional fields should be provided to
+	// give more context on the debug information. Should only be used for
+	// non-user facing information.
+	//
+	// The msg argument should be used to add some constant description to
+	// the log line.The key/value pairs can then be used to add additional
+	// variable information. The key/value pairs should alternate string
+	// keys and arbitrary values.
+	Debug(msg string, keysAndValues ...interface{})
+
+	// Trace logs an error, with the given message and key/value pairs as context.
+	// Trace should be a non-user facing error log which contains the full trace of
+	// the error including causing function, line number, etc.
+	//
+	// The msg field should be used to add context to any underlying error,
+	// while the `err` field should be used to attach the actual error that
+	// triggered this log line, if present.
+	Trace(err error, msg string, keysAndValues ...interface{})
 
 	// WithValues adds some key-value pairs of context to a logger.
 	// See Info for documentation on how key/value pairs work.
-	WithValues(keysAndValues ...interface{}) logr.Logger
+	WithValues(keysAndValues ...interface{}) *logger.Logger
 
 	// WithName adds a new element to the logger's name.
 	// Successive calls with WithName continue to append
 	// suffixes to the logger's name.  It's strongly recommended
 	// that name segments contain only letters, digits, and hyphens
 	// (see the package documentation for more information).
-	WithName(name string) logr.Logger
+	WithName(name string) *logger.Logger
 }
 
 // ClusterScoper is the interface for a cluster scope.

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +28,8 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/logger"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -37,7 +38,7 @@ import (
 // ClusterScopeParams defines the input parameters used to create a new Scope.
 type ClusterScopeParams struct {
 	Client         client.Client
-	Logger         *logr.Logger
+	Logger         *logger.Logger
 	Cluster        *clusterv1.Cluster
 	AWSCluster     *infrav1.AWSCluster
 	ControllerName string
@@ -57,7 +58,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 
 	if params.Logger == nil {
 		log := klogr.New()
-		params.Logger = &log
+		params.Logger = logger.NewWithLogger(log)
 	}
 
 	clusterScope := &ClusterScope{
@@ -87,7 +88,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 
 // ClusterScope defines the basic context for an actuator to operate upon.
 type ClusterScope struct {
-	logr.Logger
+	logger.Logger
 	client      client.Client
 	patchHelper *patch.Helper
 

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -23,7 +23,6 @@ import (
 
 	amazoncni "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +34,8 @@ import (
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/logger"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -53,7 +54,7 @@ func init() {
 // ManagedControlPlaneScopeParams defines the input parameters used to create a new Scope.
 type ManagedControlPlaneScopeParams struct {
 	Client         client.Client
-	Logger         *logr.Logger
+	Logger         *logger.Logger
 	Cluster        *clusterv1.Cluster
 	ControlPlane   *ekscontrolplanev1.AWSManagedControlPlane
 	ControllerName string
@@ -75,11 +76,11 @@ func NewManagedControlPlaneScope(params ManagedControlPlaneScopeParams) (*Manage
 	}
 	if params.Logger == nil {
 		log := klogr.New()
-		params.Logger = &log
+		params.Logger = logger.NewWithLogger(log)
 	}
 
 	managedScope := &ManagedControlPlaneScope{
-		Logger:               *params.Logger,
+		Logger:               params.Logger,
 		Client:               params.Client,
 		Cluster:              params.Cluster,
 		ControlPlane:         params.ControlPlane,
@@ -109,7 +110,7 @@ func NewManagedControlPlaneScope(params ManagedControlPlaneScopeParams) (*Manage
 
 // ManagedControlPlaneScope defines the basic context for an actuator to operate upon.
 type ManagedControlPlaneScope struct {
-	logr.Logger
+	*logger.Logger
 	Client      client.Client
 	patchHelper *patch.Helper
 

--- a/pkg/cloud/scope/session.go
+++ b/pkg/cloud/scope/session.go
@@ -30,21 +30,22 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/identity"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/throttle"
-	"sigs.k8s.io/cluster-api-provider-aws/util/system"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/identity"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/logger"
+	"sigs.k8s.io/cluster-api-provider-aws/util/system"
 )
 
 const (
@@ -103,9 +104,9 @@ func sessionForRegion(region string, endpoint []ServiceEndpoint) (*session.Sessi
 	return ns, sl, nil
 }
 
-func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.ClusterScoper, region string, endpoint []ServiceEndpoint, logger logr.Logger) (*session.Session, throttle.ServiceLimiters, error) {
+func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.ClusterScoper, region string, endpoint []ServiceEndpoint, logger logger.Logger) (*session.Session, throttle.ServiceLimiters, error) {
 	log := logger.WithName("identity")
-	log.V(4).Info("Creating an AWS Session")
+	log.Info("Creating an AWS Session")
 
 	resolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		for _, s := range endpoint {
@@ -119,7 +120,7 @@ func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.Cl
 		return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
 	}
 
-	providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScoper, log)
+	providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScoper, *log)
 	if err != nil {
 		// could not get providers and retrieve the credentials
 		conditions.MarkFalse(clusterScoper.InfraCluster(), infrav1.PrincipalCredentialRetrievedCondition, infrav1.PrincipalCredentialRetrievalFailedReason, clusterv1.ConditionSeverityError, err.Error())
@@ -250,16 +251,16 @@ func buildProvidersForRef(
 	k8sClient client.Client,
 	clusterScoper cloud.ClusterScoper,
 	ref *infrav1.AWSIdentityReference,
-	log logr.Logger) ([]identity.AWSPrincipalTypeProvider, error) {
+	log logger.Logger) ([]identity.AWSPrincipalTypeProvider, error) {
 	if ref == nil {
-		log.V(4).Info("AWSCluster does not have a IdentityRef specified")
+		log.Warning("AWSCluster does not have a IdentityRef specified")
 		return providers, nil
 	}
 
 	var provider identity.AWSPrincipalTypeProvider
 	identityObjectKey := client.ObjectKey{Name: ref.Name}
-	log = log.WithValues("identityKey", identityObjectKey)
-	log.V(4).Info("Getting identity")
+	log = *log.WithValues("identityKey", identityObjectKey)
+	log.Info("Getting identity")
 
 	switch ref.Kind {
 	case infrav1.ControllerIdentityKind:
@@ -281,7 +282,7 @@ func buildProvidersForRef(
 		if err != nil {
 			return providers, err
 		}
-		log.V(4).Info("Principal retrieved")
+		log.Info("Principal retrieved")
 		canUse, err := isClusterPermittedToUsePrincipal(k8sClient, roleIdentity.Spec.AllowedNamespaces, clusterScoper.Namespace())
 		if err != nil {
 			return providers, err
@@ -402,7 +403,7 @@ func buildAWSClusterControllerIdentity(ctx context.Context, identityObjectKey cl
 	return nil
 }
 
-func getProvidersForCluster(ctx context.Context, k8sClient client.Client, clusterScoper cloud.ClusterScoper, log logr.Logger) ([]identity.AWSPrincipalTypeProvider, error) {
+func getProvidersForCluster(ctx context.Context, k8sClient client.Client, clusterScoper cloud.ClusterScoper, log logger.Logger) ([]identity.AWSPrincipalTypeProvider, error) {
 	providers := make([]identity.AWSPrincipalTypeProvider, 0)
 	providers, err := buildProvidersForRef(ctx, providers, k8sClient, clusterScoper, clusterScoper.IdentityRef(), log)
 	if err != nil {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,104 @@
+package logger
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// INFO human-readable log level.
+	INFO = "INFO"
+	// WARNING human-readable log level.
+	WARNING = "WARNING"
+	// ERROR human-readable log level.
+	ERROR = "ERROR"
+	// FATAL human-readable log level.
+	FATAL = "FATAL"
+	// DEBUG human-readable log level.
+	DEBUG = "DEBUG"
+	// TRACE human-readable log level.
+	TRACE = "TRACE"
+
+	// LogLevelInfo for V(k) based numbering.
+	LogLevelInfo = iota
+	// LogLevelWarning for V(k) based numbering.
+	LogLevelWarning
+	// LogLevelError for V(k) based numbering.
+	LogLevelError
+	// LogLevelFatal for V(k) based numbering.
+	LogLevelFatal
+	// LogLevelDebug for V(k) based numbering.
+	LogLevelDebug
+	// LogLevelTrace for V(k) based numbering.
+	LogLevelTrace
+)
+
+type Logger struct {
+	logger logr.Logger
+}
+
+func (l *Logger) Enabled() bool {
+	return l.logger.Enabled()
+}
+
+func (l *Logger) Info(msg string, keysAndValues ...interface{}) {
+	l.logger = l.logger.V(LogLevelInfo)
+	l.logger.WithValues("level", INFO).Info(msg, keysAndValues...)
+}
+
+func (l *Logger) Warning(msg string, keysAndValues ...interface{}) {
+	l.logger = l.logger.V(LogLevelWarning)
+	l.logger.WithValues("level", WARNING).Info(msg, keysAndValues...)
+}
+
+func (l *Logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.logger = l.logger.V(LogLevelError)
+	l.logger.WithValues("level", ERROR).Error(err, msg, keysAndValues...)
+}
+
+func (l *Logger) Fatal(msg string, keysAndValues ...interface{}) {
+	l.logger = l.logger.V(LogLevelFatal)
+	l.logger.WithValues("level", FATAL).Info(msg, keysAndValues...)
+}
+
+func (l *Logger) Debug(msg string, keysAndValues ...interface{}) {
+	l.logger = l.logger.V(LogLevelDebug)
+	l.logger.WithValues("level", DEBUG).Info(msg, keysAndValues...)
+}
+
+func (l *Logger) Trace(err error, msg string, keysAndValues ...interface{}) {
+	l.logger = l.logger.V(LogLevelTrace)
+	l.logger.WithValues("level", TRACE).Error(err, msg, keysAndValues...)
+}
+
+func (l *Logger) WithValues(keysAndValues ...interface{}) *Logger {
+	l.logger = l.logger.WithValues(keysAndValues...)
+	return l
+}
+
+func (l *Logger) WithName(name string) *Logger {
+	l.logger = l.logger.WithName(name)
+	return l
+}
+
+func (l *Logger) Logger() logr.Logger {
+	return l.logger
+}
+
+// FromContext gets a logr.Logger from context and wraps it into a verbose logger
+// with grep-able log levels displayed as `level=INFO`.
+func FromContext(ctx context.Context) *Logger {
+	log := ctrl.LoggerFrom(ctx)
+	return &Logger{
+		logger: log,
+	}
+}
+
+// NewWithLogger creates a new logger using a passed in logr.Logger.
+func NewWithLogger(log logr.Logger) *Logger {
+	return &Logger{
+		logger: log,
+	}
+}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3101

This is a WIP PR which suggests a clean Logging interface. Right now, it's using klog in the background but a discussion in https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3152 and https://github.com/kubernetes-sigs/cluster-api/issues/5571#issuecomment-1034000389 suggests the usage of a JSON logger such as zap or zerolog or something else.

The API is pretty simple. Provides a couple of functions such as Info, Warning, Debug, Trace, Fatal, etc. It basically works right now by adding "level=INFO" as a Key, value pair to the log output.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add grep-able log message to the controllers
```
