### PR TITLE
fix: asgNeedsUpdates invalid condition (pointers)

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -510,7 +510,11 @@ func (r *AWSMachinePoolReconciler) reconcileTags(machinePoolScope *scope.Machine
 
 // asgNeedsUpdates compares incoming AWSMachinePool and compares against existing ASG.
 func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *expinfrav1.AutoScalingGroup) bool {
-	if machinePoolScope.MachinePool.Spec.Replicas != nil && machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity {
+	if machinePoolScope.MachinePool.Spec.Replicas != nil {
+		if existingASG.DesiredCapacity == nil || *machinePoolScope.MachinePool.Spec.Replicas != *existingASG.DesiredCapacity {
+			return true
+		}
+	} else if existingASG.DesiredCapacity != nil {
 		return true
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`machinePoolScope.MachinePool.Spec.Replicas` and `existingASG.DesiredCapacity` are both pointers.
The previous condition compared memory addresses instead of integer values.

**Special notes for your reviewer**:
I'm not sure if the check for `existingASG.DesiredCapacity == nil` is needed (i.e. can it happen at all?) but I played a bit on the safe side here. The check could still fail overall if `machinePoolScope.MachinePool.Spec.Replicas` is nil, but I guess that should never happen. Or does it?

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
fixes logic for determining if an AutoScalingGroup needs updates
```
