### PR TITLE
Add EventBridge ec2 event reconciliation and rule creation to eks managed control planes

### DIFF
--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -118,6 +118,7 @@ variables:
   KUBERNETES_VERSION_MANAGEMENT: "v1.22.9" # Kind bootstrap
   EXP_MACHINE_POOL: "true"
   EXP_CLUSTER_RESOURCE_SET: "true"
+  EVENT_BRIDGE_INSTANCE_STATE: "true"
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_MACHINE_TYPE_VCPU_USAGE: 2
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"


### PR DESCRIPTION

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

The EventBridge feature for importing ec2 events is not supported for EKS in the AWS managed control planes controller. The logic to reconcile the events and create any roles/policies needed is missing.

**Special notes for your reviewer**:
Slack context: https://kubernetes.slack.com/archives/CD6U2V71N/p1663962497725469

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
