### PR TITLE
Only attempt to delete bootstrap data secret if InsecureSkipSecretsManager isn't set

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -733,8 +733,10 @@ func (r *AWSMachineReconciler) ignitionUserData(scope *scope.MachineScope, objec
 }
 
 func (r *AWSMachineReconciler) deleteBootstrapData(machineScope *scope.MachineScope, clusterScope cloud.ClusterScoper, objectStoreScope scope.S3Scope) error {
-	if err := r.deleteEncryptedBootstrapDataSecret(machineScope, clusterScope); err != nil {
-		return err
+	if !machineScope.AWSMachine.Spec.CloudInit.InsecureSkipSecretsManager {
+		if err := r.deleteEncryptedBootstrapDataSecret(machineScope, clusterScope); err != nil {
+			return err
+		}
 	}
 
 	if objectStoreScope != nil {

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -1079,6 +1079,20 @@ func TestAWSMachineReconciler(t *testing.T) {
 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
+			t.Run("should not attempt to delete the secret if InsecureSkipSecretsManager is set on CloudInit", func(t *testing.T) {
+				g := NewWithT(t)
+				awsMachine := getAWSMachine()
+				setup(t, g, awsMachine)
+				defer teardown(t, g)
+				setNodeRef(t, g)
+
+				ms.AWSMachine.Spec.CloudInit.InsecureSkipSecretsManager = true
+
+				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(0)
+				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+
+				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
+			})
 		})
 
 		t.Run("Secrets management lifecycle when there's only a secret ARN and no node ref", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Addresses an issue where setting `InsecureSkipSecretsManager` option on CloudInit on an AWSMachine will cause errors when attempting to reconcile deletes later on. Open to discussion on whether adding e2e tests that cover this is necessary/in-scope :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3394

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
