### PR TITLE
feat: Create bastion security group only when bastion is enabled

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -57,15 +57,12 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
-var (
-	awsSecurityGroupRoles = []infrav1.SecurityGroupRole{
-		infrav1.SecurityGroupBastion,
-		infrav1.SecurityGroupAPIServerLB,
-		infrav1.SecurityGroupLB,
-		infrav1.SecurityGroupControlPlane,
-		infrav1.SecurityGroupNode,
-	}
-)
+var defaultAWSSecurityGroupRoles = []infrav1.SecurityGroupRole{
+	infrav1.SecurityGroupAPIServerLB,
+	infrav1.SecurityGroupLB,
+	infrav1.SecurityGroupControlPlane,
+	infrav1.SecurityGroupNode,
+}
 
 // AWSClusterReconciler reconciles a AwsCluster object.
 type AWSClusterReconciler struct {
@@ -103,12 +100,24 @@ func (r *AWSClusterReconciler) getNetworkService(scope scope.ClusterScope) servi
 	return network.NewService(&scope)
 }
 
+// securityGroupRolesForCluster returns the security group roles determined by the cluster configuration.
+func securityGroupRolesForCluster(scope scope.ClusterScope) []infrav1.SecurityGroupRole {
+	// Copy to ensure we do not modify the package-level variable.
+	roles := make([]infrav1.SecurityGroupRole, len(defaultAWSSecurityGroupRoles))
+	copy(roles, defaultAWSSecurityGroupRoles)
+
+	if scope.Bastion().Enabled {
+		roles = append(roles, infrav1.SecurityGroupBastion)
+	}
+	return roles
+}
+
 // getSecurityGroupService factory func is added for testing purpose so that we can inject mocked SecurityGroupService to the AWSClusterReconciler.
 func (r *AWSClusterReconciler) getSecurityGroupService(scope scope.ClusterScope) services.SecurityGroupInterface {
 	if r.securityGroupFactory != nil {
 		return r.securityGroupFactory(scope)
 	}
-	return securitygroup.NewService(&scope, awsSecurityGroupRoles)
+	return securitygroup.NewService(&scope, securityGroupRolesForCluster(scope))
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusters,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
For EC2 clusters, create the bastion security group only if the bastion is enabled. #3028 introduced this feature for EKS clusters.

This repeats the original PR (#3482), which was merged before I added unit tests, and unfortunately had a bug in the implementation. That PR was reverted in #3495.

Special thanks to @pydctw for finding the cause of the bug, and suggesting a fix! :bow: 

The first commit of this PR is the original fix, with the bug. The second commit adds a _failing_  test that confirms the implementation bug , and the final commit fixes the bug. I want to squash the commits before merging.

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@dkoshkin pointed out that this is a **breaking change**, since today, EC2 clusters with a disabled Bastion have the bastion security group, and users may be relying on its existence. I'd like feedback on this, please!

I've added a unit test that verifies
(a) the correct roles are returned
(b) the default roles are not modified by calls to the function

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
