### PR TITLE
Fix aws-node-env checker to use the correct input and context

### DIFF
--- a/test/e2e/suites/managed/aws_node_env.go
+++ b/test/e2e/suites/managed/aws_node_env.go
@@ -66,7 +66,7 @@ func CheckAwsNodeEnvVarsSet(ctx context.Context, inputGetter func() UpdateAwsNod
 	shared.Byf("Checking if aws-node has been updated with the defined environment variables on the workload cluster")
 	daemonSet := &appsv1.DaemonSet{}
 
-	clusterClient := e2eCtx.Environment.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName).GetClient()
+	clusterClient := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName).GetClient()
 	err = clusterClient.Get(ctx, crclient.ObjectKey{Namespace: "kube-system", Name: "aws-node"}, daemonSet)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

This PR fixes the aws-node-env checker to use the right context for accessing the Kubernetes client. The `e2eCtx` it was using is declared in a test file.

This check is part of the normal e2e_eks test, so I'm wondering how this ever passed / worked recently.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
