### PR TITLE
Remove .metadata.clusterName usage

### DIFF
--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -196,7 +196,7 @@ func (s *Service) translateAPIToAddon(addons []ekscontrolplanev1.Addon) []*eksad
 		convertedAddon := &eksaddons.EKSAddon{
 			Name:                  &addon.Name,
 			Version:               &addon.Version,
-			Tags:                  ngTags(s.scope.Cluster.ClusterName, s.scope.AdditionalTags()),
+			Tags:                  ngTags(s.scope.Cluster.Name, s.scope.AdditionalTags()),
 			ResolveConflict:       convertConflictResolution(*addon.ConflictResolution),
 			ServiceAccountRoleARN: addon.ServiceAccountRoleArn,
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
k8s upstream plans to drop ObjectMeta.ClusterName field as it has always been force cleared by the API server.
See kubernetes/kubernetes#108717.

Searched CAPA codebase and there is only one occasion where `ObjectMeta.ClusterName` is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3321 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Remove .metadata.clusterName usage
```
