### PR TITLE
[E2E] fix min desired value of MachinePool nodes for spot instance MachinePool test manifest

### DIFF
--- a/test/e2e/data/infrastructure-aws/kustomize_sources/machine-pool/spot-instance-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-aws/kustomize_sources/machine-pool/spot-instance-machine-pool.yaml
@@ -24,7 +24,7 @@ kind: AWSMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-1
 spec:
-  minSize: 1
+  minSize: 0
   maxSize: 4
   awsLaunchTemplate:
     instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
This PR corrects the minimum desired size of spot instances MachinePool, in accordance to https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3253#issuecomment-1050792767

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
