### PR TITLE
Introduce args in releasechangelog script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -572,7 +572,7 @@ release-manifests: ## Release manifest files
 
 .PHONY: release-changelog
 release-changelog: $(GH) ## Generates release notes using Github release notes.
-	./hack/releasechangelog.sh > $(RELEASE_DIR)/CHANGELOG.md
+	./hack/releasechangelog.sh -v $(VERSION) -p $(PREVIOUS_VERSION) -o $(GH_ORG_NAME) -r $(GH_REPO_NAME) -c $(CORE_CONTROLLER_PROMOTED_IMG) > $(RELEASE_DIR)/CHANGELOG.md
 
 .PHONY: release-binaries
 release-binaries: ## Builds the binaries to publish with a release

--- a/hack/releasechangelog.sh
+++ b/hack/releasechangelog.sh
@@ -17,6 +17,50 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+function show_help()
+{
+  cat << EOF
+Usage: ${0##*/} -v VERSION -p PREVIOUS_VERSION -o GH_ORG_NAME -r GH_REPO_NAME -c CORE_CONTROLLER_PROMOTED_IMG
+
+This generates the release notes for the new CAPA version being released.
+
+Required Arguments:
+    -v VERSION                      Version of the Cluster API Provider AWS (CAPA) being released
+    -p PREVIOUS_VERSION             Current CAPA version previously released
+    -o GH_ORG_NAME                  GitHub organization name
+    -r GH_REPO_NAME                 GitHub repository name
+    -c CORE_CONTROLLER_PROMOTED_IMG Image used for this release
+EOF
+}
+
+while getopts "v:p:o:r:c:h" opt; do
+  case $opt in
+    v)
+      VERSION=${OPTARG}
+      ;;
+    p)
+      PREVIOUS_VERSION=${OPTARG}
+      ;;
+    o)
+      GH_ORG_NAME=${OPTARG}
+      ;;
+    r)
+      GH_REPO_NAME=${OPTARG}
+      ;;
+    c)
+      CORE_CONTROLLER_PROMOTED_IMG=${OPTARG}
+      ;;
+    h)
+      show_help
+      exit 0
+      ;;
+    *)
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
 echo "# Release notes for Cluster API Provider AWS (CAPA) $VERSION"
 echo "[Documentation](https://cluster-api-aws.sigs.k8s.io/)"
 echo "# Changelog since $PREVIOUS_VERSION"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind refactor

**What this PR does / why we need it**:

The [releasechangelog.sh](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/hack/releasechangelog.sh) script now uses arguments instead of relying on the right variables being set out side the script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3405

**Special notes for your reviewer**:
The `PREVIOUS_VERSION` arg is not set in the `Makefile`, as of now it ends up being parsed as `-o`. I need help in order to get the previous version and pass it or set a default value, but I don't think it's doable cause of the call to gh api.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
