### PR TITLE
[wip] AMI Lookup Modifications

### DIFF
--- a/api/v1beta1/awscluster_types.go
+++ b/api/v1beta1/awscluster_types.go
@@ -56,32 +56,45 @@ type AWSClusterSpec struct {
 	// +optional
 	ControlPlaneLoadBalancer *AWSLoadBalancerSpec `json:"controlPlaneLoadBalancer,omitempty"`
 
-	// ImageLookupFormat is the AMI naming format to look up machine images when
-	// a machine does not specify an AMI. When set, this will be used for all
-	// cluster machines unless a machine specifies a different ImageLookupOrg.
-	// Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base
-	// OS and kubernetes version, respectively. The BaseOS will be the value in
-	// ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as
-	// defined by the packages produced by kubernetes/release without v as a
-	// prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default
+	// AMI ID is the first method for finding an AMI ID, if this field is set all other methods will be ignored.
+	// example: ami-1234567890abcdef0
+	AMI AMIReference `json:"ami,omitempty"`
+
+	// ImageLookupSSMParameterName is the second method for finding an AMI ID, if this field is set the following AMI Name
+	// format will be ignored. This field is for the name of the parameter to check in SSM and this method for lookup
+	// will work for self-managed instances if you maintain your own SSM Keys. AWS maintains public SSM keys for EKS
+	// optimized images see the docs to find keys https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
+	// When using this lookup method make sure you use the whole path to the key.
+	// example: /aws/service/eks/optimized-ami/1.22/amazon-linux-2/recommended/image_id
+	ImageLookupSSMParameterName string `json:"imageLookupSSMParameterName"`
+
+	// ImageLookupFormat this is the third method for finding an AMI ID and takes creates describe images query filters
+	// and gets the results and returns the most recent image based on creation date.
+	// The go template supports the following substitutions
+	// - {{.BaseOS}} the value of ImageLookupBaseOS, default ubuntu-18.04
+	// - {{.Arch}} the value of ImageLookupArch, defaults to amd64 (x86_64)
+	// - {{.K8sVersion}} the kubernetes semver pulled from MachinePool Spec with the v prefix trimmed
+	// For example, the default
 	// image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up
-	// searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a
+	// searching for AMIs that match the pattern capa-ami-ubuntu-18.04-?1.18.0-* for a
 	// Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See
 	// also: https://golang.org/pkg/text/template/
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
-	// ImageLookupOrg is the AWS Organization ID to look up machine images when a
-	// machine does not specify an AMI. When set, this will be used for all
-	// cluster machines unless a machine specifies a different ImageLookupOrg.
+	// ImageLookupOrg the Organization ID to query for AMIs, default is the AWS Organization ID 258751437250
 	// +optional
 	ImageLookupOrg string `json:"imageLookupOrg,omitempty"`
 
-	// ImageLookupBaseOS is the name of the base operating system used to look
-	// up machine images when a machine does not specify an AMI. When set, this
-	// will be used for all cluster machines unless a machine specifies a
-	// different ImageLookupBaseOS.
+	// ImageLookupBaseOS is the name of the base operating system to query for AMIs, the default is ubuntu-18.04
+	// +optional
+	// +kubebuilder:validation:Enum:=amazon-2,amazon-2-gpu,ubuntu-18.04,ubuntu-20.04,centos-7,flatcar-stable,bottlerocket,windows-2019-core,windows-2019-full,windows-2022-core,windows-2022-full
 	ImageLookupBaseOS string `json:"imageLookupBaseOS,omitempty"`
+
+	// ImageLookupArch is the name of the base operating system to query for AMIs, the default is amd64
+	// +optional
+	// +kubebuilder:validation:Enum:=amd64,arm64
+	ImageLookupArch string `json:"imageLookupArch,omitempty"`
 
 	// Bastion contains options to configure the bastion host.
 	// +optional

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -53,6 +53,7 @@ type AMIReference struct {
 	// EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store
 	// +kubebuilder:validation:Enum:=AmazonLinux;AmazonLinuxGPU
 	// +optional
+	// Deprecated: This field has no function and is going to be removed in the next release.
 	EKSOptimizedLookupType *EKSAMILookupType `json:"eksLookupType,omitempty"`
 }
 

--- a/cmd/clusterawsadm/ami/copy.go
+++ b/cmd/clusterawsadm/ami/copy.go
@@ -57,7 +57,7 @@ func Copy(input CopyInput) (*amiv1.AWSAMI, error) {
 	}
 	ec2Client := ec2.New(sourceSession)
 
-	image, err := ec2service.DefaultAMILookup(ec2Client, input.OwnerID, input.OperatingSystem, input.KubernetesVersion, "")
+	image, err := ec2service.DefaultAMILookup(ec2Client, input.OwnerID, input.OperatingSystem, ec2service.AMD64, input.KubernetesVersion, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -230,7 +230,7 @@ func getAllImages(ec2Client ec2iface.EC2API, ownerID string) (map[string][]*ec2.
 
 func findAMI(imagesMap map[string][]*ec2.Image, baseOS, kubernetesVersion string) (*ec2.Image, error) {
 	amiNameFormat := "capa-ami-{{.BaseOS}}-{{.K8sVersion}}"
-	amiName, err := ec2service.GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion)
+	amiName, err := ec2service.GenerateAmiName(amiNameFormat, baseOS, ec2service.AMD64, kubernetesVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to process ami format: %q", amiNameFormat)
 	}

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
@@ -107,32 +107,42 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
-	// ImageLookupFormat is the AMI naming format to look up machine images when
-	// a machine does not specify an AMI. When set, this will be used for all
-	// cluster machines unless a machine specifies a different ImageLookupOrg.
-	// Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base
-	// OS and kubernetes version, respectively. The BaseOS will be the value in
-	// ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as
-	// defined by the packages produced by kubernetes/release without v as a
-	// prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default
+	// ImageLookupSSMParameterName is the second method for finding an AMI ID, if this field is set the following AMI Name
+	// format will be ignored. This field is for the name of the parameter to check in SSM and this method for lookup
+	// will work for self-managed instances if you maintain your own SSM Keys. AWS maintains public SSM keys for EKS
+	// optimized images see the docs to find keys https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
+	// When using this lookup method make sure you use the whole path to the key.
+	// example: /aws/service/eks/optimized-ami/1.22/amazon-linux-2/recommended/image_id
+	ImageLookupSSMParameterName string `json:"imageLookupSSMParameterName"`
+
+	// ImageLookupFormat this is the third method for finding an AMI ID and takes creates describe images query filters
+	// and gets the results and returns the most recent image based on creation date.
+	// The go template supports the following substitutions
+	// - {{.BaseOS}} the value of ImageLookupBaseOS, default ubuntu-18.04
+	// - {{.Arch}} the value of ImageLookupArch, defaults to amd64 (x86_64)
+	// - {{.K8sVersion}} the kubernetes semver pulled from MachinePool Spec with the v prefix trimmed
+	// For example, the default
 	// image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up
-	// searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a
+	// searching for AMIs that match the pattern capa-ami-ubuntu-18.04-?1.18.0-* for a
 	// Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See
 	// also: https://golang.org/pkg/text/template/
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
-	// ImageLookupOrg is the AWS Organization ID to look up machine images when a
-	// machine does not specify an AMI. When set, this will be used for all
-	// cluster machines unless a machine specifies a different ImageLookupOrg.
+	// ImageLookupOrg the Organization ID to query for AMIs, default is the AWS Organization ID 258751437250
 	// +optional
 	ImageLookupOrg string `json:"imageLookupOrg,omitempty"`
 
-	// ImageLookupBaseOS is the name of the base operating system used to look
-	// up machine images when a machine does not specify an AMI. When set, this
-	// will be used for all cluster machines unless a machine specifies a
-	// different ImageLookupBaseOS.
+	// ImageLookupBaseOS is the name of the base operating system to query for AMIs, the default is ubuntu-18.04
+	// +optional
+	// +kubebuilder:validation:Enum:=amazon-2,amazon-2-gpu,ubuntu-18.04,ubuntu-20.04,centos-7,flatcar-stable,bottlerocket,windows-2019-core,windows-2019-full,windows-2022-core,windows-2022-full
 	ImageLookupBaseOS string `json:"imageLookupBaseOS,omitempty"`
+
+	// ImageLookupArch is the name of the base operating system to query for AMIs in workload pools only and is ignored
+	// for the management plane
+	// +optional
+	// +kubebuilder:validation:Enum:=amd64,arm64
+	ImageLookupArch string `json:"imageLookupArch,omitempty"`
 
 	// Bastion contains options to configure the bastion host.
 	// +optional

--- a/exp/api/v1beta1/types.go
+++ b/exp/api/v1beta1/types.go
@@ -70,30 +70,45 @@ type AWSLaunchTemplate struct {
 	// role.
 	IamInstanceProfile string `json:"iamInstanceProfile,omitempty"`
 
-	// AMI is the reference to the AMI from which to create the machine instance.
-	// +optional
+	// AMI ID is the first method for finding an AMI ID, if this field is set all other methods will be ignored.
+	// example: ami-1234567890abcdef0
 	AMI infrav1.AMIReference `json:"ami,omitempty"`
 
-	// ImageLookupFormat is the AMI naming format to look up the image for this
-	// machine It will be ignored if an explicit AMI is set. Supports
-	// substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and
-	// kubernetes version, respectively. The BaseOS will be the value in
-	// ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as
-	// defined by the packages produced by kubernetes/release without v as a
-	// prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default
+	// ImageLookupSSMParameterName is the second method for finding an AMI ID, if this field is set the following AMI Name
+	// format will be ignored. This field is for the name of the parameter to check in SSM and this method for lookup
+	// will work for self-managed instances if you maintain your own SSM Keys. AWS maintains public SSM keys for EKS
+	// optimized images see the docs to find keys https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
+	// When using this lookup method make sure you use the whole path to the key.
+	// example: /aws/service/eks/optimized-ami/1.22/amazon-linux-2/recommended/image_id
+	ImageLookupSSMParameterName string `json:"imageLookupSSMParameterName"`
+
+	// ImageLookupFormat this is the third method for finding an AMI ID and takes creates describe images query filters
+	// and gets the results and returns the most recent image based on creation date.
+	// The go template supports the following substitutions
+	// - {{.BaseOS}} the value of ImageLookupBaseOS, default ubuntu-18.04
+	// - {{.Arch}} the value of ImageLookupArch, defaults to amd64 (x86_64)
+	// - {{.K8sVersion}} the kubernetes semver pulled from MachinePool Spec with the v prefix trimmed
+	// For example, the default
 	// image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up
-	// searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a
+	// searching for AMIs that match the pattern capa-ami-ubuntu-18.04-?1.18.0-* for a
 	// Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See
 	// also: https://golang.org/pkg/text/template/
 	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
-	// ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.
+	// ImageLookupOrg the Organization ID to query for AMIs, default is the AWS Organization ID 258751437250
+	// +optional
 	ImageLookupOrg string `json:"imageLookupOrg,omitempty"`
 
-	// ImageLookupBaseOS is the name of the base operating system to use for
-	// image lookup the AMI is not set.
+	// ImageLookupBaseOS is the name of the base operating system to query for AMIs, the default is ubuntu-18.04
+	// +optional
+	// +kubebuilder:validation:Enum:=amazon-2,amazon-2-gpu,ubuntu-18.04,ubuntu-20.04,centos-7,flatcar-stable,bottlerocket,windows-2019-core,windows-2019-full,windows-2022-core,windows-2022-full
 	ImageLookupBaseOS string `json:"imageLookupBaseOS,omitempty"`
+
+	// ImageLookupArch is the name of the base operating system to query for AMIs, the default is amd64
+	// +optional
+	// +kubebuilder:validation:Enum:=amd64,arm64
+	ImageLookupArch string `json:"imageLookupArch,omitempty"`
 
 	// InstanceType is the type of instance to create. Example: m4.xlarge
 	InstanceType string `json:"instanceType,omitempty"`

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -347,3 +347,13 @@ func (s *ClusterScope) ImageLookupOrg() string {
 func (s *ClusterScope) ImageLookupBaseOS() string {
 	return s.AWSCluster.Spec.ImageLookupBaseOS
 }
+
+// ImageLookupArch returns the base operating system architecture name to use when looking up AMIs.
+func (s *ClusterScope) ImageLookupArch() string {
+	return s.AWSCluster.Spec.ImageLookupArch
+}
+
+// ImageLookupSSMParameterName returns the SSM parameter name to use when looking up AMIs.
+func (s *ClusterScope) ImageLookupSSMParameterName() string {
+	return s.AWSCluster.Spec.ImageLookupSSMParameterName
+}

--- a/pkg/cloud/scope/ec2.go
+++ b/pkg/cloud/scope/ec2.go
@@ -46,6 +46,9 @@ type EC2Scope interface {
 	// SSHKeyName returns the SSH key name to use for instances.
 	SSHKeyName() *string
 
+	// ImageLookupSSMParameterName returns the parameter name to use to look up a key in SSM that contains an AMI ID
+	ImageLookupSSMParameterName() string
+
 	// ImageLookupFormat returns the format string to use when looking up AMIs
 	ImageLookupFormat() string
 
@@ -54,4 +57,7 @@ type EC2Scope interface {
 
 	// ImageLookupBaseOS returns the base operating system name to use when looking up AMIs
 	ImageLookupBaseOS() string
+
+	// ImageLookupArch returns the base operating system architecture to use when looking up AMIs
+	ImageLookupArch() string
 }

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -346,6 +346,16 @@ func (s *ManagedControlPlaneScope) ImageLookupBaseOS() string {
 	return s.ControlPlane.Spec.ImageLookupBaseOS
 }
 
+// ImageLookupArch returns the base operating system architecture to use when looking up AMIs.
+func (s *ManagedControlPlaneScope) ImageLookupArch() string {
+	return s.ControlPlane.Spec.ImageLookupArch
+}
+
+// ImageLookupSSMParameterName returns the SSM Parameter Name to use when looking up AMIs.
+func (s *ManagedControlPlaneScope) ImageLookupSSMParameterName() string {
+	return s.ControlPlane.Spec.ImageLookupSSMParameterName
+}
+
 // IAMAuthConfig returns the IAM authenticator config. The returned value will never be nil.
 func (s *ManagedControlPlaneScope) IAMAuthConfig() *ekscontrolplanev1.IAMAuthenticatorConfig {
 	if s.ControlPlane.Spec.IAMAuthenticatorConfig == nil {

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -24,6 +24,9 @@ import (
 	"text/template"
 	"time"
 
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -36,6 +39,24 @@ import (
 )
 
 const (
+	Amazon2         = "amazon-2"          // self, eks
+	Amazon2GPU      = "amazon-2-gpu"      // eks
+	Ubuntu1804      = "ubuntu-18.04"      // self, eks
+	Ubuntu2004      = "ubuntu-20.04"      // self, eks
+	CentOS7         = "centos-7"          // self
+	FlatcarStable   = "flatcar-stable"    // self
+	BottleRocket    = "bottlerocket"      // eks
+	Windows2019Core = "windows-2019-core" // eks
+	Windows2019Full = "windows-2019-full" // eks
+	Windows2022Core = "windows-2022-core" // eks (coming soon)
+	Windows2022Full = "windows-2022-full" // eks (coming soon)
+
+	AMD64 = "x86_64"
+	ARM64 = "arm64"
+
+	// DefaultMachineAMILookupArch is the default architecture to use when looking up machine AMIs.
+	DefaultMachineAMILookupArch = AMD64
+
 	// DefaultMachineAMIOwnerID is a heptio/VMware owned account. Please see:
 	// https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/487
 	DefaultMachineAMIOwnerID = "258751437250"
@@ -47,15 +68,20 @@ const (
 	// Description regex for fetching Ubuntu AMIs for bastion host.
 	ubuntuImageDescription = "Canonical??Ubuntu??20.04?LTS??amd64?focal?image*"
 
-	// defaultMachineAMILookupBaseOS is the default base operating system to use
+	// DefaultMachineAMILookupBaseOS is the default base operating system to use
 	// when looking up machine AMIs.
-	defaultMachineAMILookupBaseOS = "ubuntu-18.04"
+	DefaultMachineAMILookupBaseOS = Ubuntu1804
+
+	// DefaultEKSMachineAMILookupBaseOS is the default base operating system to use
+	// when looking up machine AMIs.
+	DefaultEKSMachineAMILookupBaseOS = Ubuntu1804
 
 	// DefaultAmiNameFormat is defined in the build/ directory of this project.
 	// The pattern is:
 	// 1. the string value `capa-ami-`
-	// 2. the baseOS of the AMI, for example: ubuntu-18.04, centos-7, amazon-2
-	// 3. the kubernetes version as defined by the packages produced by kubernetes/release with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1, v1.17.3
+	// 2. the baseOS of the AMI, for example: ubuntu-18.04, ubuntu-20.04, centos-7, amazon-2, flatcar-stable
+	// 3. the kubernetes version as defined by the packages produced by kubernetes/release with or without v as a prefix,
+	// for example: 1.13.0, 1.12.5-mybuild.1, v1.17.3
 	// 4. a `-` followed by any additional characters.
 	DefaultAmiNameFormat = "capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*"
 
@@ -69,33 +95,86 @@ const (
 	eksGPUAmiSSMParameterFormat = "/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id"
 )
 
+var machineAMINameFormats = map[string]string{
+	Amazon2:         DefaultAmiNameFormat,
+	Amazon2GPU:      "",
+	Ubuntu1804:      DefaultAmiNameFormat,
+	Ubuntu2004:      DefaultAmiNameFormat,
+	BottleRocket:    "",
+	Windows2019Core: "",
+	Windows2019Full: "",
+	Windows2022Core: "",
+	Windows2022Full: "",
+	CentOS7:         "",
+	FlatcarStable:   DefaultAmiNameFormat,
+}
+
+// go template for AMI Name Lookup
+var eksAMINameFormats = map[string]string{
+	Amazon2:         "amazon-eks-node-{{.K8sVersion}}-v*",
+	Amazon2GPU:      "amazon-eks-gpu-node-{{.K8sVersion}}-v*",
+	Ubuntu1804:      "ubuntu-eks/k8s_{{.K8sVersion}}/images/*18.04*",
+	Ubuntu2004:      "ubuntu-eks/k8s_{{.K8sVersion}}/images/*20.04*",
+	BottleRocket:    "bottlerocket-aws-k8s-{{.K8sVersion}}*",
+	Windows2019Core: "Windows_Server-2019-English-Core-EKS_Optimized-{{.K8sVersion}}-*", // coming soon
+	Windows2019Full: "Windows_Server-2019-English-Full-EKS_Optimized-{{.K8sVersion}}-*", // coming soon
+	Windows2022Core: "Windows_Server-2022-English-Core-EKS_Optimized-{{.K8sVersion}}-*", // currently unavailable
+	Windows2022Full: "Windows_Server-2022-English-Full-EKS_Optimized-{{.K8sVersion}}-*", // currently unavailable
+	CentOS7:         "",                                                                 // unavailable, leave empty so ok check fails and return default, add pattern if they become available
+	FlatcarStable:   "",                                                                 // unavailable, leave empty so ok check fails and return default, add pattern if they become available
+}
+
 // AMILookup contains the parameters used to template AMI names used for lookup.
 type AMILookup struct {
 	BaseOS     string
 	K8sVersion string
+	Arch       string
 }
 
 // GenerateAmiName will generate an AMI name.
-func GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion string) (string, error) {
-	amiNameParameters := AMILookup{baseOS, strings.TrimPrefix(kubernetesVersion, "v")}
+func GenerateAmiName(amiNameFormat, baseOS, arch, kubernetesVersion string) (string, error) {
 	// revert to default if not specified
 	if amiNameFormat == "" {
 		amiNameFormat = DefaultAmiNameFormat
 	}
+	if baseOS == "" {
+		baseOS = DefaultMachineAMILookupBaseOS
+	}
+	amiNameParameters := AMILookup{
+		BaseOS:     baseOS,
+		K8sVersion: strings.TrimPrefix(kubernetesVersion, "v"),
+		Arch:       arch,
+	}
+
 	var templateBytes bytes.Buffer
-	template, err := template.New("amiName").Parse(amiNameFormat)
+	tpl, err := template.New("amiName").Parse(amiNameFormat)
 	if err != nil {
 		return amiNameFormat, errors.Wrapf(err, "failed create template from string: %q", amiNameFormat)
 	}
-	err = template.Execute(&templateBytes, amiNameParameters)
+	err = tpl.Execute(&templateBytes, amiNameParameters)
 	if err != nil {
 		return amiNameFormat, errors.Wrapf(err, "failed to substitute string: %q", amiNameFormat)
 	}
 	return templateBytes.String(), nil
 }
 
+// cleanArch since this is kube the arch options are amd64/arm64 so trying to account for what AWS is looking for
+func cleanArch(arch string) string {
+	switch arch {
+	case AMD64:
+		return arch
+	case ARM64:
+		return arch
+	case "amd64":
+		return AMD64 // only accepted in query filter is "x86_64"
+	case "aarch64":
+		return ARM64 // for a query filter needs to be "arm64"
+	}
+	return arch
+}
+
 // DefaultAMILookup will do a default AMI lookup.
-func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVersion, amiNameFormat string) (*ec2.Image, error) {
+func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, arch, kubernetesVersion, amiNameFormat string) (*ec2.Image, error) {
 	if amiNameFormat == "" {
 		amiNameFormat = DefaultAmiNameFormat
 	}
@@ -103,13 +182,20 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 		ownerID = DefaultMachineAMIOwnerID
 	}
 	if baseOS == "" {
-		baseOS = defaultMachineAMILookupBaseOS
+		baseOS = DefaultMachineAMILookupBaseOS
+	}
+	if arch == "" {
+		arch = DefaultMachineAMILookupArch
 	}
 
-	amiName, err := GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion)
+	// generate the name before we clean Arch in case the user expected their version expanded in the template
+	amiName, err := GenerateAmiName(amiNameFormat, baseOS, arch, kubernetesVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to process ami format: %q", amiNameFormat)
 	}
+
+	arch = cleanArch(arch) // account for what AWS wants in a filter
+
 	describeImageInput := &ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -122,7 +208,7 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 			},
 			{
 				Name:   aws.String("architecture"),
-				Values: []*string{aws.String("x86_64")},
+				Values: []*string{aws.String(arch)},
 			},
 			{
 				Name:   aws.String("state"),
@@ -151,8 +237,8 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 }
 
 // defaultAMIIDLookup returns the default AMI based on region.
-func (s *Service) defaultAMIIDLookup(amiNameFormat, ownerID, baseOS, kubernetesVersion string) (string, error) {
-	latestImage, err := DefaultAMILookup(s.EC2Client, ownerID, baseOS, kubernetesVersion, amiNameFormat)
+func (s *Service) defaultAMIIDLookup(amiNameFormat, ownerID, baseOS, arch, kubernetesVersion string) (string, error) {
+	latestImage, err := DefaultAMILookup(s.EC2Client, ownerID, baseOS, arch, kubernetesVersion, amiNameFormat)
 	if err != nil {
 		record.Eventf(s.scope.InfraCluster(), "FailedDescribeImages", "Failed to find ami for OS=%s and Kubernetes-version=%s: %v", baseOS, kubernetesVersion, err)
 		return "", errors.Wrapf(err, "failed to find ami")
@@ -234,19 +320,150 @@ func (s *Service) defaultBastionAMILookup() (string, error) {
 	return *latestImage.ImageId, nil
 }
 
+// SSMParameterLookup takes an SSM parameter name and returns the value which is presumed to be an AMI ID
+func (s *Service) SSMParameterLookup(name string) (string, error) {
+	input := &ssm.GetParameterInput{
+		Name: aws.String(name),
+	}
+
+	out, err := s.SSMClient.GetParameter(input)
+	if err != nil {
+		record.Eventf(s.scope.InfraCluster(), "FailedGetParameter", "Failed to get ami SSM parameter %q: %v", name, err)
+
+		return "", errors.Wrapf(err, "failed to get ami SSM parameter: %q", name)
+	}
+
+	if out.Parameter == nil || out.Parameter.Value == nil {
+		return "", errors.Errorf("SSM parameter returned with nil value: %q", name)
+	}
+
+	id := aws.StringValue(out.Parameter.Value)
+	s.scope.Info("found AMI", "id", id)
+
+	return id, nil
+}
+
+func (s *Service) GetMachineAMIID(scope *scope.MachineScope) (string, error) {
+	// Pick image from the machine configuration, or use a default one.
+	if scope.AWSMachine.Spec.AMI.ID != nil { //nolint:nestif
+		return *scope.AWSMachine.Spec.AMI.ID, nil
+	}
+
+	if scope.AWSMachine.Spec.ImageLookupSSMParameterName != "" {
+		return s.SSMParameterLookup(scope.AWSMachine.Spec.ImageLookupSSMParameterName)
+	}
+
+	if scope.Machine.Spec.Version == nil {
+		err := errors.New("Either AWSMachine's spec.ami.id or Machine's spec.version must be defined")
+		scope.SetFailureReason(capierrors.CreateMachineError)
+		scope.SetFailureMessage(err)
+		return "", err
+	}
+
+	if *scope.AWSMachine.Spec.AMI.EKSOptimizedLookupType != "" {
+		lookupAMI, err := s.eksAMILookup(*scope.Machine.Spec.Version, scope.AWSMachine.Spec.AMI.EKSOptimizedLookupType)
+		if err != nil {
+			return "", err
+		}
+		return lookupAMI, nil
+	}
+
+	imageLookupFormat := scope.AWSMachine.Spec.ImageLookupFormat
+	if imageLookupFormat == "" {
+		imageLookupFormat = scope.InfraCluster.ImageLookupFormat()
+	}
+
+	imageLookupOrg := scope.AWSMachine.Spec.ImageLookupOrg
+	if imageLookupOrg == "" {
+		imageLookupOrg = scope.InfraCluster.ImageLookupOrg()
+	}
+
+	imageLookupBaseOS := scope.AWSMachine.Spec.ImageLookupBaseOS
+	if imageLookupBaseOS == "" {
+		imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
+	}
+
+	imageLookupArch := scope.AWSMachine.Spec.ImageLookupArch
+	if imageLookupArch == "" {
+		imageLookupArch = scope.InfraCluster.ImageLookupArch()
+	}
+
+	return s.defaultAMIIDLookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, imageLookupArch, *scope.Machine.Spec.Version)
+}
+
+func (s *Service) GetMachinePoolAMIID(scope *scope.MachinePoolScope) (string, error) {
+	lt := scope.AWSMachinePool.Spec.AWSLaunchTemplate
+
+	if lt.AMI.ID != nil {
+		return *lt.AMI.ID, nil
+	}
+
+	if lt.ImageLookupSSMParameterName != "" {
+		return s.SSMParameterLookup(lt.ImageLookupSSMParameterName)
+	}
+
+	if scope.MachinePool.Spec.Template.Spec.Version == nil {
+		err := errors.New("Either AWSMachinePool's spec.awslaunchtemplate.ami.id or MachinePool's spec.template.spec.version must be defined")
+		scope.Error(err, "")
+		return "", err
+	}
+
+	// deprecated method covers the case someone set this field it will fall back to the old func
+	if *lt.AMI.EKSOptimizedLookupType != "" {
+		return s.eksAMILookup(*scope.MachinePool.Spec.Template.Spec.Version, lt.AMI.EKSOptimizedLookupType)
+	}
+
+	imageLookupFormat := lt.ImageLookupFormat
+	if imageLookupFormat == "" {
+		imageLookupFormat = scope.InfraCluster.ImageLookupFormat()
+	}
+
+	imageLookupOrg := lt.ImageLookupOrg
+	if imageLookupOrg == "" {
+		imageLookupOrg = scope.InfraCluster.ImageLookupOrg()
+	}
+
+	imageLookupBaseOS := lt.ImageLookupBaseOS
+	if imageLookupBaseOS == "" {
+		imageLookupBaseOS = scope.InfraCluster.ImageLookupBaseOS()
+	}
+
+	imageLookupArch := lt.ImageLookupArch
+	if imageLookupArch == "" {
+		imageLookupArch = scope.InfraCluster.ImageLookupArch()
+	}
+
+	// if this is EKS we can't use CAPA defaults and this is where we have scope
+	if scope.IsEKSManaged() {
+		// if EKS and trying to use AMI Lookup we need to convert from the capa-ami name formats to EKS ones.
+		if imageLookupOrg == "" {
+			imageLookupOrg = DefaultMachineAMIOwnerID
+		}
+		if imageLookupBaseOS == "" {
+			imageLookupBaseOS = DefaultEKSMachineAMILookupBaseOS
+		}
+		if imageLookupArch == "" {
+			imageLookupArch = DefaultMachineAMILookupArch
+		}
+		if imageLookupFormat == "" {
+			imageLookupFormat = s.eksGetAMINameFormat(imageLookupBaseOS)
+		}
+	}
+
+	return s.defaultAMIIDLookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, imageLookupArch, *scope.MachinePool.Spec.Template.Spec.Version)
+}
+
 func (s *Service) eksAMILookup(kubernetesVersion string, amiType *infrav1.EKSAMILookupType) (string, error) {
 	// format ssm parameter path properly
 	formattedVersion, err := formatVersionForEKS(kubernetesVersion)
 	if err != nil {
 		return "", err
 	}
-
-	var paramName string
-
 	if amiType == nil {
 		amiType = new(infrav1.EKSAMILookupType)
 	}
 
+	var paramName string
 	switch *amiType {
 	case infrav1.AmazonLinuxGPU:
 		paramName = fmt.Sprintf(eksGPUAmiSSMParameterFormat, formattedVersion)
@@ -254,25 +471,19 @@ func (s *Service) eksAMILookup(kubernetesVersion string, amiType *infrav1.EKSAMI
 		paramName = fmt.Sprintf(eksAmiSSMParameterFormat, formattedVersion)
 	}
 
-	input := &ssm.GetParameterInput{
-		Name: aws.String(paramName),
+	return s.SSMParameterLookup(paramName)
+}
+
+// EKSGetAMINameFormat takes a baseOS and will return the proper name search format
+func (s *Service) eksGetAMINameFormat(baseOS string) string {
+	r := eksAMINameFormats[DefaultEKSMachineAMILookupBaseOS]
+	if format, ok := eksAMINameFormats[baseOS]; ok {
+		if format == "" {
+			return r
+		}
+		return format
 	}
-
-	out, err := s.SSMClient.GetParameter(input)
-	if err != nil {
-		record.Eventf(s.scope.InfraCluster(), "FailedGetParameter", "Failed to get ami SSM parameter %q: %v", paramName, err)
-
-		return "", errors.Wrapf(err, "failed to get ami SSM parameter: %q", paramName)
-	}
-
-	if out.Parameter == nil || out.Parameter.Value == nil {
-		return "", errors.Errorf("SSM parameter returned with nil value: %q", paramName)
-	}
-
-	id := aws.StringValue(out.Parameter.Value)
-	s.scope.Info("found AMI", "id", id, "version", formattedVersion)
-
-	return id, nil
+	return r
 }
 
 func formatVersionForEKS(version string) (string, error) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
WIp for https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3663


/kind feature

**What this PR does / why we need it**:
- API Changes: 
 - Adds ImageLookupArch
 - adds ImageLookupSSMParameterName
 - Deprecates AMI.EKSOptimizedLookupType
- Adds ubuntu18.04/20.04, bottlerocket and preps Windows for EKS
- Enables Arm64 support
- Fixes logic error that you could be using EKS and set lookup BaseOS or Org and accidently pull a `capa-ami` image instead of an eks optimized.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
