### PR TITLE
 Fix flaky integration test

### DIFF
--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -64,7 +64,7 @@ func TestAWSClusterReconciler_IntegrationTests(t *testing.T) {
 		mockCtrl.Finish()
 	}
 
-	t.Run("Should successfully reconcile AWCluster creation with unmanaged VPC", func(t *testing.T) {
+	t.Run("Should successfully reconcile AWSCluster creation with unmanaged VPC", func(t *testing.T) {
 		g := NewWithT(t)
 		mockCtrl = gomock.NewController(t)
 		ec2Mock := mock_ec2iface.NewMockEC2API(mockCtrl)


### PR DESCRIPTION
**What type of PR is this?**
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes flaky integration test in AWSCluster controller. The sorting of tags by keys are in place in the test, this PR is just making it a bit more generic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3352 

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release Notes**:
```release-note
None
```