### PR TITLE
Fix multitenancy topic for secretRef syntax

### DIFF
--- a/docs/book/src/topics/multitenancy.md
+++ b/docs/book/src/topics/multitenancy.md
@@ -85,9 +85,7 @@ kind: AWSClusterStaticIdentity
 metadata:
   name: "test-account"
 spec:
-  secretRef:
-    name: test-account-creds
-    namespace: capa-system
+  secretRef: test-account-creds
   allowedNamespaces:
     selector:
       matchLabels:


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

Small fix for the usage of `secretRef` for `v1beta1` in the multi-tenancy topic. It was using the old format.

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3717

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
