### PR TITLE
docs: Added documentation for usage of spot instances

### DIFF
--- a/docs/book/src/SUMMARY_PREFIX.md
+++ b/docs/book/src/SUMMARY_PREFIX.md
@@ -8,6 +8,7 @@
 - [Topics](./topics/index.md)
   - [Using clusterawsadm to fulfill prerequisites](./topics/using-clusterawsadm-to-fulfill-prerequisites.md)
   - [Accessing EC2 instances](./topics/accessing-ec2-instances.md)
+  - [Spot instances](./topics/spot-instances.md)
   - [Machine Pools](./topics/machinepools.md)
   - [Multi-tenancy](./topics/multitenancy.md)
   - [EKS Support](./topics/eks/index.md)

--- a/docs/book/src/topics/spot-instances.md
+++ b/docs/book/src/topics/spot-instances.md
@@ -1,0 +1,37 @@
+# Spot Instances
+
+[AWS Spot Instances](https://aws.amazon.com/ec2/spot/?cards.sort-by=item.additionalFields.startDateTime&cards.sort-order=asc&trk=a9b30b20-d23f-4d61-9452-c51a7e407fcd&sc_channel=ps&sc_campaign=acquisition&sc_medium=ACQ-P|PS-GO|Brand|Desktop|SU|Compute|EC2%20Spot|IN|EN|Text&s_kwcid=AL!4422!3!517651795636!e!!g!!amazon%20ec2%20spot&ef_id=Cj0KCQiA95aRBhCsARIsAC2xvfxB17BKyQFcn9UUKZ1GT2sfvxKyhboEKa87gl8wBO37fSrNXmx52cIaAtqwEALw_wcB:G:s&s_kwcid=AL!4422!3!517651795636!e!!g!!amazon%20ec2%20spot) allows user to reduce the costs of their compute resources by utilising AWS spare capacity for a lower price.
+
+Because Spot Instances are tightly integrated with AWS services such as Auto Scaling, ECS and CloudFormation, users can choose how to launch and maintain their applications running on Spot Instances.
+
+Although, with this lower cost, comes the risk of preemption. When capacity within a particular Availability Zone is increased, AWS may need to reclaim Spot instances to satisfy the demand on their data centres.
+
+## When to use spot instances? 
+
+Spot instances are ideal for workloads that can be interrupted. For example, short jobs or stateless services that can be rescheduled quickly, without data loss, and resume operation with limited degradation to a service.
+
+## How to use spot instances?
+
+To enable AWS Machine to be backed by a Spot Instance, users need to add `spotMarketOptions` to AWSMachineTemplate:
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: ${AWS_NODE_MACHINE_TYPE}
+      spotMarketOptions:
+        maxPrice: ""
+      sshKeyName: ${AWS_SSH_KEY_NAME}
+```
+Users may also add a `maxPrice` to the options to limit the maximum spend for the instance. It is however, recommended not to set a maxPrice as AWS will cap your spending at the on-demand price if this field is left empty, and you will experience fewer interruptions.
+```yaml
+spec:
+  template:
+    spotMarketOptions:
+      maxPrice: 0.02 # Price in USD per hour (up to 5 decimal places)
+```
+> **IMPORTANT NOTE**: The experimental feature `MachinePool` does not support using spot instances as of now.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR adds the documentation for usage of spot instances in CAPA for AWS Machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3246 

**Checklist**:
- [x] squashed commits
- [X] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Added documentation for usage of spot instances for AWS Machines.
```
