### PR TITLE
Add timeout to AllocateAddress

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -164,9 +164,14 @@ func (i *AWSInfrastructure) AllocateAddress() AWSInfrastructure {
 		return *i
 	}
 
-	if addr, _ := GetAddress(i.Context, *aa.AllocationId); addr != nil {
-		i.ElasticIP = addr
+	t := 0
+	addr, _ := GetAddress(i.Context, *aa.AllocationId)
+	for addr == nil || t < 180 {
+		time.Sleep(1 * time.Second)
+		addr, _ = GetAddress(i.Context, *aa.AllocationId)
+		t++
 	}
+	i.ElasticIP = addr
 	return *i
 }
 
@@ -235,9 +240,11 @@ func (i *AWSInfrastructure) CreateInfrastructure() AWSInfrastructure {
 		i.CreateInternetGateway()
 	}
 	i.AllocateAddress()
-	i.CreateNatGateway("public")
-	if i.NatGateway != nil && i.NatGateway.NatGatewayId != nil {
-		WaitForNatGatewayState(i.Context, *i.NatGateway.NatGatewayId, 180, "available")
+	if i.ElasticIP != nil && i.ElasticIP.AllocationId != nil {
+		i.CreateNatGateway("public")
+		if i.NatGateway != nil && i.NatGateway.NatGatewayId != nil {
+			WaitForNatGatewayState(i.Context, *i.NatGateway.NatGatewayId, 180, "available")
+		}
 	}
 	if len(i.Subnets) == 2 {
 		i.CreateRouteTable("public")


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The flaky e2e infrastructure test stems from a lack of AllocationId field on the ElasticIP field of the AWSInfrastructure struct

<!-- Enter a description of the change and why this change is needed -->
This change adds a retry and timeout for obtaining the allocation ID for the elastic IP. Additionally, AWSInfrastructure's CreateNatGateway function is made conditional based on setting that allocation ID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3455

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests
