### PR TITLE
eks: allow specifying multiple instance types for AWSManagedMachinePool

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -574,6 +574,13 @@ spec:
               instanceType:
                 description: InstanceType specifies the AWS instance type
                 type: string
+              instanceTypeList:
+                description: InstanceTypeList specifies a list of AWS instance types
+                  this pool can choose from. Mutually exclusive with instanceType.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
               labels:
                 additionalProperties:
                   type: string

--- a/docs/book/src/topics/spot-instances.md
+++ b/docs/book/src/topics/spot-instances.md
@@ -47,6 +47,26 @@ spec:
   ...
 ```
 
+Multiple instance types can be provided via `instanceTypeList` to increase the
+number of Spot capacity pools available for allocating capacity from:
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSManagedMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-pool-0
+spec:
+  capacityType: spot
+  instanceTypeList:
+    - "t3.small"
+    - "t3a.small"
+    - "t3.medium"
+    - "t3a.medium"
+    - "t2.medium"
+    - "m1.large"
+  ...
+```
+
+
 See [AWS doc](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) for more details.
 
 > **IMPORTANT NOTE**: The experimental feature `AWSMachinePool` does not support using spot instances as of now.

--- a/exp/api/v1alpha3/zz_generated.conversion.go
+++ b/exp/api/v1alpha3/zz_generated.conversion.go
@@ -783,6 +783,7 @@ func autoConvert_v1beta1_AWSManagedMachinePoolSpec_To_v1alpha3_AWSManagedMachine
 	// WARNING: in.Taints requires manual conversion: does not exist in peer-type
 	out.DiskSize = (*int32)(unsafe.Pointer(in.DiskSize))
 	out.InstanceType = (*string)(unsafe.Pointer(in.InstanceType))
+	// WARNING: in.InstanceTypeList requires manual conversion: does not exist in peer-type
 	out.Scaling = (*ManagedMachinePoolScaling)(unsafe.Pointer(in.Scaling))
 	out.RemoteAccess = (*ManagedRemoteAccess)(unsafe.Pointer(in.RemoteAccess))
 	out.ProviderIDList = *(*[]string)(unsafe.Pointer(&in.ProviderIDList))

--- a/exp/api/v1alpha4/zz_generated.conversion.go
+++ b/exp/api/v1alpha4/zz_generated.conversion.go
@@ -739,6 +739,7 @@ func autoConvert_v1beta1_AWSManagedMachinePoolSpec_To_v1alpha4_AWSManagedMachine
 	out.Taints = *(*Taints)(unsafe.Pointer(&in.Taints))
 	out.DiskSize = (*int32)(unsafe.Pointer(in.DiskSize))
 	out.InstanceType = (*string)(unsafe.Pointer(in.InstanceType))
+	// WARNING: in.InstanceTypeList requires manual conversion: does not exist in peer-type
 	out.Scaling = (*ManagedMachinePoolScaling)(unsafe.Pointer(in.Scaling))
 	out.RemoteAccess = (*ManagedRemoteAccess)(unsafe.Pointer(in.RemoteAccess))
 	out.ProviderIDList = *(*[]string)(unsafe.Pointer(&in.ProviderIDList))

--- a/exp/api/v1beta1/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta1/awsmanagedmachinepool_types.go
@@ -125,6 +125,12 @@ type AWSManagedMachinePoolSpec struct {
 	// +optional
 	InstanceType *string `json:"instanceType,omitempty"`
 
+	// InstanceTypeList specifies a list of AWS instance types this pool can
+	// choose from. Mutually exclusive with instanceType.
+	// +kubebuilder:validation:MaxItems:=20
+	// +optional
+	InstanceTypeList []string `json:"instanceTypeList,omitempty"`
+
 	// Scaling specifies scaling for the ASG behind this pool
 	// +optional
 	Scaling *ManagedMachinePoolScaling `json:"scaling,omitempty"`

--- a/exp/api/v1beta1/awsmanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/awsmanagedmachinepool_webhook.go
@@ -116,6 +116,16 @@ func (r *AWSManagedMachinePool) validateRemoteAccess() field.ErrorList {
 	return allErrs
 }
 
+func (r *AWSManagedMachinePool) validateInstanceTypeFieldExclusive() field.ErrorList {
+	var allErrs field.ErrorList
+
+	if r.Spec.InstanceType != nil && len(r.Spec.InstanceTypeList) > 0 {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "instanceTypeList"), "instanceType & instanceTypeList are mutually exclusive"))
+	}
+
+	return allErrs
+}
+
 // ValidateCreate will do any extra validation when creating a AWSManagedMachinePool.
 func (r *AWSManagedMachinePool) ValidateCreate() error {
 	mmpLog.Info("AWSManagedMachinePool validate create", "name", r.Name)
@@ -132,6 +142,9 @@ func (r *AWSManagedMachinePool) ValidateCreate() error {
 		allErrs = append(allErrs, errs...)
 	}
 	if errs := r.validateNodegroupUpdateConfig(); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+	if errs := r.validateInstanceTypeFieldExclusive(); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
 
@@ -166,6 +179,9 @@ func (r *AWSManagedMachinePool) ValidateUpdate(old runtime.Object) error {
 		allErrs = append(allErrs, errs...)
 	}
 	if errs := r.validateNodegroupUpdateConfig(); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+	if errs := r.validateInstanceTypeFieldExclusive(); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
 

--- a/exp/api/v1beta1/awsmanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/awsmanagedmachinepool_webhook_test.go
@@ -126,6 +126,37 @@ func TestAWSManagedMachinePool_ValidateCreate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "with both instanceType and instanceTypeList",
+			pool: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-4",
+					InstanceType:     aws.String("a"),
+					InstanceTypeList: []string{"a", "b", "c"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "with only instanceType",
+			pool: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-4",
+					InstanceType:     aws.String("a"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with only instanceTypeList",
+			pool: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-4",
+					InstanceTypeList: []string{"a", "b", "c"},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -415,6 +415,11 @@ func (in *AWSManagedMachinePoolSpec) DeepCopyInto(out *AWSManagedMachinePoolSpec
 		*out = new(string)
 		**out = **in
 	}
+	if in.InstanceTypeList != nil {
+		in, out := &in.InstanceTypeList, &out.InstanceTypeList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Scaling != nil {
 		in, out := &in.Scaling, &out.Scaling
 		*out = new(ManagedMachinePoolScaling)

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -226,6 +226,9 @@ func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 	if managedPool.InstanceType != nil {
 		input.InstanceTypes = []*string{managedPool.InstanceType}
 	}
+	if len(managedPool.InstanceTypeList) > 0 {
+		input.InstanceTypes = aws.StringSlice(managedPool.InstanceTypeList)
+	}
 	if len(managedPool.Taints) > 0 {
 		s.Info("adding taints to nodegroup", "nodegroup", nodegroupName)
 		taints, err := converters.TaintsToSDK(managedPool.Taints)

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -203,6 +203,8 @@ providers:
         targetName: "cluster-template-eks-managed-machinepool-only.yaml"
       - sourcePath: "./eks/cluster-template-eks-managedmachinepool.yaml"
         targetName: "cluster-template-eks-managedmachinepool.yaml"
+      - sourcePath: "./eks/cluster-template-eks-managedmachinepool-instancetypes.yaml"
+        targetName: "cluster-template-eks-managedmachinepool-instancetypes.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.22.9"

--- a/test/e2e/data/eks/cluster-template-eks-managedmachinepool-instancetypes.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-managedmachinepool-instancetypes.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+  controlPlaneRef:
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  region: "${AWS_REGION}"
+  sshKeyName: "${AWS_SSH_KEY_NAME}"
+  version: "${KUBERNETES_VERSION}"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-pool-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSManagedMachinePool
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSManagedMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool-0"
+spec:
+  capacityType: spot
+  amiType: AL2_x86_64
+  instanceTypeList:
+    - "t3.small"
+    - "t3a.small"
+    - "t3.medium"
+    - "t3a.medium"
+    - "t2.medium"
+    - "m1.large"
+
+  updateConfig:
+    maxUnavailable: 1
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool-1"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-pool-1"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSManagedMachinePool
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSManagedMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool-1"
+spec:
+  capacityType: onDemand
+  amiType: AL2_x86_64
+  instanceType: "m1.large"
+
+  updateConfig:
+    maxUnavailable: 1


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Adds a new field to `AWSManagedmachinePool` called `spec.instanceTypeList` that let's you specify a list of instance types that the underlying node group should use. This is primarily useful for `spec.capacityType: spot`, where specifying a set of instances increases your odds of finding an adequate instance, but there's nothing stopping you from using it with `spec.capacityType: onDemand`. More here https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types

For backwards compatibility (and to avoid confusion), `spec.instanceType` is left as-is, but it's made mutually exclusive with `spec.instanceTypeList` so only one can be set.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#2701 had this as a request, but it was never added.

**Special notes for your reviewer**: I've named it `instanceTypeList` instead of `instanceTypes` to make it visually different from `instanceType` to avoid any confusion, but I'm not too strongly attached to that if you want to change it.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
