### PR TITLE
[clusterawsadm] Fix attaching CSI policy to control plane IAM role

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/csi.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/csi.go
@@ -24,7 +24,7 @@ import (
 
 func (t Template) csiControlPlaneAwsRoles() []string {
 	roles := []string{}
-	if !t.Spec.ControlPlane.EnableCSIPolicy {
+	if !t.Spec.ControlPlane.DisableCloudProviderPolicy && t.Spec.ControlPlane.EnableCSIPolicy {
 		roles = append(roles, cloudformation.Ref(AWSIAMRoleControlPlane))
 	}
 	return roles


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
During CloudFormation creation, when EnableCSIPolicy is set to true, clusterawsadm was creating the policy for it but not attaching it to control plane role. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3527

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
