### PR TITLE
Modify e2e EKS config to use cluster api v1.1.5

### DIFF
--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -68,17 +68,6 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.2.99 # next;
-        value: "https://storage.googleapis.com/artifacts.k8s-staging-cluster-api.appspot.com/components/nightly_main_20220725/core-components.yaml"
-        type: "url"
-        contract: v1beta1
-        files:
-        - sourcePath: "./shared/v1beta1/metadata.yaml"
-        replacements:
-        - old: "imagePullPolicy: Always"
-          new: "imagePullPolicy: IfNotPresent"
-        - old: --metrics-bind-addr=127.0.0.1:8080
-          new: --metrics-bind-addr=:8080
   - name: kubeadm
     type: BootstrapProvider
     files:
@@ -115,17 +104,6 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.2.99 # next;
-        value: "https://storage.googleapis.com/artifacts.k8s-staging-cluster-api.appspot.com/components/nightly_main_20220725/bootstrap-components.yaml"
-        type: "url"
-        contract: v1beta1
-        files:
-        - sourcePath: "./shared/v1beta1/metadata.yaml"
-        replacements:
-        - old: "imagePullPolicy: Always"
-          new: "imagePullPolicy: IfNotPresent"
-        - old: --metrics-bind-addr=127.0.0.1:8080
-          new: --metrics-bind-addr=:8080
   - name: kubeadm
     type: ControlPlaneProvider
     files:
@@ -163,21 +141,10 @@ providers:
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=127.0.0.1:8080
             new: --metrics-bind-addr=:8080
-      - name: v1.2.99 # next;
-        value: "https://storage.googleapis.com/artifacts.k8s-staging-cluster-api.appspot.com/components/nightly_main_20220725/control-plane-components.yaml"
-        type: "url"
-        contract: v1beta1
-        files:
-        - sourcePath: "./shared/v1beta1/metadata.yaml"
-        replacements:
-        - old: "imagePullPolicy: Always"
-          new: "imagePullPolicy: IfNotPresent"
-        - old: --metrics-bind-addr=127.0.0.1:8080
-          new: --metrics-bind-addr=:8080
   - name: aws
     type: InfrastructureProvider
     versions:
-      - name: v1.2.99
+      - name: v1.4.99
         # Use manifest from source files
         value: ../../../config/default
         contract: v1beta1


### PR DESCRIPTION


**What this PR does / why we need it**:
We no longer need to use a nightly build, so pinning e2e EKS CAPI version to 1.1.5.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
