### PR TITLE
Block ELB re-creation after the cluster has been provisioned

### DIFF
--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -193,6 +193,10 @@ func (s *ClusterScope) ControlPlaneLoadBalancerName() *string {
 	return nil
 }
 
+func (s *ClusterScope) ControlPlaneEndpoint() clusterv1.APIEndpoint {
+	return s.AWSCluster.Spec.ControlPlaneEndpoint
+}
+
 // ControlPlaneConfigMapName returns the name of the ConfigMap used to
 // coordinate the bootstrapping of control plane nodes.
 func (s *ClusterScope) ControlPlaneConfigMapName() string {

--- a/pkg/cloud/scope/elb.go
+++ b/pkg/cloud/scope/elb.go
@@ -19,6 +19,7 @@ package scope
 import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // ELBScope is a scope for use with the ELB reconciling service.
@@ -45,4 +46,7 @@ type ELBScope interface {
 
 	// ControlPlaneLoadBalancerName returns the Classic ELB name
 	ControlPlaneLoadBalancerName() *string
+
+	// ControlPlaneEndpoint returns AWSCluster control plane endpoint
+	ControlPlaneEndpoint() clusterv1.APIEndpoint
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Since ELB is created only when it's not found, this PR blocks the ELB creation in the scenario where if user deletes ELB post the cluster has been provisioned. The reason to do this is if ELB is created again after the cluster has been provisioned, then CAPA will create new ELB with new DNS endpoint which won't work.
As `AWSClusterSpec.ControlPlaneEndpoint` becomes immutable after cluster is provisioned, we are relying on the validity of this endpoint to know the status of provisioning of the cluster to check whether ELB has to be created or not. If this endpoint is valid and ELB is not found, then we inform the user that AWSCluster is in failed state and unrecoverable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2608 

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Block ELB re-creation after cluster is provisioned.
```
