### PR TITLE
Remove manager_name from tilt-provider.json

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -15,8 +15,7 @@
         "controlplane/eks",
         "bootstrap/eks"
       ],
-      "label": "CAPA",
-      "manager_name": "capa-controller-manager"
+      "label": "CAPA"
     }
   }
 ]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
CAPI's Tiltfile is not using manager_name while loading providers anymore. Cleaning up the unused field.
See [slack](https://kubernetes.slack.com/archives/C8TSNPY4T/p1646076234442319) for more information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```
