### PR TITLE
Refactored reconciler creation in controllers

### DIFF
--- a/controllers/awsmachine_annotations.go
+++ b/controllers/awsmachine_annotations.go
@@ -26,7 +26,7 @@ import (
 // `content`. `content` in this case should be a `map[string]interface{}`
 // suitable for turning into JSON. This `content` map will be marshalled into a
 // JSON string before being set as the given `annotation`.
-func (r *AWSMachineReconciler) updateMachineAnnotationJSON(machine *infrav1.AWSMachine, annotation string, content map[string]interface{}) error {
+func (r *awsMachineReconciler) updateMachineAnnotationJSON(machine *infrav1.AWSMachine, annotation string, content map[string]interface{}) error {
 	b, err := json.Marshal(content)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func (r *AWSMachineReconciler) updateMachineAnnotationJSON(machine *infrav1.AWSM
 
 // updateMachineAnnotation updates the `annotation` on the given `machine` with
 // `content`.
-func (r *AWSMachineReconciler) updateMachineAnnotation(machine *infrav1.AWSMachine, annotation, content string) {
+func (r *awsMachineReconciler) updateMachineAnnotation(machine *infrav1.AWSMachine, annotation, content string) {
 	// Get the annotations
 	annotations := machine.GetAnnotations()
 
@@ -54,7 +54,7 @@ func (r *AWSMachineReconciler) updateMachineAnnotation(machine *infrav1.AWSMachi
 // Returns a map[string]interface from a JSON annotation.
 // This method gets the given `annotation` from the `machine` and unmarshalls it
 // from a JSON string into a `map[string]interface{}`.
-func (r *AWSMachineReconciler) machineAnnotationJSON(machine *infrav1.AWSMachine, annotation string) (map[string]interface{}, error) {
+func (r *awsMachineReconciler) machineAnnotationJSON(machine *infrav1.AWSMachine, annotation string) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 
 	jsonAnnotation := r.machineAnnotation(machine, annotation)
@@ -71,6 +71,6 @@ func (r *AWSMachineReconciler) machineAnnotationJSON(machine *infrav1.AWSMachine
 }
 
 // Fetches the specific machine annotation.
-func (r *AWSMachineReconciler) machineAnnotation(machine *infrav1.AWSMachine, annotation string) string {
+func (r *awsMachineReconciler) machineAnnotation(machine *infrav1.AWSMachine, annotation string) string {
 	return machine.GetAnnotations()[annotation]
 }

--- a/controllers/awsmachine_security_groups.go
+++ b/controllers/awsmachine_security_groups.go
@@ -38,7 +38,7 @@ const (
 // Returns bool, error
 // Bool indicates if changes were made or not, allowing the caller to decide
 // if the machine should be updated.
-func (r *AWSMachineReconciler) ensureSecurityGroups(ec2svc service.EC2Interface, scope *scope.MachineScope, additional []infrav1.AWSResourceReference, existing map[string][]string) (bool, error) {
+func (r *awsMachineReconciler) ensureSecurityGroups(ec2svc service.EC2Interface, scope *scope.MachineScope, additional []infrav1.AWSResourceReference, existing map[string][]string) (bool, error) {
 	annotation, err := r.machineAnnotationJSON(scope.AWSMachine, SecurityGroupsLastAppliedAnnotation)
 	if err != nil {
 		return false, err
@@ -77,7 +77,7 @@ func (r *AWSMachineReconciler) ensureSecurityGroups(ec2svc service.EC2Interface,
 }
 
 // securityGroupsChanged determines which security groups to delete and which to add.
-func (r *AWSMachineReconciler) securityGroupsChanged(annotation map[string]interface{}, core []string, additional []string, existing map[string][]string) (bool, []string) {
+func (r *awsMachineReconciler) securityGroupsChanged(annotation map[string]interface{}, core []string, additional []string, existing map[string][]string) (bool, []string) {
 	state := map[string]bool{}
 	for _, s := range additional {
 		state[s] = true

--- a/controllers/awsmachine_tags.go
+++ b/controllers/awsmachine_tags.go
@@ -39,7 +39,7 @@ const (
 // Returns bool, error
 // Bool indicates if changes were made or not, allowing the caller to decide
 // if the machine should be updated.
-func (r *AWSMachineReconciler) ensureTags(svc service.EC2Interface, machine *infrav1.AWSMachine, instanceID *string, additionalTags map[string]string) (bool, error) {
+func (r *awsMachineReconciler) ensureTags(svc service.EC2Interface, machine *infrav1.AWSMachine, instanceID *string, additionalTags map[string]string) (bool, error) {
 	annotation, err := r.machineAnnotationJSON(machine, TagsLastAppliedAnnotation)
 	if err != nil {
 		return false, err
@@ -68,7 +68,7 @@ func (r *AWSMachineReconciler) ensureTags(svc service.EC2Interface, machine *inf
 
 // Ensure that the tags of the volumes in the machine are correct
 // Returns tags which are being created/updated/deleted and error.
-func (r *AWSMachineReconciler) ensureVolumeTags(svc service.EC2Interface, volumeID *string, annotation map[string]interface{}, additionalTags map[string]string) (map[string]interface{}, error) {
+func (r *awsMachineReconciler) ensureVolumeTags(svc service.EC2Interface, volumeID *string, annotation map[string]interface{}, additionalTags map[string]string) (map[string]interface{}, error) {
 	// Check if the volume tags were changed. If they were, update them.
 	// It would be possible here to only send new/updated tags, but for the
 	// moment we send everything, even if only a single tag was created or
@@ -85,7 +85,7 @@ func (r *AWSMachineReconciler) ensureVolumeTags(svc service.EC2Interface, volume
 }
 
 // tagsChanged determines which tags to delete and which to add.
-func (r *AWSMachineReconciler) tagsChanged(annotation map[string]interface{}, src map[string]string) (bool, map[string]string, map[string]string, map[string]interface{}) {
+func (r *awsMachineReconciler) tagsChanged(annotation map[string]interface{}, src map[string]string) (bool, map[string]string, map[string]string, map[string]interface{}) {
 	// Bool tracking if we found any changed state.
 	changed := false
 

--- a/main.go
+++ b/main.go
@@ -175,25 +175,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.AWSMachineReconciler{
-		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("controllers").WithName("AWSMachine"),
-		Recorder:         mgr.GetEventRecorderFor("awsmachine-controller"),
-		Endpoints:        AWSServiceEndpoints,
+	if err = (controllers.NewMachineReconciler(controllers.NewMachineReconcilerInput{
+		Manager:          mgr,
 		WatchFilterValue: watchFilterValue,
-	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsMachineConcurrency, RecoverPanic: true}); err != nil {
+		Endpoints:        AWSServiceEndpoints,
+	})).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsClusterConcurrency, RecoverPanic: true}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AWSMachine")
 		os.Exit(1)
 	}
-	if err = (&controllers.AWSClusterReconciler{
-		Client:           mgr.GetClient(),
-		Recorder:         mgr.GetEventRecorderFor("awscluster-controller"),
-		Endpoints:        AWSServiceEndpoints,
+
+	if err = (controllers.NewClusterReconciler(controllers.NewClusterReconcilerInput{
+		Manager:          mgr,
 		WatchFilterValue: watchFilterValue,
-	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsClusterConcurrency, RecoverPanic: true}); err != nil {
+		Endpoints:        AWSServiceEndpoints,
+	})).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsClusterConcurrency, RecoverPanic: true}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AWSCluster")
 		os.Exit(1)
 	}
+
 	enableGates(ctx, mgr, AWSServiceEndpoints)
 
 	if err = (&infrav1.AWSMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/area testing
/kind refactor

**What this PR does / why we need it**:
This PR refactors AWSCluster and AWSMachine reconcilers, so that the code inside them shouldn't be aware about creation of service clients(tests or main function calls).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3181 

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Refactored reconciler creation in controllers.
```
