### PR TITLE
[WIP] feat: deprecate DisableVPCCNI in AWSManagedControlPlane

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2266,12 +2266,13 @@ spec:
                 type: object
               disableVPCCNI:
                 default: false
-                description: DisableVPCCNI indicates that the Amazon VPC CNI should
-                  be disabled. With EKS clusters the Amazon VPC CNI is automatically
-                  installed into the cluster. For clusters where you want to use an
-                  alternate CNI this option provides a way to specify that the Amazon
-                  VPC CNI should be deleted. You cannot set this to true if you are
-                  using the Amazon VPC CNI addon.
+                description: 'DEPRECATED: This property has moved to vpcCni.disable
+                  and will be removed in a future release. DisableVPCCNI indicates
+                  that the Amazon VPC CNI should be disabled. With EKS clusters the
+                  Amazon VPC CNI is automatically installed into the cluster. For
+                  clusters where you want to use an alternate CNI this option provides
+                  a way to specify that the Amazon VPC CNI should be deleted. You
+                  cannot set this to true if you are using the Amazon VPC CNI addon.'
                 type: boolean
               eksClusterName:
                 description: EKSClusterName allows you to specify the name of the
@@ -2702,6 +2703,15 @@ spec:
                 description: VpcCni is used to set configuration options for the VPC
                   CNI plugin
                 properties:
+                  disable:
+                    default: false
+                    description: Disable indicates that the Amazon VPC CNI should
+                      be disabled. With EKS clusters the Amazon VPC CNI is automatically
+                      installed into the cluster. For clusters where you want to use
+                      an alternate CNI this option provides a way to specify that
+                      the Amazon VPC CNI should be deleted. You cannot set this to
+                      true if you are using the Amazon VPC CNI addon.
+                    type: boolean
                   env:
                     description: Env defines a list of environment variables to apply
                       to the `aws-node` DaemonSet

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
@@ -160,6 +160,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// +optional
 	OIDCIdentityProviderConfig *OIDCIdentityProviderConfig `json:"oidcIdentityProviderConfig,omitempty"`
 
+	// DEPRECATED: This property has moved to vpcCni.disable and will be removed in a future release.
 	// DisableVPCCNI indicates that the Amazon VPC CNI should be disabled. With EKS clusters the
 	// Amazon VPC CNI is automatically installed into the cluster. For clusters where you want
 	// to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI
@@ -189,6 +190,14 @@ type KubeProxy struct {
 
 // VpcCni specifies configuration related to the VPC CNI.
 type VpcCni struct {
+	// Disable indicates that the Amazon VPC CNI should be disabled. With EKS clusters the
+	// Amazon VPC CNI is automatically installed into the cluster. For clusters where you want
+	// to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI
+	// should be deleted. You cannot set this to true if you are using the
+	// Amazon VPC CNI addon.
+	// +kubebuilder:default=false
+	Disable bool `json:"disable,omitempty"`
+
 	// Env defines a list of environment variables to apply to the `aws-node` DaemonSet
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -372,7 +372,7 @@ func (s *ManagedControlPlaneScope) DisableVPCCNI() bool {
 	return s.ControlPlane.Spec.DisableVPCCNI
 }
 
-// VpcCni returns a list of environment variables to apply to the `aws-node` DaemonSet.
+// VpcCni returns configuration options for the VPC CNI plugin
 func (s *ManagedControlPlaneScope) VpcCni() ekscontrolplanev1.VpcCni {
 	return s.ControlPlane.Spec.VpcCni
 }

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -49,7 +49,8 @@ func (s *Service) ReconcileCNI(ctx context.Context) error {
 		return fmt.Errorf("getting client for remote cluster: %w", err)
 	}
 
-	if s.scope.DisableVPCCNI() {
+	vpcCni := s.scope.VpcCni()
+	if s.scope.DisableVPCCNI() || vpcCni.Disable {
 		if err := s.deleteCNI(ctx, remoteClient); err != nil {
 			return fmt.Errorf("disabling aws vpc cni: %w", err)
 		}
@@ -63,7 +64,7 @@ func (s *Service) ReconcileCNI(ctx context.Context) error {
 		return ErrCNIMissing
 	}
 
-	envVars := s.scope.VpcCni().Env
+	envVars := vpcCni.Env
 	if len(envVars) > 0 {
 		s.scope.Info("updating aws-node daemonset environment variables", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind deprecation
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR deprecates the `disableVPCCNI` field on `AWSManagedControlPlane` in favour of `vpcCni.disable`.

**Which issue(s) this PR fixes**
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3410

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
