### PR TITLE
Fix the update logic for aws-node daemonset environment properties

### DIFF
--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -159,9 +159,9 @@ func (s *Service) ReconcileCNI(ctx context.Context) error {
 	}
 
 	s.scope.Info("updating containers", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
-	for _, container := range ds.Spec.Template.Spec.Containers {
-		if container.Name == "aws-node" {
-			container.Env = append(s.filterEnv(container.Env),
+	for i := range ds.Spec.Template.Spec.Containers {
+		if ds.Spec.Template.Spec.Containers[i].Name == "aws-node" {
+			ds.Spec.Template.Spec.Containers[i].Env = append(s.filterEnv(ds.Spec.Template.Spec.Containers[i].Env),
 				corev1.EnvVar{
 					Name:  "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG",
 					Value: "true",

--- a/pkg/cloud/services/awsnode/cni_test.go
+++ b/pkg/cloud/services/awsnode/cni_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/apps/v1"
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
 )
@@ -206,6 +208,92 @@ func TestReconcileCniVpcCniValues(t *testing.T) {
 	}
 }
 
+func TestReconcileCniVpcCniValuesWithSecondaryCidrBlock(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	g := NewWithT(t)
+	daemonSet := &v1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "DaemonSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-node",
+			Namespace: "kube-system",
+		},
+		Spec: v1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "aws-node",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "NAME1",
+									Value: "OVERWRITE",
+								},
+								{
+									Name:  "NAME3",
+									Value: "VALUE3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	values := ekscontrolplanev1.VpcCni{
+		Env: []corev1.EnvVar{
+			{
+				Name:  "NAME1",
+				Value: "VALUE1",
+			},
+		},
+	}
+	mockClient := &cachingClient{
+		getValue: daemonSet,
+	}
+	m := &mockScope{
+		client:             mockClient,
+		cni:                values,
+		secondaryCidrBlock: aws.String("100.0.0.1/20"),
+		securityGroups: map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+			"node": {
+				ID:   "sg-1234",
+				Name: "node",
+			},
+		},
+		subnets: []infrav1.SubnetSpec{},
+	}
+	s := NewService(m)
+
+	err := s.ReconcileCNI(context.Background())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(mockClient.updateChain).NotTo(BeEmpty())
+	ds, ok := mockClient.updateChain[0].(*v1.DaemonSet)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(ds.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+	g.Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf([]corev1.EnvVar{
+		{
+			Name:  "NAME1",
+			Value: "VALUE1",
+		},
+		{
+			Name:  "NAME3",
+			Value: "VALUE3",
+		},
+		{
+			Name:  "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG",
+			Value: "true",
+		},
+		{
+			Name:  "ENI_CONFIG_LABEL_DEF",
+			Value: "failure-domain.beta.kubernetes.io/zone",
+		},
+	}))
+}
+
 type cachingClient struct {
 	client.Client
 	getValue    client.Object
@@ -225,10 +313,17 @@ func (c *cachingClient) Update(ctx context.Context, obj client.Object, opts ...c
 	return nil
 }
 
+func (c *cachingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}
+
 type mockScope struct {
 	scope.AWSNodeScope
-	client client.Client
-	cni    ekscontrolplanev1.VpcCni
+	client             client.Client
+	cni                ekscontrolplanev1.VpcCni
+	secondaryCidrBlock *string
+	securityGroups     map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+	subnets            infrav1.Subnets
 }
 
 func (s *mockScope) RemoteClient() (client.Client, error) {
@@ -256,5 +351,13 @@ func (s *mockScope) DisableVPCCNI() bool {
 }
 
 func (s *mockScope) SecondaryCidrBlock() *string {
-	return nil
+	return s.secondaryCidrBlock
+}
+
+func (s *mockScope) SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup {
+	return s.securityGroups
+}
+
+func (s *mockScope) Subnets() infrav1.Subnets {
+	return s.subnets
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We apply environment property changes to aws-node. These changes are only applied to the loop variable, but the actual update doesn't update them correctly.

When I change the values, the update doesn't do anything.

Before:

- create node
```
Environment:
      ADDITIONAL_ENI_TAGS:                    {}
      AWS_VPC_CNI_NODE_PORT_SUPPORT:          true
      AWS_VPC_ENI_MTU:                        9001
      AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER:     false
      AWS_VPC_K8S_CNI_EXTERNALSNAT:           false
      AWS_VPC_K8S_CNI_LOGLEVEL:               DEBUG
      AWS_VPC_K8S_CNI_LOG_FILE:               /host/var/log/aws-routed-eni/ipamd.log
      AWS_VPC_K8S_CNI_RANDOMIZESNAT:          prng
      AWS_VPC_K8S_CNI_VETHPREFIX:             eni
      AWS_VPC_K8S_PLUGIN_LOG_FILE:            /var/log/aws-routed-eni/plugin.log
      AWS_VPC_K8S_PLUGIN_LOG_LEVEL:           DEBUG
      DISABLE_INTROSPECTION:                  false
      DISABLE_METRICS:                        false
      DISABLE_NETWORK_RESOURCE_PROVISIONING:  false
      ENABLE_IPv4:                            true
      ENABLE_IPv6:                            false
      ENABLE_POD_ENI:                         false
      ENABLE_PREFIX_DELEGATION:               false
      MY_NODE_NAME:                            (v1:spec.nodeName)
      WARM_ENI_TARGET:                        1
      WARM_PREFIX_TARGET:                     1
      AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG:     true
```
- change value
```
Environment:
      ADDITIONAL_ENI_TAGS:                    {}
      AWS_VPC_CNI_NODE_PORT_SUPPORT:          true
      AWS_VPC_ENI_MTU:                        9001
      AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER:     false
      AWS_VPC_K8S_CNI_EXTERNALSNAT:           false
      AWS_VPC_K8S_CNI_LOGLEVEL:               DEBUG
      AWS_VPC_K8S_CNI_LOG_FILE:               /host/var/log/aws-routed-eni/ipamd.log
      AWS_VPC_K8S_CNI_RANDOMIZESNAT:          prng
      AWS_VPC_K8S_CNI_VETHPREFIX:             eni
      AWS_VPC_K8S_PLUGIN_LOG_FILE:            /var/log/aws-routed-eni/plugin.log
      AWS_VPC_K8S_PLUGIN_LOG_LEVEL:           DEBUG
      DISABLE_INTROSPECTION:                  false
      DISABLE_METRICS:                        false
      DISABLE_NETWORK_RESOURCE_PROVISIONING:  false
      ENABLE_IPv4:                            true
      ENABLE_IPv6:                            false
      ENABLE_POD_ENI:                         false
      ENABLE_PREFIX_DELEGATION:               false
      MY_NODE_NAME:                            (v1:spec.nodeName)
      WARM_ENI_TARGET:                        1
      WARM_PREFIX_TARGET:                     1
      AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG:     true
```
- observe that nothing changes

With this modification:

- create aws-node without hardcoded new values:
```
Environment:
      ADDITIONAL_ENI_TAGS:                    {}
      AWS_VPC_CNI_NODE_PORT_SUPPORT:          true
      AWS_VPC_ENI_MTU:                        9001
      AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER:     false
      AWS_VPC_K8S_CNI_EXTERNALSNAT:           false
      AWS_VPC_K8S_CNI_LOGLEVEL:               DEBUG
      AWS_VPC_K8S_CNI_LOG_FILE:               /host/var/log/aws-routed-eni/ipamd.log
      AWS_VPC_K8S_CNI_RANDOMIZESNAT:          prng
      AWS_VPC_K8S_CNI_VETHPREFIX:             eni
      AWS_VPC_K8S_PLUGIN_LOG_FILE:            /var/log/aws-routed-eni/plugin.log
      AWS_VPC_K8S_PLUGIN_LOG_LEVEL:           DEBUG
      DISABLE_INTROSPECTION:                  false
      DISABLE_METRICS:                        false
      DISABLE_NETWORK_RESOURCE_PROVISIONING:  false
      ENABLE_IPv4:                            true
      ENABLE_IPv6:                            false
      ENABLE_POD_ENI:                         false
      ENABLE_PREFIX_DELEGATION:               false
      MY_NODE_NAME:                            (v1:spec.nodeName)
      WARM_ENI_TARGET:                        1
      WARM_PREFIX_TARGET:                     1
```
- then change the code to include new values:
```
Environment:
      ADDITIONAL_ENI_TAGS:                    {}
      AWS_VPC_CNI_NODE_PORT_SUPPORT:          true
      AWS_VPC_ENI_MTU:                        9001
      AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER:     false
      AWS_VPC_K8S_CNI_EXTERNALSNAT:           false
      AWS_VPC_K8S_CNI_LOGLEVEL:               DEBUG
      AWS_VPC_K8S_CNI_LOG_FILE:               /host/var/log/aws-routed-eni/ipamd.log
      AWS_VPC_K8S_CNI_RANDOMIZESNAT:          prng
      AWS_VPC_K8S_CNI_VETHPREFIX:             eni
      AWS_VPC_K8S_PLUGIN_LOG_FILE:            /var/log/aws-routed-eni/plugin.log
      AWS_VPC_K8S_PLUGIN_LOG_LEVEL:           DEBUG
      DISABLE_INTROSPECTION:                  false
      DISABLE_METRICS:                        false
      DISABLE_NETWORK_RESOURCE_PROVISIONING:  false
      ENABLE_IPv4:                            true
      ENABLE_IPv6:                            false
      ENABLE_POD_ENI:                         false
      ENABLE_PREFIX_DELEGATION:               false
      MY_NODE_NAME:                            (v1:spec.nodeName)
      WARM_ENI_TARGET:                        1
      WARM_PREFIX_TARGET:                     1
      AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG:     true
      ENI_CONFIG_LABEL_DEF:                   failure-domain.beta.kubernetes.io/zone
      SOME_NAME:                              some-vale
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
