### PR TITLE
Added subnet IDs lookup by AWSMachinePool Spec Subnets.Filters

### DIFF
--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -222,12 +221,7 @@ func (m *MachinePoolScope) IsEKSManaged() bool {
 }
 
 // SubnetIDs returns the machine pool subnet IDs.
-func (m *MachinePoolScope) SubnetIDs() ([]string, error) {
-	subnetIDs := make([]string, len(m.AWSMachinePool.Spec.Subnets))
-	for i, v := range m.AWSMachinePool.Spec.Subnets {
-		subnetIDs[i] = aws.StringValue(v.ID)
-	}
-
+func (m *MachinePoolScope) SubnetIDs(subnetIDs []string) ([]string, error) {
 	strategy, err := newDefaultSubnetPlacementStrategy(&m.Logger)
 	if err != nil {
 		return subnetIDs, fmt.Errorf("getting subnet placement strategy: %w", err)

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"k8s.io/utils/pointer"
 
@@ -144,7 +145,7 @@ func (s *Service) GetASGByName(scope *scope.MachinePoolScope) (*expinfrav1.AutoS
 
 // CreateASG runs an autoscaling group.
 func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error) {
-	subnets, err := scope.SubnetIDs()
+	subnets, err := s.SubnetIDs(scope)
 	if err != nil {
 		return nil, fmt.Errorf("getting subnets for ASG: %w", err)
 	}
@@ -267,15 +268,9 @@ func (s *Service) DeleteASG(name string) error {
 
 // UpdateASG will update the ASG of a service.
 func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
-	subnetIDs := make([]string, len(scope.AWSMachinePool.Spec.Subnets))
-	for i, v := range scope.AWSMachinePool.Spec.Subnets {
-		subnetIDs[i] = aws.StringValue(v.ID)
-	}
-
-	if len(subnetIDs) == 0 {
-		for _, subnet := range scope.InfraCluster.Subnets() {
-			subnetIDs = append(subnetIDs, subnet.ID)
-		}
+	subnetIDs, err := s.SubnetIDs(scope)
+	if err != nil {
+		return fmt.Errorf("getting subnets for ASG: %w", err)
 	}
 
 	input := &autoscaling.UpdateAutoScalingGroupInput{
@@ -464,4 +459,39 @@ func mapToTags(input map[string]string, resourceID *string) []*autoscaling.Tag {
 		})
 	}
 	return tags
+}
+
+// SubnetIDs return subnet IDs of a AWSMachinePool based on given subnetIDs and filters.
+func (s *Service) SubnetIDs(scope *scope.MachinePoolScope) ([]string, error) {
+	subnetIDs := make([]string, 0)
+	var inputFilters = make([]*ec2.Filter, 0)
+
+	for _, subnet := range scope.AWSMachinePool.Spec.Subnets {
+		switch {
+		case subnet.ID != nil:
+			subnetIDs = append(subnetIDs, aws.StringValue(subnet.ID))
+		case subnet.Filters != nil:
+			for _, eachFilter := range subnet.Filters {
+				inputFilters = append(inputFilters, &ec2.Filter{
+					Name:   aws.String(eachFilter.Name),
+					Values: aws.StringSlice(eachFilter.Values),
+				})
+			}
+		}
+	}
+
+	if len(inputFilters) > 0 {
+		out, err := s.EC2Client.DescribeSubnets(&ec2.DescribeSubnetsInput{
+			Filters: inputFilters,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, subnet := range out.Subnets {
+			subnetIDs = append(subnetIDs, *subnet.SubnetId)
+		}
+	}
+
+	return scope.SubnetIDs(subnetIDs)
 }

--- a/pkg/cloud/services/autoscaling/service.go
+++ b/pkg/cloud/services/autoscaling/service.go
@@ -18,6 +18,7 @@ package asg
 
 import (
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
@@ -29,6 +30,7 @@ import (
 type Service struct {
 	scope     cloud.ClusterScoper
 	ASGClient autoscalingiface.AutoScalingAPI
+	EC2Client ec2iface.EC2API
 }
 
 // NewService returns a new service given the asg api client.
@@ -36,5 +38,6 @@ func NewService(clusterScope cloud.ClusterScoper) *Service {
 	return &Service{
 		scope:     clusterScope,
 		ASGClient: scope.NewASGClient(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
+		EC2Client: scope.NewEC2Client(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
 	}
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Currently we are doing lookup by subnet IDs only. But with this PR we enable
```
if subnet id is there, do a lookup using that
if filter is there, do a lookup using that
If both are given then it will throw a validation error as per comment on AWSResourceReference
```


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3254 
Fixes #2609 
Part of #2087 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Added subnet IDs lookup by AWSMachinePool Spec Subnets.Filters in case IDs not provided
```
