### PR TITLE
Validate Tags created for the resources

### DIFF
--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
@@ -74,10 +75,18 @@ func (t Tags) Merge(other Tags) {
 	}
 }
 
-// Validate checks if tags are valid for the AWS API. Keys must have at
-// least 1 character and max 128. Values must be max 256 characters long.
+// Validate checks if tags are valid for the AWS API/Resources.
+// Keys must have at least 1 and max 128 characters.
+// Values must be max 256 characters long.
+// Keys and Values can only have alphabets, numbers, spaces and _ . : / = + - @ as characters.
+// Tag's key cannot have prefix "aws:".
+// Max count of User tags for a specific resource can be 50.
 func (t Tags) Validate() []*field.Error {
+	// Defines the maximum number of user tags which can be created for a specific resource
+	const maxUserTagsAllowed = 50
 	var errs field.ErrorList
+	var userTagCount = len(t)
+	re := regexp.MustCompile(`^[a-zA-Z0-9\\s\_\.\:\=\+\-\@\/]*$`)
 
 	for k, v := range t {
 		if len(k) < 1 {
@@ -95,9 +104,37 @@ func (t Tags) Validate() []*field.Error {
 				field.Invalid(field.NewPath("spec", "additionalTags"), v, "value cannot be longer than 256 characters"),
 			)
 		}
+		if wrongUserTagNomenclature(k) {
+			errs = append(errs,
+				field.Invalid(field.NewPath("spec", "additionalTags"), k, "user created tag's key cannot have prefix aws:"),
+			)
+		}
+		val := re.MatchString(k)
+		if !val {
+			errs = append(errs,
+				field.Invalid(field.NewPath("spec", "additionalTags"), k, "key cannot have characters other than alphabets, numbers, spaces and _ . : / = + - @ ."),
+			)
+		}
+		val = re.MatchString(v)
+		if !val {
+			errs = append(errs,
+				field.Invalid(field.NewPath("spec", "additionalTags"), v, "value cannot have characters other than alphabets, numbers, spaces and _ . : / = + - @ ."),
+			)
+		}
+	}
+
+	if userTagCount > maxUserTagsAllowed {
+		errs = append(errs,
+			field.Invalid(field.NewPath("spec", "additionalTags"), t, "user created tags cannot be more than 50"),
+		)
 	}
 
 	return errs
+}
+
+// Checks whether the tag created is user tag or not.
+func wrongUserTagNomenclature(k string) bool {
+	return len(k) > 3 && k[0:4] == "aws:"
 }
 
 // ResourceLifecycle configures the lifecycle of a resource.

--- a/api/v1beta1/tags_test.go
+++ b/api/v1beta1/tags_test.go
@@ -271,6 +271,68 @@ func TestTags_Validate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "key has aws: prefix",
+			self: Tags{
+				"aws:key": "validValue",
+			},
+			expected: []*field.Error{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "user created tag's key cannot have prefix aws:",
+					Field:    "spec.additionalTags",
+					BadValue: "aws:key",
+				},
+			},
+		},
+		{
+			name: "key has wrong characters",
+			self: Tags{
+				"wrong*key": "validValue",
+			},
+			expected: []*field.Error{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "key cannot have characters other than alphabets, numbers, spaces and _ . : / = + - @ .",
+					Field:    "spec.additionalTags",
+					BadValue: "wrong*key",
+				},
+			},
+		},
+		{
+			name: "value has wrong characters",
+			self: Tags{
+				"validKey": "wrong*value",
+			},
+			expected: []*field.Error{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "value cannot have characters other than alphabets, numbers, spaces and _ . : / = + - @ .",
+					Field:    "spec.additionalTags",
+					BadValue: "wrong*value",
+				},
+			},
+		},
+		{
+			name: "value and key both has wrong characters",
+			self: Tags{
+				"wrong*key": "wrong*value",
+			},
+			expected: []*field.Error{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "key cannot have characters other than alphabets, numbers, spaces and _ . : / = + - @ .",
+					Field:    "spec.additionalTags",
+					BadValue: "wrong*key",
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "value cannot have characters other than alphabets, numbers, spaces and _ . : / = + - @ .",
+					Field:    "spec.additionalTags",
+					BadValue: "wrong*value",
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR validates the tags created for resources
1. Added code for checking max number of user tags which can be created for a resource [50 user tags can be created]
2. Added code for checking characters which can be used in user tags created for a resource [letters, numbers, spaces and the following characters: _ . : / = + - @]

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1746

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
