### PR TITLE
:bug: fixes services for EKS clusters 

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -171,10 +171,10 @@ func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScal
 	// Make sure to use the MachinePoolScope here to get the merger of AWSCluster and AWSMachinePool tags
 	additionalTags := scope.AdditionalTags()
 	// Set the cloud provider tag
-	additionalTags[infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name())] = string(infrav1.ResourceLifecycleOwned)
+	additionalTags[infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName())] = string(infrav1.ResourceLifecycleOwned)
 
 	input.Tags = infrav1.Build(infrav1.BuildParams{
-		ClusterName: s.scope.Name(),
+		ClusterName: s.scope.KubernetesClusterName(),
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        aws.String(scope.Name()),
 		Role:        aws.String("node"),

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -123,14 +123,13 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte) (*i
 
 	// Make sure to use the MachineScope here to get the merger of AWSCluster and AWSMachine tags
 	additionalTags := scope.AdditionalTags()
-
 	input.Tags = infrav1.Build(infrav1.BuildParams{
-		ClusterName: s.scope.Name(),
+		ClusterName: s.scope.KubernetesClusterName(),
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        aws.String(scope.Name()),
 		Role:        aws.String(scope.Role()),
 		Additional:  additionalTags,
-	}.WithCloudProvider(s.scope.Name()).WithMachineName(scope.Machine))
+	}.WithCloudProvider(s.scope.KubernetesClusterName()).WithMachineName(scope.Machine))
 
 	var err error
 	// Pick image from the machine configuration, or use a default one.

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -300,3 +300,4 @@ intervals:
   default/wait-machine-pool-upgrade: [ "50m", "10s" ]
   default/wait-create-identity: ["1m", "10s"]
   default/wait-job: ["10m", "10s"]
+  default/wait-create-service: ["60s", "10s"]

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -236,3 +236,4 @@ intervals:
   default/wait-control-plane-upgrade: ["35m", "30s"]
   default/wait-addon-status: ["10m", "30s"]
   default/wait-create-identity: ["1m", "10s"]
+  default/wait-create-service: ["60s", "10s"]

--- a/test/e2e/shared/services.go
+++ b/test/e2e/shared/services.go
@@ -1,0 +1,195 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elb"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateLBService(e2eCtx *E2EContext, svcNamespace string, svcName string, k8sclient crclient.Client) string {
+	Byf("Creating service of type Load Balancer with name: %s under namespace: %s", svcName, svcNamespace)
+	svcSpec := corev1.ServiceSpec{
+		Type: corev1.ServiceTypeLoadBalancer,
+		Ports: []corev1.ServicePort{
+			{
+				Port:     80,
+				Protocol: corev1.ProtocolTCP,
+			},
+		},
+		Selector: map[string]string{
+			"app": "nginx",
+		},
+	}
+	CreateService(svcName, svcNamespace, nil, svcSpec, k8sclient)
+	elbName := ""
+	Eventually(func() bool {
+		svcCreated := &corev1.Service{}
+		err := k8sclient.Get(context.TODO(), apimachinerytypes.NamespacedName{Namespace: svcNamespace, Name: svcName}, svcCreated)
+		Expect(err).NotTo(HaveOccurred())
+		if lbs := len(svcCreated.Status.LoadBalancer.Ingress); lbs > 0 {
+			ingressHostname := svcCreated.Status.LoadBalancer.Ingress[0].Hostname
+			elbName = strings.Split(ingressHostname, "-")[0]
+			return true
+		}
+		return false
+	}, e2eCtx.E2EConfig.GetIntervals("", "wait-create-service")...).Should(BeTrue())
+	Byf("Created Load Balancer service and ELB name is: %s", elbName)
+	return elbName
+}
+
+func DeleteLBService(svcNamespace string, svcName string, k8sclient crclient.Client) {
+	svcSpec := corev1.ServiceSpec{
+		Type: corev1.ServiceTypeLoadBalancer,
+		Ports: []corev1.ServicePort{
+			{
+				Port:     80,
+				Protocol: corev1.ProtocolTCP,
+			},
+		},
+		Selector: map[string]string{
+			"app": "nginx",
+		},
+	}
+	deleteService(svcName, svcNamespace, nil, svcSpec, k8sclient)
+}
+
+func CreateService(svcName string, svcNamespace string, labels map[string]string, serviceSpec corev1.ServiceSpec, k8sClient crclient.Client) {
+	svcToCreate := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: svcNamespace,
+			Name:      svcName,
+		},
+		Spec: serviceSpec,
+	}
+	if len(labels) > 0 {
+		svcToCreate.ObjectMeta.Labels = labels
+	}
+	Expect(k8sClient.Create(context.TODO(), &svcToCreate)).NotTo(HaveOccurred())
+}
+
+func CreateDefaultNginxDeployment(deploymentNamespace, deploymentName string, k8sClient crclient.Client) {
+	Byf("Creating Deployment with name: %s under namespace: %s", deploymentName, deploymentNamespace)
+	deployment := defaultNginxDeployment(deploymentName, deploymentNamespace)
+	Expect(k8sClient.Create(context.TODO(), &deployment)).NotTo(HaveOccurred())
+	Eventually(func() bool {
+		getDeployment := &v1.Deployment{}
+		err := k8sClient.Get(context.TODO(), apimachinerytypes.NamespacedName{Namespace: deploymentNamespace, Name: deploymentName}, getDeployment)
+		Expect(err).NotTo(HaveOccurred())
+		for _, c := range getDeployment.Status.Conditions {
+			if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
+				return getDeployment.Status.AvailableReplicas > 0
+			}
+		}
+		return false
+	}, 60*time.Second).Should(BeTrue())
+}
+
+func DeleteDefaultNginxDeployment(deploymentNamespace, deploymentName string, k8sClient crclient.Client) {
+	Byf("Deleting Deployment with name: %s under namespace: %s", deploymentName, deploymentNamespace)
+	deployment := defaultNginxDeployment(deploymentName, deploymentNamespace)
+	Expect(k8sClient.Delete(context.TODO(), &deployment)).NotTo(HaveOccurred())
+}
+
+func deleteService(svcName, svcNamespace string, labels map[string]string, serviceSpec corev1.ServiceSpec, k8sClient crclient.Client) {
+	svcToDelete := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: svcNamespace,
+			Name:      svcName,
+		},
+		Spec: serviceSpec,
+	}
+	if len(labels) > 0 {
+		svcToDelete.ObjectMeta.Labels = labels
+	}
+	Expect(k8sClient.Delete(context.TODO(), &svcToDelete)).NotTo(HaveOccurred())
+}
+
+func VerifyElbExists(e2eCtx *E2EContext, elbName string, exists bool) {
+	Byf("Verifying ELB with name %s present and instances are attached", elbName)
+	input := &elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: []*string{
+			aws.String(elbName),
+		},
+	}
+	elbClient := elb.New(e2eCtx.AWSSession)
+	elbsOutput, err := elbClient.DescribeLoadBalancers(input)
+	if exists {
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(elbsOutput.LoadBalancerDescriptions)).To(Equal(1))
+		Expect(len(elbsOutput.LoadBalancerDescriptions[0].Instances)).Should(BeNumerically(">=", 1))
+		Byf("ELB with name %s exists", elbName)
+	} else {
+		aerr, ok := err.(awserr.Error)
+		Expect(ok).To(BeTrue())
+		Expect(aerr.Code()).To(Equal(elb.ErrCodeAccessPointNotFoundException))
+		Byf("ELB with name %s doesn't exists", elbName)
+	}
+}
+
+func defaultNginxDeployment(deploymentName, deploymentNamespace string) v1.Deployment {
+	selector, err := metav1.ParseToLabelSelector("app=nginx")
+	Expect(err).To(BeNil())
+	deploymentSpec := v1.DeploymentSpec{
+		Selector: selector,
+		Replicas: pointer.Int32(1),
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nginx",
+				Labels: map[string]string{
+					"app": "nginx",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "nginx",
+						Image: "k8s.gcr.io/nginx-slim:0.8",
+						Ports: []corev1.ContainerPort{{
+							Name: "nginx-port", ContainerPort: int32(80),
+						}},
+					},
+				},
+			},
+		},
+	}
+	return v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: deploymentNamespace,
+			Name:      deploymentName,
+			Labels: map[string]string{
+				"app": "nginx",
+			},
+		},
+		Spec: deploymentSpec,
+	}
+}

--- a/test/e2e/suites/managed/eks_test.go
+++ b/test/e2e/suites/managed/eks_test.go
@@ -110,6 +110,7 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 				AWSSession:            e2eCtx.BootstrapUserAWSSession,
 				Namespace:             namespace,
 				ClusterName:           clusterName,
+				IncludeLBTest:         true,
 				Replicas:              1,
 				Cleanup:               true,
 			}
@@ -124,6 +125,7 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 				AWSSession:            e2eCtx.BootstrapUserAWSSession,
 				Namespace:             namespace,
 				ClusterName:           clusterName,
+				IncludeLBTest:         true,
 				IncludeScaling:        true,
 				Cleanup:               true,
 			}
@@ -136,7 +138,6 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 			Name:      clusterName,
 		})
 		Expect(cluster).NotTo(BeNil(), "couldn't find CAPI cluster")
-
 		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
 			Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
 			Cluster: cluster,

--- a/test/e2e/suites/managed/machine_deployment.go
+++ b/test/e2e/suites/managed/machine_deployment.go
@@ -23,14 +23,17 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
 )
 
 // MachineDeploymentSpecInput is the input for MachineDeploymentSpec.
@@ -42,6 +45,7 @@ type MachineDeploymentSpecInput struct {
 	Namespace             *corev1.Namespace
 	Replicas              int64
 	ClusterName           string
+	IncludeLBTest         bool
 	Cleanup               bool
 }
 
@@ -92,17 +96,26 @@ func MachineDeploymentSpec(ctx context.Context, inputGetter func() MachineDeploy
 		StatusChecks: statusChecks,
 	}
 	framework.WaitForMachineStatusCheck(ctx, machineStatusInput, input.E2EConfig.GetIntervals("", "wait-machine-status")...)
+	if input.IncludeLBTest {
+		clusterClient := e2eCtx.Environment.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName).GetClient()
+		ginkgo.By("Creating the Nginx deployment")
+		deploymentName := "test-deployment-" + util.RandomString(6)
+		shared.CreateDefaultNginxDeployment(metav1.NamespaceDefault, deploymentName, clusterClient)
+		ginkgo.By("Creating the LB service")
+		lbServiceName := "test-svc-" + util.RandomString(6)
+		elbName := shared.CreateLBService(e2eCtx, metav1.NamespaceDefault, lbServiceName, clusterClient)
+		shared.VerifyElbExists(e2eCtx, elbName, true)
+		ginkgo.By("Deleting the Nginx deployment")
+		shared.DeleteDefaultNginxDeployment(metav1.NamespaceDefault, deploymentName, clusterClient)
+		ginkgo.By("Deleting LB service")
+		shared.DeleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
+	}
 
 	if input.Cleanup {
 		deleteMachineDeployment(ctx, deleteMachineDeploymentInput{
 			Deleter:           input.BootstrapClusterProxy.GetClient(),
 			MachineDeployment: md[0],
 		})
-		// deleteMachine(ctx, deleteMachineInput{
-		// 	Deleter: input.BootstrapClusterProxy.GetClient(),
-		// 	Machine: &workerMachines[0],
-		// })
-
 		waitForMachineDeploymentDeleted(ctx, waitForMachineDeploymentDeletedInput{
 			Getter:            input.BootstrapClusterProxy.GetClient(),
 			MachineDeployment: md[0],

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -245,8 +245,8 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 
 			ginkgo.By("Creating the LB service")
 			lbServiceName := "test-svc-" + util.RandomString(6)
-			elbName := createLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
-			verifyElbExists(elbName, true)
+			elbName := shared.CreateLBService(e2eCtx, metav1.NamespaceDefault, lbServiceName, clusterClient)
+			shared.VerifyElbExists(e2eCtx, elbName, true)
 
 			ginkgo.By("Checking v1.22 StatefulSet still healthy after the upgrade")
 			waitForStatefulSetRunning(nginxStatefulsetInfo, clusterClient)
@@ -259,7 +259,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 			verifyVolumesExists(awsVolIds)
 
 			ginkgo.By("Deleting LB service")
-			deleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
+			shared.DeleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
 
 			ginkgo.By("Deleting the Clusters")
 			deleteCluster(ctx, cluster2)
@@ -314,8 +314,8 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 
 			ginkgo.By("Creating the LB service")
 			lbServiceName := "test-svc-" + util.RandomString(6)
-			elbName := createLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
-			verifyElbExists(elbName, true)
+			elbName := shared.CreateLBService(e2eCtx, metav1.NamespaceDefault, lbServiceName, clusterClient)
+			shared.VerifyElbExists(e2eCtx, elbName, true)
 
 			ginkgo.By("Checking v1.22 StatefulSet still healthy after the upgrade")
 			waitForStatefulSetRunning(nginxStatefulsetInfo, clusterClient)
@@ -328,7 +328,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 			verifyVolumesExists(awsVolIds)
 
 			ginkgo.By("Deleting LB service")
-			deleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
+			shared.DeleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
 
 			ginkgo.By("Deleting the Clusters")
 			deleteCluster(ctx, cluster2)
@@ -383,8 +383,8 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 
 			ginkgo.By("Creating the LB service")
 			lbServiceName := "test-svc-" + util.RandomString(6)
-			elbName := createLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
-			verifyElbExists(elbName, true)
+			elbName := shared.CreateLBService(e2eCtx, metav1.NamespaceDefault, lbServiceName, clusterClient)
+			shared.VerifyElbExists(e2eCtx, elbName, true)
 
 			ginkgo.By("Checking v1.22 StatefulSet still healthy after the upgrade")
 			waitForStatefulSetRunning(nginxStatefulsetInfo, clusterClient)
@@ -397,7 +397,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 			verifyVolumesExists(awsVolIds)
 
 			ginkgo.By("Deleting LB service")
-			deleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
+			shared.DeleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
 
 			ginkgo.By("Deleting the Clusters")
 			deleteCluster(ctx, cluster2)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR creates  a failing test for #3329  as well as extending the existing test for non managed clusters to ensure the LB for service is actually backed by instances.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
changes AWSCloudProvider tag for ec2 instances to be KubernetesClusterName() instead of ClusterName() to support load balancer services for EKS clusters 
```
