### PR TITLE
Fix typo in AWSManagedMachinePool UpdateConfig

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -357,7 +357,7 @@ spec:
                     maximum: 100
                     minimum: 1
                     type: integer
-                  maxUnavailablePrecentage:
+                  maxUnavailablePercentage:
                     description: MaxUnavailablePercentage is the maximum percentage
                       of nodes unavailable during a version update. This percentage
                       of nodes will be updated in parallel, up to 100 nodes at once.

--- a/exp/api/v1beta1/types.go
+++ b/exp/api/v1beta1/types.go
@@ -276,5 +276,5 @@ type UpdateConfig struct {
 	// +optional
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Minimum=1
-	MaxUnavailablePercentage *int `json:"maxUnavailablePrecentage,omitempty"`
+	MaxUnavailablePercentage *int `json:"maxUnavailablePercentage,omitempty"`
 }


### PR DESCRIPTION

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
I noticed a small typo in the spelling of "percentage" in the struct tag for ``UpdateConfig.MaxUnavailablePercentage`.  

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
