### PR TITLE
update docs to refect cluster namespace used

### DIFF
--- a/docs/book/src/topics/full-multitenancy-implementation.md
+++ b/docs/book/src/topics/full-multitenancy-implementation.md
@@ -89,7 +89,7 @@ spec:
       Condition:
         "ForAnyValue:StringEquals":
           "oidc.eks.${AWS_REGION}.amazonaws.com/id/${OIDC_PROVIDER_ID}:sub":
-            - system:serviceaccount:capa-system:capa-controller-manager
+            - system:serviceaccount:capi-providers:capa-controller-manager
             - system:serviceaccount:capa-eks-control-plane-system:capa-eks-control-plane-controller-manager # Include if also using EKS
 EOL
 ```
@@ -144,7 +144,7 @@ Follow AWS documentation to create an OIDC provider https://docs.aws.amazon.com/
 export OIDC_PROVIDER_ID=<OIDC_ID_OF_THE_CLUSTER>
 ```
 
-run the [Prepare the manager account](./full-multitenancy-implementation.md#prepare-the-manager-aws-account-0-account) step again
+run the [Prepare the manager account](./full-multitenancy-implementation.md#prepare-the-manager-account) step again
 
 ### Get manager cluster credentials
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updates the docs to ensure manager cluster from the Multitenancy setup guide is able to assume the role into the managed account and successfully create a cluster. Also updates a link to return to a previous section which was broken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3554

**Special notes for your reviewer**:
N/A

**Checklist**:
- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
