### PR TITLE
Add strings.ReplaceAll func for AMI name format template

### DIFF
--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -82,8 +82,11 @@ func GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion string) (string, e
 	if amiNameFormat == "" {
 		amiNameFormat = DefaultAmiNameFormat
 	}
+	funcMap := template.FuncMap{
+		"replaceAll": strings.ReplaceAll,
+	}
 	var templateBytes bytes.Buffer
-	template, err := template.New("amiName").Parse(amiNameFormat)
+	template, err := template.New("amiName").Funcs(funcMap).Parse(amiNameFormat)
 	if err != nil {
 		return amiNameFormat, errors.Wrapf(err, "failed create template from string: %q", amiNameFormat)
 	}

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -285,6 +285,15 @@ func TestGenerateAmiName(t *testing.T) {
 			},
 			want: "random-centos-7-?1.23.3-*",
 		},
+		{
+			name: "Should return valid amiName if custom AMI name format passed calling replaceAll func",
+			args: args{
+				amiNameFormat:     "random-{{.BaseOS}}-?{{replaceAll .K8sVersion \"+\" \"-\"}}-*",
+				baseOS:            "centos-7",
+				kubernetesVersion: "1.23.3+build.0",
+			},
+			want: "random-centos-7-?1.23.3-build.0-*",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
Introducing a mechanism to support Kubernetes versions with a build name, e.g. `v1.21.8+fips.0`, to be used in the `ImageLookupFormat`. The benefit of this approach is that its an opt-in feature, generic enough to be used for other substitutions and does not modify existing behavior.

Please see the unit test for a real usecase we have.

I hope the maintainers will consider this change, but I do understand that https://github.com/kubernetes-sigs/cluster-api/pull/6181 is actively being worked on.

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3076

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
