### PR TITLE
chore: adding rbac generation back in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,11 +214,20 @@ generate-go-apis: ## Alias for .build/generate-go-apis
 		paths=./bootstrap/eks/api/... \
 		paths=./controlplane/eks/api/... \
 		paths=./iam/api/... \
-		output:crd:dir=config/crd/bases \
-		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt \
 		crd:crdVersions=v1 \
-		rbac:roleName=manager-role \
+		output:crd:dir=config/crd/bases \
+		output:webhook:dir=$(WEBHOOK_ROOT) \
+		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt \
 		webhook
+
+	$(CONTROLLER_GEN) \
+		paths=./controllers/... \
+		paths=./$(EXP_DIR)/controllers/... \
+		paths=./bootstrap/eks/controllers/... \
+		paths=./controlplane/eks/controllers/... \
+		output:rbac:dir=$(RBAC_ROOT) \
+		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt \
+		rbac:roleName=manager-role
 
 	$(CONTROLLER_GEN) \
 		paths=./cmd/... \

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
**What type of PR is this?**

/kind regression


**What this PR does / why we need it**:
As part of a previous change we lost the rbac generation done via
controller-gen. This mean that any changes to the `// +kubebuilder:rbac`
comments where not being picked up.

This change adds rbac generation back in.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
