### PR TITLE
fix: Do not change default security groups during EKS control plane reconcile

### DIFF
--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_unit_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_unit_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+)
+
+func TestSecurityGroupRolesForCluster(t *testing.T) {
+	tests := []struct {
+		name           string
+		bastionEnabled bool
+	}{
+		{
+			name:           "Should use bastion security group when bastion is enabled",
+			bastionEnabled: true,
+		},
+		{
+			name:           "Should not use bastion security group when bastion is disabled",
+			bastionEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c := getAWSManagedControlPlane("test", "test")
+			c.Spec.Bastion.Enabled = tt.bastionEnabled
+			s, err := getManagedControlPlaneScope(c)
+			g.Expect(err).To(BeNil(), "failed to create cluster scope for test")
+
+			got := securityGroupRolesForControlPlane(s)
+			if tt.bastionEnabled {
+				g.Expect(got).To(ContainElement(infrav1.SecurityGroupBastion))
+			} else {
+				g.Expect(got).ToNot(ContainElement(infrav1.SecurityGroupBastion))
+			}
+
+			// Verify that function does not modify the package-level variable.
+			gotAgain := securityGroupRolesForControlPlane(s)
+			g.Expect(gotAgain).To(BeEquivalentTo(got), "two identical calls return different values")
+		})
+	}
+}

--- a/controlplane/eks/controllers/helpers_test.go
+++ b/controlplane/eks/controllers/helpers_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func getAWSManagedControlPlane(name, namespace string) ekscontrolplanev1.AWSManagedControlPlane {
+	return ekscontrolplanev1.AWSManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+			Region: "us-east-1",
+			NetworkSpec: infrav1.NetworkSpec{
+				VPC: infrav1.VPCSpec{
+					ID:        "vpc-exists",
+					CidrBlock: "10.0.0.0/8",
+				},
+				Subnets: infrav1.Subnets{
+					{
+						ID:               "subnet-1",
+						AvailabilityZone: "us-east-1a",
+						CidrBlock:        "10.0.10.0/24",
+						IsPublic:         false,
+					},
+					{
+						ID:               "subnet-2",
+						AvailabilityZone: "us-east-1c",
+						CidrBlock:        "10.0.11.0/24",
+						IsPublic:         true,
+					},
+				},
+				SecurityGroupOverrides: map[infrav1.SecurityGroupRole]string{},
+			},
+			Bastion: infrav1.Bastion{Enabled: true},
+		},
+	}
+}
+
+func getManagedControlPlaneScope(cp ekscontrolplanev1.AWSManagedControlPlane) (*scope.ManagedControlPlaneScope, error) {
+	scheme := runtime.NewScheme()
+	_ = ekscontrolplanev1.AddToScheme(scheme)
+	_ = infrav1.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	return scope.NewManagedControlPlaneScope(
+		scope.ManagedControlPlaneScopeParams{
+			Client: client,
+			Cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+			},
+			ControlPlane: &cp,
+		},
+	)
+}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:
For EKS clusters, #3028 enabled the bastion security group only when the bastion is enabled. However, the implementation introduced a bug: every reconcile appends to a package-level variable!

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I'd like to add a pair of unit tests, but haven't done that yet.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
