### PR TITLE
Use ginkgo v2 conformance config for Kubernetes >= 1.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ TEST_E2E_DIR := test/e2e
 E2E_DATA_DIR ?= $(REPO_ROOT)/test/e2e/data
 E2E_CONF_PATH  ?= $(E2E_DATA_DIR)/e2e_conf.yaml
 E2E_EKS_CONF_PATH ?= $(E2E_DATA_DIR)/e2e_eks_conf.yaml
-KUBETEST_CONF_FILE ?= "conformance.yaml"
-KUBETEST_CONF_PATH ?= $(E2E_DATA_DIR)/kubetest/$(KUBETEST_CONF_FILE)
+KUBETEST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance.yaml)
 EXP_DIR := exp
 
 # Binaries.

--- a/test/e2e/data/kubetest/conformance-ginkgo-v2.yaml
+++ b/test/e2e/data/kubetest/conformance-ginkgo-v2.yaml
@@ -4,7 +4,7 @@ ginkgo.focus: \[Conformance\]|LoadBalancers ESIPP
 ginkgo.skip: \[sig-scheduling\].*\[Serial\]
 disable-log-dump: true
 ginkgo.progress: true
-ginkgo.slowSpecThreshold: 120.0
+ginkgo.slow-spec-threshold: 120s
 ginkgo.flakeAttempts: 3
 ginkgo.trace: true
 ginkgo.v: true

--- a/test/e2e/suites/conformance/conformance_test.go
+++ b/test/e2e/suites/conformance/conformance_test.go
@@ -24,7 +24,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
+	"github.com/blang/semver"
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -72,6 +74,16 @@ var _ = ginkgo.Describe("[unmanaged] [conformance] tests", func() {
 		controlPlaneMachineCount, err := strconv.ParseInt(e2eCtx.E2EConfig.GetVariable("CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT"), 10, 64)
 		Expect(err).NotTo(HaveOccurred())
 
+		// Starting with Kubernetes v1.25, the kubetest config file needs to be compatible with Ginkgo V2.
+		v125 := semver.MustParse("1.25.0-alpha.0.0")
+		v, err := semver.ParseTolerant(kubernetesVersion)
+		Expect(err).NotTo(HaveOccurred())
+		kubetestConfigFilePath := e2eCtx.Settings.KubetestConfigFilePath
+		if v.GTE(v125) {
+			// Use the Ginkgo V2 config file.
+			kubetestConfigFilePath = getGinkgoV2ConfigFilePath(e2eCtx.Settings.KubetestConfigFilePath)
+		}
+
 		runtime := b.Time("cluster creation", func() {
 			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
@@ -99,7 +111,7 @@ var _ = ginkgo.Describe("[unmanaged] [conformance] tests", func() {
 				kubetest.RunInput{
 					ClusterProxy:   workloadProxy,
 					NumberOfNodes:  int(workerMachineCount),
-					ConfigFilePath: e2eCtx.Settings.KubetestConfigFilePath,
+					ConfigFilePath: kubetestConfigFilePath,
 				},
 			)
 		})
@@ -113,3 +125,7 @@ var _ = ginkgo.Describe("[unmanaged] [conformance] tests", func() {
 	})
 
 })
+
+func getGinkgoV2ConfigFilePath(kubetestConfigFilePath string) string {
+	return strings.Replace(kubetestConfigFilePath, ".yaml", "-ginkgo-v2.yaml", 1)
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
As a follow up to https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3592, instead of passing the ci conformance config via prow config, adding a check for Kubernetes version to use CI conformance config only if Kubernetes version is >=1.25.0.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
