### PR TITLE
Add elasticloadbalancing:DeregisterTargets to control plane role policy

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cloud_provider_integration_control_plane.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cloud_provider_integration_control_plane.go
@@ -84,6 +84,7 @@ func (t Template) cloudProviderControlPlaneAwsPolicy() *iamv1.PolicyDocument {
 					"elasticloadbalancing:CreateTargetGroup",
 					"elasticloadbalancing:DeleteListener",
 					"elasticloadbalancing:DeleteTargetGroup",
+					"elasticloadbalancing:DeregisterTargets",
 					"elasticloadbalancing:DescribeListeners",
 					"elasticloadbalancing:DescribeLoadBalancerPolicies",
 					"elasticloadbalancing:DescribeTargetGroups",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -73,6 +73,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -73,6 +73,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -73,6 +73,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -70,6 +70,7 @@ Resources:
           - elasticloadbalancing:CreateTargetGroup
           - elasticloadbalancing:DeleteListener
           - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
           - elasticloadbalancing:DescribeListeners
           - elasticloadbalancing:DescribeLoadBalancerPolicies
           - elasticloadbalancing:DescribeTargetGroups


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Adds the missing "elasticloadbalancing:DeregisterTargets" action permission to the control plane role policy document.

Fixes #3486
