### PR TITLE
add binary releases for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -573,6 +573,8 @@ release-binaries: ## Builds the binaries to publish with a release
 	RELEASE_BINARY=./cmd/clusterawsadm GOOS=linux GOARCH=arm64 $(MAKE) release-binary
 	RELEASE_BINARY=./cmd/clusterawsadm GOOS=darwin GOARCH=amd64 $(MAKE) release-binary
 	RELEASE_BINARY=./cmd/clusterawsadm GOOS=darwin GOARCH=arm64 $(MAKE) release-binary
+	RELEASE_BINARY=./cmd/clusterawsadm GOOS=windows GOARCH=amd64 EXT=.exe $(MAKE) release-binary
+	RELEASE_BINARY=./cmd/clusterawsadm GOOS=windows GOARCH=arm64 EXT=.exe $(MAKE) release-binary
 
 .PHONY: release-binary
 release-binary: $(RELEASE_DIR) versions.mk build-toolchain ## Release binary
@@ -587,7 +589,7 @@ release-binary: $(RELEASE_DIR) versions.mk build-toolchain ## Release binary
 		-w /workspace \
 		$(TOOLCHAIN_IMAGE) \
 		go build -ldflags '$(LDFLAGS) -extldflags "-static"' \
-		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(RELEASE_BINARY)
+		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH)$(EXT) $(RELEASE_BINARY)
 
 .PHONY: release-staging
 release-staging: ## Builds and push container images and manifests to the staging bucket.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Adds windows amd64 and arm64 binaries to the releases for clusterawsadm.

```
~\kube\cluster-api-provider-aws [main] > .\out\clusterawsadm-windows-amd64.exe version
clusterawsadm version: &version.Info{Major:"", Minor:"", GitVersion:"", GitCommit:"", GitTreeState:"", BuildDate:"", GoVersion:"go1.17.3", AwsSdkVersion:"v1.43.29", Compiler:"gc", Platform:"windows/amd64"}
```

As far as i can tell right now everything works fine and I browsed the code for common windows pitfalls like filepath joining etc. and looks like it will be fine.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
