### PR TITLE
rework vpc cni envvar logic to drop the forced keys

### DIFF
--- a/docs/book/src/topics/eks/pod-networking.md
+++ b/docs/book/src/topics/eks/pod-networking.md
@@ -7,8 +7,26 @@ When creating a EKS cluster the Amazon VPC CNI will be used by default for Pod N
 ## Using the VPC CNI Addon
 You can use an explicit version of the Amazon VPC CNI by using the **vpc-cni** EKS addon. See the [addons](./addons.md) documentation for further details of how to use addons.
 
+## Using Custom VPC CNI Configuration
+If your use case demands [custom networking](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html) VPC CNI configuration you might already be familiar with the [helm chart](https://github.com/aws/amazon-vpc-cni-k8s) which helps with the process. This gives you access to ENI Configs and you can set Environment Variables on the `aws-node` DaemonSet where the VPC CNI runs. CAPA is able to tune the same DaemonSet through Kubernetes.
 
-## Increase node pod limit
+The following example shows how to turn on custom network config and set a [label definition](https://github.com/aws/amazon-vpc-cni-k8s#eni_config_label_def).
+
+```yaml
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "capi-managed-test-control-plane"
+spec:
+  vpcCni:
+    env:
+    - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
+      value: "true" 
+    - name: ENABLE_PREFIX_DELEGATION
+      value: "true"
+```
+
+### Increase node pod limit
 You can increase the pod limit per-node as [per the upstream AWS documentation](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/). You'll need to enable the `vpc-cni` plugin addon on your EKS cluster as well as enable prefix assignment mode through the `ENABLE_PREFIX_DELEGATION` environment variable.
 
 ```yaml
@@ -19,6 +37,8 @@ metadata:
 spec:
   vpcCni:
     env:
+    - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
+      value: "true" 
     - name: ENABLE_PREFIX_DELEGATION
       value: "true"
   addons:

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -72,7 +72,6 @@ func (s *Service) ReconcileCNI(ctx context.Context) error {
 		for i := range ds.Spec.Template.Spec.Containers {
 			container := &ds.Spec.Template.Spec.Containers[i]
 			if container.Name == "aws-node" {
-				container.Env = s.filterEnv(container.Env)
 				container.Env, needsUpdate = s.applyUserProvidedEnvironmentProperties(container.Env)
 			}
 		}
@@ -161,22 +160,7 @@ func (s *Service) ReconcileCNI(ctx context.Context) error {
 		}
 	}
 
-	s.scope.Info("updating containers", "cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()))
-	for i := range ds.Spec.Template.Spec.Containers {
-		if ds.Spec.Template.Spec.Containers[i].Name == "aws-node" {
-			ds.Spec.Template.Spec.Containers[i].Env = append(s.filterEnv(ds.Spec.Template.Spec.Containers[i].Env),
-				corev1.EnvVar{
-					Name:  "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG",
-					Value: "true",
-				},
-				corev1.EnvVar{
-					Name:  "ENI_CONFIG_LABEL_DEF",
-					Value: "failure-domain.beta.kubernetes.io/zone",
-				},
-			)
-		}
-	}
-
+	s.scope.Info("updating containers", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
 	return remoteClient.Update(ctx, &ds, &client.UpdateOptions{})
 }
 
@@ -194,18 +178,6 @@ func (s *Service) getSecurityGroups() ([]string, error) {
 	}
 
 	return sgs, nil
-}
-
-func (s *Service) filterEnv(env []corev1.EnvVar) []corev1.EnvVar {
-	var i int
-	for _, e := range env {
-		if e.Name == "ENI_CONFIG_LABEL_DEF" || e.Name == "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG" {
-			continue
-		}
-		env[i] = e
-		i++
-	}
-	return env[:i]
 }
 
 // applyUserProvidedEnvironmentProperties takes a container environment and applies user provided values to it.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

when adding vpc cni env it [forced envvars](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/pkg/cloud/services/awsnode/cni.go#L165-L172) for `aws-node` but we now know due to a [bug](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3677) were never being applied. This PR drops them entirely and pushes all the onus for VPC CNI Environment Variables to the user and makes CAPA less opinionated since these env vars are being added/dropped/deprecated constantly.

In addition, this Fixes #3678 because we aren't looping/assigning the env a second time and the dedupe [code above](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/pkg/cloud/services/awsnode/cni.go#L71-L75) is already fixing the daemonset container env properly.

**What this PR does / why we need it**:
Cleans up envvar assigning and makes CAPA less opinionated.

**Special notes for your reviewer**:
I merged the env var tests into one which does the tests twice once with secondary cidr and once without.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
