### PR TITLE
[E2E] Test to check if bastion host is running when enabled

### DIFF
--- a/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - role.yaml
 patchesStrategicMerge:
   - patches/role-identity.yaml
+  - patches/bastion-enabled.yaml

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/patches/bastion-enabled.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/patches/bastion-enabled.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  bastion:
+    enabled: true

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -136,6 +136,11 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				WaitForControlPlaneIntervals: e2eCtx.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			}, result)
 
+			// Check if bastion host is up and running
+			awsCluster, err := GetAWSClusterByName(ctx, namespace.Name, clusterName)
+			Expect(err).To(BeNil())
+			Expect(awsCluster.Status.Bastion.State).To(Equal(infrav1.InstanceStateRunning))
+			expectAWSClusterConditions(awsCluster, []conditionAssertion{{infrav1.BastionHostReadyCondition, corev1.ConditionTrue, "", ""}})
 			ginkgo.By("PASSED!")
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**
/area testing

**What this PR does / why we need it**:
Since we don't have any existing E2E tests to check if bastion host is up and running when enabled, this PR adds this check in existing multitenancy test(as it's faster as compared to other functional tests). This would also give assurity that bastion default AMI lookup is functioning properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow up for #3298 

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
```release-note
Added E2E test to check if bastion host is running when enabled.
```
