### PR TITLE
Use ginkgo.timeout for only ci conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ TEST_E2E_DIR := test/e2e
 E2E_DATA_DIR ?= $(REPO_ROOT)/test/e2e/data
 E2E_CONF_PATH  ?= $(E2E_DATA_DIR)/e2e_conf.yaml
 E2E_EKS_CONF_PATH ?= $(E2E_DATA_DIR)/e2e_eks_conf.yaml
-KUBETEST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance.yaml)
+KUBETEST_CONF_FILE ?= "conformance.yaml"
+KUBETEST_CONF_PATH ?= $(E2E_DATA_DIR)/kubetest/$(KUBETEST_CONF_FILE)
 EXP_DIR := exp
 
 # Binaries.

--- a/test/e2e/data/kubetest/conformance-ci.yaml
+++ b/test/e2e/data/kubetest/conformance-ci.yaml
@@ -1,11 +1,13 @@
 # Adding Service Type=Loadbalancer migrated from functional test suite
 # In-tree volume storage removed
 ginkgo.focus: \[Conformance\]|LoadBalancers ESIPP
+ginkgo.skip: \[sig-scheduling\].*\[Serial\]
 disable-log-dump: true
 ginkgo.progress: true
 ginkgo.slowSpecThreshold: 120.0
 ginkgo.flakeAttempts: 3
 ginkgo.trace: true
 ginkgo.v: true
+ginkgo.timeout: 10800s
 # TODO @randomvariable: Wire up credentials to Docker mount after https://github.com/kubernetes-sigs/cluster-api/pull/4930
 # provider: aws


### PR DESCRIPTION
/kind failing-test


**What this PR does / why we need it**:
After https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3586 is in, non-ci conformance tests started failing:
(https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-e2e-conformance/1547086357950631936)

The reason for this is only K8s >= 1.25 is using ginkgo v2, so we need to use ginkgo v1 flags until we bump all conformance test versions to >= 1.25.

As a follow up to this PR, I will create a test-infra PR to pass the new conformance-ci.yaml to be used in CI conformance test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
