### PR TITLE
Add sanity check for VPC ID in VPC deletion reconcile loop

### DIFF
--- a/pkg/cloud/services/network/vpc.go
+++ b/pkg/cloud/services/network/vpc.go
@@ -202,6 +202,12 @@ func (s *Service) createVPC() (*infrav1.VPCSpec, error) {
 func (s *Service) deleteVPC() error {
 	vpc := s.scope.VPC()
 
+	// Skip deletion if .spec.vpc.id is not set.
+	if vpc.ID == "" {
+		s.scope.V(4).Info("Skipping VPC deletion as VPC ID is not set")
+		return nil
+	}
+
 	if vpc.IsUnmanaged(s.scope.Name()) {
 		s.scope.V(4).Info("Skipping VPC deletion in unmanaged mode")
 		return nil

--- a/pkg/cloud/services/network/vpc_test.go
+++ b/pkg/cloud/services/network/vpc_test.go
@@ -402,6 +402,13 @@ func Test_DeleteVPC(t *testing.T) {
 				})).Return(nil, awserr.New("InvalidVpcID.NotFound", "not found", nil))
 			},
 		},
+		{
+			name:    "Should skip reconciliation if VPC ID is not mentioned",
+			input:   &infrav1.VPCSpec{ID: ""},
+			wantErr: false,
+			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In case of unmanaged VPC, if user forgets to set the VPC ID in machinepool, AWSManagedControlPlane wont be deployed. If user wants to delete the resources to recreate the cluster, VPC reconciliation fails as it doesn't find any VPC ID to delete. This PR adds a nil check to validate if we really have VPC ID in place to proceed with the deletion.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2758 

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Add sanity check for VPC ID in VPC deletion.
```
