### PR TITLE
Modify internal ELB test to only use private subnet

### DIFF
--- a/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/patches/az-select.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/patches/az-select.yaml
@@ -6,5 +6,15 @@ spec:
   template:
     spec:
       failureDomain: "us-west-2a"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      failureDomain: "us-west-2a"
+
 
 

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/patches/internal-elb.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/internal-elb/patches/internal-elb.yaml
@@ -9,6 +9,5 @@ spec:
     vpc:
       id: "${WL_VPC_ID}"
     subnets:
-    - id: "${WL_PUBLIC_SUBNET_ID}"
     - id: "${WL_PRIVATE_SUBNET_ID}"
 

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/patches/az-select.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/patches/az-select.yaml
@@ -6,4 +6,15 @@ spec:
   template:
     spec:
       failureDomain: "us-west-2a"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      failureDomain: "us-west-2a"
+
+
 

--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -107,7 +107,29 @@ func DumpMachines(ctx context.Context, e2eCtx *E2EContext, namespace *corev1.Nam
 		if instanceID == "" {
 			return
 		}
-		DumpMachine(ctx, e2eCtx, m, instanceID)
+		DumpMachine(ctx, e2eCtx, m, instanceID, nil)
+	}
+}
+
+func DumpMachinesFromProxy(ctx context.Context, e2eCtx *E2EContext, namespace *corev1.Namespace, proxy framework.ClusterProxy) {
+	machines := MachinesForSpec(ctx, proxy, namespace)
+	instances, err := allMachines(ctx, e2eCtx)
+	if err != nil {
+		return
+	}
+	instanceID := ""
+	for _, m := range machines.Items {
+		for _, i := range instances {
+			if i.name == m.Name {
+				instanceID = i.instanceID
+				break
+			}
+		}
+		if instanceID == "" {
+			return
+		}
+		clusterName := proxy.GetName()
+		DumpMachine(ctx, e2eCtx, m, instanceID, &clusterName)
 	}
 }
 
@@ -121,8 +143,11 @@ func MachinesForSpec(ctx context.Context, clusterProxy framework.ClusterProxy, n
 	return list
 }
 
-func DumpMachine(ctx context.Context, e2eCtx *E2EContext, machine infrav1.AWSMachine, instanceID string) {
+func DumpMachine(ctx context.Context, e2eCtx *E2EContext, machine infrav1.AWSMachine, instanceID string, cluster *string) {
 	logPath := filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName())
+	if cluster != nil {
+		logPath = filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", *cluster)
+	}
 	machineLogBase := path.Join(logPath, "instances", machine.Namespace, machine.Name)
 	metaLog := path.Join(machineLogBase, "instance.log")
 	if err := os.MkdirAll(filepath.Dir(metaLog), 0750); err != nil {
@@ -173,6 +198,14 @@ func DumpSpecResources(ctx context.Context, e2eCtx *E2EContext, namespace *corev
 		Lister:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
 		Namespace: namespace.Name,
 		LogPath:   filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName(), "resources"),
+	})
+}
+
+func DumpSpecResourcesFromProxy(ctx context.Context, e2eCtx *E2EContext, namespace *corev1.Namespace, proxy framework.ClusterProxy) {
+	framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+		Lister:    proxy.GetClient(),
+		Namespace: namespace.Name,
+		LogPath:   filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", proxy.GetName(), "resources"),
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR does the following:
- Modifies the internal ELB E2E test to only utilize the private subnet created in the AWSCluster resource. 
- Adds the us-west-2a AZ to the failure domain of the machine deployments created for both clusters. 
- Adds functions to dump spec and machine resources using the management cluster proxy.
- Adds logic to the E2E test to respect the skip cleanup logic

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3353

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

```release-note
Modifies Internal ELB E2E test to only utilize private subnet, E2E function additions/cleanup.
```