### PR TITLE
Allow disabling vpc cni when setting secondary cidr block

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -158,8 +158,7 @@ spec:
                   installed into the cluster. For clusters where you want to use an
                   alternate CNI this option provides a way to specify that the Amazon
                   VPC CNI should be deleted. You cannot set this to true if you are
-                  using the Amazon VPC CNI addon or if you have specified a secondary
-                  CIDR block.
+                  using the Amazon VPC CNI addon.
                 type: boolean
               eksClusterName:
                 description: EKSClusterName allows you to specify the name of the
@@ -1169,8 +1168,7 @@ spec:
                   installed into the cluster. For clusters where you want to use an
                   alternate CNI this option provides a way to specify that the Amazon
                   VPC CNI should be deleted. You cannot set this to true if you are
-                  using the Amazon VPC CNI addon or if you have specified a secondary
-                  CIDR block.
+                  using the Amazon VPC CNI addon.
                 type: boolean
               eksClusterName:
                 description: EKSClusterName allows you to specify the name of the
@@ -2273,8 +2271,7 @@ spec:
                   installed into the cluster. For clusters where you want to use an
                   alternate CNI this option provides a way to specify that the Amazon
                   VPC CNI should be deleted. You cannot set this to true if you are
-                  using the Amazon VPC CNI addon or if you have specified a secondary
-                  CIDR block.
+                  using the Amazon VPC CNI addon.
                 type: boolean
               eksClusterName:
                 description: EKSClusterName allows you to specify the name of the

--- a/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha3/awsmanagedcontrolplane_types.go
@@ -158,7 +158,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// Amazon VPC CNI is automatically installed into the cluster. For clusters where you want
 	// to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI
 	// should be deleted. You cannot set this to true if you are using the
-	// Amazon VPC CNI addon or if you have specified a secondary CIDR block.
+	// Amazon VPC CNI addon.
 	// +kubebuilder:default=false
 	DisableVPCCNI bool `json:"disableVPCCNI,omitempty"`
 }

--- a/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_types.go
@@ -163,7 +163,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// Amazon VPC CNI is automatically installed into the cluster. For clusters where you want
 	// to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI
 	// should be deleted. You cannot set this to true if you are using the
-	// Amazon VPC CNI addon or if you have specified a secondary CIDR block.
+	// Amazon VPC CNI addon.
 	// +kubebuilder:default=false
 	DisableVPCCNI bool `json:"disableVPCCNI,omitempty"`
 }

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
@@ -163,7 +163,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// Amazon VPC CNI is automatically installed into the cluster. For clusters where you want
 	// to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI
 	// should be deleted. You cannot set this to true if you are using the
-	// Amazon VPC CNI addon or if you have specified a secondary CIDR block.
+	// Amazon VPC CNI addon.
 	// +kubebuilder:default=false
 	DisableVPCCNI bool `json:"disableVPCCNI,omitempty"`
 

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
@@ -337,10 +337,6 @@ func (r *AWSManagedControlPlane) validateDisableVPCCNI() field.ErrorList {
 	if r.Spec.DisableVPCCNI {
 		disableField := field.NewPath("spec", "disableVPCCNI")
 
-		if r.Spec.SecondaryCidrBlock != nil {
-			allErrs = append(allErrs, field.Invalid(disableField, r.Spec.DisableVPCCNI, "cannot disable vpc cni if a secondary cidr is specified"))
-		}
-
 		if r.Spec.Addons != nil {
 			for _, addon := range *r.Spec.Addons {
 				if addon.Name == vpcCniAddon {

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook_test.go
@@ -235,7 +235,16 @@ func TestWebhookCreate(t *testing.T) {
 			disableVPCCNI:  true,
 		},
 		{
-			name:           "disable vpc cni not allowed with secondary",
+			name:           "disable vpc cni allowed with valid secondary",
+			eksClusterName: "default_cluster1",
+			eksVersion:     "v1.19",
+			expectError:    false,
+			hasAddons:      false,
+			disableVPCCNI:  true,
+			secondaryCidr:  aws.String("100.64.0.0/16"),
+		},
+		{
+			name:           "disable vpc cni allowed with invalid secondary",
 			eksClusterName: "default_cluster1",
 			eksVersion:     "v1.19",
 			expectError:    true,

--- a/docs/book/src/topics/eks/pod-networking.md
+++ b/docs/book/src/topics/eks/pod-networking.md
@@ -27,7 +27,7 @@ spec:
   disableVPCCNI: true
 ```
 
-> You cannot set **disableVPCCNI** to true if you are using the VPC CNI addon or if you have specified a secondary CIDR block.
+> You cannot set **disableVPCCNI** to true if you are using the VPC CNI addon.
 
 Some alternative CNIs provide for the replacement of kube-proxy, such as in [Calico](https://projectcalico.docs.tigera.io/maintenance/ebpf/enabling-ebpf#configure-kube-proxy) and [Cilium](https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/). When enabling the kube-proxy alternative, the kube-proxy installed by EKS must be deleted. This can be done via the **disable** property of **kubeProxy** in **AWSManagedControlPlane**:
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

cilium has an eni mode that requires a secondary cidr block on the vpc but does not use the vpc cni.

**Special notes for your reviewer**:

I looked for e2e tests but I didn't see anything specific related to this functionality. If I missed it please point me in the right direction and I'd be happy to update the code.

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
