### PR TITLE
Rename quick-start ClusterClass to ci-default

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -152,7 +152,7 @@ providers:
           - sourcePath: "./infrastructure-aws/generated/cluster-template-upgrades.yaml"
           - sourcePath: "./infrastructure-aws/generated/cluster-template-peered-remote.yaml"
           - sourcePath: "./infrastructure-aws/generated/cluster-template-internal-elb.yaml"
-          - sourcePath: "./infrastructure-aws/kustomize_sources/topology/clusterclass-quick-start.yaml"
+          - sourcePath: "./infrastructure-aws/kustomize_sources/topology/clusterclass-ci-default.yaml"
           - sourcePath: "./infrastructure-aws/generated/cluster-template-nested-multitenancy-clusterclass.yaml"
           - sourcePath: "./infrastructure-aws/kustomize_sources/nested-multitenancy-clusterclass/clusterclass-multi-tenancy.yaml"
           - sourcePath: "./infrastructure-aws/generated/cluster-template-self-hosted-clusterclass.yaml"

--- a/test/e2e/data/infrastructure-aws/e2e_test_templates/cluster-template-topology.yaml
+++ b/test/e2e/data/infrastructure-aws/e2e_test_templates/cluster-template-topology.yaml
@@ -10,7 +10,7 @@ spec:
       cidrBlocks:
       - 192.168.0.0/16
   topology:
-    class: quick-start
+    class: ci-default
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     variables:

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/topology/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/topology/cluster-template.yaml
@@ -10,7 +10,7 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   topology:
-    class: "quick-start"
+    class: "ci-default"
     version: "${KUBERNETES_VERSION}"
     controlPlane:
       replicas: "${CONTROL_PLANE_MACHINE_COUNT}"

--- a/test/e2e/data/infrastructure-aws/kustomize_sources/topology/clusterclass-ci-default.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/topology/clusterclass-ci-default.yaml
@@ -1,23 +1,23 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
-  name: quick-start
+  name: ci-default
 spec:
   controlPlane:
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: quick-start-control-plane
+      name: ci-default-control-plane
     machineInfrastructure:
       ref:
         kind: AWSMachineTemplate
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        name: quick-start-control-plane
+        name: ci-default-control-plane
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: AWSClusterTemplate
-      name: quick-start
+      name: ci-default
   workers:
     machineDeployments:
     - class: default-worker
@@ -26,12 +26,12 @@ spec:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: KubeadmConfigTemplate
-            name: quick-start-worker-bootstraptemplate
+            name: ci-default-worker-bootstraptemplate
         infrastructure:
           ref:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: AWSMachineTemplate
-            name: quick-start-worker-machinetemplate
+            name: ci-default-worker-machinetemplate
   variables:
   - name: region
     required: true
@@ -218,7 +218,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSClusterTemplate
 metadata:
-  name: quick-start
+  name: ci-default
 spec:
   template:
     spec: {}
@@ -226,7 +226,7 @@ spec:
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
-  name: quick-start-control-plane
+  name: ci-default-control-plane
 spec:
   template:
     spec:
@@ -252,7 +252,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
-  name: quick-start-control-plane
+  name: ci-default-control-plane
 spec:
   template:
     spec:
@@ -264,7 +264,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
-  name: quick-start-worker-machinetemplate
+  name: ci-default-worker-machinetemplate
 spec:
   template:
     spec:
@@ -276,7 +276,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: quick-start-worker-bootstraptemplate
+  name: ci-default-worker-bootstraptemplate
 spec:
   template:
     spec:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Following up comment from https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3491
Rename quick-start ClusterClass to ci-default to decouple the ClusterClass name from a test name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
