### PR TITLE
Support customizing `amiNameFormat` in AMI list

### DIFF
--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -228,8 +228,7 @@ func getAllImages(ec2Client ec2iface.EC2API, ownerID string) (map[string][]*ec2.
 	return imagesMap, nil
 }
 
-func findAMI(imagesMap map[string][]*ec2.Image, baseOS, kubernetesVersion string) (*ec2.Image, error) {
-	amiNameFormat := "capa-ami-{{.BaseOS}}-{{.K8sVersion}}"
+func findAMI(imagesMap map[string][]*ec2.Image, baseOS, kubernetesVersion, amiNameFormat string) (*ec2.Image, error) {
 	amiName, err := ec2service.GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to process ami format: %q", amiNameFormat)

--- a/cmd/clusterawsadm/ami/list.go
+++ b/cmd/clusterawsadm/ami/list.go
@@ -34,6 +34,7 @@ type ListInput struct {
 	KubernetesVersion string
 	OperatingSystem   string
 	OwnerID           string
+	AMINameFormat     string
 }
 
 const lastNReleases = 3
@@ -51,6 +52,10 @@ func List(input ListInput) (*amiv1.AWSAMIList, error) {
 		imageRegionList = getimageRegionList()
 	} else {
 		imageRegionList = append(imageRegionList, input.Region)
+	}
+	amiNameFormat := input.AMINameFormat
+	if amiNameFormat == "" {
+		amiNameFormat = "capa-ami-{{.BaseOS}}-{{.K8sVersion}}"
 	}
 
 	supportedVersions := []string{}
@@ -96,7 +101,7 @@ func List(input ListInput) (*amiv1.AWSAMIList, error) {
 		}
 		for _, version := range supportedVersions {
 			for _, os := range supportedOsList {
-				image, err := findAMI(imageMap, os, version)
+				image, err := findAMI(imageMap, os, version, amiNameFormat)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -33,6 +33,7 @@ var (
 	opSystem          string
 	outputPrinter     string
 	ownerID           string
+	amiNameFormat     string
 )
 
 // ListAMICmd is a CLI command that will list AMIs from the default AWS account where AMIs are stored.
@@ -41,8 +42,9 @@ func ListAMICmd() *cobra.Command {
 		Use:   "list",
 		Short: "List AMIs from the default AWS account where AMIs are stored",
 		Long: cmd.LongDesc(`
-			List AMIs based on Kubernetes version, OS, region. If no arguments are provided,
-			it will print all AMIs in all regions, OS types for the supported Kubernetes versions.
+			List AMIs based on Kubernetes version, OS, region, owner ID and AMI name format. If no arguments are provided,
+			it will print all AMIs in all regions, OS types, supported Kubernetes versions, with the default owner ID set
+			to "258751437250" and default AMI name format set to "capa-ami-{{.BaseOS}}-{{.K8sVersion}}".
             Supported Kubernetes versions start from the latest stable version and goes 2 release back:
 			if the latest stable release is v1.20.4- v1.19.x and v1.18.x are supported.
 			Note: First release of each version will be skipped, e.g., v1.21.0
@@ -54,6 +56,8 @@ func ListAMICmd() *cobra.Command {
 		clusterawsadm ami list --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
 		# To list all supported AMIs in all supported Kubernetes versions, regions, and linux distributions:
 		clusterawsadm ami list
+		# To list all supported AMIs in all supported Kubernetes versions, regions, and linux distributions with custom AMI name format and owner ID:
+		clusterawsadm ami list --ami-name-format test-capa-ami-{{.BaseOS}}-{{.K8sVersion}} --owner-id 123456654321
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,6 +73,7 @@ func ListAMICmd() *cobra.Command {
 				KubernetesVersion: kubernetesVersion,
 				OperatingSystem:   opSystem,
 				OwnerID:           ownerID,
+				AMINameFormat:     amiNameFormat,
 			})
 			if err != nil {
 				return err
@@ -94,6 +99,8 @@ func ListAMICmd() *cobra.Command {
 	addKubernetesVersionFlag(newCmd)
 	addOutputFlag(newCmd)
 	addOwnerIDFlag(newCmd)
+	addAMINameFormat(newCmd)
+
 	return newCmd
 }
 
@@ -111,4 +118,8 @@ func addOutputFlag(c *cobra.Command) {
 
 func addOwnerIDFlag(c *cobra.Command) {
 	c.Flags().StringVarP(&ownerID, "owner-id", "", "", "The owner ID of the AWS account to be used for listing AMIs")
+}
+
+func addAMINameFormat(c *cobra.Command) {
+	c.Flags().StringVarP(&amiNameFormat, "ami-name-format", "", "", "The naming format of AMIs to be listed")
 }


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This would enable us to check for AMIs with naming formats other than the default one _(`capa-ami-{{.BaseOS}}-{{.K8sVersion}}`)_, such as ones with custom added prefixes/postfixes like `test-capa-ami-{{.BaseOS}}-{{.K8sVersion}}`.

cc - @sedefsavas 
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
