### PR TITLE
fix validation for aws tags with spaces

### DIFF
--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -86,7 +86,7 @@ func (t Tags) Validate() []*field.Error {
 	const maxUserTagsAllowed = 50
 	var errs field.ErrorList
 	var userTagCount = len(t)
-	re := regexp.MustCompile(`^[a-zA-Z0-9\\s\_\.\:\=\+\-\@\/]*$`)
+	re := regexp.MustCompile(`^[a-zA-Z0-9\s\_\.\:\=\+\-\@\/]*$`)
 
 	for k, v := range t {
 		if len(k) < 1 {

--- a/api/v1beta1/tags_test.go
+++ b/api/v1beta1/tags_test.go
@@ -180,6 +180,13 @@ func TestTags_Validate(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "no errors - spaces allowed",
+			self: Tags{
+				"validKey": "valid Value",
+			},
+			expected: nil,
+		},
+		{
 			name: "key cannot be empty",
 			self: Tags{
 				"": "validValue",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes #3701 

- Fixes incorrect regex of invaliding aws tags with spaces
- Introduces test case to check for it


**Special notes for your reviewer**:

**Checklist**:

- [ x] squashed commits
- [x ] includes documentation
- [x ] adds unit tests
- [ x] adds or updates e2e tests
