### PR TITLE
Fix eks-fargate cluster template

### DIFF
--- a/templates/cluster-template-eks-fargate.yaml
+++ b/templates/cluster-template-eks-fargate.yaml
@@ -16,11 +16,6 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: "${CLUSTER_NAME}-control-plane"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AWSManagedCluster
-metadata:
-  name: "${CLUSTER_NAME}"
----
 kind: AWSManagedControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove the deprecated AWSManagedCluster from the template. It doesn't exist in v1beta1. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
