### PR TITLE
Add ASG Instance AZ SDK API to CAPA API conversion

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -83,8 +83,9 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 	if len(v.Instances) > 0 {
 		for _, autoscalingInstance := range v.Instances {
 			tmp := &infrav1.Instance{
-				ID:    aws.StringValue(autoscalingInstance.InstanceId),
-				State: infrav1.InstanceState(*autoscalingInstance.LifecycleState),
+				ID:               aws.StringValue(autoscalingInstance.InstanceId),
+				State:            infrav1.InstanceState(*autoscalingInstance.LifecycleState),
+				AvailabilityZone: *autoscalingInstance.AvailabilityZone,
 			}
 			i.Instances = append(i.Instances, *tmp)
 		}

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -218,8 +218,9 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 				},
 				Instances: []*autoscaling.Instance{
 					{
-						InstanceId:     aws.String("instanceId"),
-						LifecycleState: aws.String("lifecycleState"),
+						InstanceId:       aws.String("instanceId"),
+						LifecycleState:   aws.String("lifecycleState"),
+						AvailabilityZone: aws.String("us-east-1a"),
 					},
 				},
 			},
@@ -249,8 +250,9 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 				},
 				Instances: []infrav1.Instance{
 					{
-						ID:    "instanceId",
-						State: "lifecycleState",
+						ID:               "instanceId",
+						State:            "lifecycleState",
+						AvailabilityZone: "us-east-1a",
 					},
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds the conversion of ASG instance AZ from SDK API to CAPA APIs because in `providerIDList` in [awsmachinepool_controller](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/d52c10c272153d008c200ea05b7c200a5d19d62d/exp/controllers/awsmachinepool_controller.go#L299) somehow the `ec2.AvailabilityZone` was coming empty. When observed ASG code [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/pkg/cloud/services/autoscaling/autoscalinggroup.go#L85), we missed AZ conversion while converting `v.Instance` to `i.Instance`(AZ being mandatory field in EC2 Instance API in `aws-sdk-go`), thus fixing below issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3742 
Fixes #3718 

**Special notes for your reviewer**:

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests
