### PR TITLE
Fix lint errors due to golangci-lint bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.23.0
 	k8s.io/apiextensions-apiserver v0.23.0
@@ -125,7 +126,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -17,9 +17,10 @@ limitations under the License.
 package record
 
 import (
-	"strings"
 	"sync"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cgrecord "k8s.io/client-go/tools/record"
@@ -44,20 +45,26 @@ func InitFromRecorder(recorder cgrecord.EventRecorder) {
 
 // Event constructs an event from the given information and puts it in the queue for sending.
 func Event(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeNormal, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeNormal, title(reason), message)
 }
 
 // Eventf is just like Event, but with Sprintf for the message field.
 func Eventf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeNormal, title(reason), message, args...)
 }
 
 // Warn constructs a warning event from the given information and puts it in the queue for sending.
 func Warn(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeWarning, title(reason), message)
 }
 
 // Warnf is just like Event, but with Sprintf for the message field.
 func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeWarning, title(reason), message, args...)
+}
+
+// title returns a copy of the string s with all Unicode letters that begin words
+// mapped to their Unicode title case.
+func title(source string) string {
+	return cases.Title(language.Und, cases.NoLower).String(source)
 }

--- a/test/helpers/external/cluster.go
+++ b/test/helpers/external/cluster.go
@@ -17,8 +17,8 @@ limitations under the License.
 package external
 
 import (
-	"strings"
-
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -50,7 +50,7 @@ func generateTestClusterAPICRD(kind, pluralKind string) *apiextensionsv1.CustomR
 			Group: "cluster.x-k8s.io",
 			Scope: apiextensionsv1.NamespaceScoped,
 			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Kind:   strings.Title(kind),
+				Kind:   cases.Title(language.Und, cases.NoLower).String(kind),
 				Plural: pluralKind,
 			},
 			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes below lint error in open PRs possibly caused by the version bump of golangci-lint(since strings.Title() is deprecated from Go 1.18).

> SA1019: strings.Title is deprecated: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
None
```
