### PR TITLE
Revert "Streamline Ginkgo variables" #3501

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,18 +137,19 @@ SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest
 
-GINKGO_FOCUS ?= ""
-GINKGO_SKIP ?= ""
-
 # Enable Cluster API Framework tests for the purposes of running the PR blocking test
-ifeq ($(findstring \[PR-Blocking\],$(GINKGO_FOCUS)),\[PR-Blocking\])
+ifeq ($(findstring \[PR-Blocking\],$(E2E_FOCUS)),\[PR-Blocking\])
   override undefine GINKGO_SKIP
 endif
 
 override E2E_ARGS += -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" -use-existing-cluster=$(USE_EXISTING_CLUSTER)
 override GINKGO_ARGS += -stream -progress -v -trace
 
-# DEPRECATED, use GINKGO_FOCUS instead
+ifdef GINKGO_SKIP
+	override GINKGO_ARGS += -skip "$(GINKGO_SKIP)"
+endif
+
+# DEPRECATED, use E2E_FOCUS instead
 ifdef E2E_UNMANAGED_FOCUS
 	override GINKGO_ARGS += -focus="$(E2E_UNMANAGED_FOCUS)"
 endif
@@ -160,9 +161,13 @@ endif
 # infrastructure reconciliation
 
 # Instead, you can run a quick smoke test, it should run fast (9 minutes)...
-# GINKGO_FOCUS := "\\[smoke\\]"
-# For running CAPI e2e tests: GINKGO_FOCUS := "\\[Cluster API Framework\\]"
-# For running CAPI blocking e2e test: GINKGO_FOCUS := "\\[PR-Blocking\\]"
+# E2E_FOCUS := "\\[smoke\\]"
+# For running CAPI e2e tests: E2E_FOCUS := "\\[Cluster API Framework\\]"
+# For running CAPI blocking e2e test: E2E_FOCUS := "\\[PR-Blocking\\]"
+ifdef E2E_FOCUS
+	override GINKGO_ARGS += -focus="$(E2E_FOCUS)"
+endif
+
 ifeq ($(E2E_SKIP_EKS_UPGRADE),"true")
 	override EKS_E2E_ARGS += --skip-eks-upgrade-tests
 endif
@@ -401,11 +406,11 @@ test-verbose: setup-envtest ## Run tests with verbose settings.
 
 .PHONY: test-e2e ## Run e2e tests using clusterctl
 test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) generate-test-flavors e2e-image ## Run e2e tests
-	time $(GINKGO) -tags=e2e -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" $(GINKGO_ARGS) -p ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" $(E2E_ARGS)
+	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) -p ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" $(E2E_ARGS)
 
 .PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
 test-e2e-eks: generate-test-flavors  $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests
-	time $(GINKGO) -tags=e2e -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" $(GINKGO_ARGS) ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" --source-template="$(EKS_SOURCE_TEMPLATE)" $(E2E_ARGS) $(EKS_E2E_ARGS)
+	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" --source-template="$(EKS_SOURCE_TEMPLATE)" $(E2E_ARGS) $(EKS_E2E_ARGS)
 
 
 CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)

--- a/docs/book/src/development/e2e.md
+++ b/docs/book/src/development/e2e.md
@@ -21,7 +21,7 @@ $ make test-e2e-eks
 The following useful env variables can help to speed up the runs:
 
 - `E2E_ARGS="--skip-cloudformation-creation --skip-cloudformation-deletion"` - in case the cloudformation stack is already properly set up, this ensures a quicker start and tear down.
-- `GINKGO_FOCUS='\[PR-Blocking\]'` - only run a subset of tests
+- `E2E_FOCUS='\[PR-Blocking\]'` - only run a subset of tests
 - `USE_EXISTING_CLUSTER` - use an existing management cluster (useful if you have a [Tilt][tilt-setup] setup)
 
 [tilt-setup]: ./tilt-setup.md

--- a/docs/book/src/topics/reference/jobs.md
+++ b/docs/book/src/topics/reference/jobs.md
@@ -17,7 +17,7 @@ Prow Presubmits:
 * [pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts] `./scripts/ci-conformance.sh`
   * E2E_ARGS: `-kubetest.use-ci-artifacts`
 * [pull-cluster-api-provider-aws-e2e-blocking] `./scripts/ci-e2e.sh`
-  * GINKGO_FOCUS: `[PR-Blocking]`
+  * E2E_FOCUS: `[PR-Blocking]`
 * [pull-cluster-api-provider-aws-e2e] `./scripts/ci-e2e.sh`
 * [pull-cluster-api-provider-aws-e2e-eks] `./scripts/ci-e2e-eks.sh`
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
After [the changes in Ginkgo variable names](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3501), e2e tests' focus regex is not working. My guess is we need to do some changes in line with the naming changes in test-infra too to make it work.
In the meantime, reverting the changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3559

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
