### PR TITLE
Fix the owner checking of a cluster

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -59,7 +59,7 @@ func (s *Service) reconcileCluster(ctx context.Context) error {
 			return errors.Wrap(err, "failed to create cluster")
 		}
 	} else {
-		tagKey := infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name())
+		tagKey := infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName())
 		ownedTag := cluster.Tags[tagKey]
 		if ownedTag == nil {
 			return fmt.Errorf("checking owner of %s is %s: %w", s.scope.KubernetesClusterName(), s.scope.Name(), err)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

During this [3573](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3573) we changed the owner tag name. That made owner lookup fail on the next run here:

```go
		tagKey := infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name())
```

Because the key no longer was used with `Name()` this check returned a `nil` value. This PR fixes that.

Unfortunately, I don't know the code enough to ascertain if the "fix" introduced in that PR actually has more ramifications. This is the only one I could find for now that seems to be related to that change.

This was surfaced in test runs for this PR: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3568 which merged these changes after which the test started to fail.

Here is a successful run with this fix though for the e2e EKS test: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/3568/pull-cluster-api-provider-aws-e2e-eks/1547472747523739648

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
