### PR TITLE
Refactor cluster upgrade tests

### DIFF
--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -185,11 +185,11 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 		})
 	})
 
-	ginkgo.Describe("Cluster Upgrade spec - Single Control Plane Cluster", func() {
+	ginkgo.Describe("Cluster Upgrade Spec - Single control plane with workers [K8s-Upgrade]", func() {
 		ginkgo.BeforeEach(func() {
 			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 			requiredResources = &shared.TestResource{EC2Normal: 5 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2}
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-cluster-upgrade-test")
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-worker-upgrade-test")
 			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
 		})
 
@@ -202,8 +202,6 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
 				SkipConformanceTests:     true,
 				ControlPlaneMachineCount: pointer.Int64(1),
-				WorkerMachineCount:       pointer.Int64(1),
-				Flavor:                   pointer.String("upgrades"), // upgrades flavor includes a MachinePool template.
 			}
 		})
 
@@ -212,7 +210,30 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 		})
 	})
 
-	ginkgo.Describe("Cluster Upgrade spec - HA Control Plane Cluster", func() {
+	ginkgo.Describe("Cluster Upgrade Spec - HA control plane with scale in rollout [K8s-Upgrade]", func() {
+		ginkgo.BeforeEach(func() {
+			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+			requiredResources = &shared.TestResource{EC2Normal: 10 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2}
+			requiredResources.WriteRequestedResources(e2eCtx, "capi-ha-cluster-upgrade-scale-in-test")
+			Expect(shared.AcquireResources(requiredResources, config.GinkgoConfig.ParallelNode, flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
+
+		capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
+			return capi_e2e.ClusterUpgradeConformanceSpecInput{
+				E2EConfig:                e2eCtx.E2EConfig,
+				ClusterctlConfigPath:     e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:           e2eCtx.Settings.ArtifactFolder,
+				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
+				SkipConformanceTests:     true,
+				ControlPlaneMachineCount: pointer.Int64(3),
+				WorkerMachineCount:       pointer.Int64(0),
+				Flavor:                   pointer.String(shared.KCPScaleInFlavor),
+			}
+		})
+	})
+
+	ginkgo.Describe("Cluster Upgrade Spec - HA Control Plane Cluster [K8s-Upgrade]", func() {
 		ginkgo.BeforeEach(func() {
 			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 			requiredResources = &shared.TestResource{EC2Normal: 10 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2}
@@ -229,7 +250,7 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
 				SkipConformanceTests:     true,
 				ControlPlaneMachineCount: pointer.Int64(3),
-				WorkerMachineCount:       pointer.Int64(1),
+				WorkerMachineCount:       pointer.Int64(0),
 				Flavor:                   pointer.String(clusterctl.DefaultFlavor),
 			}
 		})


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Refactored cluster upgrade tests:

1. Use 0 workers for KCP upgrade tests
2. Add test for upgrading KCP with scale in rollout
3. Add [K8s-Upgrade] so that we can run all upgrades with Ginkgo-focus.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2993 and #3087

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
