### PR TITLE
deleting additional vpc cni resources when disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	sigs.k8s.io/cluster-api v1.2.0
 	sigs.k8s.io/cluster-api/test v1.2.0
 	sigs.k8s.io/controller-runtime v0.12.3
+	sigs.k8s.io/kustomize/api v0.11.4
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -73,6 +74,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -158,5 +160,6 @@ require (
 	k8s.io/kubectl v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kind v0.14.0 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,7 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -1269,9 +1270,11 @@ sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87J
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/kind v0.14.0 h1:cNmI3jGBvp7UegEGbC5we8plDtCUmaNRL+bod7JoSCE=
 sigs.k8s.io/kind v0.14.0/go.mod h1:UrFRPHG+2a5j0Q7qiR4gtJ4rEyn8TuMQwuOPf+m4oHg=
+sigs.k8s.io/kustomize/api v0.11.4 h1:/0Mr3kfBBNcNPOW5Qwk/3eb8zkswCwnqQxxKtmrTkRo=
 sigs.k8s.io/kustomize/api v0.11.4/go.mod h1:k+8RsqYbgpkIrJ4p9jcdPqe8DprLxFUUO0yNOq8C+xI=
 sigs.k8s.io/kustomize/cmd/config v0.10.6/go.mod h1:/S4A4nUANUa4bZJ/Edt7ZQTyKOY9WCER0uBS1SW2Rco=
 sigs.k8s.io/kustomize/kustomize/v4 v4.5.4/go.mod h1:Zo/Xc5FKD6sHl0lilbrieeGeZHVYCA4BzxeAaLI05Bg=
+sigs.k8s.io/kustomize/kyaml v0.13.6 h1:eF+wsn4J7GOAXlvajv6OknSunxpcOBQQqsnPxObtkGs=
 sigs.k8s.io/kustomize/kyaml v0.13.6/go.mod h1:yHP031rn1QX1lr/Xd934Ri/xdVNG8BE2ECa78Ht/kEg=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +49,7 @@ func init() {
 	_ = amazoncni.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
 }
 
 // ManagedControlPlaneScopeParams defines the input parameters used to create a new Scope.

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -23,12 +23,15 @@ import (
 	amazoncni "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/api/konfig"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/awserrors"
@@ -239,26 +242,77 @@ func (s *Service) applyUserProvidedEnvironmentProperties(containerEnv []corev1.E
 }
 
 func (s *Service) deleteCNI(ctx context.Context, remoteClient client.Client) error {
-	s.scope.Info("Ensuring aws-node DaemonSet in cluster is deleted", "cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()))
+	// EKS has a tendency to pre-install the vpc-cni automagically even if you don't specify it as an addon
+	// and looks like a kubectl apply from a script of a manifest that looks like this
+	// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/master/aws-k8s-cni.yaml
+	// and removing these pieces will enable someone to install and alternative CNI. There is also another use
+	// case where someone would want to remove the vpc-cni and reinstall it via the helm chart located here
+	// https://github.com/aws/amazon-vpc-cni-k8s/tree/master/charts/aws-vpc-cni meaning we need to account for
+	// managed-by: Helm label, or we will delete the helm chart resources every reconcile loop. EKS does make
+	// a CRD for eniconfigs but the default env var on the vpc-cni pod is ENABLE_POD_ENI=false. We will make an
+	// assumption no CRs are ever created and leave the CRD to reduce complexity of this operation.
 
-	ds := &appsv1.DaemonSet{}
-	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: awsNodeNamespace, Name: awsNodeName}, ds); err != nil {
-		if apierrors.IsNotFound(err) {
-			s.scope.V(2).Info("The aws-node DaemonSet is not found, not action")
-			return nil
-		}
-		return fmt.Errorf("getting aws-node daemonset: %w", err)
+	s.scope.Info("Ensuring all resources for AWS VPC CNI in cluster are deleted", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
+
+	s.scope.Info("Trying to delete AWS VPC CNI DaemonSet", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
+	if err := s.deleteResource(ctx, remoteClient, types.NamespacedName{
+		Namespace: awsNodeNamespace,
+		Name:      awsNodeName,
+	}, &appsv1.DaemonSet{}); err != nil {
+		return err
 	}
 
-	s.scope.V(2).Info("The aws-node DaemonSet found, deleting")
-	if err := remoteClient.Delete(ctx, ds, &client.DeleteOptions{}); err != nil {
-		if apierrors.IsNotFound(err) {
-			s.scope.V(2).Info("The aws-node DaemonSet is not found, not deleted")
-			return nil
-		}
-		return fmt.Errorf("deleting aws-node DaemonSet: %w", err)
+	s.scope.Info("Trying to delete AWS VPC CNI ServiceAccount", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
+	if err := s.deleteResource(ctx, remoteClient, types.NamespacedName{
+		Namespace: awsNodeNamespace,
+		Name:      awsNodeName,
+	}, &corev1.ServiceAccount{}); err != nil {
+		return err
 	}
+
+	s.scope.Info("Trying to delete AWS VPC CNI ClusterRoleBinding", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
+	if err := s.deleteResource(ctx, remoteClient, types.NamespacedName{
+		Namespace: string(meta.RESTScopeNameRoot),
+		Name:      awsNodeName,
+	}, &rbacv1.ClusterRoleBinding{}); err != nil {
+		return err
+	}
+
+	s.scope.Info("Trying to delete AWS VPC CNI ClusterRole", "cluster-name", s.scope.Name(), "cluster-namespace", s.scope.Namespace())
+	if err := s.deleteResource(ctx, remoteClient, types.NamespacedName{
+		Namespace: string(meta.RESTScopeNameRoot),
+		Name:      awsNodeName,
+	}, &rbacv1.ClusterRole{}); err != nil {
+		return err
+	}
+
 	record.Eventf(s.scope.InfraCluster(), "DeletedVPCCNI", "The AWS VPC CNI has been removed from the cluster. Ensure you enable a CNI via another mechanism")
+
+	return nil
+}
+
+func (s *Service) deleteResource(ctx context.Context, remoteClient client.Client, key client.ObjectKey, obj client.Object) error {
+	if err := remoteClient.Get(ctx, key, obj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting resource %s: %w", key, err)
+		}
+		s.scope.V(2).Info(fmt.Sprintf("resource %s was not found, no action", key))
+	} else {
+		// resource found, delete if no label or not managed by helm
+		if val, ok := obj.GetLabels()[konfig.ManagedbyLabelKey]; !ok || val != "Helm" {
+			if err := remoteClient.Delete(ctx, obj, &client.DeleteOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("deleting %s: %w", key, err)
+				}
+				s.scope.V(2).Info(fmt.Sprintf(
+					"resource %s was not found, not deleted", key))
+			} else {
+				s.scope.V(2).Info(fmt.Sprintf("resource %s was deleted", key))
+			}
+		} else {
+			s.scope.V(2).Info(fmt.Sprintf("resource %s is managed by helm, not deleted", key))
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds additional logic to removing vpc-cni pre-installed resources when you set disableVPCCNI to true. Previous logic only deleted the `aws-node` DaemonSet when in reality there are ServiceAccounts, ClusterRole, ClusterRoleBinding and a CRD.

New logic deletes the SA/CR/CRB but leaves the CRD and any CRs. This is important because some people manage the VPC CNI via the helm chart and with these pieces around the chart fails to install citing the SA/CR/CRB already existing. Additionally... if you choose to disable vpc-cni through capa and install via helm, capa would continually smash it out of existing during reconciliation so added a check for managed-by: Helm

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3729 

**Special notes for your reviewer**:
I tested this pretty thoroughly, check the issue for more details but the basics are this is pretty bullet proof for cycling back/forth from disableVPCCNI to installing the addon again.


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
