### PR TITLE
fix: Fail apidiff make target when git fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,13 +317,19 @@ verify-gen: generate ## Verify generated files
 		echo "generated files are out of date, run make generate"; exit 1; \
 	fi
 
-APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
-
 .PHONY: apidiff
+apidiff: APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 apidiff: $(GO_APIDIFF) ## Check for API differences
-	@if (git --no-pager diff --name-only FETCH_HEAD | grep "api/"); then \
+	@$(call checkdiff) > /dev/null
+	@if ($(call checkdiff) | grep "api/"); then \
 		$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible; \
+	else
+		@echo "No changes to 'api/'. Nothing to do."
 	fi
+
+define checkdiff
+	git --no-pager diff --name-only FETCH_HEAD
+endef
 
 ##@ build:
 


### PR DESCRIPTION
_Description has been updated to summarise discussion and eventual changes._

The `apidiff` target runs 2 commands (piped) in an `if` which swallows
the exit code, meaning it never fails.

What we want:
- exit 1 when `git diff` fails
- exit 0 when `grep` fails
- call `go-apidiff` when `git diff` and `grep` succeeds
- exit 1 when `go-apidiff` fails

This is honestly a complete pain to do in a Makefile.

One option was to move bits into another `.sh` script (not the
`scripts/ci-apidiff.sh` one as that would make the target pointless).

Another option was to fork the `go-apidiff` command so that we can make
it only run on the `api/` dir, since that is all we care about. While that option
is the easiest to run, we don't want to have to maintain another
thing.

So, if we can live with a little repetition, we can do the following:
- Check the `git diff` can run, exit 1 if not
- Run the `git diff` again, this time piping the successful command to
  `grep`
- If `grep` fails, then no worries, the target will roll on and exit 0
  like it always has.
- If `grep` succeeds then the `go-apidiff` tool is called and the target
  runs as intended.

------

In the case of `$(APIDIFF_OLD_COMMIT)`, there is some annoying `make`
magic going on here. Which I can't simply make fail since it will cause any
job which uses something in this Makefile to fail out of proximity.
The `shell` is expanded when the file is loaded meaning even targets
which do not care about the value will end up erroring (but not exiting)
when it fails. These are not errors which impact the target's run, but
they look annoying in CI.

Since this var is only used by `apidiff`, we can move it into that
target so it is only evaluated when specifically called.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**


/kind bug

Fixes #3443 

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
