### PR TITLE
Remove AWSCloudProvider tags from unmanaged subnets when deleting a cluster

### DIFF
--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -40,10 +40,18 @@ func (t Tags) HasOwned(cluster string) bool {
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
 }
 
-// HasAWSCloudProviderOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of the in-tree cloud provider.
+// HasAWSCloudProviderOwned returns true if the tags contains a tag that marks the resource as owned by the cluster
+// from the perspective of the AWS cloud provider.
 func (t Tags) HasAWSCloudProviderOwned(cluster string) bool {
 	value, ok := t[ClusterAWSCloudProviderTagKey(cluster)]
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
+}
+
+// HasAWSCloudProviderShared returns true if the tags contains a tag that marks the resource as shared by the cluster
+// from the perspective of the AWS cloud provider.
+func (t Tags) HasAWSCloudProviderShared(cluster string) bool {
+	value, ok := t[ClusterAWSCloudProviderTagKey(cluster)]
+	return ok && ResourceLifecycle(value) == ResourceLifecycleShared
 }
 
 // GetRole returns the Cluster API role for the tagged resource.

--- a/pkg/cloud/converters/tags.go
+++ b/pkg/cloud/converters/tags.go
@@ -17,6 +17,8 @@ limitations under the License.
 package converters
 
 import (
+	"sort"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -49,14 +51,21 @@ func MapPtrToMap(src map[string]*string) infrav1.Tags {
 	return tags
 }
 
-// MapToTags converts a infrav1.Tags to a []*ec2.Tag.
+// MapToTags converts infrav1.Tags to []*ec2.Tag.
 func MapToTags(src infrav1.Tags) []*ec2.Tag {
 	tags := make([]*ec2.Tag, 0, len(src))
 
-	for k, v := range src {
+	// For testing, we need sorted keys
+	sortedKeys := make([]string, 0, len(tags))
+	for k := range src {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	for _, k := range sortedKeys {
 		tag := &ec2.Tag{
 			Key:   aws.String(k),
-			Value: aws.String(v),
+			Value: aws.String(src[k]),
 		}
 
 		tags = append(tags, tag)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CAPA adds AWSCloudProvider tags to unmanaged subnets but didn't remove the those tags when deleting the cluster. This PR fixes it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3074 

**Special notes for your reviewer**:
In addition to adding unit tests, I tested creating a cluster, observed the tags, deleted the cluster and confirmed the tags are removed. See CAPA log showing tag deletion.

```
I0307 22:51:28.693067      16 subnets.go:279] controller/awscluster "msg"="Deleting AWSCloudProvider tags from unmanaged subnets" "cluster"="ec2-cluster" "name"="ec2-cluster" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSCluster" 
I0307 22:51:28.853169      16 subnets.go:251] controller/awscluster "msg"="Deleted AWSCloudProvider tags from unmanaged subnets" "cluster"="ec2-cluster" "name"="ec2-cluster" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSCluster"
```

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Remove CAPA-added AWSCloudProvider tags from unmanaged subnets when deleting a cluster
```
