### PR TITLE
Added AWSMachinepool webhook create and update test

### DIFF
--- a/exp/api/v1beta1/awsmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/awsmachinepool_webhook_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
@@ -69,6 +70,41 @@ func TestAWSMachinePool_ValidateCreate(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "Should fail if both subnet ID and filters passed in AWSMachinePool spec",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AdditionalTags: infrav1.Tags{
+						"key-1": "value-1",
+						"key-2": "value-2",
+					},
+					Subnets: []infrav1.AWSResourceReference{
+						{
+							ID:      pointer.StringPtr("subnet-id"),
+							Filters: []infrav1.Filter{{Name: "filter_name", Values: []string{"filter_value"}}},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should pass if either subnet ID or filters passed in AWSMachinePool spec",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AdditionalTags: infrav1.Tags{
+						"key-1": "value-1",
+						"key-2": "value-2",
+					},
+					Subnets: []infrav1.AWSResourceReference{
+						{
+							ID: pointer.StringPtr("subnet-id"),
+						},
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -131,6 +167,55 @@ func TestAWSMachinePool_ValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "Should fail update if both subnetID and filters passed in AWSMachinePool spec",
+			old: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AdditionalTags: infrav1.Tags{
+						"key-1": "value-1",
+					},
+				},
+			},
+			new: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AdditionalTags: infrav1.Tags{
+						"key-1": "value-1",
+						"key-2": "value-2",
+					},
+					Subnets: []infrav1.AWSResourceReference{
+						{
+							ID:      pointer.StringPtr("subnet-id"),
+							Filters: []infrav1.Filter{{Name: "filter_name", Values: []string{"filter_value"}}},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should pass update if either subnetID or filters passed in AWSMachinePool spec",
+			old: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AdditionalTags: infrav1.Tags{
+						"key-1": "value-1",
+					},
+				},
+			},
+			new: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AdditionalTags: infrav1.Tags{
+						"key-1": "value-1",
+						"key-2": "value-2",
+					},
+					Subnets: []infrav1.AWSResourceReference{
+						{
+							ID: pointer.StringPtr("subnet-id"),
+						},
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR add the webhook unit test for AWSMachinePool create and update operation. This PR covers test cases for [this](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3255/files) PR.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Added test cases for AWSMachinePool webhook
```
