### PR TITLE
[WIP] Upgrade Go version to 1.18

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,9 +157,9 @@ linters-settings:
       - pkg: "sigs.k8s.io/cluster-api/exp/api/v1beta1"
         alias: expclusterv1
   staticcheck:
-    go: "1.17"
+    go: "1.18"
   stylecheck:
-    go: "1.17"
+    go: "1.18"
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.17.3 as toolchain
+FROM golang:1.18.0 as toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org

--- a/docs/book/src/development/development.md
+++ b/docs/book/src/development/development.md
@@ -5,7 +5,7 @@
 ### Install prerequisites
 
 1. Install [go][go]
-    - Get the latest patch version for go v1.17.
+    - Get the latest patch version for go v1.18.
 2. Install [jq][jq]
     - `brew install jq` on macOS.
     - `chocolatey install jq` on Windows.

--- a/docs/triage-party/Dockerfile
+++ b/docs/triage-party/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-FROM golang:1.17  as builder
+FROM golang:1.18  as builder
 
 RUN go get github.com/google/triage-party/cmd/server
 RUN go install github.com/google/triage-party/cmd/server@latest

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.17.0
+  minimum_go_version=go1.18.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.17"
+    GO_VERSION = "1.18"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What type of PR is this?**
/area release

**What this PR does / why we need it**:
This PR upgrade Go version to 1.18

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Bump Go version from 1.17.3 to 1.18.0
```
