### PR TITLE
Added `owner-id` flag for `clusterawsadm ami list`

### DIFF
--- a/cmd/clusterawsadm/ami/list.go
+++ b/cmd/clusterawsadm/ami/list.go
@@ -33,6 +33,7 @@ type ListInput struct {
 	Region            string
 	KubernetesVersion string
 	OperatingSystem   string
+	OwnerID           string
 }
 
 const lastNReleases = 3
@@ -81,7 +82,7 @@ func List(input ListInput) (*amiv1.AWSAMIList, error) {
 		}
 
 		ec2Client := ec2.New(sess)
-		imagesForRegion, err := getAllImages(ec2Client, "")
+		imagesForRegion, err := getAllImages(ec2Client, input.OwnerID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -32,6 +32,7 @@ var (
 	kubernetesVersion string
 	opSystem          string
 	outputPrinter     string
+	ownerID           string
 )
 
 // ListAMICmd is a CLI command that will list AMIs from the default AWS account where AMIs are stored.
@@ -67,6 +68,7 @@ func ListAMICmd() *cobra.Command {
 				Region:            region,
 				KubernetesVersion: kubernetesVersion,
 				OperatingSystem:   opSystem,
+				OwnerID:           ownerID,
 			})
 			if err != nil {
 				return err
@@ -87,6 +89,7 @@ func ListAMICmd() *cobra.Command {
 	addOsFlag(newCmd)
 	addKubernetesVersionFlag(newCmd)
 	addOutputFlag(newCmd)
+	addOwnerIDFlag(newCmd)
 	return newCmd
 }
 
@@ -100,4 +103,8 @@ func addKubernetesVersionFlag(c *cobra.Command) {
 
 func addOutputFlag(c *cobra.Command) {
 	c.Flags().StringVarP(&outputPrinter, "output", "o", "table", "The output format of the results. Possible values: table,json,yaml")
+}
+
+func addOwnerIDFlag(c *cobra.Command) {
+	c.Flags().StringVarP(&ownerID, "owner-id", "", "", "The owner ID of the AWS account to be used for listing AMIs")
 }


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Currently there’s no way to pass a custom owner ID for listing AMIs using `clusterawsadm ami list [...]` command, but there’s already an implementation for doing the same which is only limited by the lack of a flag to pass a custom owner ID instead of having to use the one owned by Heptio that’s hard-coded within the source at `pkg/cloud/services/ec2/ami.go -> DefaultMachineAMIOwnerID`.

This PR adds an additional `--owner-id` flag that can be used to list CAPA AMIs _(following the `capa-ami-{{.BaseOS}}-{{.K8sVersion}}` naming format)_ on accounts other than the hard-coded one.

cc - @sedefsavas 
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
