### PR TITLE
Add specific AZ to peered VPC and  ELB test

### DIFF
--- a/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/kustomization.yaml
@@ -2,4 +2,5 @@ resources:
   - ../remote-management-cluster
 patchesStrategicMerge:
   - patches/internal-elb.yaml
+  - patches/az-select.yaml
 

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/patches/az-select.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/patches/az-select.yaml
@@ -1,0 +1,10 @@
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      failureDomain: "us-west-2a"
+
+

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/kustomization.yaml
@@ -2,4 +2,5 @@ resources:
   - ../remote-management-cluster
 patchesStrategicMerge:
   - patches/management.yaml
+  - patches/az-select.yaml
 

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/patches/az-select.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/patches/az-select.yaml
@@ -1,0 +1,9 @@
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      failureDomain: "us-west-2a"
+

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -835,6 +835,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				VpcCidr:           "10.0.0.0/23",
 				PublicSubnetCidr:  "10.0.0.0/24",
 				PrivateSubnetCidr: "10.0.1.0/24",
+				AvailabilityZone:  "us-west-2a",
 			}, e2eCtx)
 			mgmtClusterInfra.CreateInfrastructure()
 			Expect(mgmtClusterInfra.VPC).NotTo(BeNil())
@@ -853,6 +854,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				VpcCidr:           "10.0.2.0/23",
 				PublicSubnetCidr:  "10.0.2.0/24",
 				PrivateSubnetCidr: "10.0.3.0/24",
+				AvailabilityZone:  "us-west-2a",
 			}, e2eCtx)
 			wlClusterInfra.CreateInfrastructure()
 			Expect(wlClusterInfra.VPC).NotTo(BeNil())


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Specifies the availability zone the subnets will be created in(us-west-2a) and forces CAPA to place instances in those same AZs.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3310

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add specific availability zone to peered VPC and  ELB E2E test
```
