### PR TITLE
[E2E] Fix failing GPU test due to update in the CUDA Linux GPG Repository Key

### DIFF
--- a/test/e2e/data/infrastructure-aws/kustomize_sources/gpu/gpu-operator-components.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/gpu/gpu-operator-components.yaml
@@ -470,8 +470,8 @@ spec:
   driver:
     repository: nvcr.io/nvidia
     image: driver
-    version: 460.32.03
-    imagePullPolicy: IfNotPresent
+    version: 510.47.03
+    imagePullPolicy: Always
     repoConfig:
       configMapName: ""
       destinationDir: ""


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
NVIDIA has updated and rotated the signing keys used by the apt, dnf/yum, and zypper package managers beginning April 27, 2022. This caused our GPU tests to fail as GPU operator was not able to fetch the drivers from the NVIDIA repo because of GPG keys mismatch.
This PR updates the `imagePullPolicy` for driver to `Always` in `cluster-policy` such that GPU Operator always pulls the updated images and we wont get the GPG key mismatch errors, as mentioned in the [workaround](https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/) provided by NVIDIA.
As part of this PR, we have also updated the NVIDIA driver version to `510.47.03` as previous version was pretty old and was not able to accommodate the above workaround.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests
