### PR TITLE
Remove CAPI test package import in `clusterawsadm`

### DIFF
--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,7 +30,6 @@ import (
 	"github.com/pkg/errors"
 
 	ec2service "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/ec2"
-	"sigs.k8s.io/cluster-api/test/framework/kubernetesversions"
 )
 
 const (
@@ -61,6 +61,37 @@ func getimageRegionList() []string {
 	}
 }
 
+// LatestPatchRelease returns the latest patch release matching.
+func LatestPatchRelease(searchVersion string) (string, error) {
+	searchSemVer, err := semver.Make(strings.TrimPrefix(searchVersion, tagPrefix))
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.Get(fmt.Sprintf(latestStableReleaseURL, "-"+strconv.Itoa(int(searchSemVer.Major))+"."+strconv.Itoa(int(searchSemVer.Minor))))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(b)), nil
+}
+
+// PreviousMinorRelease returns the latest patch release for the previous version
+// of Kubernetes, e.g. v1.19.1 returns v1.18.8 as of Sep 2020.
+func PreviousMinorRelease(searchVersion string) (string, error) {
+	semVer, err := semver.Make(strings.TrimPrefix(searchVersion, tagPrefix))
+	if err != nil {
+		return "", err
+	}
+	semVer.Minor--
+
+	return LatestPatchRelease(semVer.String())
+}
+
 // getSupportedKubernetesVersions returns all possible k8s versions till last nth kubernetes release.
 func getSupportedKubernetesVersions(lastNReleases int) ([]string, error) {
 	currentVersion, err := latestStableRelease()
@@ -76,7 +107,7 @@ func getSupportedKubernetesVersions(lastNReleases int) ([]string, error) {
 	versionPatches = append(versionPatches, currentVersion)
 
 	for lastNReleases != 0 {
-		currentVersion, err = kubernetesversions.PreviousMinorRelease(currentVersion)
+		currentVersion, err = PreviousMinorRelease(currentVersion)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Importing `sigs.k8s.io/cluster-api/test/framework/kubernetesversions` package inside `cmd/clusterawsadm/ami/helper.go` causes a version error while installing the `sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/ami` package.
```logtalk
❯ go get sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/ami
go get: sigs.k8s.io/cluster-api@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```
This PR duplicates the functions required from `sigs.k8s.io/cluster-api/test/framework/kubernetesversions` within `cmd/clusterawsadm/ami/helper.go`.

cc - @sedefsavas 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
