### PR TITLE
Allow for Self-Managed VPC with a Secondary Subnet for Pods

### DIFF
--- a/pkg/cloud/services/awsnode/cni_test.go
+++ b/pkg/cloud/services/awsnode/cni_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -225,13 +226,30 @@ func TestReconcileCniVpcCniValues(t *testing.T) {
 						Name: "node",
 					},
 				},
+				subnets: infrav1.Subnets{
+					{
+						// we aren't testing reconcileSubnets where this extra conf is added so putting it in by hand
+						ID:        "sn-1234",
+						CidrBlock: "100.0.0.1/20",
+						Tags: infrav1.Tags{
+							infrav1.NameAWSSubnetAssociation: infrav1.SecondarySubnetTagValue,
+						},
+					},
+				},
 			}
 			s := NewService(m)
 
 			err := s.ReconcileCNI(context.Background())
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(mockClient.updateChain).NotTo(BeEmpty())
-			ds, ok := mockClient.updateChain[0].(*v1.DaemonSet)
+
+			g.Expect(mockClient.updateChain).NotTo(BeEmpty()) // 0: eniconfig 1: daemonset
+			eniconf, ok := mockClient.updateChain[0].(*v1alpha1.ENIConfig)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(len(eniconf.Spec.SecurityGroups)).To(Equal(1))
+			g.Expect(eniconf.Spec.SecurityGroups[0]).To(Equal(m.securityGroups["node"].ID))
+			g.Expect(eniconf.Spec.Subnet).To(Equal(m.subnets[0].ID))
+
+			ds, ok := mockClient.updateChain[1].(*v1.DaemonSet)
 			g.Expect(ok).To(BeTrue())
 			g.Expect(ds.Spec.Template.Spec.Containers).NotTo(BeEmpty())
 			g.Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(tc.consistsOf))

--- a/pkg/internal/cidr/cidr_test.go
+++ b/pkg/internal/cidr/cidr_test.go
@@ -34,20 +34,20 @@ func TestSplitIntoSubnetsIPv4(t *testing.T) {
 		{
 			// https://aws.amazon.com/about-aws/whats-new/2018/10/amazon-eks-now-supports-additional-vpc-cidr-blocks/
 			name:        "default secondary cidr block configuration with primary cidr",
-			cidrblock:   "100.64.0.0/16",
+			cidrblock:   "100.64.0.0/10",
 			subnetcount: 3,
 			expected: []*net.IPNet{
 				{
 					IP:   net.IPv4(100, 64, 0, 0).To4(),
-					Mask: net.IPv4Mask(255, 255, 192, 0),
+					Mask: net.IPv4Mask(255, 240, 0, 0),
 				},
 				{
-					IP:   net.IPv4(100, 64, 64, 0).To4(),
-					Mask: net.IPv4Mask(255, 255, 192, 0),
+					IP:   net.IPv4(100, 80, 0, 0).To4(),
+					Mask: net.IPv4Mask(255, 240, 0, 0),
 				},
 				{
-					IP:   net.IPv4(100, 64, 128, 0).To4(),
-					Mask: net.IPv4Mask(255, 255, 192, 0),
+					IP:   net.IPv4(100, 96, 0, 0).To4(),
+					Mask: net.IPv4Mask(255, 240, 0, 0),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is quite the logic puzzle so apologies in advance and try and bear with me. I found a situation when trying to configure the VPC/CNI you are unable to generate ENIConfigs for secondary subnets for the pods. CAPA is making the assumption that if you want a secondary subnet you are using SecondaryCIDRBlock. 

This is the core logic
* ENIConfig creation is gated behind a not nil SecondaryCIDRBlock
* ENIConfig creation only creates ENIConfigs for subnets tagged `sigs.k8s.io/cluster-api-provider-aws/association=secondary`
* subnet creation is gated behind a VPC ID being not present

The only scenario you can get ENIConfigs for an unmanaged VPC is by setting the VPC ID, setting SecondaryCIDRBlock (which is ignored) to one of the two allowed ranges and tagging your subnets.

To fix I propose we only make ENIConfigs if we have secondary subnets. This will leave the managed VPCs with the same logic around SecondaryCIDRBlock while allowing unmanaged VPC users to tag and choose which subnets CAPA will create ENIConfigs.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR contains a cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3681 because it has the updated networking docs so only look at 946c0b90dfdf69732209bf3af2e245f9d95f8e05. It also seems I wrote wrote the cidr parser test for a /16 instead of a /10

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
