### PR TITLE
Makefile: don't log verbose from tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,10 @@ e2e-image: docker-pull-prerequisites $(TOOLS_BIN_DIR)/start.sh $(TOOLS_BIN_DIR)/
 
 .PHONY: test
 test: ## Run tests
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test ./...
+
+.PHONY: test-verbose
+test-verbose: ## Run tests with verbose settings.
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./...
 
 .PHONY: test-e2e ## Run e2e tests using clusterctl
@@ -388,7 +392,7 @@ test-conformance: generate-test-flavors $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOM
 
 .PHONY: test-cover
 test-cover: ## Run tests with code coverage and code generate  reports
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -coverprofile=coverage.out ./... $(TEST_ARGS)
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -coverprofile=coverage.out ./... $(TEST_ARGS)
 	go tool cover -func=coverage.out -o coverage.txt
 	go tool cover -html=coverage.out -o coverage.html
 

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -26,4 +26,4 @@ cd "${REPO_ROOT}" &&
   source ./scripts/fetch_ext_bins.sh &&
   fetch_tools &&
   setup_envs &&
-  make lint test
+  make lint test-verbose


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Test logs are mainly useful either when developing/debugging tests or
when the tests are failing. If some test fails, Go will automatically
print the outputs from this tests.

Printing all test logs all the time makes it much difficult to find
which test is actually failing and which output belongs to it, so I
suggest we don't use -v by default.

Similar change has been made in CAPI a while ago:
https://github.com/kubernetes-sigs/cluster-api/pull/4187

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>

<!-- Enter a description of the change and why this change is needed -->

**Release note**:

```
NONE
```