### PR TITLE
Enable EKS upgrade test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ USE_EXISTING_CLUSTER ?= "false"
 
 # Set E2E_SKIP_EKS_UPGRADE to false to test EKS upgrades.
 # Warning, this takes a long time
-E2E_SKIP_EKS_UPGRADE ?= "true"
+E2E_SKIP_EKS_UPGRADE ?= "false"
 
 # Set EKS_SOURCE_TEMPLATE to override the source template
 EKS_SOURCE_TEMPLATE ?= eks/cluster-template-eks-control-plane-only.yaml

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -2,8 +2,6 @@
 # E2E test scenario using local dev images and manifests built from the source tree for following providers:
 # - cluster-api
 # - infrastructure aws
-# - boostrap aws-eks
-# - control-plane aws-eks
 
 # To run tests, run the following from the root of this repository.
 # `AWS_REGION=eu-west-1 make e2e GINKGO_ARGS=-stream E2E_ARGS=-skip-cloudformation-deletion`

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -169,6 +169,11 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 
 	CreateAWSClusterControllerIdentity(e2eCtx.Environment.BootstrapClusterProxy.GetClient())
 
+	if e2eCtx.IsManaged {
+		By("Setting up AWS static credentials")
+		SetupStaticCredentials(e2eCtx)
+	}
+
 	conf := synchronizedBeforeTestSuiteConfig{
 		ArtifactFolder:           e2eCtx.Settings.ArtifactFolder,
 		ConfigPath:               e2eCtx.Settings.ConfigPath,
@@ -257,6 +262,12 @@ func Node1AfterSuite(e2eCtx *E2EContext) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Minute)
 	DumpEKSClusters(ctx, e2eCtx)
 	DumpCloudTrailEvents(e2eCtx)
+
+	if e2eCtx.IsManaged {
+		By("Deleting AWS static credentials")
+		CleanupStaticCredentials(ctx, e2eCtx)
+	}
+
 	defer cancel()
 	By("Tearing down the management cluster")
 	if !e2eCtx.Settings.SkipCleanup {

--- a/test/e2e/suites/managed/cluster.go
+++ b/test/e2e/suites/managed/cluster.go
@@ -123,27 +123,3 @@ type DeleteClusterSpecInput struct {
 	Namespace             *corev1.Namespace
 	ClusterName           string
 }
-
-// DeleteClusterSpec implements a test for deleting a Cluster.
-func DeleteClusterSpec(ctx context.Context, inputGetter func() DeleteClusterSpecInput) {
-	input := inputGetter()
-	Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil")
-	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil")
-	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil")
-	Expect(input.ClusterName).ShouldNot(HaveLen(0), "Invalid argument. input.ClusterName can't be empty")
-
-	shared.Byf("getting cluster with name %s", input.ClusterName)
-	cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
-		Getter:    input.BootstrapClusterProxy.GetClient(),
-		Namespace: input.Namespace.Name,
-		Name:      input.ClusterName,
-	})
-	Expect(cluster).NotTo(BeNil(), "couldn't find cluster")
-
-	shared.Byf("Deleting cluster %s/%s", input.Namespace, input.ClusterName)
-
-	framework.DeleteCluster(ctx, framework.DeleteClusterInput{
-		Deleter: input.BootstrapClusterProxy.GetClient(),
-		Cluster: cluster,
-	})
-}

--- a/test/e2e/suites/managed/eks_test.go
+++ b/test/e2e/suites/managed/eks_test.go
@@ -56,9 +56,6 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
 		clusterName = fmt.Sprintf("cluster-%s", util.RandomString(6))
 
-		ginkgo.By("setting up AWS static credentials")
-		shared.SetupStaticCredentials(ctx, namespace, e2eCtx)
-
 		ginkgo.By("default iam role should exist")
 		verifyRoleExistsAndOwned(ekscontrolplanev1.DefaultEKSControlPlaneRole, clusterName, false, e2eCtx.BootstrapUserAWSSession)
 
@@ -148,8 +145,5 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 			Getter:  e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
 			Cluster: cluster,
 		}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
-
-		ginkgo.By("Deleting AWS static credentials")
-		shared.CleanupStaticCredentials(ctx, namespace, e2eCtx)
 	})
 })

--- a/test/e2e/suites/managed/upgrade_test.go
+++ b/test/e2e/suites/managed/upgrade_test.go
@@ -23,20 +23,21 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util"
 )
 
 // EKS cluster upgrade tests.
-var _ = Describe("EKS Cluster upgrade test", func() {
+var _ = ginkgo.Describe("EKS Cluster upgrade test", func() {
 	const (
-		initialVersion   = "v1.17.0"
-		upgradeToversion = "v1.18.0"
+		initialVersion   = "v1.20.0"
+		upgradeToversion = "v1.21.0"
 	)
 	var (
 		namespace   *corev1.Namespace
@@ -46,7 +47,7 @@ var _ = Describe("EKS Cluster upgrade test", func() {
 	)
 
 	shared.ConditionalIt(runUpgradeTests, "[managed] [upgrade] should create a cluster and upgrade the kubernetes version", func() {
-		By("should have a valid test configuration")
+		ginkgo.By("should have a valid test configuration")
 		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
 		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
@@ -55,7 +56,10 @@ var _ = Describe("EKS Cluster upgrade test", func() {
 		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
 		clusterName = fmt.Sprintf("cluster-%s", util.RandomString(6))
 
-		By("should create an EKS control plane")
+		ginkgo.By("default iam role should exist")
+		verifyRoleExistsAndOwned(ekscontrolplanev1.DefaultEKSControlPlaneRole, clusterName, false, e2eCtx.BootstrapUserAWSSession)
+
+		ginkgo.By("should create an EKS control plane")
 		ManagedClusterSpec(ctx, func() ManagedClusterSpecInput {
 			return ManagedClusterSpecInput{
 				E2EConfig:                e2eCtx.E2EConfig,
@@ -104,16 +108,13 @@ var _ = Describe("EKS Cluster upgrade test", func() {
 
 		// TODO (richardcase): add test for the node group upgrade
 
-		shared.Byf("should delete cluster %s", clusterName)
-		DeleteClusterSpec(ctx, func() DeleteClusterSpecInput {
-			return DeleteClusterSpecInput{
-				E2EConfig:             e2eCtx.E2EConfig,
-				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-				ClusterName:           clusterName,
-				Namespace:             namespace,
-			}
+		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+			Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
 		})
-
+		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+			Getter:  e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
 	})
-
 })


### PR DESCRIPTION
**What type of PR is this?**


**What this PR does / why we need it**:
Enable EKS upgrade test, updated k8s version to EKS supported versions and setup AWSClusterStaticIdentity in a central location for use by multiple tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3228 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
