### PR TITLE
Disassociate secondary CIDR after subnets are deleted

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -402,6 +402,8 @@ func (t Template) ControllersPolicyEKS() *iamv1.PolicyDocument {
 			Effect: iamv1.EffectAllow,
 		}, {
 			Action: iamv1.Actions{
+				"ec2:AssociateVpcCidrBlock",
+				"ec2:DisassociateVpcCidrBlock",
 				"eks:ListAddons",
 				"eks:CreateAddon",
 				"eks:DescribeAddonVersions",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -324,6 +324,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -324,6 +324,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -337,6 +337,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -331,6 +331,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -331,6 +331,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -324,6 +324,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -324,6 +324,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -324,6 +324,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -324,6 +324,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -331,6 +331,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -333,6 +333,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -324,6 +324,8 @@ Resources:
           - arn:*:eks:*:*:cluster/*
           - arn:*:eks:*:*:nodegroup/*/*/*
         - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
           - eks:ListAddons
           - eks:CreateAddon
           - eks:DescribeAddonVersions

--- a/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
@@ -34,3 +34,4 @@ spec:
   identityRef:
     kind: AWSClusterStaticIdentity
     name: e2e-account
+  secondaryCidrBlock: 100.64.0.0/16


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes following:
- Order of disassociation of secondary CIDR post subnet deletion, otherwise the CIDR wont get deleted if subnet is still in use.
- Adds ec2:AssociateVpcCidrBlock and ec2:DisassociateVpcCidrBlock permissions to EKS controller policy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3277 
Fixes #3273 

**Checklist**:

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
```release-note
- Disassociate secondary CIDR after subnets are deleted.
- Adds ec2:AssociateVpcCidrBlock and ec2:DisassociateVpcCidrBlock permissions to EKS controller policy.
```
