### PR TITLE
Revert ":bug: ./build/generate-go-apis to run on api change"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 GO_INSTALL := ./scripts/go_install.sh
 
 API_DIRS := cmd/clusterawsadm/api api exp/api controlplane/eks/api bootstrap/eks/api iam/api
-API_FILES := $(foreach dir, $(API_DIRS), $(call rwildcard,$(dir),*.go))
+API_SRCS := $(foreach dir, $(API_DIRS), $(call rwildcard,../../$(dir),*.go))
 
 BIN_DIR := bin
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -192,7 +192,7 @@ generate: ## Generate code
 	$(MAKE) generate-go
 	$(MAKE) $(CRD_DOCS)
 
-$(CRD_DOCS_DIR)/%: $(API_FILES)
+$(CRD_DOCS_DIR)/%: $(API_SRCS)
 	$(MAKE) -C docs/book src/crd/$*
 
 .PHONY: generate-go ## Generate all Go api files
@@ -207,7 +207,7 @@ generate-go-apis: ## Alias for .build/generate-go-apis
 .build: ## Create the .build folder
 	mkdir -p .build
 
-.build/generate-go-apis: .build $(API_FILES) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN) ## Generate all Go api files
+.build/generate-go-apis: .build $(API_SRCS) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN) ## Generate all Go api files
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		paths=./$(EXP_DIR)/api/... \

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -16093,8 +16093,8 @@ AWSMachineTemplateResource
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>)
 </p>
 <p>
-<p>AWSResourceReference is a reference to a specific AWS resource by ID or filters.
-Only one of ID or Filters may be specified. Specifying more than one will result in
+<p>AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
+Only one of ID, ARN or Filters may be specified. Specifying more than one will result in
 a validation error.</p>
 </p>
 <table>
@@ -16126,8 +16126,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ARN of resource.
-Deprecated: This field has no function and is going to be removed in the next release.</p>
+<p>ARN of resource</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:
Reverts kubernetes-sigs/cluster-api-provider-aws#3344 because of `make generate` out of date error.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

Checklist:

- [ ]  squashed commits
- [ ]  includes documentation
- [ ]  adds unit tests
- [ ]  adds or updates e2e tests