### PR TITLE
Group Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,83 +163,20 @@ ifeq ($(E2E_SKIP_EKS_UPGRADE),"true")
 	override EKS_E2E_ARGS += --skip-eks-upgrade-tests
 endif
 
-## --------------------------------------
-## Testing
-## --------------------------------------
+##@ generate:
 
-$(ARTIFACTS):
-	mkdir -p $@
-
-.PHONY: test
-test: ## Run tests
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./...
-
-.PHONY: generate-test-flavors
-generate-test-flavors: $(KUSTOMIZE)  ## Generate test template flavors
-	./hack/gen-test-flavors.sh
-
-.PHONY: test-e2e ## Run e2e tests using clusterctl
-test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) generate-test-flavors e2e-image ## Run e2e tests
-	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) -p ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" $(E2E_ARGS)
-
-.PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
-test-e2e-eks: generate-test-flavors  $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests
-	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" --source-template="$(EKS_SOURCE_TEMPLATE)" $(E2E_ARGS) $(EKS_E2E_ARGS)
-
-.PHONY: e2e-image
-e2e-image: docker-pull-prerequisites $(TOOLS_BIN_DIR)/start.sh $(TOOLS_BIN_DIR)/restart.sh
-	docker build -f Dockerfile --tag="gcr.io/k8s-staging-cluster-api/capa-manager:e2e" .
-
-CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)
-CONFORMANCE_E2E_ARGS += $(E2E_ARGS)
-CONFORMANCE_GINKGO_ARGS += $(GINKGO_ARGS)
-.PHONY: test-conformance
-test-conformance: generate-test-flavors $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run clusterctl based conformance test on workload cluster (requires Docker).
-	time $(GINKGO) -tags=e2e -focus="conformance" $(CONFORMANCE_GINKGO_ARGS) ./test/e2e/suites/conformance/... -- -config-path="$(E2E_CONF_PATH)" $(CONFORMANCE_E2E_ARGS)
-
-.PHONY: test-cover
-test-cover: ## Run tests with code coverage and code generate  reports
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -coverprofile=coverage.out ./... $(TEST_ARGS)
-	go tool cover -func=coverage.out -o coverage.txt
-	go tool cover -html=coverage.out -o coverage.html
-## --------------------------------------
-## Binaries
-## --------------------------------------
-.PHONY: binaries
-binaries: managers clusterawsadm ## Builds and installs all binaries
-
-.PHONY: managers
-managers:
-	$(MAKE) manager-aws-infrastructure
-
-.PHONY: manager-aws-infrastructure
-manager-aws-infrastructure: ## Build manager binary.
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS} -extldflags '-static'" -o $(BIN_DIR)/manager .
-
-.PHONY: clusterawsadm
-clusterawsadm: ## Build clusterawsadm binary.
-	go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/clusterawsadm ./cmd/clusterawsadm
-
-## --------------------------------------
-## Linting
-## --------------------------------------
-
-.PHONY: lint
-lint: $(GOLANGCI_LINT) ## Lint codebase
-	$(GOLANGCI_LINT) run -v --fast=false $(GOLANGCI_LINT_EXTRA_ARGS)
-
-.PHONY: lint-fix
-lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
-	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
-
-## --------------------------------------
-## Generate
-## --------------------------------------
-
-.PHONY: modules
-modules: ## Runs go mod to ensure proper vendoring.
-	go mod tidy
-	cd $(TOOLS_DIR); go mod tidy
+.PHONY: defaulters
+defaulters: $(DEFAULTER_GEN) ## Generate all Go types
+	$(DEFAULTER_GEN) \
+		--input-dirs=./api/v1alpha3 \
+		--input-dirs=./api/v1alpha4 \
+		--input-dirs=./api/v1beta1 \
+		--input-dirs=./$(EXP_DIR)/api/v1beta1 \
+		--input-dirs=./cmd/clusterawsadm/api/bootstrap/v1beta1 \
+		--input-dirs=./cmd/clusterawsadm/api/bootstrap/v1alpha1 \
+		--extra-peer-dirs=sigs.k8s.io/cluster-api/api/v1beta1 \
+		--v=0 $(GEN_OUTPUT_BASE) \
+		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
 
 .PHONY: generate
 generate: ## Generate code
@@ -249,19 +186,19 @@ generate: ## Generate code
 $(CRD_DOCS_DIR)/%: $(API_SRCS)
 	$(MAKE) -C docs/book src/crd/$*
 
-.PHONY: generate-go
+.PHONY: generate-go ## Generate all Go api files
 generate-go: $(MOCKGEN)
 	$(MAKE) generate-go-apis
 	go generate ./...
 
 .PHONY: generate-go-apis
-generate-go-apis: ## Runs Go related generate targets
+generate-go-apis: ## Alias for .build/generate-go-apis
 	$(MAKE) .build/generate-go-apis
 
-.build:
+.build: ## Create the .build folder
 	mkdir -p .build
 
-.build/generate-go-apis: .build $(API_SRCS) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN)
+.build/generate-go-apis: .build $(API_SRCS) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN) ## Generate all Go api files
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		paths=./$(EXP_DIR)/api/... \
@@ -325,51 +262,187 @@ generate-go-apis: ## Runs Go related generate targets
 
 		touch $@
 
-.PHONY: defaulters
-defaulters: $(DEFAULTER_GEN)
-	$(DEFAULTER_GEN) \
-		--input-dirs=./api/v1alpha3 \
-		--input-dirs=./api/v1alpha4 \
-		--input-dirs=./api/v1beta1 \
-		--input-dirs=./$(EXP_DIR)/api/v1beta1 \
-		--input-dirs=./cmd/clusterawsadm/api/bootstrap/v1beta1 \
-		--input-dirs=./cmd/clusterawsadm/api/bootstrap/v1alpha1 \
-		--extra-peer-dirs=sigs.k8s.io/cluster-api/api/v1beta1 \
-		--v=0 $(GEN_OUTPUT_BASE) \
-		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
+##@ lint and verify:
 
-## --------------------------------------
-## Docker
-## --------------------------------------
+.PHONY: modules
+
+.PHONY: lint
+lint: $(GOLANGCI_LINT) ## Lint codebase
+	$(GOLANGCI_LINT) run -v --fast=false $(GOLANGCI_LINT_EXTRA_ARGS)
+
+.PHONY: lint-fix
+lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
+	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
+
+modules: ## Runs go mod to ensure proper vendoring.
+	go mod tidy
+	cd $(TOOLS_DIR); go mod tidy
+
+.PHONY: verify ## Verify ties together the rest of the verification targets into one target
+verify: verify-boilerplate verify-modules verify-gen verify-conversions verify-shellcheck release-manifests
+
+.PHONY: verify-boilerplate
+verify-boilerplate: ## Verify boilerplate
+	-rm ./hack/tools/bin/*.sh
+	./hack/verify-boilerplate.sh
+
+.PHONY: verify-modules
+verify-modules: modules ## Verify go modules integrity
+	@if !(git diff --quiet HEAD -- go.sum go.mod hack/tools/go.mod hack/tools/go.sum); then \
+		git diff; \
+		echo "go module files are out of date"; exit 1; \
+	fi
+
+.PHONY: verify-conversions
+verify-conversions: $(CONVERSION_VERIFIER)  ## Verifies expected API conversion are in place
+	echo verification of api conversions initiated
+	$(CONVERSION_VERIFIER)
+
+.PHONY: verify-shellcheck
+verify-shellcheck: ## Verify shell files
+	./hack/verify-shellcheck.sh
+
+.PHONY: verify-gen
+verify-gen: generate ## Verify generated files
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated files are out of date, run make generate"; exit 1; \
+	fi
+
+##@ build:
+
+.PHONY: binaries
+binaries: managers clusterawsadm ## Builds and installs all binaries
+
+.PHONY: clusterawsadm
+clusterawsadm: ## Build clusterawsadm binary
+	go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/clusterawsadm ./cmd/clusterawsadm
+
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
 	docker build --build-arg ARCH=$(ARCH) --build-arg LDFLAGS="$(LDFLAGS)" . -t $(CORE_CONTROLLER_IMG)-$(ARCH):$(TAG)
 
-.PHONY: docker-push
-docker-push: ## Push the docker image
-	docker push $(CORE_CONTROLLER_IMG)-$(ARCH):$(TAG)
-
-.PHONY: docker-pull-prerequisites
-docker-pull-prerequisites:
-	docker pull docker.io/docker/dockerfile:1.1-experimental
-	docker pull gcr.io/distroless/static:latest
-
-## --------------------------------------
-## Docker — All ARCH
-## --------------------------------------
-
 .PHONY: docker-build-all ## Build all the architecture docker images
 docker-build-all: $(addprefix docker-build-,$(ALL_ARCH))
 
-docker-build-%:
+docker-build-%: ## Build docker images for a given ARCH
 	$(MAKE) ARCH=$* docker-build
+
+.PHONY: docker-pull-prerequisites
+docker-pull-prerequisites: ## Build prerequisites using docker
+	docker pull docker.io/docker/dockerfile:1.1-experimental
+	docker pull gcr.io/distroless/static:latest
+
+.PHONY: managers
+managers: ## Alias for manager-aws-infrastructure
+	$(MAKE) manager-aws-infrastructure
+
+.PHONY: manager-aws-infrastructure
+manager-aws-infrastructure: ## Build manager binary
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS} -extldflags '-static'" -o $(BIN_DIR)/manager .
+
+##@ test:
+
+$(ARTIFACTS):
+	mkdir -p $@
+
+.PHONY: generate-test-flavors
+generate-test-flavors: $(KUSTOMIZE)  ## Generate test template flavors
+	./hack/gen-test-flavors.sh
+
+.PHONY: e2e-image
+e2e-image: docker-pull-prerequisites $(TOOLS_BIN_DIR)/start.sh $(TOOLS_BIN_DIR)/restart.sh ## Build an e2e test image
+	docker build -f Dockerfile --tag="gcr.io/k8s-staging-cluster-api/capa-manager:e2e" .
+
+.PHONY: test
+test: ## Run tests
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./...
+
+.PHONY: test-e2e ## Run e2e tests using clusterctl
+test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) generate-test-flavors e2e-image ## Run e2e tests
+	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) -p ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" $(E2E_ARGS)
+
+.PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
+test-e2e-eks: generate-test-flavors  $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests
+	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" --source-template="$(EKS_SOURCE_TEMPLATE)" $(E2E_ARGS) $(EKS_E2E_ARGS)
+
+
+CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)
+CONFORMANCE_E2E_ARGS += $(E2E_ARGS)
+CONFORMANCE_GINKGO_ARGS += $(GINKGO_ARGS)
+.PHONY: test-conformance
+test-conformance: generate-test-flavors $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run clusterctl based conformance test on workload cluster (requires Docker).
+	time $(GINKGO) -tags=e2e -focus="conformance" $(CONFORMANCE_GINKGO_ARGS) ./test/e2e/suites/conformance/... -- -config-path="$(E2E_CONF_PATH)" $(CONFORMANCE_E2E_ARGS)
+
+.PHONY: test-cover
+test-cover: ## Run tests with code coverage and code generate  reports
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -coverprofile=coverage.out ./... $(TEST_ARGS)
+	go tool cover -func=coverage.out -o coverage.txt
+	go tool cover -html=coverage.out -o coverage.html
+
+.PHONY: serve-book
+serve-book: ## Run a server with the documentation book
+	$(MAKE) -C docs/book serve
+
+.PHONY: compile-e2e
+compile-e2e: ## Test e2e compilation
+	go test -c -o /dev/null -tags=e2e ./test/e2e/suites/unmanaged
+	go test -c -o /dev/null -tags=e2e ./test/e2e/suites/conformance
+	go test -c -o /dev/null -tags=e2e ./test/e2e/suites/managed
+
+
+.PHONY: docker-pull-e2e-preloads
+docker-pull-e2e-preloads: ## Preloads the docker images used for e2e testing and can speed it up
+	-docker pull k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:$(CAPI_VERSION)
+	-docker pull k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:$(CAPI_VERSION)
+	-docker pull k8s.gcr.io/cluster-api/cluster-api-controller:$(CAPI_VERSION)
+	-docker pull quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
+	-docker pull quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
+	-docker pull quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)
+
+##@ release:
+
+$(RELEASE_DIR):
+	mkdir -p $@
+
+.PHONY: build-toolchain
+build-toolchain: ## Build the toolchain
+	docker build --target toolchain -t $(TOOLCHAIN_IMAGE) .
+
+.PHONY: check-github-token
+check-github-token: ## Check if the github token is set
+	@if [ -z "${GITHUB_TOKEN}" ]; then echo "GITHUB_TOKEN is not set"; exit 1; fi
+
+.PHONY: check-previous-release-tag
+check-previous-release-tag: ## Check if the previous release tag is set
+	@if [ -z "${PREVIOUS_VERSION}" ]; then echo "PREVIOUS_VERSION is not set"; exit 1; fi
+
+.PHONY: check-release-tag
+check-release-tag: ## Check if the release tag is set
+	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
+	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
+
+.PHONY: create-gh-release
+create-gh-release:$(GH) ## Create release on Github
+	$(GH) release create $(VERSION) -d -F $(RELEASE_DIR)/CHANGELOG.md -t $(VERSION) -R $(GH_REPO)
+
+.PHONY: compiled-manifest
+compiled-manifest: $(RELEASE_DIR) $(KUSTOMIZE) ## Compile the manifest files
+	$(MAKE) image-patch-source-manifest
+	$(MAKE) image-patch-pull-policy
+	$(MAKE) image-patch-kustomization
+	$(KUSTOMIZE) build $(IMAGE_PATCH_DIR)/$(PROVIDER) > $(RELEASE_DIR)/$(PROVIDER).yaml
+
+.PHONY: docker-push
+docker-push: ## Push the docker image
+	docker push $(CORE_CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push-all ## Push all the architecture docker images
 docker-push-all: $(addprefix docker-push-,$(ALL_ARCH))
 	$(MAKE) docker-push-core-manifest
 
-docker-push-%:
+docker-push-%: ## Docker push
 	$(MAKE) ARCH=$* docker-push
 
 .PHONY: docker-push-core-manifest
@@ -378,42 +451,40 @@ docker-push-core-manifest: ## Push the fat manifest docker image.
 	$(MAKE) docker-push-manifest CONTROLLER_IMG=$(CORE_CONTROLLER_IMG) MANIFEST_FILE=$(CORE_MANIFEST_FILE)
 
 .PHONY: docker-push-manifest
-docker-push-manifest:
+docker-push-manifest: ## Push the manifest image
 	docker manifest create --amend $(CONTROLLER_IMG):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(CONTROLLER_IMG)\-&:$(TAG)~g")
 	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${CONTROLLER_IMG}:${TAG} ${CONTROLLER_IMG}-$${arch}:${TAG}; done
 	docker manifest push --purge ${CONTROLLER_IMG}:${TAG}
 
-.PHONY: staging-manifests
-staging-manifests:
-	$(MAKE) $(RELEASE_DIR)/$(CORE_MANIFEST_FILE).yaml PULL_POLICY=IfNotPresent TAG=$(RELEASE_ALIAS_TAG)
+.PHONY: image-patch-source-manifest
+image-patch-source-manifest: $(IMAGE_PATCH_DIR) $(KUSTOMIZE) ## Patch the source manifest
+	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
+	$(KUSTOMIZE) build $(PROVIDER_CONFIG_DIR) > $(IMAGE_PATCH_DIR)/$(PROVIDER)/source-manifest.yaml
 
-## --------------------------------------
-## Release
-## --------------------------------------
+.PHONY: image-patch-kustomization
+image-patch-kustomization: $(IMAGE_PATCH_DIR) ## Alias for image-patch-kustomization-without-webhook
+	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
+	$(MAKE) image-patch-kustomization-without-webhook
 
-$(RELEASE_DIR):
-	mkdir -p $@
+.PHONY: image-patch-kustomization-without-webhook
+image-patch-kustomization-without-webhook: $(IMAGE_PATCH_DIR) $(GOJQ) ## Patch the image in the kustomization file
+	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
+	$(GOJQ) --yaml-input --yaml-output '.images[0]={"name":"$(OLD_IMG)","newName":"$(MANIFEST_IMG)","newTag":"$(TAG)"}|.patchesJson6902[0].target.name="$(CONTROLLER_NAME)"|.patchesJson6902[0].target.namespace="$(NAMESPACE)"' \
+		"hack/image-patch/kustomization.yaml" > $(IMAGE_PATCH_DIR)/$(PROVIDER)/kustomization.yaml
+
+.PHONY: image-patch-pull-policy
+image-patch-pull-policy: $(IMAGE_PATCH_DIR) $(GOJQ) ## Patch the pull policy
+	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
+	echo Setting imagePullPolicy to $(PULL_POLICY)
+	$(GOJQ) --yaml-input --yaml-output '.[0].value="$(PULL_POLICY)"' "hack/image-patch/pull-policy-patch.yaml" > $(IMAGE_PATCH_DIR)/$(PROVIDER)/pull-policy-patch.yaml
 
 .PHONY: list-staging-releases
 list-staging-releases: ## List staging images for image promotion
 	@echo $(CORE_IMAGE_NAME):
 	$(MAKE) list-image RELEASE_TAG=$(RELEASE_TAG) IMAGE=$(CORE_IMAGE_NAME)
 
-list-image:
+list-image: ## List images for RELEASE_TAG
 	gcloud container images list-tags $(STAGING_REGISTRY)/$(IMAGE) --filter="tags=('$(RELEASE_TAG)')" --format=json
-
-.PHONY: check-release-tag
-check-release-tag:
-	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
-	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
-
-.PHONY: check-previous-release-tag
-check-previous-release-tag:
-	@if [ -z "${PREVIOUS_VERSION}" ]; then echo "PREVIOUS_VERSION is not set"; exit 1; fi
-
-.PHONY: check-github-token
-check-github-token:
-	@if [ -z "${GITHUB_TOKEN}" ]; then echo "GITHUB_TOKEN is not set"; exit 1; fi
 
 .PHONY: release
 release: $(RELEASE_NOTES) clean-release check-release-tag $(RELEASE_DIR)  ## Builds and push container images using the latest git tag for the commit.
@@ -424,7 +495,7 @@ release: $(RELEASE_NOTES) clean-release check-release-tag $(RELEASE_DIR)  ## Bui
 	$(MAKE) release-templates
 	$(MAKE) release-policies
 
-release-policies: $(RELEASE_POLICIES)
+release-policies: $(RELEASE_POLICIES) ## Release policies
 
 $(RELEASE_DIR)/AWSIAMManagedPolicyControllers.json: $(RELEASE_DIR) $(CLUSTERAWSADM_SRCS)
 	go run ./cmd/clusterawsadm bootstrap iam print-policy --document AWSIAMManagedPolicyControllers > $@
@@ -439,7 +510,7 @@ $(RELEASE_DIR)/AWSIAMManagedPolicyCloudProviderNodes.json: $(RELEASE_DIR) $(CLUS
 	go run ./cmd/clusterawsadm bootstrap iam print-policy --document AWSIAMManagedPolicyCloudProviderNodes > $(RELEASE_DIR)/AWSIAMManagedPolicyCloudProviderNodes.json
 
 .PHONY: release-manifests
-release-manifests:
+release-manifests: ## Release manifest files
 	$(MAKE) $(RELEASE_DIR)/$(CORE_MANIFEST_FILE).yaml TAG=$(RELEASE_TAG) PULL_POLICY=IfNotPresent
 	# Add metadata to the release artifacts
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
@@ -455,12 +526,8 @@ release-binaries: ## Builds the binaries to publish with a release
 	RELEASE_BINARY=./cmd/clusterawsadm GOOS=darwin GOARCH=amd64 $(MAKE) release-binary
 	RELEASE_BINARY=./cmd/clusterawsadm GOOS=darwin GOARCH=arm64 $(MAKE) release-binary
 
-.PHONY: build-toolchain
-build-toolchain:
-	docker build --target toolchain -t $(TOOLCHAIN_IMAGE) .
-
 .PHONY: release-binary
-release-binary: $(RELEASE_DIR) versions.mk build-toolchain
+release-binary: $(RELEASE_DIR) versions.mk build-toolchain ## Release binary
 	docker run \
 		--rm \
 		-e CGO_ENABLED=0 \
@@ -490,18 +557,6 @@ release-staging-nightly: ## Tags and push container images to the staging bucket
 	$(MAKE) staging-manifests RELEASE_ALIAS_TAG=$(NEW_RELEASE_ALIAS_TAG)
 	$(MAKE) upload-staging-artifacts RELEASE_ALIAS_TAG=$(NEW_RELEASE_ALIAS_TAG)
 
-.PHONY: upload-staging-artifacts
-upload-staging-artifacts: ## Upload release artifacts to the staging bucket
-	gsutil cp $(RELEASE_DIR)/* gs://$(BUCKET)/components/$(RELEASE_ALIAS_TAG)
-
-.PHONY: create-gh-release
-create-gh-release:$(GH) ## Create release on Github
-	$(GH) release create $(VERSION) -d -F $(RELEASE_DIR)/CHANGELOG.md -t $(VERSION) -R $(GH_REPO)
-
-.PHONY: upload-gh-artifacts
-upload-gh-artifacts: $(GH) ## Upload artifacts to Github release
-	$(GH) release upload $(VERSION) -R $(GH_REPO) --clobber  $(RELEASE_DIR)/*
-
 .PHONY: release-alias-tag
 release-alias-tag: # Adds the tag to the last build tag.
 	gcloud container images add-tag -q $(CORE_CONTROLLER_IMG):$(TAG) $(CORE_CONTROLLER_IMG):$(RELEASE_ALIAS_TAG)
@@ -509,6 +564,14 @@ release-alias-tag: # Adds the tag to the last build tag.
 .PHONY: release-templates
 release-templates: $(RELEASE_DIR) ## Generate release templates
 	cp templates/cluster-template*.yaml $(RELEASE_DIR)/
+
+.PHONY: upload-staging-artifacts
+upload-staging-artifacts: ## Upload release artifacts to the staging bucket
+	gsutil cp $(RELEASE_DIR)/* gs://$(BUCKET)/components/$(RELEASE_ALIAS_TAG)
+
+.PHONY: upload-gh-artifacts
+upload-gh-artifacts: $(GH) ## Upload artifacts to Github release
+	$(GH) release upload $(VERSION) -R $(GH_REPO) --clobber  $(RELEASE_DIR)/*
 
 IMAGE_PATCH_DIR := $(ARTIFACTS)/image-patch
 
@@ -525,39 +588,11 @@ $(RELEASE_DIR)/$(CORE_MANIFEST_FILE).yaml:
 		PROVIDER_CONFIG_DIR=$(CORE_CONFIG_DIR) \
 		NAMESPACE=$(CORE_NAMESPACE) \
 
-.PHONY: compiled-manifest
-compiled-manifest: $(RELEASE_DIR) $(KUSTOMIZE)
-	$(MAKE) image-patch-source-manifest
-	$(MAKE) image-patch-pull-policy
-	$(MAKE) image-patch-kustomization
-	$(KUSTOMIZE) build $(IMAGE_PATCH_DIR)/$(PROVIDER) > $(RELEASE_DIR)/$(PROVIDER).yaml
+.PHONY: staging-manifests
+staging-manifests: ## Staging manifests
+	$(MAKE) $(RELEASE_DIR)/$(CORE_MANIFEST_FILE).yaml PULL_POLICY=IfNotPresent TAG=$(RELEASE_ALIAS_TAG)
 
-.PHONY: image-patch-source-manifest
-image-patch-source-manifest: $(IMAGE_PATCH_DIR) $(KUSTOMIZE)
-	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
-	$(KUSTOMIZE) build $(PROVIDER_CONFIG_DIR) > $(IMAGE_PATCH_DIR)/$(PROVIDER)/source-manifest.yaml
-
-.PHONY: image-patch-kustomization
-image-patch-kustomization: $(IMAGE_PATCH_DIR)
-	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
-	$(MAKE) image-patch-kustomization-without-webhook
-
-.PHONY: image-patch-kustomization-without-webhook
-image-patch-kustomization-without-webhook: $(IMAGE_PATCH_DIR) $(GOJQ)
-	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
-	$(GOJQ) --yaml-input --yaml-output '.images[0]={"name":"$(OLD_IMG)","newName":"$(MANIFEST_IMG)","newTag":"$(TAG)"}|.patchesJson6902[0].target.name="$(CONTROLLER_NAME)"|.patchesJson6902[0].target.namespace="$(NAMESPACE)"' \
-		"hack/image-patch/kustomization.yaml" > $(IMAGE_PATCH_DIR)/$(PROVIDER)/kustomization.yaml
-
-.PHONY: image-patch-pull-policy
-image-patch-pull-policy: $(IMAGE_PATCH_DIR) $(GOJQ)
-	mkdir -p $(IMAGE_PATCH_DIR)/$(PROVIDER)
-	echo Setting imagePullPolicy to $(PULL_POLICY)
-	$(GOJQ) --yaml-input --yaml-output '.[0].value="$(PULL_POLICY)"' "hack/image-patch/pull-policy-patch.yaml" > $(IMAGE_PATCH_DIR)/$(PROVIDER)/pull-policy-patch.yaml
-
-
-## --------------------------------------
-## Cleanup / Verification
-## --------------------------------------
+##@ clean:
 
 .PHONY: clean
 clean: ## Remove all generated files
@@ -565,9 +600,17 @@ clean: ## Remove all generated files
 	$(MAKE) clean-bin
 	$(MAKE) clean-temporary
 
+.PHONY: clean-artifacts
+clean-artifacts: ## Remove the _artifacts directory
+	rm -rf _artifacts
+
 .PHONY: clean-bin
 clean-bin: ## Remove all generated binaries
 	rm -rf bin
+
+.PHONY: clean-release
+clean-release: ## Remove the release folder
+	rm -rf $(RELEASE_DIR)
 
 .PHONY: clean-temporary
 clean-temporary: ## Remove all temporary files and folders
@@ -582,60 +625,3 @@ clean-temporary: ## Remove all temporary files and folders
 	rm -rf test/e2e/capi-kubeadm-control-plane-controller-manager
 	rm -rf test/e2e/logs
 	rm -rf test/e2e/resources
-
-.PHONY: serve-book
-serve-book: ## Run a server with the documentation book
-	$(MAKE) -C docs/book serve
-
-.PHONY: clean-release
-clean-release: ## Remove the release folder
-	rm -rf $(RELEASE_DIR)
-
-.PHONY: verify
-verify: verify-boilerplate verify-modules verify-gen verify-conversions verify-shellcheck release-manifests
-
-.PHONY: verify-boilerplate
-verify-boilerplate:
-	-rm ./hack/tools/bin/*.sh
-	./hack/verify-boilerplate.sh
-
-.PHONY: verify-modules
-verify-modules: modules
-	@if !(git diff --quiet HEAD -- go.sum go.mod hack/tools/go.mod hack/tools/go.sum); then \
-		git diff; \
-		echo "go module files are out of date"; exit 1; \
-	fi
-
-.PHONY: verify-conversions
-verify-conversions: $(CONVERSION_VERIFIER)  ## Verifies expected API conversion are in place
-	echo verification of api conversions initiated
-	$(CONVERSION_VERIFIER)
-
-.PHONY: verify-shellcheck
-verify-shellcheck: ## Verify shell files
-	./hack/verify-shellcheck.sh
-
-verify-gen: generate
-	@if !(git diff --quiet HEAD); then \
-		git diff; \
-		echo "generated files are out of date, run make generate"; exit 1; \
-	fi
-
-.PHONY: compile-e2e
-compile-e2e: ## Test e2e compilation
-	go test -c -o /dev/null -tags=e2e ./test/e2e/suites/unmanaged
-	go test -c -o /dev/null -tags=e2e ./test/e2e/suites/conformance
-	go test -c -o /dev/null -tags=e2e ./test/e2e/suites/managed
-
-.PHONY: clean-artifacts
-clean-artifacts: ## Remove the _artifacts directory
-	rm -rf _artifacts
-
-.PHONY: docker-pull-e2e-preloads
-docker-pull-e2e-preloads: ## Preloads the docker images used for e2e testing and can speed it up
-	-docker pull k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:$(CAPI_VERSION)
-	-docker pull k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:$(CAPI_VERSION)
-	-docker pull k8s.gcr.io/cluster-api/cluster-api-controller:$(CAPI_VERSION)
-	-docker pull quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
-	-docker pull quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
-	-docker pull quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)

--- a/common.mk
+++ b/common.mk
@@ -49,9 +49,11 @@ export GOPROXY
 $(TOOLS_BIN_DIR)/%: $(TOOLS_DIR_DEPS)
 	make -C $(TOOLS_DIR) $(subst $(TOOLS_DIR)/,,$@)
 
-## --------------------------------------
-## Help
-## --------------------------------------
+##@ help:
 
 help:  ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+ifeq ($(OS),Windows_NT)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make <target>\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  %-40s %s\n", $$1, $$2 } /^##@/ { printf "\n%s\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+else
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-40s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+endif


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

A nicer Makefile help output:

```
➜  cluster-api-provider-aws git:(group_makefile) ✗ make

Usage:
  make <target>

Testing
  test                                      Run tests
  generate-test-flavors                     Generate test template flavors
  test-conformance                          Run clusterctl based conformance test on workload cluster (requires Docker).
  test-cover                                Run tests with code coverage and code generate  reports

Binaries
  binaries                                  Builds and installs all binaries
  manager-aws-infrastructure                Build manager binary.
  clusterawsadm                             Build clusterawsadm binary.

Linting
  lint                                      Lint codebase
  lint-fix                                  Lint the codebase and run auto-fixers if supported by the linter

Generate
  modules                                   Runs go mod to ensure proper vendoring.
  generate                                  Generate code
  generate-go-apis                          Runs Go related generate targets

Docker
  docker-build                              Build the docker image for controller-manager
  docker-push                               Push the docker image
  docker-push-core-manifest                 Push the fat manifest docker image.

Release
  list-staging-releases                     List staging images for image promotion
  release                                   Builds and push container images using the latest git tag for the commit.
  release-changelog                         Builds the changelog for a release
  release-binaries                          Builds the binaries to publish with a release
  release-staging                           Builds and push container images and manifests to the staging bucket.
  release-staging-nightly                   Tags and push container images to the staging bucket.
  upload-staging-artifacts                  Upload release artifacts to the staging bucket
  create-gh-release                         Create release on Github
  upload-gh-artifacts                       Upload artifacts to Github release
  release-templates                         Generate release templates

Cleanup / Verification
  clean                                     Remove all generated files
  clean-bin                                 Remove all generated binaries
  clean-temporary                           Remove all temporary files and folders
  serve-book                                Run a server with the documentation book
  clean-release                             Remove the release folder
  verify-conversions                        Verifies expected API conversion are in place
  verify-shellcheck                         Verify shell files
  clean-artifacts                           Remove the _artifacts directory

Help
  help                                      Display this help
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3188

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Adding a nicer Makefile help output so it's easy to locate a certain target.
```
