### PR TITLE
Add AWSMachinePool test to eks e2e test

### DIFF
--- a/docs/book/src/topics/machinepools.md
+++ b/docs/book/src/topics/machinepools.md
@@ -20,7 +20,7 @@ Make sure to set up your AWS environment as described [here](https://cluster-api
 ```shell
 export EXP_MACHINE_POOL=true
 clusterctl init --infrastructure aws
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.8 --flavor machinepool > my-cluster.yaml
+clusterctl generate cluster my-cluster --kubernetes-version v1.24.0 --flavor machinepool > my-cluster.yaml
 ```
 
 The template used for this [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors) is located [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template-machinepool.yaml).
@@ -29,7 +29,7 @@ The template used for this [flavor](https://cluster-api.sigs.k8s.io/clusterctl/c
 
 Cluster API Provider AWS (CAPA) has experimental support for [EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) using `MachinePool` through the infrastructure type `AWSManagedMachinePool`. An `AWSManagedMachinePool` corresponds to an [AWS AutoScaling Groups](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html) that is used for an EKS managed node group. .
 
-The AWSManagedMachinePool controller creates and manages an EKS managed node group with in turn manages an AWS AutoScaling Group of managed EC2 instance types.
+The AWSManagedMachinePool controller creates and manages an EKS managed node group which in turn manages an AWS AutoScaling Group of managed EC2 instance types.
 
 To use the managed machine pools certain IAM permissions are needed. The easiest way to ensure the required IAM permissions are in place is to use `clusterawsadm` to create them. To do this, follow the EKS instructions in [using clusterawsadm to fulfill prerequisites](using-clusterawsadm-to-fulfill-prerequisites.md).
 
@@ -42,7 +42,7 @@ Make sure to set up your AWS environment as described [here](https://cluster-api
 ```shell
 export EXP_MACHINE_POOL=true
 clusterctl init --infrastructure aws
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.8 --flavor eks-managedmachinepool > my-cluster.yaml
+clusterctl generate cluster my-cluster --kubernetes-version v1.22.0 --flavor eks-managedmachinepool > my-cluster.yaml
 ```
 
 The template used for this [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors) is located [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template-eks-managedmachinepool.yaml).
@@ -76,7 +76,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachinePool
         name: capa-mp-0
-      version: v1.16.8
+      version: v1.24.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachinePool

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -201,6 +201,8 @@ providers:
         targetName: "cluster-template-eks-machine-deployment-only.yaml"
       - sourcePath: "./eks/cluster-template-eks-managed-machinepool-only.yaml"
         targetName: "cluster-template-eks-managed-machinepool-only.yaml"
+      - sourcePath: "./eks/cluster-template-eks-machinepool-only.yaml"
+        targetName: "cluster-template-eks-machinepool-only.yaml"
       - sourcePath: "./eks/cluster-template-eks-managedmachinepool.yaml"
         targetName: "cluster-template-eks-managedmachinepool.yaml"
 

--- a/test/e2e/data/eks/cluster-template-eks-machinepool-only.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-machinepool-only.yaml
@@ -1,0 +1,38 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: "${CLUSTER_NAME}-mp-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: EKSConfig
+          name: "${CLUSTER_NAME}-mp-0"
+      clusterName: "${CLUSTER_NAME}"
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSMachinePool
+        name: "${CLUSTER_NAME}-mp-0"
+      version: "${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-mp-0"
+spec:
+  minSize: 1
+  maxSize: 3
+  awsLaunchTemplate:
+    iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
+    instanceType: "${AWS_NODE_MACHINE_TYPE}"
+    sshKeyName: "${AWS_SSH_KEY_NAME}"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: EKSConfig
+metadata:
+  name: "${CLUSTER_NAME}-mp-0"
+spec: {}

--- a/test/e2e/suites/managed/README.md
+++ b/test/e2e/suites/managed/README.md
@@ -12,3 +12,5 @@ For example, in [eks_test.go](eks_test.go) we perform the following steps:
 4. Perform tests against the machine deployment
 5. Apply a AWSManagedMachinePool
 6. Perform tests against the machine pool
+7. Apply a AWSMachinePool
+8. Perform tests against the machine pool

--- a/test/e2e/suites/managed/eks_test.go
+++ b/test/e2e/suites/managed/eks_test.go
@@ -126,8 +126,8 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 		})
 
 		ginkgo.By("should create a managed node pool and scale")
-		ManagedMachinePoolSpec(ctx, func() ManagedMachinePoolSpecInput {
-			return ManagedMachinePoolSpecInput{
+		MachinePoolSpec(ctx, func() MachinePoolSpecInput {
+			return MachinePoolSpecInput{
 				E2EConfig:             e2eCtx.E2EConfig,
 				ConfigClusterFn:       defaultConfigCluster,
 				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
@@ -136,6 +136,24 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 				ClusterName:           clusterName,
 				IncludeScaling:        true,
 				Cleanup:               true,
+				ManagedMachinePool:    true,
+				Flavor:                EKSManagedMachinePoolOnlyFlavor,
+			}
+		})
+
+		ginkgo.By("should create a machine pool and scale")
+		MachinePoolSpec(ctx, func() MachinePoolSpecInput {
+			return MachinePoolSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ConfigClusterFn:       defaultConfigCluster,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				AWSSession:            e2eCtx.BootstrapUserAWSSession,
+				Namespace:             namespace,
+				ClusterName:           clusterName,
+				IncludeScaling:        true,
+				Cleanup:               true,
+				ManagedMachinePool:    false,
+				Flavor:                EKSMachinePoolOnlyFlavor,
 			}
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
EKS e2e do not test AWSMachinePool flavor. This is an important flavor to support so added e2e test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2865 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
