### PR TITLE
Apidiff test runs only if there are changes in api/ or exp/api/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,9 @@ APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 
 .PHONY: apidiff
 apidiff: $(GO_APIDIFF) ## Check for API differences
-	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
+	@if (git --no-pager diff --name-only FETCH_HEAD | grep "api/"); then \
+		$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible; \
+	fi
 
 ##@ build:
 


### PR DESCRIPTION
Signed-off-by: Meghana Jangi <mjangi@vmware.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR will limit the apidiff test to run only if there are changes made in the directory api/ and exp/api/

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3282 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
