### PR TITLE
:bug: ./build/generate-go-apis to run on api change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 GO_INSTALL := ./scripts/go_install.sh
 
 API_DIRS := cmd/clusterawsadm/api api exp/api controlplane/eks/api bootstrap/eks/api iam/api
-API_SRCS := $(foreach dir, $(API_DIRS), $(call rwildcard,../../$(dir),*.go))
+API_FILES := $(foreach dir, $(API_DIRS), $(call rwildcard,$(dir),*.go))
 
 BIN_DIR := bin
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -192,7 +192,7 @@ generate: ## Generate code
 	$(MAKE) generate-go
 	$(MAKE) $(CRD_DOCS)
 
-$(CRD_DOCS_DIR)/%: $(API_SRCS)
+$(CRD_DOCS_DIR)/%: $(API_FILES)
 	$(MAKE) -C docs/book src/crd/$*
 
 .PHONY: generate-go ## Generate all Go api files
@@ -207,7 +207,7 @@ generate-go-apis: ## Alias for .build/generate-go-apis
 .build: ## Create the .build folder
 	mkdir -p .build
 
-.build/generate-go-apis: .build $(API_SRCS) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN) ## Generate all Go api files
+.build/generate-go-apis: .build $(API_FILES) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN) ## Generate all Go api files
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		paths=./$(EXP_DIR)/api/... \

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -16093,8 +16093,8 @@ AWSMachineTemplateResource
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>)
 </p>
 <p>
-<p>AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
-Only one of ID, ARN or Filters may be specified. Specifying more than one will result in
+<p>AWSResourceReference is a reference to a specific AWS resource by ID or filters.
+Only one of ID or Filters may be specified. Specifying more than one will result in
 a validation error.</p>
 </p>
 <table>
@@ -16126,7 +16126,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ARN of resource</p>
+<p>ARN of resource.
+Deprecated: This field has no function and is going to be removed in the next release.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes the wrong behavior where running `make generate` after an api change wont regenerate the CRD definitions. 

**Which issue(s) this PR fixes**:

Fixes #3336 

**Special notes for your reviewer**:

1. `make clean`
2. change the [API definition](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/exp/api/v1beta1/awsmanagedmachinepool_types.go)
3. `make generate`
4. change the [API definition](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/exp/api/v1beta1/awsmanagedmachinepool_types.go) again
5. `make generate`

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
3. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note

```
