### PR TITLE
Correct broken links for EKS addons and multitenancy

### DIFF
--- a/docs/book/src/topics/eks/addons.md
+++ b/docs/book/src/topics/eks/addons.md
@@ -23,8 +23,8 @@ spec:
       conflictResolution: "overwrite"
 ```
 
-Additionally, there is a cluster [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#flavors)
-called [eks-managedmachinepool-vpccni](../../templates/cluster-template-eks-managedmachinepool-vpccni.yaml) that you can use with **clusterctl**:
+Additionally, there is a cluster [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors)
+called [eks-managedmachinepool-vpccni](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template-eks-managedmachinepool-vpccni.yaml) that you can use with **clusterctl**:
 
 ```shell
 clusterctl generate cluster my-cluster --kubernetes-version v1.18.0 --flavor eks-managedmachinepool-vpccni > my-cluster.yaml

--- a/docs/book/src/topics/multitenancy.md
+++ b/docs/book/src/topics/multitenancy.md
@@ -269,11 +269,11 @@ spec:
     name: "test-multi-tenant-workload"
 ```
 
-More specific examples can be referenced from the existing [templates](../../../../templates/) directory.
+More specific examples can be referenced from the existing [templates](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/) directory.
 
-In order to use the [EC2 template](../../../../templates/cluster-template.yaml) with identity type, you can add the `identityRef` section to `kind: AWSCluster` spec section in the template. If you do not, CAPA will automatically add the default identity provider (which is usually your local account credentials).
+In order to use the [EC2 template](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template.yaml) with identity type, you can add the `identityRef` section to `kind: AWSCluster` spec section in the template. If you do not, CAPA will automatically add the default identity provider (which is usually your local account credentials).
 
-Similarly, to use the [EKS template](../../../../templates/cluster-template-eks.yaml) with identity type, you can add the `identityRef` section to `kind: AWSManagedControlPlane` spec section in the template. If you do not, CAPA will automatically add the default identity provider (which is usually your local account credentials).
+Similarly, to use the [EKS template](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template-eks.yaml) with identity type, you can add the `identityRef` section to `kind: AWSManagedControlPlane` spec section in the template. If you do not, CAPA will automatically add the default identity provider (which is usually your local account credentials).
 
 ## Secure Access to Identities
 `allowedNamespaces` field is used to grant access to the namespaces to use Identities.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Fix broken links under [EKS Addons](https://cluster-api-aws.sigs.k8s.io/topics/eks/addons.html) and [Multi-tenancy](https://cluster-api-aws.sigs.k8s.io/topics/multitenancy.html) which leads to `Document not found (404)`

This should help new users who are following the EKS guide to not be confused with broken links.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3614

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
