### PR TITLE
:bug: Fix/generate go apis target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 GO_INSTALL := ./scripts/go_install.sh
 
 API_DIRS := cmd/clusterawsadm/api api exp/api controlplane/eks/api bootstrap/eks/api iam/api
-API_SRCS := $(foreach dir, $(API_DIRS), $(call rwildcard,../../$(dir),*.go))
+API_FILES := $(foreach dir, $(API_DIRS), $(call rwildcard,$(dir),*.go))
 
 BIN_DIR := bin
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -192,7 +192,7 @@ generate: ## Generate code
 	$(MAKE) generate-go
 	$(MAKE) $(CRD_DOCS)
 
-$(CRD_DOCS_DIR)/%: $(API_SRCS)
+$(CRD_DOCS_DIR)/%: $(API_FILES)
 	$(MAKE) -C docs/book src/crd/$*
 
 .PHONY: generate-go ## Generate all Go api files
@@ -207,7 +207,7 @@ generate-go-apis: ## Alias for .build/generate-go-apis
 .build: ## Create the .build folder
 	mkdir -p .build
 
-.build/generate-go-apis: .build $(API_SRCS) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN) ## Generate all Go api files
+.build/generate-go-apis: .build $(API_FILES) $(CONTROLLER_GEN) $(DEFAULTER_GEN) $(CONVERSION_GEN) ## Generate all Go api files
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		paths=./$(EXP_DIR)/api/... \

--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -39,7 +39,7 @@ src/crd:
 	mkdir -p src/crd
 
 src/crd/index.md: $(API_FILTERED_SRCS) src/crd
-	$(MAKE) gen_crd_docs API_DIR="../.." OUT_FILE=$@
+	$(MAKE) gen_crd_docs API_DIR="$(shell go list -m)" OUT_FILE=$@
 
 .PHONY: gen_crd_docs
 gen_crd_docs: $(GENCRDAPIREFERENCEDOCS) src/crd $(GENCRDAPIREFERENCEDOCS_SRCS)

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -16093,8 +16093,8 @@ AWSMachineTemplateResource
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>)
 </p>
 <p>
-<p>AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
-Only one of ID, ARN or Filters may be specified. Specifying more than one will result in
+<p>AWSResourceReference is a reference to a specific AWS resource by ID or filters.
+Only one of ID or Filters may be specified. Specifying more than one will result in
 a validation error.</p>
 </p>
 <table>
@@ -16126,7 +16126,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ARN of resource</p>
+<p>ARN of resource.
+Deprecated: This field has no function and is going to be removed in the next release.</p>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -352,7 +352,9 @@ string
 <td>
 <code>secureSecretBackends</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.SecretBackend
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecretBackend">
+[]SecretBackend
+</a>
 </em>
 </td>
 <td>
@@ -523,7 +525,9 @@ string
 <td>
 <code>secureSecretBackends</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.SecretBackend
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecretBackend">
+[]SecretBackend
+</a>
 </em>
 </td>
 <td>
@@ -600,7 +604,9 @@ See &ldquo;sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/api/iam/v1beta
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -701,7 +707,9 @@ string
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -1209,7 +1217,9 @@ string
 <td>
 <code>secureSecretBackends</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.SecretBackend
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecretBackend">
+[]SecretBackend
+</a>
 </em>
 </td>
 <td>
@@ -1408,7 +1418,9 @@ string
 <td>
 <code>secureSecretBackends</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.SecretBackend
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecretBackend">
+[]SecretBackend
+</a>
 </em>
 </td>
 <td>
@@ -1501,7 +1513,9 @@ See &ldquo;sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/api/iam/v1beta
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -1602,7 +1616,9 @@ string
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -2946,7 +2962,9 @@ based on the namespace and name of the managed control plane.</p>
 <td>
 <code>identityRef</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.AWSIdentityReference
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSIdentityReference">
+AWSIdentityReference
+</a>
 </em>
 </td>
 <td>
@@ -2958,7 +2976,9 @@ Cluster API AWS api/v1alpha4.AWSIdentityReference
 <td>
 <code>network</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.NetworkSpec
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.NetworkSpec">
+NetworkSpec
+</a>
 </em>
 </td>
 <td>
@@ -3078,7 +3098,9 @@ EncryptionConfig
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -3186,7 +3208,9 @@ different ImageLookupBaseOS.</p>
 <td>
 <code>bastion</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Bastion
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Bastion">
+Bastion
+</a>
 </em>
 </td>
 <td>
@@ -3226,8 +3250,8 @@ provider for the controller for use with IAM roles for service accounts</p>
 <td>
 <code>addons</code><br/>
 <em>
-<a href="#controlplane.cluster.x-k8s.io/v1alpha4.[]../../controlplane/eks/api/v1alpha4.Addon">
-[]../../controlplane/eks/api/v1alpha4.Addon
+<a href="#controlplane.cluster.x-k8s.io/v1alpha4.[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4.Addon">
+[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4.Addon
 </a>
 </em>
 </td>
@@ -3317,7 +3341,9 @@ based on the namespace and name of the managed control plane.</p>
 <td>
 <code>identityRef</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.AWSIdentityReference
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSIdentityReference">
+AWSIdentityReference
+</a>
 </em>
 </td>
 <td>
@@ -3329,7 +3355,9 @@ Cluster API AWS api/v1alpha4.AWSIdentityReference
 <td>
 <code>network</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.NetworkSpec
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.NetworkSpec">
+NetworkSpec
+</a>
 </em>
 </td>
 <td>
@@ -3449,7 +3477,9 @@ EncryptionConfig
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -3557,7 +3587,9 @@ different ImageLookupBaseOS.</p>
 <td>
 <code>bastion</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Bastion
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Bastion">
+Bastion
+</a>
 </em>
 </td>
 <td>
@@ -3597,8 +3629,8 @@ provider for the controller for use with IAM roles for service accounts</p>
 <td>
 <code>addons</code><br/>
 <em>
-<a href="#controlplane.cluster.x-k8s.io/v1alpha4.[]../../controlplane/eks/api/v1alpha4.Addon">
-[]../../controlplane/eks/api/v1alpha4.Addon
+<a href="#controlplane.cluster.x-k8s.io/v1alpha4.[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4.Addon">
+[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha4.Addon
 </a>
 </em>
 </td>
@@ -3659,7 +3691,9 @@ Amazon VPC CNI addon or if you have specified a secondary CIDR block.</p>
 <td>
 <code>networkStatus</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.NetworkStatus
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.NetworkStatus">
+NetworkStatus
+</a>
 </em>
 </td>
 <td>
@@ -3685,7 +3719,9 @@ Cluster API api/v1alpha4.FailureDomains
 <td>
 <code>bastion</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Instance
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Instance">
+Instance
+</a>
 </em>
 </td>
 <td>
@@ -4473,7 +4509,9 @@ all prefixing.</p>
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -4678,7 +4716,9 @@ based on the namespace and name of the managed control plane.</p>
 <td>
 <code>identityRef</code><br/>
 <em>
-Cluster API AWS api/v1beta1.AWSIdentityReference
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSIdentityReference">
+AWSIdentityReference
+</a>
 </em>
 </td>
 <td>
@@ -4690,7 +4730,9 @@ Cluster API AWS api/v1beta1.AWSIdentityReference
 <td>
 <code>network</code><br/>
 <em>
-Cluster API AWS api/v1beta1.NetworkSpec
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.NetworkSpec">
+NetworkSpec
+</a>
 </em>
 </td>
 <td>
@@ -4810,7 +4852,9 @@ EncryptionConfig
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -4918,7 +4962,9 @@ different ImageLookupBaseOS.</p>
 <td>
 <code>bastion</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Bastion
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Bastion">
+Bastion
+</a>
 </em>
 </td>
 <td>
@@ -4958,8 +5004,8 @@ provider for the controller for use with IAM roles for service accounts</p>
 <td>
 <code>addons</code><br/>
 <em>
-<a href="#controlplane.cluster.x-k8s.io/v1beta1.[]../../controlplane/eks/api/v1beta1.Addon">
-[]../../controlplane/eks/api/v1beta1.Addon
+<a href="#controlplane.cluster.x-k8s.io/v1beta1.[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1.Addon">
+[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1.Addon
 </a>
 </em>
 </td>
@@ -5049,7 +5095,9 @@ based on the namespace and name of the managed control plane.</p>
 <td>
 <code>identityRef</code><br/>
 <em>
-Cluster API AWS api/v1beta1.AWSIdentityReference
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSIdentityReference">
+AWSIdentityReference
+</a>
 </em>
 </td>
 <td>
@@ -5061,7 +5109,9 @@ Cluster API AWS api/v1beta1.AWSIdentityReference
 <td>
 <code>network</code><br/>
 <em>
-Cluster API AWS api/v1beta1.NetworkSpec
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.NetworkSpec">
+NetworkSpec
+</a>
 </em>
 </td>
 <td>
@@ -5181,7 +5231,9 @@ EncryptionConfig
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -5289,7 +5341,9 @@ different ImageLookupBaseOS.</p>
 <td>
 <code>bastion</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Bastion
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Bastion">
+Bastion
+</a>
 </em>
 </td>
 <td>
@@ -5329,8 +5383,8 @@ provider for the controller for use with IAM roles for service accounts</p>
 <td>
 <code>addons</code><br/>
 <em>
-<a href="#controlplane.cluster.x-k8s.io/v1beta1.[]../../controlplane/eks/api/v1beta1.Addon">
-[]../../controlplane/eks/api/v1beta1.Addon
+<a href="#controlplane.cluster.x-k8s.io/v1beta1.[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1.Addon">
+[]sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1.Addon
 </a>
 </em>
 </td>
@@ -5391,7 +5445,9 @@ Amazon VPC CNI addon or if you have specified a secondary CIDR block.</p>
 <td>
 <code>networkStatus</code><br/>
 <em>
-Cluster API AWS api/v1beta1.NetworkStatus
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.NetworkStatus">
+NetworkStatus
+</a>
 </em>
 </td>
 <td>
@@ -5417,7 +5473,9 @@ Cluster API api/v1beta1.FailureDomains
 <td>
 <code>bastion</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Instance
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Instance">
+Instance
+</a>
 </em>
 </td>
 <td>
@@ -6205,7 +6263,9 @@ all prefixing.</p>
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -6355,7 +6415,7 @@ Resource Types:
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.AMIReference">AMIReference
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSLaunchTemplate">AWSLaunchTemplate</a>)
 </p>
 <p>
 <p>AMIReference is a reference to a specific AWS resource by ID, ARN, or filters.
@@ -7603,7 +7663,7 @@ AWSClusterTemplateResource
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.AWSIdentityReference">AWSIdentityReference
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterRoleIdentitySpec">AWSClusterRoleIdentitySpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterRoleIdentitySpec">AWSClusterRoleIdentitySpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1alpha4.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>)
 </p>
 <p>
 <p>AWSIdentityReference specifies a identity.</p>
@@ -8921,7 +8981,7 @@ AWSMachineTemplateResource
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.AWSResourceReference">AWSResourceReference
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSLaunchTemplate">AWSLaunchTemplate</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachinePoolSpec">AWSMachinePoolSpec</a>)
 </p>
 <p>
 <p>AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
@@ -9120,7 +9180,7 @@ AWSClusterIdentity from any namespace.</p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Bastion">Bastion
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1alpha4.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>)
 </p>
 <p>
 <p>Bastion defines a bastion host.</p>
@@ -9346,7 +9406,7 @@ int64
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.CNIIngressRules">CNIIngressRules
-(<code>[]../../api/v1alpha4.CNIIngressRule</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.CNIIngressRule</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.CNISpec">CNISpec</a>)
 </p>
@@ -9797,7 +9857,7 @@ will use AWS Secrets Manager instead.</p>
 <p>ConditionOperator defines an AWS condition operator.</p>
 </p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Conditions">Conditions
-(<code>map[../../api/v1alpha4.ConditionOperator]interface{}</code> alias)</p></h3>
+(<code>map[sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.ConditionOperator]interface{}</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.StatementEntry">StatementEntry</a>)
 </p>
@@ -9942,7 +10002,7 @@ int64
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.IngressRules">IngressRules
-(<code>[]../../api/v1alpha4.IngressRule</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.IngressRule</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.SecurityGroup">SecurityGroup</a>)
 </p>
@@ -9952,7 +10012,7 @@ int64
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Instance">Instance
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterStatus">AWSClusterStatus</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterStatus">AWSClusterStatus</a>, <a href="#controlplane.cluster.x-k8s.io/v1alpha4.AWSManagedControlPlaneStatus">AWSManagedControlPlaneStatus</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AutoScalingGroup">AutoScalingGroup</a>)
 </p>
 <p>
 <p>Instance describes an AWS instance.</p>
@@ -10234,7 +10294,7 @@ string
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.NetworkSpec">NetworkSpec
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1alpha4.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>)
 </p>
 <p>
 <p>NetworkSpec encapsulates all things related to AWS network.</p>
@@ -10293,7 +10353,7 @@ CNISpec
 <td>
 <code>securityGroupOverrides</code><br/>
 <em>
-map[../../api/v1alpha4.SecurityGroupRole]string
+map[sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.SecurityGroupRole]string
 </em>
 </td>
 <td>
@@ -10307,7 +10367,7 @@ This is optional - if not provided new security groups will be created for the c
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.NetworkStatus">NetworkStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterStatus">AWSClusterStatus</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterStatus">AWSClusterStatus</a>, <a href="#controlplane.cluster.x-k8s.io/v1alpha4.AWSManagedControlPlaneStatus">AWSManagedControlPlaneStatus</a>)
 </p>
 <p>
 <p>NetworkStatus encapsulates AWS networking resources.</p>
@@ -10325,7 +10385,7 @@ This is optional - if not provided new security groups will be created for the c
 <code>securityGroups</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.SecurityGroup">
-map[../../api/v1alpha4.SecurityGroupRole]../../api/v1alpha4.SecurityGroup
+map[sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.SecurityGroupRole]sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.SecurityGroup
 </a>
 </em>
 </td>
@@ -10407,7 +10467,7 @@ string
 <p>PrincipalType defines an AWS principle type.</p>
 </p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Principals">Principals
-(<code>map[../../api/v1alpha4.PrincipalType]../../api/v1alpha4.PrincipalID</code> alias)</p></h3>
+(<code>map[sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.PrincipalType]sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.PrincipalID</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.StatementEntry">StatementEntry</a>)
 </p>
@@ -10673,7 +10733,7 @@ Conditions
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Statements">Statements
-(<code>[]../../api/v1alpha4.StatementEntry</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.StatementEntry</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.PolicyDocument">PolicyDocument</a>)
 </p>
@@ -10779,7 +10839,7 @@ Tags
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Subnets">Subnets
-(<code>[]../../api/v1alpha4.SubnetSpec</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4.SubnetSpec</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.NetworkSpec">NetworkSpec</a>)
 </p>
@@ -10789,7 +10849,7 @@ Tags
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Tags">Tags
 (<code>map[string]string</code> alias)</p></h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.BuildParams">BuildParams</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.SecurityGroup">SecurityGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.SubnetSpec">SubnetSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.VPCSpec">VPCSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSClusterSpec">AWSClusterSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.BuildParams">BuildParams</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.SecurityGroup">SecurityGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.SubnetSpec">SubnetSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.VPCSpec">VPCSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1alpha4.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1alpha4.OIDCIdentityProviderConfig">OIDCIdentityProviderConfig</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachinePoolSpec">AWSMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AutoScalingGroup">AutoScalingGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.FargateProfileSpec">FargateProfileSpec</a>)
 </p>
 <p>
 <p>Tags defines a map of tags.</p>
@@ -10894,7 +10954,7 @@ Defaults to Ordered</p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Volume">Volume
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Instance">Instance</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Instance">Instance</a>, <a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSLaunchTemplate">AWSLaunchTemplate</a>)
 </p>
 <p>
 <p>Volume encapsulates the configuration options for the storage device</p>
@@ -11093,7 +11153,9 @@ auto scaling group of this nodegroup.</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -11191,7 +11253,9 @@ role.</p>
 <td>
 <code>ami</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.AMIReference
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AMIReference">
+AMIReference
+</a>
 </em>
 </td>
 <td>
@@ -11259,7 +11323,9 @@ string
 <td>
 <code>rootVolume</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Volume
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Volume">
+Volume
+</a>
 </em>
 </td>
 <td>
@@ -11299,7 +11365,9 @@ Typically a new version is created when at least one of the following happens:
 <td>
 <code>additionalSecurityGroups</code><br/>
 <em>
-[]Cluster API AWS api/v1alpha4.AWSResourceReference
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSResourceReference">
+[]AWSResourceReference
+</a>
 </em>
 </td>
 <td>
@@ -11400,7 +11468,9 @@ int32
 <td>
 <code>subnets</code><br/>
 <em>
-[]Cluster API AWS api/v1alpha4.AWSResourceReference
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSResourceReference">
+[]AWSResourceReference
+</a>
 </em>
 </td>
 <td>
@@ -11412,7 +11482,9 @@ int32
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -11625,7 +11697,9 @@ int32
 <td>
 <code>subnets</code><br/>
 <em>
-[]Cluster API AWS api/v1alpha4.AWSResourceReference
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSResourceReference">
+[]AWSResourceReference
+</a>
 </em>
 </td>
 <td>
@@ -11637,7 +11711,9 @@ int32
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -11956,7 +12032,9 @@ auto scaling group of this nodegroup</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -12190,7 +12268,9 @@ auto scaling group of this nodegroup</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -12486,7 +12566,9 @@ string
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -12602,7 +12684,9 @@ ASGStatus
 <td>
 <code>instances</code><br/>
 <em>
-[]Cluster API AWS api/v1alpha4.Instance
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Instance">
+[]Instance
+</a>
 </em>
 </td>
 <td>
@@ -12764,7 +12848,9 @@ auto scaling group of this nodegroup.</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1alpha4.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha4.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -13350,7 +13436,7 @@ string
 <p>TaintEffect is the effect for a Kubernetes taint.</p>
 </p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha4.Taints">Taints
-(<code>[]../../exp/api/v1alpha4.Taint</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha4.Taint</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1alpha4.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>)
 </p>
@@ -13367,7 +13453,7 @@ Resource Types:
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.AMIReference">AMIReference
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSLaunchTemplate">AWSLaunchTemplate</a>)
 </p>
 <p>
 <p>AMIReference is a reference to a specific AWS resource by ID, ARN, or filters.
@@ -14683,7 +14769,7 @@ AWSClusterTemplateResource
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.AWSIdentityReference">AWSIdentityReference
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterRoleIdentitySpec">AWSClusterRoleIdentitySpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterRoleIdentitySpec">AWSClusterRoleIdentitySpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>)
 </p>
 <p>
 <p>AWSIdentityReference specifies a identity.</p>
@@ -16090,7 +16176,7 @@ AWSMachineTemplateResource
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.AWSResourceReference">AWSResourceReference
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSLaunchTemplate">AWSLaunchTemplate</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachinePoolSpec">AWSMachinePoolSpec</a>)
 </p>
 <p>
 <p>AWSResourceReference is a reference to a specific AWS resource by ID or filters.
@@ -16282,7 +16368,7 @@ AWSClusterIdentity from any namespace.</p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.Bastion">Bastion
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>)
 </p>
 <p>
 <p>Bastion defines a bastion host.</p>
@@ -16508,7 +16594,7 @@ int64
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.CNIIngressRules">CNIIngressRules
-(<code>[]../../api/v1beta1.CNIIngressRule</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/api/v1beta1.CNIIngressRule</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.CNISpec">CNISpec</a>)
 </p>
@@ -17114,7 +17200,7 @@ int64
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.IngressRules">IngressRules
-(<code>[]../../api/v1beta1.IngressRule</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/api/v1beta1.IngressRule</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecurityGroup">SecurityGroup</a>)
 </p>
@@ -17124,7 +17210,7 @@ int64
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.Instance">Instance
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterStatus">AWSClusterStatus</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterStatus">AWSClusterStatus</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneStatus">AWSManagedControlPlaneStatus</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AutoScalingGroup">AutoScalingGroup</a>)
 </p>
 <p>
 <p>Instance describes an AWS instance.</p>
@@ -17406,7 +17492,7 @@ string
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.NetworkSpec">NetworkSpec
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>)
 </p>
 <p>
 <p>NetworkSpec encapsulates all things related to AWS network.</p>
@@ -17465,7 +17551,7 @@ CNISpec
 <td>
 <code>securityGroupOverrides</code><br/>
 <em>
-map[../../api/v1beta1.SecurityGroupRole]string
+map[sigs.k8s.io/cluster-api-provider-aws/api/v1beta1.SecurityGroupRole]string
 </em>
 </td>
 <td>
@@ -17479,7 +17565,7 @@ This is optional - if not provided new security groups will be created for the c
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.NetworkStatus">NetworkStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterStatus">AWSClusterStatus</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterStatus">AWSClusterStatus</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneStatus">AWSManagedControlPlaneStatus</a>)
 </p>
 <p>
 <p>NetworkStatus encapsulates AWS networking resources.</p>
@@ -17497,7 +17583,7 @@ This is optional - if not provided new security groups will be created for the c
 <code>securityGroups</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecurityGroup">
-map[../../api/v1beta1.SecurityGroupRole]../../api/v1beta1.SecurityGroup
+map[sigs.k8s.io/cluster-api-provider-aws/api/v1beta1.SecurityGroupRole]sigs.k8s.io/cluster-api-provider-aws/api/v1beta1.SecurityGroup
 </a>
 </em>
 </td>
@@ -17608,7 +17694,7 @@ string
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.SecretBackend">SecretBackend
 (<code>string</code> alias)</p></h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.CloudInit">CloudInit</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.CloudInit">CloudInit</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1.AWSIAMConfigurationSpec">AWSIAMConfigurationSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1.AWSIAMConfigurationSpec">AWSIAMConfigurationSpec</a>)
 </p>
 <p>
 <p>SecretBackend defines variants for backend secret storage.</p>
@@ -17824,7 +17910,7 @@ Tags
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.Subnets">Subnets
-(<code>[]../../api/v1beta1.SubnetSpec</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/api/v1beta1.SubnetSpec</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.NetworkSpec">NetworkSpec</a>)
 </p>
@@ -17834,7 +17920,7 @@ Tags
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.Tags">Tags
 (<code>map[string]string</code> alias)</p></h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.BuildParams">BuildParams</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecurityGroup">SecurityGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.SubnetSpec">SubnetSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.VPCSpec">VPCSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSClusterSpec">AWSClusterSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.BuildParams">BuildParams</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.SecurityGroup">SecurityGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.SubnetSpec">SubnetSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.VPCSpec">VPCSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1.AWSIAMRoleSpec">AWSIAMRoleSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1.BootstrapUser">BootstrapUser</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1.AWSIAMRoleSpec">AWSIAMRoleSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1.BootstrapUser">BootstrapUser</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.OIDCIdentityProviderConfig">OIDCIdentityProviderConfig</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachinePoolSpec">AWSMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AutoScalingGroup">AutoScalingGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.FargateProfileSpec">FargateProfileSpec</a>)
 </p>
 <p>
 <p>Tags defines a map of tags.</p>
@@ -17939,7 +18025,7 @@ Defaults to Ordered</p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.Volume">Volume
 </h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.Instance">Instance</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.Instance">Instance</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSLaunchTemplate">AWSLaunchTemplate</a>)
 </p>
 <p>
 <p>Volume encapsulates the configuration options for the storage device.</p>
@@ -18138,7 +18224,9 @@ auto scaling group of this nodegroup.</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -18236,7 +18324,9 @@ role.</p>
 <td>
 <code>ami</code><br/>
 <em>
-Cluster API AWS api/v1beta1.AMIReference
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.AMIReference">
+AMIReference
+</a>
 </em>
 </td>
 <td>
@@ -18304,7 +18394,9 @@ string
 <td>
 <code>rootVolume</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Volume
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Volume">
+Volume
+</a>
 </em>
 </td>
 <td>
@@ -18344,7 +18436,9 @@ Typically a new version is created when at least one of the following happens:
 <td>
 <code>additionalSecurityGroups</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.AWSResourceReference
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSResourceReference">
+[]AWSResourceReference
+</a>
 </em>
 </td>
 <td>
@@ -18445,7 +18539,9 @@ int32
 <td>
 <code>subnets</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.AWSResourceReference
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSResourceReference">
+[]AWSResourceReference
+</a>
 </em>
 </td>
 <td>
@@ -18457,7 +18553,9 @@ int32
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -18670,7 +18768,9 @@ int32
 <td>
 <code>subnets</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.AWSResourceReference
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSResourceReference">
+[]AWSResourceReference
+</a>
 </em>
 </td>
 <td>
@@ -18682,7 +18782,9 @@ int32
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -19001,7 +19103,9 @@ auto scaling group of this nodegroup</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -19264,7 +19368,9 @@ auto scaling group of this nodegroup</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -19589,7 +19695,9 @@ string
 <td>
 <code>tags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -19705,7 +19813,9 @@ ASGStatus
 <td>
 <code>instances</code><br/>
 <em>
-[]Cluster API AWS api/v1beta1.Instance
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Instance">
+[]Instance
+</a>
 </em>
 </td>
 <td>
@@ -19867,7 +19977,9 @@ auto scaling group of this nodegroup.</p>
 <td>
 <code>additionalTags</code><br/>
 <em>
-Cluster API AWS api/v1beta1.Tags
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.Tags">
+Tags
+</a>
 </em>
 </td>
 <td>
@@ -20452,7 +20564,7 @@ string
 <p>TaintEffect is the effect for a Kubernetes taint.</p>
 </p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.Taints">Taints
-(<code>[]../../exp/api/v1beta1.Taint</code> alias)</p></h3>
+(<code>[]sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1.Taint</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>)
 </p>


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This fixes the wrong behavior where running make generate after an api change wont regenerate the CRD definitions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3336 

**Special notes for your reviewer**:

1. `make clean`
2. change the [API definition](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/exp/api/v1beta1/awsmanagedmachinepool_types.go)
3. `make generate`
4. change the [API definition](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/exp/api/v1beta1/awsmanagedmachinepool_types.go) again
5. `make generate`

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
