### PR TITLE
Scope cleanup

### DIFF
--- a/pkg/cloud/scope/awsnode.go
+++ b/pkg/cloud/scope/awsnode.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+)
+
+// AWSNodeScope is the interface for the scope to be used with the awsnode reconciling service.
+type AWSNodeScope interface {
+	cloud.ClusterScoper
+
+	// RemoteClient returns the Kubernetes client for connecting to the workload cluster.
+	RemoteClient() (client.Client, error)
+	// Subnets returns the cluster subnets.
+	Subnets() infrav1.Subnets
+	// SecondaryCidrBlock returns the optional secondary CIDR block to use for pod IPs
+	SecondaryCidrBlock() *string
+	// SecurityGroups returns the control plane security groups as a map, it creates the map if empty.
+	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+	// DisableVPCCNI returns whether the AWS VPC CNI should be disabled
+	DisableVPCCNI() bool
+}

--- a/pkg/cloud/scope/iamauth.go
+++ b/pkg/cloud/scope/iamauth.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+)
+
+// IAMAuthScope is the interface for the scope to be used with iamauth reconciling service.
+type IAMAuthScope interface {
+	cloud.ClusterScoper
+
+	// RemoteClient returns the Kubernetes client for connecting to the workload cluster.
+	RemoteClient() (client.Client, error)
+	// IAMAuthConfig returns the IAM authenticator config
+	IAMAuthConfig() *ekscontrolplanev1.IAMAuthenticatorConfig
+}

--- a/pkg/cloud/scope/network.go
+++ b/pkg/cloud/scope/network.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+)
+
+// NetworkScope is the interface for the scope to be used with the network services.
+type NetworkScope interface {
+	cloud.ClusterScoper
+
+	// Network returns the cluster network object.
+	Network() *infrav1.NetworkStatus
+	// VPC returns the cluster VPC.
+	VPC() *infrav1.VPCSpec
+	// Subnets returns the cluster subnets.
+	Subnets() infrav1.Subnets
+	// SetSubnets updates the clusters subnets.
+	SetSubnets(subnets infrav1.Subnets)
+	// CNIIngressRules returns the CNI spec ingress rules.
+	CNIIngressRules() infrav1.CNIIngressRules
+	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
+	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+	// SecondaryCidrBlock returns the optional secondary CIDR block to use for pod IPs
+	SecondaryCidrBlock() *string
+
+	// Bastion returns the bastion details for the cluster.
+	Bastion() *infrav1.Bastion
+}

--- a/pkg/cloud/scope/sg.go
+++ b/pkg/cloud/scope/sg.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+)
+
+// SGScope is the interface for the scope to be used with the sg service.
+type SGScope interface {
+	cloud.ClusterScoper
+
+	// Network returns the cluster network object.
+	Network() *infrav1.NetworkStatus
+
+	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
+	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+
+	// SecurityGroupOverrides returns the security groups that are overridden in the cluster spec
+	SecurityGroupOverrides() map[infrav1.SecurityGroupRole]string
+
+	// VPC returns the cluster VPC.
+	VPC() *infrav1.VPCSpec
+
+	// CNIIngressRules returns the CNI spec ingress rules.
+	CNIIngressRules() infrav1.CNIIngressRules
+
+	// Bastion returns the bastion details for the cluster.
+	Bastion() *infrav1.Bastion
+}

--- a/pkg/cloud/services/awsnode/service.go
+++ b/pkg/cloud/services/awsnode/service.go
@@ -17,35 +17,16 @@ limitations under the License.
 package awsnode
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
-
-// Scope is a scope for use with the awsnode reconciling service.
-type Scope interface {
-	cloud.ClusterScoper
-
-	// RemoteClient returns the Kubernetes client for connecting to the workload cluster.
-	RemoteClient() (client.Client, error)
-	// Subnets returns the cluster subnets.
-	Subnets() infrav1.Subnets
-	// SecondaryCidrBlock returns the optional secondary CIDR block to use for pod IPs
-	SecondaryCidrBlock() *string
-	// SecurityGroups returns the control plane security groups as a map, it creates the map if empty.
-	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
-	// DisableVPCCNI returns whether the AWS VPC CNI should be disabled
-	DisableVPCCNI() bool
-}
 
 // Service defines the spec for a service.
 type Service struct {
-	scope Scope
+	scope scope.AWSNodeScope
 }
 
 // NewService will create a new service.
-func NewService(awsnodeScope Scope) *Service {
+func NewService(awsnodeScope scope.AWSNodeScope) *Service {
 	return &Service{
 		scope: awsnodeScope,
 	}

--- a/pkg/cloud/services/iamauth/service.go
+++ b/pkg/cloud/services/iamauth/service.go
@@ -20,31 +20,19 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
 
-// Scope is a scope for use with the iamauth reconciling service.
-type Scope interface {
-	cloud.ClusterScoper
-
-	// RemoteClient returns the Kubernetes client for connecting to the workload cluster.
-	RemoteClient() (client.Client, error)
-	// IAMAuthConfig returns the IAM authenticator config
-	IAMAuthConfig() *ekscontrolplanev1.IAMAuthenticatorConfig
-}
-
 // Service defines the specs for a service.
 type Service struct {
-	scope     Scope
+	scope     scope.IAMAuthScope
 	backend   BackendType
 	client    client.Client
 	STSClient stsiface.STSAPI
 }
 
 // NewService will create a new Service object.
-func NewService(iamScope Scope, backend BackendType, client client.Client) *Service {
+func NewService(iamScope scope.IAMAuthScope, backend BackendType, client client.Client) *Service {
 	return &Service{
 		scope:     iamScope,
 		backend:   backend,

--- a/pkg/cloud/services/network/service.go
+++ b/pkg/cloud/services/network/service.go
@@ -19,44 +19,19 @@ package network
 import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
-
-// Scope is scope for use with the network service.
-type Scope interface {
-	cloud.ClusterScoper
-
-	// Network returns the cluster network object.
-	Network() *infrav1.NetworkStatus
-	// VPC returns the cluster VPC.
-	VPC() *infrav1.VPCSpec
-	// Subnets returns the cluster subnets.
-	Subnets() infrav1.Subnets
-	// SetSubnets updates the clusters subnets.
-	SetSubnets(subnets infrav1.Subnets)
-	// CNIIngressRules returns the CNI spec ingress rules.
-	CNIIngressRules() infrav1.CNIIngressRules
-	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
-	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
-	// SecondaryCidrBlock returns the optional secondary CIDR block to use for pod IPs
-	SecondaryCidrBlock() *string
-
-	// Bastion returns the bastion details for the cluster.
-	Bastion() *infrav1.Bastion
-}
 
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
 // One alternative is to have a large list of functions from the ec2 client.
 type Service struct {
-	scope     Scope
+	scope     scope.NetworkScope
 	EC2Client ec2iface.EC2API
 }
 
 // NewService returns a new service given the ec2 api client.
-func NewService(networkScope Scope) *Service {
+func NewService(networkScope scope.NetworkScope) *Service {
 	return &Service{
 		scope:     networkScope,
 		EC2Client: scope.NewEC2Client(networkScope, networkScope, networkScope, networkScope.InfraCluster()),

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -2115,7 +2115,7 @@ func TestDeleteSubnets(t *testing.T) {
 // Test helpers
 
 type ScopeBuilder interface {
-	Build() (Scope, error)
+	Build() (scope.NetworkScope, error)
 }
 
 func NewClusterScope() *ClusterScopeBuilder {
@@ -2136,7 +2136,7 @@ func (b *ClusterScopeBuilder) WithNetwork(n *infrav1.NetworkSpec) *ClusterScopeB
 	return b
 }
 
-func (b *ClusterScopeBuilder) Build() (Scope, error) {
+func (b *ClusterScopeBuilder) Build() (scope.NetworkScope, error) {
 	scheme := runtime.NewScheme()
 	_ = infrav1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -2185,7 +2185,7 @@ func (b *ManagedControlPlaneScopeBuilder) WithEKSClusterName(name string) *Manag
 	return b
 }
 
-func (b *ManagedControlPlaneScopeBuilder) Build() (Scope, error) {
+func (b *ManagedControlPlaneScopeBuilder) Build() (scope.NetworkScope, error) {
 	scheme := runtime.NewScheme()
 	_ = infrav1.AddToScheme(scheme)
 	_ = ekscontrolplanev1.AddToScheme(scheme)

--- a/pkg/cloud/services/securitygroup/service.go
+++ b/pkg/cloud/services/securitygroup/service.go
@@ -20,45 +20,21 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
-
-// Scope is a scope for use with the security group reconciling service.
-type Scope interface {
-	cloud.ClusterScoper
-
-	// Network returns the cluster network object.
-	Network() *infrav1.NetworkStatus
-
-	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
-	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
-
-	// SecurityGroupOverrides returns the security groups that are overridden in the cluster spec
-	SecurityGroupOverrides() map[infrav1.SecurityGroupRole]string
-
-	// VPC returns the cluster VPC.
-	VPC() *infrav1.VPCSpec
-
-	// CNIIngressRules returns the CNI spec ingress rules.
-	CNIIngressRules() infrav1.CNIIngressRules
-
-	// Bastion returns the bastion details for the cluster.
-	Bastion() *infrav1.Bastion
-}
 
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
 // One alternative is to have a large list of functions from the ec2 client.
 type Service struct {
-	scope     Scope
+	scope     scope.SGScope
 	roles     []infrav1.SecurityGroupRole
 	EC2Client ec2iface.EC2API
 }
 
 // NewService returns a new service given the api clients with a defined
 // set of roles.
-func NewService(sgScope Scope, roles []infrav1.SecurityGroupRole) *Service {
+func NewService(sgScope scope.SGScope, roles []infrav1.SecurityGroupRole) *Service {
 	return &Service{
 		scope:     sgScope,
 		roles:     roles,


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Half of the scope interfaces are in `scope` package to avoid cyclic imports.
This PR moves all scope interfaces to that package for having all interfaces in the same package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
