### PR TITLE
fix: remove flaky deployment code

### DIFF
--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -236,4 +236,4 @@ intervals:
   default/wait-control-plane-upgrade: ["35m", "30s"]
   default/wait-addon-status: ["10m", "30s"]
   default/wait-create-identity: ["1m", "10s"]
-  default/wait-create-service: ["60s", "10s"]
+  default/wait-create-service: ["5m", "10s"]

--- a/test/e2e/suites/managed/machine_deployment.go
+++ b/test/e2e/suites/managed/machine_deployment.go
@@ -98,15 +98,10 @@ func MachineDeploymentSpec(ctx context.Context, inputGetter func() MachineDeploy
 	framework.WaitForMachineStatusCheck(ctx, machineStatusInput, input.E2EConfig.GetIntervals("", "wait-machine-status")...)
 	if input.IncludeLBTest {
 		clusterClient := e2eCtx.Environment.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName).GetClient()
-		ginkgo.By("Creating the Nginx deployment")
-		deploymentName := "test-deployment-" + util.RandomString(6)
-		shared.CreateDefaultNginxDeployment(metav1.NamespaceDefault, deploymentName, clusterClient)
 		ginkgo.By("Creating the LB service")
 		lbServiceName := "test-svc-" + util.RandomString(6)
 		elbName := shared.CreateLBService(e2eCtx, metav1.NamespaceDefault, lbServiceName, clusterClient)
 		shared.VerifyElbExists(e2eCtx, elbName, true)
-		ginkgo.By("Deleting the Nginx deployment")
-		shared.DeleteDefaultNginxDeployment(metav1.NamespaceDefault, deploymentName, clusterClient)
 		ginkgo.By("Deleting LB service")
 		shared.DeleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
 	}

--- a/test/e2e/suites/managed/machine_pool.go
+++ b/test/e2e/suites/managed/machine_pool.go
@@ -108,15 +108,10 @@ func ManagedMachinePoolSpec(ctx context.Context, inputGetter func() ManagedMachi
 
 	if input.IncludeLBTest {
 		clusterClient := e2eCtx.Environment.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName).GetClient()
-		ginkgo.By("Creating the Nginx deployment")
-		deploymentName := "test-deployment-" + util.RandomString(6)
-		shared.CreateDefaultNginxDeployment(metav1.NamespaceDefault, deploymentName, clusterClient)
 		ginkgo.By("Creating the LB service")
 		lbServiceName := "test-svc-" + util.RandomString(6)
 		elbName := shared.CreateLBService(e2eCtx, metav1.NamespaceDefault, lbServiceName, clusterClient)
 		shared.VerifyElbExists(e2eCtx, elbName, true)
-		ginkgo.By("Deleting the Nginx deployment")
-		shared.DeleteDefaultNginxDeployment(metav1.NamespaceDefault, deploymentName, clusterClient)
 		ginkgo.By("Deleting LB service")
 		shared.DeleteLBService(metav1.NamespaceDefault, lbServiceName, clusterClient)
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind flake 
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR fixes the flake on e2e eks tests by removing a NOOP deployment that isn't checked for: 

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-cluster-api-provider-aws-eks-e2e/1509216501851230208

this was the first instance of the test failing.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
