### PR TITLE
Added lookup for fields of type AWSResourcesReference

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -17,22 +17,9 @@ limitations under the License.
 package v1alpha4
 
 import (
-	apiconversion "k8s.io/apimachinery/pkg/conversion"
-	conversion "k8s.io/apimachinery/pkg/conversion"
-	v1beta1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 )
-
-// Convert_v1alpha4_APIEndpoint_To_v1beta1_APIEndpoint .
-func Convert_v1alpha4_ObjectMeta_To_v1beta1_ObjectMeta(in *clusterv1alpha4.ObjectMeta, out *clusterv1.ObjectMeta, s apiconversion.Scope) error {
-	return clusterv1alpha4.Convert_v1alpha4_ObjectMeta_To_v1beta1_ObjectMeta(in, out, s)
-}
-
-// Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint .
-func Convert_v1beta1_ObjectMeta_To_v1alpha4_ObjectMeta(in *clusterv1.ObjectMeta, out *clusterv1alpha4.ObjectMeta, s apiconversion.Scope) error {
-	return clusterv1alpha4.Convert_v1beta1_ObjectMeta_To_v1alpha4_ObjectMeta(in, out, s)
-}
 
 func Convert_v1beta1_AWSClusterSpec_To_v1alpha4_AWSClusterSpec(in *v1beta1.AWSClusterSpec, out *AWSClusterSpec, s conversion.Scope) error {
 	return autoConvert_v1beta1_AWSClusterSpec_To_v1alpha4_AWSClusterSpec(in, out, s)

--- a/api/v1beta1/awsmachine_webhook.go
+++ b/api/v1beta1/awsmachine_webhook.go
@@ -30,7 +30,7 @@ import (
 )
 
 // log is for logging in this package.
-var _ = logf.Log.WithName("awsmachine-resource")
+var log = logf.Log.WithName("awsmachine-resource")
 
 func (r *AWSMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -252,6 +252,9 @@ func (r *AWSMachine) validateAdditionalSecurityGroups() field.ErrorList {
 	for _, additionalSecurityGroup := range r.Spec.AdditionalSecurityGroups {
 		if len(additionalSecurityGroup.Filters) > 0 && additionalSecurityGroup.ID != nil {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.additionalSecurityGroups"), "only one of ID or Filters may be specified, specifying both is forbidden"))
+		}
+		if additionalSecurityGroup.ARN != nil {
+			log.Info("ARN field is deprecated and is no operation function.")
 		}
 	}
 	return allErrs

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -22,16 +22,17 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
-// Only one of ID, ARN or Filters may be specified. Specifying more than one will result in
+// AWSResourceReference is a reference to a specific AWS resource by ID or filters.
+// Only one of ID or Filters may be specified. Specifying more than one will result in
 // a validation error.
 type AWSResourceReference struct {
 	// ID of resource
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// ARN of resource
+	// ARN of resource.
 	// +optional
+	// Deprecated: This field has no function and is going to be removed in the next release.
 	ARN *string `json:"arn,omitempty"`
 
 	// Filters is a set of key/value pairs used to identify a resource

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -1018,12 +1018,13 @@ spec:
                       groups defined at the cluster level or in the actuator.
                     items:
                       description: AWSResourceReference is a reference to a specific
-                        AWS resource by ID, ARN, or filters. Only one of ID, ARN or
-                        Filters may be specified. Specifying more than one will result
-                        in a validation error.
+                        AWS resource by ID or filters. Only one of ID or Filters may
+                        be specified. Specifying more than one will result in a validation
+                        error.
                       properties:
                         arn:
-                          description: ARN of resource
+                          description: 'ARN of resource. Deprecated: This field has
+                            no function and is going to be removed in the next release.'
                           type: string
                         filters:
                           description: 'Filters is a set of key/value pairs used to
@@ -1263,12 +1264,12 @@ spec:
                 description: Subnets is an array of subnet configurations
                 items:
                   description: AWSResourceReference is a reference to a specific AWS
-                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
-                    may be specified. Specifying more than one will result in a validation
-                    error.
+                    resource by ID or filters. Only one of ID or Filters may be specified.
+                    Specifying more than one will result in a validation error.
                   properties:
                     arn:
-                      description: ARN of resource
+                      description: 'ARN of resource. Deprecated: This field has no
+                        function and is going to be removed in the next release.'
                       type: string
                     filters:
                       description: 'Filters is a set of key/value pairs used to identify

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -987,12 +987,12 @@ spec:
                   change too.
                 items:
                   description: AWSResourceReference is a reference to a specific AWS
-                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
-                    may be specified. Specifying more than one will result in a validation
-                    error.
+                    resource by ID or filters. Only one of ID or Filters may be specified.
+                    Specifying more than one will result in a validation error.
                   properties:
                     arn:
-                      description: ARN of resource
+                      description: 'ARN of resource. Deprecated: This field has no
+                        function and is going to be removed in the next release.'
                       type: string
                     filters:
                       description: 'Filters is a set of key/value pairs used to identify
@@ -1245,7 +1245,8 @@ spec:
                   If not specified, the cluster subnet will be used.
                 properties:
                   arn:
-                    description: ARN of resource
+                    description: 'ARN of resource. Deprecated: This field has no function
+                      and is going to be removed in the next release.'
                     type: string
                   filters:
                     description: 'Filters is a set of key/value pairs used to identify

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -789,12 +789,14 @@ spec:
                           the attached security groups might change too.
                         items:
                           description: AWSResourceReference is a reference to a specific
-                            AWS resource by ID, ARN, or filters. Only one of ID, ARN
-                            or Filters may be specified. Specifying more than one
-                            will result in a validation error.
+                            AWS resource by ID or filters. Only one of ID or Filters
+                            may be specified. Specifying more than one will result
+                            in a validation error.
                           properties:
                             arn:
-                              description: ARN of resource
+                              description: 'ARN of resource. Deprecated: This field
+                                has no function and is going to be removed in the
+                                next release.'
                               type: string
                             filters:
                               description: 'Filters is a set of key/value pairs used
@@ -1059,7 +1061,9 @@ spec:
                           be used.
                         properties:
                           arn:
-                            description: ARN of resource
+                            description: 'ARN of resource. Deprecated: This field
+                              has no function and is going to be removed in the next
+                              release.'
                             type: string
                           filters:
                             description: 'Filters is a set of key/value pairs used

--- a/controllers/awsmachine_security_groups.go
+++ b/controllers/awsmachine_security_groups.go
@@ -49,7 +49,7 @@ func (r *AWSMachineReconciler) ensureSecurityGroups(ec2svc service.EC2Interface,
 		return false, err
 	}
 
-	additionalSecurityGroupsIDs, err := r.getAdditionalSecurityGroupsIDs(ec2svc, additional)
+	additionalSecurityGroupsIDs, err := ec2svc.GetAdditionalSecurityGroupsIDs(additional)
 	if err != nil {
 		return false, nil // nolint:nilerr
 	}
@@ -120,25 +120,4 @@ func (r *AWSMachineReconciler) securityGroupsChanged(annotation map[string]inter
 	}
 
 	return false, res
-}
-
-func (r *AWSMachineReconciler) getAdditionalSecurityGroupsIDs(ec2svc service.EC2Interface, securitygroups []infrav1.AWSResourceReference) ([]string, error) {
-	additionalSecurityGroupsIDs := []string{}
-
-	for _, sg := range securitygroups {
-		if sg.ID != nil {
-			additionalSecurityGroupsIDs = append(additionalSecurityGroupsIDs, *sg.ID)
-		}
-
-		if sg.Filters != nil {
-			id, err := ec2svc.GetFilteredSecurityGroupID(sg)
-			if err != nil {
-				return nil, err
-			}
-
-			additionalSecurityGroupsIDs = append(additionalSecurityGroupsIDs, id)
-		}
-	}
-
-	return additionalSecurityGroupsIDs, nil
 }

--- a/exp/api/v1alpha3/conversion.go
+++ b/exp/api/v1alpha3/conversion.go
@@ -168,28 +168,9 @@ func Convert_v1beta1_AWSManagedMachinePoolSpec_To_v1alpha3_AWSManagedMachinePool
 	return autoConvert_v1beta1_AWSManagedMachinePoolSpec_To_v1alpha3_AWSManagedMachinePoolSpec(in, out, s)
 }
 
-// Convert_v1beta1_Instance_To_v1alpha3_Instance is a conversion function.
-func Convert_v1beta1_Instance_To_v1alpha3_Instance(in *infrav1.Instance, out *infrav1alpha3.Instance, s apiconversion.Scope) error {
-	return infrav1alpha3.Convert_v1beta1_Instance_To_v1alpha3_Instance(in, out, s)
-}
-
 // Convert_v1alpha3_Instance_To_v1beta1_Instance is a conversion function.
 func Convert_v1alpha3_Instance_To_v1beta1_Instance(in *infrav1alpha3.Instance, out *infrav1.Instance, s apiconversion.Scope) error {
 	return infrav1alpha3.Convert_v1alpha3_Instance_To_v1beta1_Instance(in, out, s)
-}
-
-// ConvertTo converts
-func Convert_v1alpha3_AWSResourceReference_To_v1beta1_AMIReference(in *infrav1alpha3.AWSResourceReference, out *infrav1.AMIReference, s apiconversion.Scope) error {
-	return infrav1alpha3.Convert_v1alpha3_AWSResourceReference_To_v1beta1_AMIReference(in, out, s)
-}
-
-func Convert_v1beta1_AMIReference_To_v1alpha3_AWSResourceReference(in *infrav1.AMIReference, out *infrav1alpha3.AWSResourceReference, s apiconversion.Scope) error {
-	return infrav1alpha3.Convert_v1beta1_AMIReference_To_v1alpha3_AWSResourceReference(in, out, s)
-}
-
-// Convert_v1beta1_Volume_To_v1alpha3_Volume is a conversion function.
-func Convert_v1beta1_Volume_To_v1alpha3_Volume(in *infrav1.Volume, out *infrav1alpha3.Volume, s apiconversion.Scope) error {
-	return infrav1alpha3.Convert_v1beta1_Volume_To_v1alpha3_Volume(in, out, s)
 }
 
 // Convert_v1alpha3_Volume_To_v1beta1_Volume is a conversion function.

--- a/exp/api/v1alpha3/conversion_test.go
+++ b/exp/api/v1alpha3/conversion_test.go
@@ -18,14 +18,14 @@ package v1alpha3
 
 import (
 	"testing"
-
-	. "github.com/onsi/gomega"
-
+	
 	fuzz "github.com/google/gofuzz"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	v1beta1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
+	
+	"sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 

--- a/exp/api/v1alpha4/conversion_test.go
+++ b/exp/api/v1alpha4/conversion_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
 
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )

--- a/exp/api/v1beta1/awsmachinepool_webhook.go
+++ b/exp/api/v1beta1/awsmachinepool_webhook.go
@@ -89,12 +89,28 @@ func (r *AWSMachinePool) validateSubnets() field.ErrorList {
 	}
 
 	for _, subnet := range r.Spec.Subnets {
+		if subnet.ARN != nil {
+			log.Info("ARN field is deprecated and is no operation function.")
+		}
 		if subnet.ID != nil && subnet.Filters != nil {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.subnets.filters"), "providing either subnet ID or filter is supported, should not provide both"))
 			break
 		}
 	}
 
+	return allErrs
+}
+
+func (r *AWSMachinePool) validateAdditionalSecurityGroups() field.ErrorList {
+	var allErrs field.ErrorList
+	for _, sg := range r.Spec.AWSLaunchTemplate.AdditionalSecurityGroups {
+		if sg.ID != nil && sg.Filters != nil {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.awsLaunchTemplate.AdditionalSecurityGroups"), "either ID or filters should be used"))
+		}
+		if sg.ARN != nil {
+			log.Info("ARN field is deprecated and is no operation function.")
+		}
+	}
 	return allErrs
 }
 
@@ -108,6 +124,7 @@ func (r *AWSMachinePool) ValidateCreate() error {
 	allErrs = append(allErrs, r.validateRootVolume()...)
 	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 	allErrs = append(allErrs, r.validateSubnets()...)
+	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
 
 	if len(allErrs) == 0 {
 		return nil
@@ -127,6 +144,7 @@ func (r *AWSMachinePool) ValidateUpdate(old runtime.Object) error {
 	allErrs = append(allErrs, r.validateDefaultCoolDown()...)
 	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 	allErrs = append(allErrs, r.validateSubnets()...)
+	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
 
 	if len(allErrs) == 0 {
 		return nil

--- a/exp/api/v1beta1/awsmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/awsmachinepool_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -67,6 +68,23 @@ func TestAWSMachinePool_ValidateCreate(t *testing.T) {
 						strings.Repeat("CAPI", 33): "value-3",
 						"key-4":                    strings.Repeat("CAPI", 65),
 					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should fail if additional security groups are provided with both ID and Filters",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{AdditionalSecurityGroups: []infrav1.AWSResourceReference{{
+						ID: aws.String("sg-1"),
+						Filters: []infrav1.Filter{
+							{
+								Name:   "sg-1",
+								Values: []string{"test"},
+							},
+						},
+					}}},
 				},
 			},
 			wantErr: true,

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -1095,8 +1095,7 @@ func getMachinePoolScope(client client.Client, clusterScope *scope.ClusterScope)
 		Spec: expinfrav1.AWSMachinePoolSpec{
 			Subnets: []infrav1.AWSResourceReference{
 				{
-					ID:  aws.String("subnet1"),
-					ARN: aws.String("subnetARN"),
+					ID: aws.String("subnet1"),
 				},
 			},
 			RefreshPreferences: &expinfrav1.RefreshPreferences{

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -139,7 +139,7 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find ami: %q", amiName)
 	}
-	if len(out.Images) == 0 {
+	if out == nil || len(out.Images) == 0 {
 		return nil, errors.Errorf("found no AMIs with the name: %q", amiName)
 	}
 	latestImage, err := GetLatestImage(out.Images)

--- a/pkg/cloud/services/ec2/helper_test.go
+++ b/pkg/cloud/services/ec2/helper_test.go
@@ -96,12 +96,11 @@ func newAWSMachinePool() *expinfrav1.AWSMachinePool {
 			AvailabilityZones: []string{"us-east-1"},
 			AdditionalTags:    infrav1.Tags{},
 			AWSLaunchTemplate: expinfrav1.AWSLaunchTemplate{
-				Name:                     "aws-launch-template",
-				IamInstanceProfile:       "instance-profile",
-				AMI:                      infrav1.AMIReference{},
-				InstanceType:             "t3.large",
-				SSHKeyName:               aws.String("default"),
-				AdditionalSecurityGroups: []infrav1.AWSResourceReference{{ID: aws.String("1")}},
+				Name:               "aws-launch-template",
+				IamInstanceProfile: "instance-profile",
+				AMI:                infrav1.AMIReference{},
+				InstanceType:       "t3.large",
+				SSHKeyName:         aws.String("default"),
 			},
 		},
 		Status: expinfrav1.AWSMachinePoolStatus{

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -990,26 +990,3 @@ func getInstanceMarketOptionsRequest(spotMarketOptions *infrav1.SpotMarketOption
 
 	return instanceMarketOptionsRequest
 }
-
-// GetFilteredSecurityGroupID get security group ID using filters.
-func (s *Service) GetFilteredSecurityGroupID(securityGroup infrav1.AWSResourceReference) (string, error) {
-	if securityGroup.Filters == nil {
-		return "", nil
-	}
-
-	filters := []*ec2.Filter{}
-	for _, f := range securityGroup.Filters {
-		filters = append(filters, &ec2.Filter{Name: aws.String(f.Name), Values: aws.StringSlice(f.Values)})
-	}
-
-	sgs, err := s.EC2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: filters})
-	if err != nil {
-		return "", err
-	}
-
-	if len(sgs.SecurityGroups) == 0 {
-		return "", fmt.Errorf("failed to find security group matching filters: %q, reason: %w", filters, err)
-	}
-
-	return *sgs.SecurityGroups[0].GroupId, nil
-}

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -3195,7 +3195,7 @@ func TestGetFilteredSecurityGroupID(t *testing.T) {
 				EC2Client: ec2Mock,
 			}
 
-			id, err := s.GetFilteredSecurityGroupID(tc.securityGroup)
+			id, err := s.getFilteredSecurityGroupID(tc.securityGroup)
 			tc.check(id, err)
 		})
 	}

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -18,6 +18,7 @@ package ec2
 
 import (
 	"encoding/base64"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -185,9 +186,11 @@ func (s *Service) createLaunchTemplateData(scope *scope.MachinePoolScope, imageI
 	}
 
 	// add additional security groups as well
-	for _, additionalGroup := range scope.AWSMachinePool.Spec.AWSLaunchTemplate.AdditionalSecurityGroups {
-		data.SecurityGroupIds = append(data.SecurityGroupIds, additionalGroup.ID)
+	securityGroupIDs, err := s.GetAdditionalSecurityGroupsIDs(scope.AWSMachinePool.Spec.AWSLaunchTemplate.AdditionalSecurityGroups)
+	if err != nil {
+		return nil, err
 	}
+	data.SecurityGroupIds = append(data.SecurityGroupIds, aws.StringSlice(securityGroupIDs)...)
 
 	// set the AMI ID
 	data.ImageId = imageID
@@ -368,9 +371,9 @@ func (s *Service) LaunchTemplateNeedsUpdate(scope *scope.MachinePoolScope, incom
 		return true, nil
 	}
 
-	incomingIDs := make([]string, len(incoming.AdditionalSecurityGroups))
-	for i, ref := range incoming.AdditionalSecurityGroups {
-		incomingIDs[i] = aws.StringValue(ref.ID)
+	incomingIDs, err := s.GetAdditionalSecurityGroupsIDs(incoming.AdditionalSecurityGroups)
+	if err != nil {
+		return false, err
 	}
 
 	coreIDs, err := s.GetCoreNodeSecurityGroups(scope)
@@ -379,12 +382,10 @@ func (s *Service) LaunchTemplateNeedsUpdate(scope *scope.MachinePoolScope, incom
 	}
 
 	incomingIDs = append(incomingIDs, coreIDs...)
-
-	existingIDs := make([]string, len(existing.AdditionalSecurityGroups))
-	for i, ref := range existing.AdditionalSecurityGroups {
-		existingIDs[i] = aws.StringValue(ref.ID)
+	existingIDs, err := s.GetAdditionalSecurityGroupsIDs(existing.AdditionalSecurityGroups)
+	if err != nil {
+		return false, err
 	}
-
 	sort.Strings(incomingIDs)
 	sort.Strings(existingIDs)
 
@@ -442,6 +443,25 @@ func (s *Service) DiscoverLaunchTemplateAMI(scope *scope.MachinePoolScope) (*str
 	return aws.String(lookupAMI), nil
 }
 
+func (s *Service) GetAdditionalSecurityGroupsIDs(securityGroups []infrav1.AWSResourceReference) ([]string, error) {
+	var additionalSecurityGroupsIDs []string
+
+	for _, sg := range securityGroups {
+		if sg.ID != nil {
+			additionalSecurityGroupsIDs = append(additionalSecurityGroupsIDs, *sg.ID)
+		} else if sg.Filters != nil {
+			id, err := s.getFilteredSecurityGroupID(sg)
+			if err != nil {
+				return nil, err
+			}
+
+			additionalSecurityGroupsIDs = append(additionalSecurityGroupsIDs, id)
+		}
+	}
+
+	return additionalSecurityGroupsIDs, nil
+}
+
 func (s *Service) buildLaunchTemplateTagSpecificationRequest(scope *scope.MachinePoolScope) []*ec2.LaunchTemplateTagSpecificationRequest {
 	tagSpecifications := make([]*ec2.LaunchTemplateTagSpecificationRequest, 0)
 	additionalTags := scope.AdditionalTags()
@@ -478,4 +498,27 @@ func (s *Service) buildLaunchTemplateTagSpecificationRequest(scope *scope.Machin
 		tagSpecifications = append(tagSpecifications, spec)
 	}
 	return tagSpecifications
+}
+
+// getFilteredSecurityGroupID get security group ID using filters.
+func (s *Service) getFilteredSecurityGroupID(securityGroup infrav1.AWSResourceReference) (string, error) {
+	if securityGroup.Filters == nil {
+		return "", nil
+	}
+
+	filters := []*ec2.Filter{}
+	for _, f := range securityGroup.Filters {
+		filters = append(filters, &ec2.Filter{Name: aws.String(f.Name), Values: aws.StringSlice(f.Values)})
+	}
+
+	sgs, err := s.EC2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: filters})
+	if err != nil {
+		return "", err
+	}
+
+	if len(sgs.SecurityGroups) == 0 {
+		return "", fmt.Errorf("failed to find security group matching filters: %q, reason: %w", filters, err)
+	}
+
+	return *sgs.SecurityGroups[0].GroupId, nil
 }

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -50,9 +50,9 @@ type EC2Interface interface {
 	CreateInstance(scope *scope.MachineScope, userData []byte, userDataFormat string) (*infrav1.Instance, error)
 	GetRunningInstanceByTags(scope *scope.MachineScope) (*infrav1.Instance, error)
 
+	GetAdditionalSecurityGroupsIDs(securityGroup []infrav1.AWSResourceReference) ([]string, error)
 	GetCoreSecurityGroups(machine *scope.MachineScope) ([]string, error)
 	GetInstanceSecurityGroups(instanceID string) (map[string][]string, error)
-	GetFilteredSecurityGroupID(securityGroup infrav1.AWSResourceReference) (string, error)
 	UpdateInstanceSecurityGroups(id string, securityGroups []string) error
 	UpdateResourceTags(resourceID *string, create, remove map[string]string) error
 

--- a/pkg/cloud/services/mock_services/ec2_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_interface_mock.go
@@ -153,6 +153,21 @@ func (mr *MockEC2InterfaceMockRecorder) DiscoverLaunchTemplateAMI(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverLaunchTemplateAMI", reflect.TypeOf((*MockEC2Interface)(nil).DiscoverLaunchTemplateAMI), arg0)
 }
 
+// GetAdditionalSecurityGroupsIDs mocks base method.
+func (m *MockEC2Interface) GetAdditionalSecurityGroupsIDs(arg0 []v1beta1.AWSResourceReference) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdditionalSecurityGroupsIDs", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAdditionalSecurityGroupsIDs indicates an expected call of GetAdditionalSecurityGroupsIDs.
+func (mr *MockEC2InterfaceMockRecorder) GetAdditionalSecurityGroupsIDs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdditionalSecurityGroupsIDs", reflect.TypeOf((*MockEC2Interface)(nil).GetAdditionalSecurityGroupsIDs), arg0)
+}
+
 // GetCoreSecurityGroups mocks base method.
 func (m *MockEC2Interface) GetCoreSecurityGroups(arg0 *scope.MachineScope) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -166,21 +181,6 @@ func (m *MockEC2Interface) GetCoreSecurityGroups(arg0 *scope.MachineScope) ([]st
 func (mr *MockEC2InterfaceMockRecorder) GetCoreSecurityGroups(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCoreSecurityGroups", reflect.TypeOf((*MockEC2Interface)(nil).GetCoreSecurityGroups), arg0)
-}
-
-// GetFilteredSecurityGroupID mocks base method.
-func (m *MockEC2Interface) GetFilteredSecurityGroupID(arg0 v1beta1.AWSResourceReference) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFilteredSecurityGroupID", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetFilteredSecurityGroupID indicates an expected call of GetFilteredSecurityGroupID.
-func (mr *MockEC2InterfaceMockRecorder) GetFilteredSecurityGroupID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilteredSecurityGroupID", reflect.TypeOf((*MockEC2Interface)(nil).GetFilteredSecurityGroupID), arg0)
 }
 
 // GetInstanceSecurityGroups mocks base method.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR does following:

- Remove unused conversion functions in APIs.
- Deprecate `ARN` field from `AWSResourceReference`.
- Add lookup for `AdditionalSecurityGroups` with filters.
- Refactored code for `GetAdditionalSecurityGroupIDs` so as to use common function in `AWSMachine` controller and `launchtemplate.go`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2087 

**Special notes for your reviewer**:
Subset [PR](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3255/) that handles the same for Subnet fields in AWSMachinePool

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
- Remove unused conversion functions in APIs.
- Deprecate `ARN` field from `AWSResourceReference`.
- Add lookup for `AdditionalSecurityGroups` with filters.
- Code refactor for  `GetAdditionalSecurityGroupIDs` to use common function in `AWSMachine` controller and `launchtemplate.go`.
```
