### PR TITLE
Fix for release log creation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 # main controller
 CORE_IMAGE_NAME ?= cluster-api-aws-controller
 CORE_CONTROLLER_IMG ?= $(REGISTRY)/$(CORE_IMAGE_NAME)
+CORE_CONTROLLER_PROMOTED_IMG := $(PROD_REGISTRY)/$(CORE_IMAGE_NAME)
 CORE_CONTROLLER_ORIGINAL_IMG := gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller
 CORE_CONTROLLER_NAME := capa-controller-manager
 CORE_MANIFEST_FILE := infrastructure-components
@@ -551,7 +552,7 @@ release-manifests: ## Release manifest files
 
 .PHONY: release-changelog
 release-changelog: $(GH) ## Generates release notes using Github release notes.
-	./hack/releasechangelog.sh -v $(VERSION) -pv $(PREVIOUS_VERSION) -gh $(GH) -ghorg $(GH_ORG_NAME) -ghrepo $(GH_REPO_NAME) -cimg $(CORE_CONTROLLER_IMG) > $(RELEASE_DIR)/CHANGELOG.md
+	./hack/releasechangelog.sh > $(RELEASE_DIR)/CHANGELOG.md
 
 .PHONY: release-binaries
 release-binaries: ## Builds the binaries to publish with a release

--- a/hack/releasechangelog.sh
+++ b/hack/releasechangelog.sh
@@ -17,22 +17,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-while getopts v:pv:gh:ghorg:ghrepo:cimg: flag
-do
-    case "${flag}" in
-        v) VERSION=${OPTARG};;
-        pv) PREVIOUS_VERSION=${OPTARG};;
-        gh) GH=${OPTARG};;
-        ghorg) GH_ORG_NAME=${OPTARG};;
-        ghrepo) GH_REPO_NAME=${OPTARG};;
-        cimg) CORE_CONTROLLER_IMG=${OPTARG};;
-    esac
-done
-
 echo "# Release notes for Cluster API Provider AWS (CAPA) $VERSION"
 echo "[Documentation](https://cluster-api-aws.sigs.k8s.io/)"
 echo "# Changelog since $PREVIOUS_VERSION"
-$GH api repos/$GH_ORG_NAME/$GH_REPO_NAME/releases/generate-notes -F tag_name=$VERSION --jq '.body'
-echo "**The image for this release is**: $CORE_CONTROLLER_IMG:$VERSION"
+$GH api repos/$GH_ORG_NAME/$GH_REPO_NAME/releases/generate-notes -F tag_name=$VERSION -F previous_tag_name=$PREVIOUS_VERSION --jq '.body'
+echo "**The image for this release is**: $CORE_CONTROLLER_PROMOTED_IMG:$VERSION"
 echo "Thanks to all our contributors!"
 


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:
Removed getopts logic from the release notes script. The variables set in the Makefile that calls this script are passed to the script. getops was not working properly, values were being overriden by Makefile because same variables names were being used in the script.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
