### PR TITLE
fix: use v1beta1 version in EKS user kubeconfig

### DIFF
--- a/pkg/cloud/services/eks/config.go
+++ b/pkg/cloud/services/eks/config.go
@@ -187,7 +187,11 @@ func (s *Service) createUserKubeconfigSecret(ctx context.Context, cluster *eks.C
 		return fmt.Errorf("creating base kubeconfig: %w", err)
 	}
 
-	execConfig := &api.ExecConfig{APIVersion: "client.authentication.k8s.io/v1alpha1"}
+	// Version v1alpha1 was removed in Kubernetes v1.23.
+	// Version v1 was released in Kubernetes v1.23.
+	// Version v1beta1 was selected as it has the widest range of support
+	// This should be changed to v1 once EKS no longer supports Kubernetes <v1.23
+	execConfig := &api.ExecConfig{APIVersion: "client.authentication.k8s.io/v1beta1"}
 	switch s.scope.TokenMethod() {
 	case ekscontrolplanev1.EKSTokenMethodIAMAuthenticator:
 		execConfig.Command = "aws-iam-authenticator"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
`client.authentication.k8s.io/v1alpha1` has been removed in Kubernetes v1.24 see https://github.com/aws/aws-cli/issues/6920. EKS will soon support v1.24, to prepare for that we should use a version that will be supported. This also breaks anyone that uses `kubectl` >=1.24, so others may already be seeing this issue.

The oldest version that EKS supports is v1.20 https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html where `v1beta1` [was already available](https://github.com/kubernetes/kubernetes/tree/release-1.20/staging/src/k8s.io/client-go/pkg/apis/clientauthentication) ([and is still available even in 1.26](https://github.com/kubernetes/kubernetes/tree/v1.26.0-alpha.1/staging/src/k8s.io/client-go/pkg/apis/clientauthentication))

```
# a newer kubectl version does not work
➜  kubectl version --client=true
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"25", GitVersion:"v1.25.0", GitCommit:"a866cbe2e5bbaa01cfd5e969aa3e033f3282a8a2", GitTreeState:"clean", BuildDate:"2022-08-23T17:36:43Z", GoVersion:"go1.19", Compiler:"gc", Platform:"darwin/amd64"}
Kustomize Version: v4.5.7
➜  kubectl get node
error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"

# downloading kubectl v1.23.x or older will work with v1alpha1
➜ curl -LO "https://dl.k8s.io/release/v1.23.12/bin/darwin/amd64/kubectl"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138  100   138    0     0   1792      0 --:--:-- --:--:-- --:--:--  1792
100 50.6M  100 50.6M    0     0  32.8M      0  0:00:01  0:00:01 --:--:-- 40.3M
➜ curl -LO "https://dl.k8s.io/release/v1.23.12/bin/darwin/amd64/kubectl"
➜ chmod +x kubectl
➜ ./kubectl get nodes
NAME                                         STATUS   ROLES    AGE   VERSION
ip-10-0-109-193.us-west-2.compute.internal   Ready    <none>   58m   v1.22.12-eks-ba74326
ip-10-0-127-152.us-west-2.compute.internal   Ready    <none>   58m   v1.22.12-eks-ba74326
ip-10-0-67-45.us-west-2.compute.internal     Ready    <none>   58m   v1.22.12-eks-ba74326
ip-10-0-73-222.us-west-2.compute.internal    Ready    <none>   58m   v1.22.12-eks-ba74326
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
