### PR TITLE
Relax the AWSManagedControlPlane version regex and remove normalising the version

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2700,7 +2700,7 @@ spec:
                   version number is supplied then the latest version of Kubernetes
                   that EKS supports will be used.
                 minLength: 2
-                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.?$
+                pattern: ^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.?(\.0|[1-9][0-9]*)?$
                 type: string
               vpcCni:
                 description: VpcCni is used to set configuration options for the VPC

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
@@ -60,7 +60,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// is supplied then the latest version of Kubernetes that EKS supports
 	// will be used.
 	// +kubebuilder:validation:MinLength:=2
-	// +kubebuilder:validation:Pattern:=^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.?$
+	// +kubebuilder:validation:Pattern:=^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.?(\.0|[1-9][0-9]*)?$
 	// +optional
 	Version *string `json:"version,omitempty"`
 

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook.go
@@ -70,15 +70,6 @@ func parseEKSVersion(raw string) (*version.Version, error) {
 	return version.MustParseGeneric(fmt.Sprintf("%d.%d", v.Major(), v.Minor())), nil
 }
 
-func normalizeVersion(raw string) (string, error) {
-	// Normalize version (i.e. remove patch, add "v" prefix) if necessary
-	eksV, err := parseEKSVersion(raw)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("v%d.%d", eksV.Major(), eksV.Minor()), nil
-}
-
 // ValidateCreate will do any extra validation when creating a AWSManagedControlPlane.
 func (r *AWSManagedControlPlane) ValidateCreate() error {
 	mcpLog.Info("AWSManagedControlPlane validate create", "name", r.Name)
@@ -374,16 +365,6 @@ func (r *AWSManagedControlPlane) Default() {
 			Kind: infrav1.ControllerIdentityKind,
 			Name: infrav1.AWSClusterControllerIdentityName,
 		}
-	}
-
-	// Normalize version (i.e. remove patch, add "v" prefix) if necessary
-	if r.Spec.Version != nil {
-		normalizedV, err := normalizeVersion(*r.Spec.Version)
-		if err != nil {
-			mcpLog.Error(err, "couldn't parse version")
-			return
-		}
-		r.Spec.Version = &normalizedV
 	}
 
 	infrav1.SetDefaults_Bastion(&r.Spec.Bastion)

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_webhook_test.go
@@ -105,7 +105,7 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceNS:   "default",
 			expectHash:   false,
 			spec:         AWSManagedControlPlaneSpec{Version: &vV1_17_1},
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Version: &vV1_17, IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator},
+			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Version: &vV1_17_1, IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator},
 		},
 		{
 			name:         "with allowed ip on bastion",


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Removes the normalisation we perform for the version given to the AWSManagedControlPlane object. EKS requires a major.minor version format and we did that by truncating any given version and having a regex validation for the version being major.minor.

This, however, lead to us editing the spec and causing diff in applied / existing configs.

This PR attempts to remove this normalisation and relax the regex, so existing configurations don't break ( normally they would break, because we no longer truncate a given version ).

However, everywhere internally where we DO use the version for various things like creating a cluster, it should already be normalised.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3594.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
