### PR TITLE
Fix for conformance tests

### DIFF
--- a/test/e2e/data/ci-artifacts-platform-kustomization.yaml
+++ b/test/e2e/data/ci-artifacts-platform-kustomization.yaml
@@ -18,3 +18,12 @@ spec:
     spec:
       ami:
         id: ${IMAGE_ID}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      kubernetesVersion: ci/${KUBERNETES_VERSION}


### PR DESCRIPTION
/kind failing-test

**What this PR does / why we need it**:
This PR sets "ci/" prefix for the kubernetes version used with Kubeadm for conformance CI job so that when a CI Kubeadm version is used, it pulls the CI version of components automatically. More details of why we need this is here: https://github.com/kubernetes-sigs/cluster-api/pull/6590

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3525

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
