### PR TITLE
Makefile: use 'rm -f' for verify-boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ verify: verify-boilerplate verify-modules verify-gen verify-conversions verify-s
 
 .PHONY: verify-boilerplate
 verify-boilerplate: ## Verify boilerplate
-	-rm ./hack/tools/bin/*.sh
+	-rm -f ./hack/tools/bin/*.sh
 	./hack/verify-boilerplate.sh
 
 .PHONY: verify-modules


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

So the target is idempotent and it does not print to stderr on CI.

Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/3344/pull-cluster-api-provider-aws-verify/1518490957455036416#1:build-log.txt%3A16