### PR TITLE
Update AWSMachine webhook validate logic on update to be consistent

### DIFF
--- a/api/v1beta2/awsmachine_webhook.go
+++ b/api/v1beta2/awsmachine_webhook.go
@@ -78,6 +78,7 @@ func (r *AWSMachine) ValidateUpdate(old runtime.Object) error {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, r.validateCloudInitSecret()...)
+	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
 	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
 	newAWSMachineSpec := newAWSMachine["spec"].(map[string]interface{})
@@ -203,7 +204,7 @@ func (r *AWSMachine) validateNonRootVolumes() field.ErrorList {
 	var allErrs field.ErrorList
 
 	for _, volume := range r.Spec.NonRootVolumes {
-		if VolumeTypesProvisioned.Has(string(r.Spec.RootVolume.Type)) && volume.IOPS == 0 {
+		if VolumeTypesProvisioned.Has(string(volume.Type)) && volume.IOPS == 0 {
 			allErrs = append(allErrs, field.Required(field.NewPath("spec.nonRootVolumes.iops"), "iops required if type is 'io1' or 'io2'"))
 		}
 


### PR DESCRIPTION
Update AWSMachine webhook validate logic on update to be consistent with validation on creation.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
* Adds the missing validation of the security groups `onUpdate` for the AWSMachine webhook. 
* Fixes the bug identified in #3105, which was introduced in #2468, where the wrong volume was compared in one of the validation non-root volumes in the AWSMachine webhook validation.
* Changes the AWSMachineTemplate  webhook `onCreate` validation to be consistent with the AWSMachine `onCreate` validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3109 & #3105

**Special notes for your reviewer**:
* Split into 2 commits, one for each webhook modified.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AWSMachine's webhook validation `onCreate` now checks that additional security groups are validated. This brings it into line with the existing AWSMachine `onUpdate` validation.
AWSMachineTemplate's webhook validation `onCreate` now checks that the template spec for the AWSMachine pass validation. Previously only volumes and ignition settings were validated.
```
