### PR TITLE
[E2E] Bump NVIDIA GPU operator version in GPU tests

### DIFF
--- a/test/e2e/data/infrastructure-aws/kustomize_sources/gpu/clusterpolicy-crd.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/gpu/clusterpolicy-crd.yaml
@@ -15,5759 +15,3862 @@ spec:
     singular: clusterpolicy
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ClusterPolicy is the Schema for the clusterpolicies API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicy is the Schema for the clusterpolicies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterPolicySpec defines the desired state of ClusterPolicy
-              properties:
-                dcgmExporter:
-                  description: DCGMExporter spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterPolicySpec defines the desired state of ClusterPolicy
+            properties:
+              daemonsets:
+                description: Daemonset defines common configuration for all Daemonsets
+                properties:
+                  priorityClassName:
+                    type: string
+                  tolerations:
+                    description: 'Optional: Set tolerations'
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
                       properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
                       type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
-                        type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: array
+                type: object
+              dcgm:
+                description: DCGM component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA DCGM Hostengine
+                      as a separate pod is enabled.
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
-                      type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
-                      each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
-                      type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                devicePlugin:
-                  description: DevicePlugin component spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
                               required:
-                                - nodeSelectorTerms
+                              - key
                               type: object
                           type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
+                      required:
+                      - name
                       type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
+                    type: array
+                  hostPort:
+                    description: 'HostPort represents host port that needs to be bound
+                      for DCGM engine (Default: 5555)'
+                    format: int32
+                    type: integer
+                  image:
+                    description: NVIDIA DCGM image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA DCGM image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA DCGM image tag
+                    type: string
+                type: object
+              dcgmExporter:
+                description: DCGMExporter spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  config:
+                    description: 'Optional: Custom metrics configuration for NVIDIA
+                      DCGM Exporter'
+                    properties:
+                      name:
+                        description: ConfigMap name with file dcgm-metrics.csv for
+                          metrics to be collected by NVIDIA DCGM Exporter
                         type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: object
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
-                      type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
-                      each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
-                      type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                driver:
-                  description: Driver component spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
                               required:
-                                - nodeSelectorTerms
+                              - key
                               type: object
                           type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
+                      required:
+                      - name
                       type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
+                    type: array
+                  image:
+                    description: NVIDIA DCGM Exporter image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA DCGM Exporter image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA DCGM Exporter image tag
+                    type: string
+                type: object
+              devicePlugin:
+                description: DevicePlugin component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  config:
+                    description: 'Optional: Configuration for the NVIDIA Device Plugin
+                      via the ConfigMap'
+                    properties:
+                      default:
+                        description: Default config name within the ConfigMap for
+                          the NVIDIA Device Plugin  config
                         type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      name:
+                        description: ConfigMap name for NVIDIA Device Plugin config
+                          including shared config between plugin and GFD
+                        type: string
+                    type: object
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
-                      type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
-                      each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
-                      type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                gfd:
-                  description: GPUFeatureDiscovery spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
                               required:
-                                - nodeSelectorTerms
+                              - key
                               type: object
                           type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
+                      required:
+                      - name
                       type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
+                    type: array
+                  image:
+                    description: NVIDIA Device Plugin image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA Device Plugin image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA Device Plugin image tag
+                    type: string
+                type: object
+              driver:
+                description: Driver component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  certConfig:
+                    description: 'Optional: Custom certificates configuration for
+                      NVIDIA Driver container'
+                    properties:
+                      name:
                         type: string
-                      type: array
-                    discoveryIntervalSeconds:
-                      description: 'Optional: Discovery Interval for GPU feature discovery
-                      plugin'
-                      type: integer
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: object
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA Driver
+                      through operator is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    migStrategy:
-                      description: 'Optional: MigStrategy for GPU feature discovery
-                      plugin'
-                      enum:
-                        - none
-                        - single
-                        - mixed
-                      type: string
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
-                      type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
-                      each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
-                      type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                operator:
-                  description: Operator component spec
-                  properties:
-                    defaultRuntime:
-                      description: Runtime defines container runtime type
-                      enum:
-                        - docker
-                        - crio
-                        - containerd
-                      type: string
-                    validator:
-                      description: ValidatorSpec describes configuration options for
-                        validation pod
-                      properties:
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
-                          type: string
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
-                          type: string
-                      type: object
-                  required:
-                    - defaultRuntime
-                  type: object
-                toolkit:
-                  description: Toolkit component spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
                               required:
-                                - nodeSelectorTerms
+                              - key
                               type: object
                           type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
+                      required:
+                      - name
                       type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
+                    type: array
+                  image:
+                    description: NVIDIA Driver image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  kernelModuleConfig:
+                    description: 'Optional: Kernel module configuration parameters
+                      for the NVIDIA Driver'
+                    properties:
+                      name:
                         type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: object
+                  licensingConfig:
+                    description: 'Optional: Licensing configuration for NVIDIA vGPU
+                      licensing'
+                    properties:
+                      configMapName:
+                        type: string
+                      nlsEnabled:
+                        description: NLSEnabled indicates if NVIDIA Licensing System
+                          is used for licensing.
+                        type: boolean
+                    type: object
+                  manager:
+                    description: Manager represents configuration for NVIDIA Driver
+                      Manager initContainer
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image represents NVIDIA Driver Manager image
+                          name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Repository represents Driver Managerrepository
+                          path
+                        type: string
+                      version:
+                        description: Version represents NVIDIA Driver Manager image
+                          tag(version)
+                        type: string
+                    type: object
+                  rdma:
+                    description: GPUDirectRDMASpec defines the properties for nvidia-peermem
+                      deployment
+                    properties:
+                      enabled:
+                        description: Enabled indicates if GPUDirect RDMA is enabled
+                          through GPU operator
+                        type: boolean
+                      useHostMofed:
+                        description: UseHostMOFED indicates to use MOFED drivers directly
+                          installed on the host to enable GPUDirect RDMA
+                        type: boolean
+                    type: object
+                  repoConfig:
+                    description: 'Optional: Custom repo configuration for NVIDIA Driver
+                      container'
+                    properties:
+                      configMapName:
+                        type: string
+                    type: object
+                  repository:
+                    description: NVIDIA Driver image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  rollingUpdate:
+                    description: 'Optional: Configuration for rolling update of NVIDIA
+                      Driver DaemonSet pods'
+                    properties:
+                      maxUnavailable:
+                        type: string
+                    type: object
+                  version:
+                    description: NVIDIA Driver image tag
+                    type: string
+                  virtualTopology:
+                    description: 'Optional: Virtual Topology Daemon configuration
+                      for NVIDIA vGPU drivers'
+                    properties:
+                      config:
+                        description: 'Optional: Config name representing virtual topology
+                          daemon configuration file nvidia-topologyd.conf'
+                        type: string
+                    type: object
+                type: object
+              gds:
+                description: GPUDirectStorage defines the spec for GDS components(Experimental)
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if GPUDirect Storage is enabled
+                      through GPU operator
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
                           type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
+                      required:
+                      - name
                       type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
+                    type: array
+                  image:
+                    description: NVIDIA GPUDirect Storage Driver image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
                       type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
+                    type: array
+                  repository:
+                    description: NVIDIA GPUDirect Storage Driver image repository
+                    type: string
+                  version:
+                    description: NVIDIA GPUDirect Storage Driver image tag
+                    type: string
+                type: object
+              gfd:
+                description: GPUFeatureDiscovery spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: GFD image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: GFD image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
                       each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
+                    type: object
+                  version:
+                    description: GFD image tag
+                    type: string
+                type: object
+              mig:
+                description: MIG spec
+                properties:
+                  strategy:
+                    description: 'Optional: MIGStrategy to apply for GFD and NVIDIA
+                      Device Plugin'
+                    enum:
+                    - none
+                    - single
+                    - mixed
+                    type: string
+                type: object
+              migManager:
+                description: MIGManager for configuration to deploy MIG Manager
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
                       type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-              required:
-                - dcgmExporter
-                - devicePlugin
-                - driver
-                - gfd
-                - operator
-                - toolkit
-              type: object
-            status:
-              description: ClusterPolicyStatus defines the observed state of ClusterPolicy
-              properties:
-                state:
-                  enum:
-                    - ignored
-                    - ready
-                    - notReady
-                  type: string
-              required:
-                - state
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: array
+                  config:
+                    description: 'Optional: Custom mig-parted configuration for NVIDIA
+                      MIG Manager container'
+                    properties:
+                      name:
+                        description: ConfigMap name
+                        type: string
+                    type: object
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA MIG Manager
+                      is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  gpuClientsConfig:
+                    description: 'Optional: Custom gpu-clients configuration for NVIDIA
+                      MIG Manager container'
+                    properties:
+                      name:
+                        description: ConfigMap name
+                        type: string
+                    type: object
+                  image:
+                    description: NVIDIA MIG Manager image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA MIG Manager image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA MIG Manager image tag
+                    type: string
+                type: object
+              nodeStatusExporter:
+                description: NodeStatusExporter spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of Node Status Exporter
+                      is enabled.
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Node Status Exporter image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: Node Status Exporterimage repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: Node Status Exporterimage tag
+                    type: string
+                type: object
+              operator:
+                description: Operator component spec
+                properties:
+                  defaultRuntime:
+                    default: docker
+                    description: Runtime defines container runtime type
+                    enum:
+                    - docker
+                    - crio
+                    - containerd
+                    type: string
+                  initContainer:
+                    description: InitContainerSpec describes configuration for initContainer
+                      image used with all components
+                    properties:
+                      image:
+                        description: Image represents image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Repository represents image repository path
+                        type: string
+                      version:
+                        description: Version represents image tag(version)
+                        type: string
+                    type: object
+                  runtimeClass:
+                    default: nvidia
+                    type: string
+                  use_ocp_driver_toolkit:
+                    description: UseOpenShiftDriverToolkit indicates if DriverToolkit
+                      image should be used on OpenShift to build and install driver
+                      modules
+                    type: boolean
+                required:
+                - defaultRuntime
+                type: object
+              psp:
+                description: PSP defines spec for handling PodSecurityPolicies
+                properties:
+                  enabled:
+                    description: Enabled indicates if PodSecurityPolicies needs to
+                      be enabled for all Pods
+                    type: boolean
+                type: object
+              sandboxDevicePlugin:
+                description: SandboxDevicePlugin component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA Sandbox
+                      Device Plugin through operator is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: NVIDIA Sandbox Device Plugin image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA Sandbox Device Plugin image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA Sandbox Device Plugin image tag
+                    type: string
+                type: object
+              sandboxWorkloads:
+                description: SandboxWorkloads defines the spec for handling sandbox
+                  workloads (i.e. Virtual Machines)
+                properties:
+                  defaultWorkload:
+                    default: container
+                    description: DefaultWorkload indicates the default GPU workload
+                      type to configure worker nodes in the cluster for
+                    enum:
+                    - container
+                    - vm-passthrough
+                    - vm-vgpu
+                    type: string
+                  enabled:
+                    description: Enabled indicates if the GPU Operator should manage
+                      additional operands required for sandbox workloads (i.e. VFIO
+                      Manager, vGPU Manager, and additional device plugins)
+                    type: boolean
+                type: object
+              toolkit:
+                description: Toolkit component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA Container
+                      Toolkit through operator is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: NVIDIA Container Toolkit image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA Container Toolkit image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA Container Toolkit image tag
+                    type: string
+                type: object
+              validator:
+                description: Validator defines the spec for operator-validator daemonset
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  cuda:
+                    description: CUDA validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  driver:
+                    description: Toolkit validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Validator image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  plugin:
+                    description: Plugin validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  repository:
+                    description: Validator image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  toolkit:
+                    description: Toolkit validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  version:
+                    description: Validator image tag
+                    type: string
+                  vfioPCI:
+                    description: VfioPCI validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  vgpuDevices:
+                    description: VGPUDevices validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  vgpuManager:
+                    description: VGPUManager validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              vfioManager:
+                description: VFIOManager for configuration to deploy VFIO-PCI Manager
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  driverManager:
+                    description: DriverManager represents configuration for NVIDIA
+                      Driver Manager
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image represents NVIDIA Driver Manager image
+                          name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Repository represents Driver Managerrepository
+                          path
+                        type: string
+                      version:
+                        description: Version represents NVIDIA Driver Manager image
+                          tag(version)
+                        type: string
+                    type: object
+                  enabled:
+                    description: Enabled indicates if deployment of VFIO Manager is
+                      enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: VFIO Manager image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: VFIO Manager image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: VFIO Manager image tag
+                    type: string
+                type: object
+              vgpuDeviceManager:
+                description: VGPUDeviceManager spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  config:
+                    description: NVIDIA vGPU devices configuration for NVIDIA vGPU
+                      Device Manager container
+                    properties:
+                      default:
+                        default: default
+                        description: Default config name within the ConfigMap
+                        type: string
+                      name:
+                        default: vgpu-devices-config
+                        description: ConfigMap name
+                        type: string
+                    type: object
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA vGPU Device
+                      Manager is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: NVIDIA vGPU Device Manager image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA vGPU Device Manager image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA vGPU Device Manager image tag
+                    type: string
+                type: object
+              vgpuManager:
+                description: VGPUManager component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  driverManager:
+                    description: DriverManager represents configuration for NVIDIA
+                      Driver Manager initContainer
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image represents NVIDIA Driver Manager image
+                          name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Repository represents Driver Managerrepository
+                          path
+                        type: string
+                      version:
+                        description: Version represents NVIDIA Driver Manager image
+                          tag(version)
+                        type: string
+                    type: object
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA vGPU Manager
+                      through operator is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: NVIDIA vGPU Manager  image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA vGPU Manager image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA vGPU Manager image tag
+                    type: string
+                type: object
+            required:
+            - daemonsets
+            - dcgm
+            - dcgmExporter
+            - devicePlugin
+            - driver
+            - gfd
+            - nodeStatusExporter
+            - operator
+            - toolkit
+            type: object
+          status:
+            description: ClusterPolicyStatus defines the observed state of ClusterPolicy
+            properties:
+              namespace:
+                description: Namespace indicates a namespace in which the operator
+                  is installed
+                type: string
+              state:
+                description: State indicates status of ClusterPolicy
+                enum:
+                - ignored
+                - ready
+                - notReady
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/gpu/gpu-operator-components.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/gpu/gpu-operator-components.yaml
@@ -6,281 +6,264 @@ metadata:
   name: gpu-operator-resources
   labels:
     app.kubernetes.io/component: "gpu-operator"
-
     openshift.io/cluster-monitoring: "true"
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gpu-operator-node-feature-discovery
-  namespace: default
-  labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gpu-operator/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gpu-operator
-  namespace: default
-  labels:
-    app.kubernetes.io/component: "gpu-operator"
----
-# Source: gpu-operator/charts/node-feature-discovery/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: gpu-operator-node-feature-discovery
-  namespace: default
-  labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
-    app.kubernetes.io/managed-by: Helm
-data:
-  nfd-worker.conf: |
-    sources:
-      pci:
-        deviceLabelFields:
-        - vendor
----
-# Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
+# Source: gpu-operator/charts/node-feature-discovery/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gpu-operator-node-feature-discovery-master
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    # when using command line flag --resource-labels to create extended resources
-    # you will need to uncomment "- nodes/status"
-    # - nodes/status
-    verbs:
-      - get
-      - patch
-      - update
----
-# Source: gpu-operator/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: gpu-operator
+  name: gpu-operator-node-feature-discovery
+  namespace: gpu-operator-resources
   labels:
-    app.kubernetes.io/component: "gpu-operator"
-
+    helm.sh/chart: node-feature-discovery-0.10.1
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.10.1"
+    app.kubernetes.io/managed-by: Helm
 rules:
-  - apiGroups:
-      - config.openshift.io
-    resources:
-      - proxies
-    verbs:
-      - get
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - roles
-      - rolebindings
-      - clusterroles
-      - clusterrolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-      - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
-      - serviceaccounts
-      - nodes
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - list
-      - create
-      - watch
-  - apiGroups:
-      - nvidia.com
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - scheduling.k8s.io
-    resources:
-      - priorityclasses
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - '*'
-  - apiGroups:
-      - config.openshift.io
-    resources:
-      - clusterversions
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  # when using command line flag --resource-labels to create extended resources
+  # you will need to uncomment "- nodes/status"
+  # - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+  - list
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
+# Source: gpu-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
-  name: gpu-operator-node-feature-discovery-master
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gpu-operator-node-feature-discovery-master
-subjects:
-  - kind: ServiceAccount
-    name: gpu-operator-node-feature-discovery
-    namespace: default
----
-# Source: gpu-operator/templates/rolebinding.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: gpu-operator
-  labels:
-    app.kubernetes.io/component: "gpu-operator"
-
-subjects:
-  - kind: ServiceAccount
-    name: gpu-operator
-    namespace: default
-roleRef:
-  kind: ClusterRole
-  name: gpu-operator
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml
-apiVersion: v1
-kind: Service
 metadata:
   name: gpu-operator-node-feature-discovery
-  namespace: default
   labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
+    helm.sh/chart: node-feature-discovery-0.8.2
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
+    app.kubernetes.io/version: "v0.8.2"
     app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-    - name: api
-      port: 8080
-      protocol: TCP
-      targetPort: api
-
-  selector:
-    app.kubernetes.io/component: master
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gpu-operator-node-feature-discovery
+subjects:
+- kind: ServiceAccount
+  name: node-feature-discovery
+  namespace: gpu-operator-resources
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/daemonset-worker.yaml
+# Source: gpu-operator/charts/node-feature-discovery/templates/master.yaml
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
-  name: gpu-operator-node-feature-discovery-worker
-  namespace: default
+  name:  gpu-operator-node-feature-discovery-master
+  namespace: gpu-operator-resources
   labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
+    helm.sh/chart: node-feature-discovery-0.10.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
+    app.kubernetes.io/version: "v0.10.1"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: worker
+    role: master
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: node-feature-discovery
       app.kubernetes.io/instance: gpu-operator
-      app.kubernetes.io/component: worker
+      role: master
   template:
     metadata:
       labels:
         app.kubernetes.io/name: node-feature-discovery
         app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/component: worker
+        role: master
+      annotations:
+        {}
     spec:
-      serviceAccountName: gpu-operator-node-feature-discovery
+      serviceAccountName: node-feature-discovery
       securityContext:
         {}
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - name: node-feature-discovery-master
+        - name: master
           securityContext:
-            {}
-          image: "quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0"
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "k8s.gcr.io/nfd/node-feature-discovery:v0.10.1"
           imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8080
+            name: grpc
+            namespace: gpu-operator-resources
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           command:
-            - "nfd-worker"
-          args:
-            - "--sleep-interval=60s"
-            - "--server=gpu-operator-node-feature-discovery:8080"
-          volumeMounts:
-            - name: host-boot
-              mountPath: "/host-boot"
-              readOnly: true
-            - name: host-os-release
-              mountPath: "/host-etc/os-release"
-              readOnly: true
-            - name: host-sys
-              mountPath: "/host-sys"
-            - name: source-d
-              mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
-            - name: features-d
-              mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
-            - name: nfd-worker-config
-              mountPath: "/etc/kubernetes/node-feature-discovery/"
+            - "nfd-master"
           resources:
             {}
-
+          args:
+            - "--extra-label-ns=nvidia.com"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: In
+                values:
+                - ""
+            weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Equal
+          value: ""
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfd-worker-conf
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.10.1
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.10.1"
+    app.kubernetes.io/managed-by: Helm
+data:
+  nfd-worker.conf: |-
+    sources:
+      pci:
+        deviceClassWhitelist:
+        - "02"
+        - "0200"
+        - "0207"
+        - "0300"
+        - "0302"
+        deviceLabelFields:
+        - vendor
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gpu-operator-node-feature-discovery-master
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.10.1
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.8.2"
+    app.kubernetes.io/managed-by: Helm
+    role: master
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+      namespace: gpu-operator-resources
+  selector:
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-feature-discovery
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.10.1
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.10.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/worker.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name:  gpu-operator-node-feature-discovery-worker
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.10.1
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.10.1"
+    app.kubernetes.io/managed-by: Helm
+    role: worker
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-feature-discovery
+      app.kubernetes.io/instance: gpu-operator
+      role: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-feature-discovery
+        app.kubernetes.io/instance: gpu-operator
+        role: worker
+      annotations:
+        {}
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      securityContext:
+        {}
+      containers:
+      - name: worker
+        securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+        image: "k8s.gcr.io/nfd/node-feature-discovery:v0.8.2"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+            {}
+        command:
+        - "nfd-worker"
+        args:
+        - "--sleep-interval=60s"
+        - "--server=gpu-operator-node-feature-discovery-master:8080"
+        volumeMounts:
+        - name: host-boot
+          mountPath: "/host-boot"
+          readOnly: true
+        - name: host-os-release
+          mountPath: "/host-etc/os-release"
+          readOnly: true
+        - name: host-sys
+          mountPath: "/host-sys"
+          readOnly: true
+        - name: source-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+          readOnly: true
+        - name: features-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+          readOnly: true
+        - name: nfd-worker-conf
+          mountPath: "/etc/kubernetes/node-feature-discovery"
+          readOnly: true
       volumes:
         - name: host-boot
           hostPath:
@@ -297,9 +280,13 @@ spec:
         - name: features-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
-        - name: nfd-worker-config
+        - name: nfd-worker-conf
           configMap:
-            name: gpu-operator-node-feature-discovery
+            name: nfd-worker-conf
+            namespace: gpu-operator-resources
+            items:
+              - key: nfd-worker.conf
+                path: nfd-worker.conf
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
@@ -310,79 +297,172 @@ spec:
           operator: Equal
           value: present
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/deployment-master.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: gpu-operator/templates/clusterpolicy.yaml
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
 metadata:
-  name: gpu-operator-node-feature-discovery-master
-  namespace: default
+  name: cluster-policy
+  namespace: gpu-operator-resources
   labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: master
+    app.kubernetes.io/component: "gpu-operator"
+
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: node-feature-discovery
-      app.kubernetes.io/instance: gpu-operator
-      app.kubernetes.io/component: master
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/component: master
-    spec:
-      serviceAccountName: gpu-operator-node-feature-discovery
-      securityContext:
-        {}
-      containers:
-        - name: node-feature-discovery-master
-          securityContext:
-            {}
-          image: "quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: api
-              containerPort: 8080
-              protocol: TCP
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          command:
-            - "nfd-master"
-          args:
-            - --extra-label-ns=nvidia.com
-          resources:
-            {}
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: In
-                    values:
-                      - ""
-              weight: 1
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Equal
+  operator:
+    defaultRuntime: docker
+    runtimeClass: nvidia
+    initContainer:
+      repository: nvcr.io/nvidia
+      image: cuda
+      version: 11.4.2-base-ubi8
+      imagePullPolicy: IfNotPresent
+  daemonsets:
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+    priorityClassName: system-node-critical
+  validator:
+    repository: nvcr.io/nvidia/cloud-native
+    image: gpu-operator-validator
+    version: v1.11.1
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+      seLinuxOptions:
+        level: s0
+    plugin:
+      env:
+        - name: WITH_WORKLOAD
+          value: "false"
+  mig:
+    strategy: single
+  psp:
+    enabled: false
+  driver:
+    enabled: true
+    repository: nvcr.io/nvidia
+    image: driver
+    version: 515.48.07
+    imagePullPolicy: IfNotPresent
+    rdma:
+      enabled: false
+      useHostMofed: false
+    manager:
+      repository: nvcr.io/nvidia/cloud-native
+      image: k8s-driver-manager
+      version: v0.4.1
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: ENABLE_AUTO_DRAIN
+          value: "true"
+        - name: DRAIN_USE_FORCE
+          value: "false"
+        - name: DRAIN_POD_SELECTOR_LABEL
           value: ""
+        - name: DRAIN_TIMEOUT_SECONDS
+          value: 0s
+        - name: DRAIN_DELETE_EMPTYDIR_DATA
+          value: "false"
+    repoConfig:
+      configMapName: ""
+    certConfig:
+      name: ""
+    licensingConfig:
+      configMapName: ""
+      nlsEnabled: false
+    virtualTopology:
+      config: ""
+    securityContext:
+      privileged: true
+      seLinuxOptions:
+        level: s0
+  toolkit:
+    enabled: true
+    repository: nvcr.io/nvidia/k8s
+    image: container-toolkit
+    version: v1.10.0-ubuntu20.04
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+      seLinuxOptions:
+        level: s0
+  devicePlugin:
+    repository: nvcr.io/nvidia
+    image: k8s-device-plugin
+    version: v0.12.2-ubi8
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+    env:
+      - name: PASS_DEVICE_SPECS
+        value: "true"
+      - name: FAIL_ON_INIT_ERROR
+        value: "true"
+      - name: DEVICE_LIST_STRATEGY
+        value: envvar
+      - name: DEVICE_ID_STRATEGY
+        value: uuid
+      - name: NVIDIA_VISIBLE_DEVICES
+        value: all
+      - name: NVIDIA_DRIVER_CAPABILITIES
+        value: all
+  dcgm:
+    enabled: false
+    repository: nvcr.io/nvidia/cloud-native
+    image: dcgm
+    version: 2.4.5-1-ubuntu20.04
+    imagePullPolicy: IfNotPresent
+    hostPort: 5555
+  dcgmExporter:
+    repository: nvcr.io/nvidia/k8s
+    image: dcgm-exporter
+    version: 2.4.5-2.6.7-ubuntu20.04
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: DCGM_EXPORTER_LISTEN
+        value: :9400
+      - name: DCGM_EXPORTER_KUBERNETES
+        value: "true"
+      - name: DCGM_EXPORTER_COLLECTORS
+        value: /etc/dcgm-exporter/dcp-metrics-included.csv
+  gfd:
+    repository: nvcr.io/nvidia
+    image: gpu-feature-discovery
+    version: v0.6.1-ubi8
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: GFD_SLEEP_INTERVAL
+        value: 60s
+      - name: GFD_FAIL_ON_INIT_ERROR
+        value: "true"
+  migManager:
+    enabled: true
+    repository: nvcr.io/nvidia/cloud-native
+    image: k8s-mig-manager
+    version: v0.4.2-ubuntu20.04
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+    env:
+      - name: WITH_REBOOT
+        value: "false"
+    config:
+      name: ""
+    gpuClientsConfig:
+      name: ""
+  nodeStatusExporter:
+    enabled: false
+    repository: nvcr.io/nvidia/cloud-native
+    image: gpu-operator-validator
+    version: v1.11.1
+    imagePullPolicy: IfNotPresent
 ---
 # Source: gpu-operator/templates/operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gpu-operator
-  namespace: default
+  namespace: gpu-operator-resources
   labels:
     app.kubernetes.io/component: "gpu-operator"
 
@@ -392,44 +472,58 @@ spec:
     matchLabels:
 
       app.kubernetes.io/component: "gpu-operator"
+      app: "gpu-operator"
   template:
     metadata:
       labels:
 
         app.kubernetes.io/component: "gpu-operator"
+        app: "gpu-operator"
       annotations:
         openshift.io/scc: restricted-readonly
     spec:
       serviceAccountName: gpu-operator
+      priorityClassName: system-node-critical
       containers:
-        - name: gpu-operator
-          image: nvcr.io/nvidia/gpu-operator:1.6.2
-          imagePullPolicy: IfNotPresent
-          command: ["gpu-operator"]
-          args:
-            - "--zap-time-encoding=epoch"
-          env:
-            - name: WATCH_NAMESPACE
-              value: ""
-            - name: OPERATOR_NAME
-              value: "gpu-operator"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          volumeMounts:
-            - name: host-os-release
-              mountPath: "/host-etc/os-release"
-              readOnly: true
-          readinessProbe:
-            exec:
-              command: ["stat", "/tmp/operator-sdk-ready"]
-            initialDelaySeconds: 4
-            periodSeconds: 10
-            failureThreshold: 1
-          ports:
-            - containerPort: 60000
-              name: metrics
+      - name: gpu-operator
+        image: nvcr.io/nvidia/gpu-operator:v1.11.1
+        imagePullPolicy: IfNotPresent
+        command: ["gpu-operator"]
+        args:
+        - --leader-elect
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+          - name: host-os-release
+            mountPath: "/host-etc/os-release"
+            readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 350Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        ports:
+          - name: metrics
+            containerPort: 8080
       volumes:
         - name: host-os-release
           hostPath:
@@ -437,102 +531,193 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: In
-                    values:
-                      - ""
-              weight: 1
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: In
+                values:
+                - ""
+            weight: 1
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Equal
           value: ""
 ---
-# Source: gpu-operator/templates/clusterpolicy.yaml
-apiVersion: nvidia.com/v1
-kind: ClusterPolicy
+# Source: gpu-operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: cluster-policy
-  namespace: default
+  creationTimestamp: null
+  name: gpu-operator
+  namespace: gpu-operator-resources
   labels:
     app.kubernetes.io/component: "gpu-operator"
 
-spec:
-  operator:
-    defaultRuntime: containerd
-    validator:
-      repository: nvcr.io/nvidia/k8s
-      image: cuda-sample
-      version: vectoradd-cuda10.2
-      imagePullPolicy: IfNotPresent
-  driver:
-    repository: nvcr.io/nvidia
-    image: driver
-    version: 510.47.03
-    imagePullPolicy: Always
-    repoConfig:
-      configMapName: ""
-      destinationDir: ""
-    licensingConfig:
-      configMapName: ""
-    tolerations:
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    securityContext:
-      privileged: true
-      seLinuxOptions:
-        level: s0
-  toolkit:
-    repository: nvcr.io/nvidia/k8s
-    image: container-toolkit
-    version: 1.4.7-ubuntu18.04
-    imagePullPolicy: IfNotPresent
-    tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    securityContext:
-      privileged: true
-      seLinuxOptions:
-        level: s0
-  devicePlugin:
-    repository: nvcr.io/nvidia
-    image: k8s-device-plugin
-    version: v0.8.2-ubi8
-    imagePullPolicy: IfNotPresent
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    securityContext:
-      privileged: true
-    args:
-      - --mig-strategy=single
-      - --pass-device-specs=true
-      - --fail-on-init-error=true
-      - --device-list-strategy=envvar
-      - --nvidia-driver-root=/run/nvidia/driver
-  dcgmExporter:
-    repository: nvcr.io/nvidia/k8s
-    image: dcgm-exporter
-    version: 2.1.4-2.2.0-ubuntu20.04
-    imagePullPolicy: IfNotPresent
-    args:
-      - -f
-      - /etc/dcgm-exporter/dcp-metrics-included.csv
-  gfd:
-    repository: nvcr.io/nvidia
-    image: gpu-feature-discovery
-    version: v0.4.1
-    imagePullPolicy: IfNotPresent
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    migStrategy: single
-    discoveryIntervalSeconds: 60
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+  - update
+- apiGroups:
+  - nvidia.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - gpu-operator-restricted
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - create
+  - get
+  - update
+  - list
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: gpu-operator/templates/rolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/component: "gpu-operator"
+
+subjects:
+- kind: ServiceAccount
+  name: gpu-operator
+  namespace: gpu-operator-resources
+- kind: ServiceAccount
+  name: node-feature-discovery
+  namespace: gpu-operator-resources
+roleRef:
+  kind: ClusterRole
+  name: gpu-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: gpu-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gpu-operator
+  namespace: gpu-operator-resources
+  labels:
+    app.kubernetes.io/component: "gpu-operator"


### PR DESCRIPTION
**What type of PR is this?**
Add one of the following kinds:
/kind failing-test

**What this PR does / why we need it**:
This PR updates the GPU operator version to v1.11.1 so as to fix the failing GPU tests.  Operator deprecated use of some of cuda base images in the init containers because of which the tests were failing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3660 
Original issue https://github.com/NVIDIA/gpu-operator/issues/388

**Special notes for your reviewer**:
Since we are maintaining manifests, we need to port the cluster policy CRD and gpu operator resources from NVIDIA gpu-operator [repo](https://github.com/NVIDIA/gpu-operator/blob/release-1.11/bundle/manifests/nvidia.com_clusterpolicies.yaml) with every version bump.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
