### PR TITLE
Updated `clusterawsadm ami list` nil AMI output

### DIFF
--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -210,7 +210,7 @@ func getAllImages(ec2Client ec2iface.EC2API, ownerID string) (map[string][]*ec2.
 		return nil, errors.Wrap(err, "failed to fetch AMIs")
 	}
 	if len(out.Images) == 0 {
-		return nil, errors.Errorf("no AMIs in the account: %q", ownerID)
+		return nil, nil
 	}
 
 	imagesMap := make(map[string][]*ec2.Image)

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -73,6 +73,10 @@ func ListAMICmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if len(listByVersion.Items) == 0 {
+				fmt.Println("No AMIs found")
+				return nil
+			}
 
 			if outputPrinter == string(cmdout.PrinterTypeTable) {
 				table := listByVersion.ToTable()
@@ -94,7 +98,7 @@ func ListAMICmd() *cobra.Command {
 }
 
 func addOsFlag(c *cobra.Command) {
-	c.Flags().StringVar(&opSystem, "os", "", "Operating system of the AMI to be copied")
+	c.Flags().StringVar(&opSystem, "os", "", "Operating system of the AMI to be listed")
 }
 
 func addKubernetesVersionFlag(c *cobra.Command) {


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The current behaviour treats absence of AMIs in the `clusterawsadm ami list ...` query as an error. This should instead be treated as normal, while notifying the user that the account does not contain any such AMI.
cc - @sedefsavas 
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
