### PR TITLE
Update multitenancy doc

### DIFF
--- a/docs/book/src/topics/multitenancy.md
+++ b/docs/book/src/topics/multitenancy.md
@@ -158,7 +158,6 @@ spec:
   roleARN: arn:aws:iam::11122233344:role/multi-tenancy-role
   sessionName: multi-tenancy-role-session
   sourceidentityRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSClusterControllerIdentity
     name: default
 ---
@@ -172,17 +171,14 @@ spec:
   roleARN: arn:aws:iam::11122233355:role/multi-tenancy-nested-role
   sessionName: multi-tenancy-nested-role-session
   sourceidentityRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSClusterRoleIdentity
     name: multi-tenancy-role
 ```
 
-## Secure Access to Identitys
-`allowedNamespaces` field is used to grant access to the namespaces to use Identitys.
+## Secure Access to Identities
+`allowedNamespaces` field is used to grant access to the namespaces to use Identities.
 Only AWSClusters that are created in one of the Identity's allowed namespaces can use that Identity.
 `allowedNamespaces` are defined by providing either a list of namespaces or label selector to select namespaces.
-
-Note that the `capa-eks-control-plane-system` namespace will need to be included in the allow namespace list and/or have labels added to allow access to identities used by AWSClusters.
 
 ### Examples
 
@@ -245,7 +241,7 @@ allowedNamespaces:
   selector: {}
 ```
 
-**Important** The default behaviour of an empty label selector is to match all objects, however here we do not follow that behavior to avoid unintended access to the identitys.
+**Important** The default behaviour of an empty label selector is to match all objects, however here we do not follow that behavior to avoid unintended access to the identities.
 This is consistent with core cluster API selectors, e.g., Machine and ClusterResourceSet selectors. The result of matchLabels and matchExpressions are ANDed.
 
 

--- a/exp/controlleridentitycreator/awscontrolleridentity_controller_test.go
+++ b/exp/controlleridentitycreator/awscontrolleridentity_controller_test.go
@@ -29,8 +29,8 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 )
 
-func TestAWSInstanceStateController(t *testing.T) {
-	t.Run("should maintain list of cluster queue URLs and reconcile failing machines", func(t *testing.T) {
+func TestAWSControllerIdentityController(t *testing.T) {
+	t.Run("should create AWSClusterControllerIdentity when identityRef is not specified", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := context.Background()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixed incorrect info on multitenancy doc
- Remove apiVersion from sourceidentityRef as there is no apiVersion field.
- Remove a paragraph mentioning capa-eks-control-plane-system namespace, which is not used anymore with EKS feature graduation.

Also, fixed test name and description of awscontrolleridentity controller

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
