### PR TITLE
test/e2e/data/e2e_conf.yaml: bump k8s version to v1.23.3

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -244,9 +244,9 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.23.0"
-  KUBERNETES_VERSION: "v1.23.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.23.3"
+  KUBERNETES_VERSION: "v1.23.3"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.3"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.22.4"
   CNI: "../../data/cni/calico.yaml"
   KUBETEST_CONFIGURATION: "../../data/kubetest/conformance.yaml"
@@ -255,7 +255,7 @@ variables:
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_MACHINE_TYPE_VCPU_USAGE: 2
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.23.0"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.23.3"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
   ETCD_VERSION_UPGRADE_TO: "3.5.1-0"


### PR DESCRIPTION


<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

To make #2271 CI pass, as current Flatcar AMIs for 1.23.0 are built
using older image-builder version which we are not compatible with.

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
