### PR TITLE
Revert "Create bastion security group only when bastion is enabled"

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -57,12 +57,15 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
-var defaultAWSSecurityGroupRoles = []infrav1.SecurityGroupRole{
-	infrav1.SecurityGroupAPIServerLB,
-	infrav1.SecurityGroupLB,
-	infrav1.SecurityGroupControlPlane,
-	infrav1.SecurityGroupNode,
-}
+var (
+	awsSecurityGroupRoles = []infrav1.SecurityGroupRole{
+		infrav1.SecurityGroupBastion,
+		infrav1.SecurityGroupAPIServerLB,
+		infrav1.SecurityGroupLB,
+		infrav1.SecurityGroupControlPlane,
+		infrav1.SecurityGroupNode,
+	}
+)
 
 // AWSClusterReconciler reconciles a AwsCluster object.
 type AWSClusterReconciler struct {
@@ -100,24 +103,12 @@ func (r *AWSClusterReconciler) getNetworkService(scope scope.ClusterScope) servi
 	return network.NewService(&scope)
 }
 
-// securityGroupRolesForCluster returns the security group roles determined by the cluster configuration.
-func securityGroupRolesForCluster(scope scope.ClusterScope) []infrav1.SecurityGroupRole {
-	roles := []infrav1.SecurityGroupRole{}
-	// Copy to ensure we do not modify the package-level variable.
-	copy(roles, defaultAWSSecurityGroupRoles)
-
-	if scope.Bastion().Enabled {
-		roles = append(roles, infrav1.SecurityGroupBastion)
-	}
-	return roles
-}
-
 // getSecurityGroupService factory func is added for testing purpose so that we can inject mocked SecurityGroupService to the AWSClusterReconciler.
 func (r *AWSClusterReconciler) getSecurityGroupService(scope scope.ClusterScope) services.SecurityGroupInterface {
 	if r.securityGroupFactory != nil {
 		return r.securityGroupFactory(scope)
 	}
-	return securitygroup.NewService(&scope, securityGroupRolesForCluster(scope))
+	return securitygroup.NewService(&scope, awsSecurityGroupRoles)
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusters,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION

**What this PR does / why we need it**:

Reverts https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3482 due to failing e2e tests: 
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-e2e/1532032209207169024

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
