### PR TITLE
chore: use "registry.k8s.io" for k8s images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api-aws
 STAGING_BUCKET ?= artifacts.k8s-staging-cluster-api-aws.appspot.com
 BUCKET ?= $(STAGING_BUCKET)
-PROD_REGISTRY := k8s.gcr.io/cluster-api-aws
+PROD_REGISTRY := registry.k8s.io/cluster-api-aws
 REGISTRY ?= $(STAGING_REGISTRY)
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 PULL_BASE_REF ?= $(RELEASE_TAG) # PULL_BASE_REF will be provided by Prow
@@ -428,9 +428,9 @@ compile-e2e: ## Test e2e compilation
 
 .PHONY: docker-pull-e2e-preloads
 docker-pull-e2e-preloads: ## Preloads the docker images used for e2e testing and can speed it up
-	-docker pull k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:$(CAPI_VERSION)
-	-docker pull k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:$(CAPI_VERSION)
-	-docker pull k8s.gcr.io/cluster-api/cluster-api-controller:$(CAPI_VERSION)
+	-docker pull registry.k8s.io/cluster-api/kubeadm-control-plane-controller:$(CAPI_VERSION)
+	-docker pull registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:$(CAPI_VERSION)
+	-docker pull registry.k8s.io/cluster-api/cluster-api-controller:$(CAPI_VERSION)
 	-docker pull quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
 	-docker pull quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 	-docker pull quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)

--- a/docs/book/src/development/releasing.md
+++ b/docs/book/src/development/releasing.md
@@ -38,8 +38,8 @@
     8. Repeat for [eks-bootstrap-controller](https://console.cloud.google.com/gcr/images/k8s-staging-cluster-api-aws/GLOBAL/eks-bootstrap-controller?gcrImageListsize=30) and [eks-controlplane-controller](https://console.cloud.google.com/gcr/images/k8s-staging-cluster-api-aws/GLOBAL/eks-controlplane-controller?gcrImageListsize=30)
     9. You can use [this PR](https://github.com/kubernetes/k8s.io/pull/1565) as example
     10. Wait for the PR to be approved and merged
-14. Finalise the release notes. Add image locations `<ADD_IMAGE_HERE>` (e.g., k8s.gcr.io/cluster-api-aws/cluster-api-aws-controller:v0.6.4) and replace `<RELEASE_VERSION>` and `<PREVIOUS_VERSION>`.
-15. Make sure image promotion is complete before publishing the release draft. The promotion job logs can be found [here](https://testgrid.k8s.io/sig-k8s-infra-k8sio#post-k8sio-image-promo) and you can also try and pull the images (i.e. ``docker pull k8s.gcr.io/cluster-api-aws/cluster-api-aws-controller:v0.6.4`) 
+14. Finalise the release notes. Add image locations `<ADD_IMAGE_HERE>` (e.g., registry.k8s.io/cluster-api-aws/cluster-api-aws-controller:v0.6.4) and replace `<RELEASE_VERSION>` and `<PREVIOUS_VERSION>`.
+15. Make sure image promotion is complete before publishing the release draft. The promotion job logs can be found [here](https://testgrid.k8s.io/sig-k8s-infra-k8sio#post-k8sio-image-promo) and you can also try and pull the images (i.e. ``docker pull registry.k8s.io/cluster-api-aws/cluster-api-aws-controller:v0.6.4`) 
 16. Publish release. Use the pre-release option for release
      candidate versions of Cluster API Provider AWS.
 17. Email `kubernetes-sig-cluster-lifecycle@googlegroups.com` to announce the release

--- a/docs/book/src/topics/external-cloud-provider-with-ebs-csi-driver.md
+++ b/docs/book/src/topics/external-cloud-provider-with-ebs-csi-driver.md
@@ -89,7 +89,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: k8s.gcr.io/nginx-slim:0.8
+          image: registry.k8s.io/nginx-slim:0.8
           ports:
             - name: nginx-web
               containerPort: 80

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -730,7 +730,7 @@ data:
                       key: access_key
                       name: aws-secret
                       optional: true
-              image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+              image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.2.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 5
@@ -766,7 +766,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
+              image: registry.k8.io/sig-storage/csi-provisioner:v2.1.1
               name: csi-provisioner
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -778,7 +778,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+              image: registry.k8.io/sig-storage/csi-attacher:v3.1.0
               name: csi-attacher
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -789,7 +789,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+              image: registry.k8.io/sig-storage/csi-snapshotter:v3.0.3
               name: csi-snapshotter
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -800,7 +800,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: k8s.gcr.io/sig-storage/csi-resizer:v1.0.0
+              image: registry.k8.io/sig-storage/csi-resizer:v1.0.0
               imagePullPolicy: Always
               name: csi-resizer
               volumeMounts:
@@ -808,7 +808,7 @@ data:
                   name: socket-dir
             - args:
                 - --csi-address=/csi/csi.sock
-              image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+              image: registry.k8.io/sig-storage/livenessprobe:v2.2.0
               name: liveness-probe
               volumeMounts:
                 - mountPath: /csi
@@ -895,7 +895,7 @@ data:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+              image: registry.k8.io/provider-aws/aws-ebs-csi-driver:v1.2.0
               livenessProbe:
                 failureThreshold: 5
                 httpGet:
@@ -928,7 +928,7 @@ data:
                   value: /csi/csi.sock
                 - name: DRIVER_REG_SOCK_PATH
                   value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-              image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+              image: registry.k8.io/sig-storage/csi-node-driver-registrar:v2.1.0
               name: node-driver-registrar
               volumeMounts:
                 - mountPath: /csi
@@ -937,7 +937,7 @@ data:
                   name: registration-dir
             - args:
                 - --csi-address=/csi/csi.sock
-              image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+              image: registry.k8.io/sig-storage/livenessprobe:v2.2.0
               name: liveness-probe
               volumeMounts:
                 - mountPath: /csi


### PR DESCRIPTION
**What type of PR is this?**

/kind support

**What this PR does / why we need it**:

Changed references of `k8s.gcr.io` to use `registry.k8s.io`. This is for
the CAPA image and any other k8s images referenced.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to: https://github.com/kubernetes-sigs/cluster-api/pull/6590

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
