### PR TITLE
[E2E] Added tests for using filters in AWSResourceReference type fields

### DIFF
--- a/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
@@ -34,4 +34,5 @@ spec:
   identityRef:
     kind: AWSClusterStaticIdentity
     name: e2e-account
+  # secondaryCidrBlock added to test it's creation and deletion functionality within the cluster.
   secondaryCidrBlock: 100.64.0.0/16

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/kustomization.yaml
@@ -3,4 +3,7 @@ resources:
   - role.yaml
 patchesStrategicMerge:
   - patches/role-identity.yaml
+  # This manifest is added to test bastion host creation.
   - patches/bastion-enabled.yaml
+  # This manifest is added to test subnet with filters in AWSMachineTemplate.
+  - patches/subnet-with-filters.yaml

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/patches/bastion-enabled.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/patches/bastion-enabled.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/patches/subnet-with-filters.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/nested-multitenancy/patches/subnet-with-filters.yaml
@@ -1,0 +1,15 @@
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      subnet:
+        filters:
+          - name: "availabilityZone"
+            values:
+              - "us-west-2a"
+          - name: "tag-key"
+            values:
+              - "kubernetes.io/role/internal-elb"

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/kustomization.yaml
@@ -4,4 +4,5 @@ patchesStrategicMerge:
   - patches/management.yaml
   - patches/az-select.yaml
   - patches/external-securitygroups.yaml
-
+  # This manifest is added to test additionalSecurityGroups with filters in AWSMachineTemplate.
+  - patches/additional-security-group.yaml

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/patches/additional-security-group.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/peered-remote/patches/additional-security-group.yaml
@@ -1,0 +1,15 @@
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      additionalSecurityGroups:
+        - filters:
+          - name: "vpc-id"
+            values:
+              - "${MGMT_VPC_ID}"
+          - name: "group-name"
+            values:
+              - "${MGMT_CLUSTER_NAME}-all"

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -695,6 +695,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 		specName := "functional-test-extinfra"
 		mgmtClusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 		mgmtClusterInfra := new(shared.AWSInfrastructure)
+		shared.SetEnvVar("MGMT_CLUSTER_NAME", mgmtClusterName, false)
 
 		wlClusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 		wlClusterInfra := new(shared.AWSInfrastructure)


### PR DESCRIPTION
**What type of PR is this?**
/area testing

**What this PR does / why we need it**:
This PR adds the E2E tests for usage of filters in AWSResourceReference type fields. It also adds comments to tests/manifests for the tests that are combined/overloaded with other existing tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3348 

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests
