### PR TITLE
Unify the logger interface in CAPA

### DIFF
--- a/controllers/awscluster_controller_unit_test.go
+++ b/controllers/awscluster_controller_unit_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/mock_services"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 )
@@ -571,7 +572,7 @@ func TestAWSClusterReconciler_RequeueAWSClusterForUnpausedCluster(t *testing.T) 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			log := ctrl.LoggerFrom(ctx)
+			log := logger.FromContext(ctx)
 			reconciler := &AWSClusterReconciler{
 				Client: testEnv.Client,
 			}

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/secretsmanager"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/ssm"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/userdata"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -140,7 +141,7 @@ func (r *AWSMachineReconciler) getObjectStoreService(scope scope.S3Scope) servic
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
 func (r *AWSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	log := ctrl.LoggerFrom(ctx)
+	log := logger.FromContext(ctx)
 
 	// Fetch the AWSMachine instance.
 	awsMachine := &infrav1.AWSMachine{}
@@ -226,7 +227,7 @@ func (r *AWSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 func (r *AWSMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	log := ctrl.LoggerFrom(ctx)
+	log := logger.FromContext(ctx)
 	AWSClusterToAWSMachines := r.AWSClusterToAWSMachines(log)
 
 	controller, err := ctrl.NewControllerManagedBy(mgr).
@@ -240,7 +241,7 @@ func (r *AWSMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 			&source.Kind{Type: &infrav1.AWSCluster{}},
 			handler.EnqueueRequestsFromMapFunc(AWSClusterToAWSMachines),
 		).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(log, r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(log.GetLogger(), r.WatchFilterValue)).
 		WithEventFilter(
 			predicate.Funcs{
 				// Avoid reconciling if the event triggering the reconciliation is related to incremental status updates
@@ -280,7 +281,7 @@ func (r *AWSMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 	return controller.Watch(
 		&source.Kind{Type: &clusterv1.Cluster{}},
 		handler.EnqueueRequestsFromMapFunc(requeueAWSMachinesForUnpausedCluster),
-		predicates.ClusterUnpausedAndInfrastructureReady(log),
+		predicates.ClusterUnpausedAndInfrastructureReady(log.GetLogger()),
 	)
 }
 
@@ -308,13 +309,13 @@ func (r *AWSMachineReconciler) reconcileDelete(machineScope *scope.MachineScope,
 		// and AWSMachine
 		// 3. Issue a delete
 		// 4. Scale controller deployment to 1
-		machineScope.V(2).Info("Unable to locate EC2 instance by ID or tags")
+		machineScope.Debug("Unable to locate EC2 instance by ID or tags")
 		r.Recorder.Eventf(machineScope.AWSMachine, corev1.EventTypeWarning, "NoInstanceFound", "Unable to find matching EC2 instance")
 		controllerutil.RemoveFinalizer(machineScope.AWSMachine, infrav1.MachineFinalizer)
 		return ctrl.Result{}, nil
 	}
 
-	machineScope.V(3).Info("EC2 instance found matching deleted AWSMachine", "instance-id", instance.ID)
+	machineScope.Debug("EC2 instance found matching deleted AWSMachine", "instance-id", instance.ID)
 
 	if err := r.reconcileLBAttachment(machineScope, elbScope, instance); err != nil {
 		// We are tolerating AccessDenied error, so this won't block for users with older version of IAM;
@@ -367,7 +368,7 @@ func (r *AWSMachineReconciler) reconcileDelete(machineScope *scope.MachineScope,
 				return ctrl.Result{}, err
 			}
 
-			machineScope.V(3).Info(
+			machineScope.Debug(
 				"Detaching security groups from provided network interface",
 				"groups", core,
 				"instanceID", instance.ID,
@@ -430,7 +431,7 @@ func (r *AWSMachineReconciler) findInstance(scope *scope.MachineScope, ec2svc se
 }
 
 func (r *AWSMachineReconciler) reconcileNormal(_ context.Context, machineScope *scope.MachineScope, clusterScope cloud.ClusterScoper, ec2Scope scope.EC2Scope, elbScope scope.ELBScope, objectStoreScope scope.S3Scope) (ctrl.Result, error) {
-	machineScope.V(4).Info("Reconciling AWSMachine")
+	machineScope.Trace("Reconciling AWSMachine")
 
 	// If the AWSMachine is in an error state, return early.
 	if machineScope.HasFailed() {
@@ -837,7 +838,7 @@ func (r *AWSMachineReconciler) reconcileLBAttachment(machineScope *scope.Machine
 
 // AWSClusterToAWSMachines is a handler.ToRequestsFunc to be used to enqeue requests for reconciliation
 // of AWSMachines.
-func (r *AWSMachineReconciler) AWSClusterToAWSMachines(log logr.Logger) handler.MapFunc {
+func (r *AWSMachineReconciler) AWSClusterToAWSMachines(log logger.Wrapper) handler.MapFunc {
 	return func(o client.Object) []ctrl.Request {
 		c, ok := o.(*infrav1.AWSCluster)
 		if !ok {
@@ -848,14 +849,14 @@ func (r *AWSMachineReconciler) AWSClusterToAWSMachines(log logr.Logger) handler.
 
 		// Don't handle deleted AWSClusters
 		if !c.ObjectMeta.DeletionTimestamp.IsZero() {
-			log.V(4).Info("AWSCluster has a deletion timestamp, skipping mapping.")
+			log.Trace("AWSCluster has a deletion timestamp, skipping mapping.")
 			return nil
 		}
 
 		cluster, err := util.GetOwnerCluster(context.TODO(), r.Client, c.ObjectMeta)
 		switch {
 		case apierrors.IsNotFound(err) || cluster == nil:
-			log.V(4).Info("Cluster for AWSCluster not found, skipping mapping.")
+			log.Trace("Cluster for AWSCluster not found, skipping mapping.")
 			return nil
 		case err != nil:
 			log.Error(err, "Failed to get owning cluster, skipping mapping.")
@@ -866,7 +867,7 @@ func (r *AWSMachineReconciler) AWSClusterToAWSMachines(log logr.Logger) handler.
 	}
 }
 
-func (r *AWSMachineReconciler) requeueAWSMachinesForUnpausedCluster(log logr.Logger) handler.MapFunc {
+func (r *AWSMachineReconciler) requeueAWSMachinesForUnpausedCluster(log logger.Wrapper) handler.MapFunc {
 	return func(o client.Object) []ctrl.Request {
 		c, ok := o.(*clusterv1.Cluster)
 		if !ok {
@@ -877,7 +878,7 @@ func (r *AWSMachineReconciler) requeueAWSMachinesForUnpausedCluster(log logr.Log
 
 		// Don't handle deleted clusters
 		if !c.ObjectMeta.DeletionTimestamp.IsZero() {
-			log.V(4).Info("Cluster has a deletion timestamp, skipping mapping.")
+			log.Trace("Cluster has a deletion timestamp, skipping mapping.")
 			return nil
 		}
 
@@ -885,7 +886,7 @@ func (r *AWSMachineReconciler) requeueAWSMachinesForUnpausedCluster(log logr.Log
 	}
 }
 
-func (r *AWSMachineReconciler) requestsForCluster(log logr.Logger, namespace, name string) []ctrl.Request {
+func (r *AWSMachineReconciler) requestsForCluster(log logger.Wrapper, namespace, name string) []ctrl.Request {
 	labels := map[string]string{clusterv1.ClusterLabelName: name}
 	machineList := &clusterv1.MachineList{}
 	if err := r.Client.List(context.TODO(), machineList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
@@ -898,21 +899,21 @@ func (r *AWSMachineReconciler) requestsForCluster(log logr.Logger, namespace, na
 		m := m
 		log.WithValues("machine", klog.KObj(&m))
 		if m.Spec.InfrastructureRef.GroupVersionKind().Kind != "AWSMachine" {
-			log.V(4).Info("Machine has an InfrastructureRef for a different type, will not add to reconciliation request.")
+			log.Trace("Machine has an InfrastructureRef for a different type, will not add to reconciliation request.")
 			continue
 		}
 		if m.Spec.InfrastructureRef.Name == "" {
-			log.V(4).Info("Machine has an InfrastructureRef with an empty name, will not add to reconciliation request.")
+			log.Trace("Machine has an InfrastructureRef with an empty name, will not add to reconciliation request.")
 			continue
 		}
 		log.WithValues("awsMachine", klog.KRef(m.Spec.InfrastructureRef.Namespace, m.Spec.InfrastructureRef.Name))
-		log.V(4).Info("Adding AWSMachine to reconciliation request.")
+		log.Trace("Adding AWSMachine to reconciliation request.")
 		result = append(result, ctrl.Request{NamespacedName: client.ObjectKey{Namespace: m.Namespace, Name: m.Spec.InfrastructureRef.Name}})
 	}
 	return result
 }
 
-func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log logr.Logger, cluster *clusterv1.Cluster, awsMachine *infrav1.AWSMachine) (scope.EC2Scope, error) {
+func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log *logger.Logger, cluster *clusterv1.Cluster, awsMachine *infrav1.AWSMachine) (scope.EC2Scope, error) {
 	var clusterScope *scope.ClusterScope
 	var managedControlPlaneScope *scope.ManagedControlPlaneScope
 	var err error
@@ -931,7 +932,7 @@ func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log logr.Log
 
 		managedControlPlaneScope, err = scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
 			Client:         r.Client,
-			Logger:         &log,
+			Logger:         log,
 			Cluster:        cluster,
 			ControlPlane:   controlPlane,
 			ControllerName: "awsManagedControlPlane",
@@ -959,7 +960,7 @@ func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log logr.Log
 	// Create the cluster scope
 	clusterScope, err = scope.NewClusterScope(scope.ClusterScopeParams{
 		Client:         r.Client,
-		Logger:         &log,
+		Logger:         log,
 		Cluster:        cluster,
 		AWSCluster:     awsCluster,
 		ControllerName: "awsmachine",

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/mock_services"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -2028,7 +2029,7 @@ func TestAWSMachineReconciler_AWSClusterToAWSMachines(t *testing.T) {
 				g.Expect(testEnv.Cleanup(ctx, tc.awsCluster, ns)).To(Succeed())
 			})
 
-			requests := reconciler.AWSClusterToAWSMachines(klog.Background())(tc.awsCluster)
+			requests := reconciler.AWSClusterToAWSMachines(logger.NewLogger(klog.Background()))(tc.awsCluster)
 			if tc.requests != nil {
 				if len(tc.requests) > 0 {
 					tc.requests[0].Namespace = ns.Name
@@ -2064,7 +2065,7 @@ func TestAWSMachineReconciler_requeueAWSMachinesForUnpausedCluster(t *testing.T)
 				Client: testEnv.Client,
 				Log:    klog.Background(),
 			}
-			requests := reconciler.requeueAWSMachinesForUnpausedCluster(klog.Background())(tc.ownerCluster)
+			requests := reconciler.requeueAWSMachinesForUnpausedCluster(logger.NewLogger(klog.Background()))(tc.ownerCluster)
 			if tc.requests != nil {
 				g.Expect(requests).To(ConsistOf(tc.requests))
 			} else {

--- a/docs/book/src/topics/bring-your-own-aws-infrastructure.md
+++ b/docs/book/src/topics/bring-your-own-aws-infrastructure.md
@@ -184,7 +184,7 @@ c, err := ctrl.NewControllerManagedBy(mgr).
         For(&providerv1.InfraCluster{}).
         Watches(...).
         WithOptions(options).
-        WithEventFilter(predicates.ResourceIsNotExternallyManaged(ctrl.LoggerFrom(ctx))).
+        WithEventFilter(predicates.ResourceIsNotExternallyManaged(logger.FromContext(ctx))).
         Build(r)
 if err != nil {
 	return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/controllers/awsfargatepool_controller.go
+++ b/exp/controllers/awsfargatepool_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
@@ -37,6 +36,7 @@ import (
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/eks"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -54,11 +54,11 @@ type AWSFargateProfileReconciler struct {
 
 // SetupWithManager is used to setup the controller.
 func (r *AWSFargateProfileReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	managedControlPlaneToFargateProfileMap := managedControlPlaneToFargateProfileMapFunc(r.Client, ctrl.LoggerFrom(ctx))
+	managedControlPlaneToFargateProfileMap := managedControlPlaneToFargateProfileMapFunc(r.Client, logger.FromContext(ctx))
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&expinfrav1.AWSFargateProfile{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(logger.FromContext(ctx).GetLogger(), r.WatchFilterValue)).
 		Watches(
 			&source.Kind{Type: &ekscontrolplanev1.AWSManagedControlPlane{}},
 			handler.EnqueueRequestsFromMapFunc(managedControlPlaneToFargateProfileMap),
@@ -74,7 +74,7 @@ func (r *AWSFargateProfileReconciler) SetupWithManager(ctx context.Context, mgr 
 
 // Reconcile reconciles AWSFargateProfiles.
 func (r *AWSFargateProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	log := ctrl.LoggerFrom(ctx)
+	log := logger.FromContext(ctx)
 
 	fargateProfile := &expinfrav1.AWSFargateProfile{}
 	if err := r.Get(ctx, req.NamespacedName, fargateProfile); err != nil {
@@ -182,7 +182,7 @@ func (r *AWSFargateProfileReconciler) reconcileDelete(
 	return res, nil
 }
 
-func managedControlPlaneToFargateProfileMapFunc(c client.Client, log logr.Logger) handler.MapFunc {
+func managedControlPlaneToFargateProfileMapFunc(c client.Client, log logger.Wrapper) handler.MapFunc {
 	return func(o client.Object) []ctrl.Request {
 		ctx := context.Background()
 

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/mock_services"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -623,7 +624,7 @@ func TestASGNeedsUpdates(t *testing.T) {
 							},
 						},
 					},
-					Logger: logr.Discard(),
+					Logger: *logger.NewLogger(logr.Discard()),
 				},
 				existingASG: &expinfrav1.AutoScalingGroup{
 					DesiredCapacity:      pointer.Int32(1),
@@ -663,7 +664,7 @@ func TestASGNeedsUpdates(t *testing.T) {
 							},
 						},
 					},
-					Logger: logr.Discard(),
+					Logger: *logger.NewLogger(logr.Discard()),
 				},
 				existingASG: &expinfrav1.AutoScalingGroup{
 					DesiredCapacity:           pointer.Int32(1),

--- a/exp/instancestate/awsinstancestate_controller.go
+++ b/exp/instancestate/awsinstancestate_controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/controllers"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/instancestate"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -116,7 +117,7 @@ func (r *AwsInstanceStateReconciler) SetupWithManager(ctx context.Context, mgr c
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.AWSCluster{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(logger.FromContext(ctx).GetLogger(), r.WatchFilterValue)).
 		Complete(r)
 }
 

--- a/pkg/cloud/identity/identity.go
+++ b/pkg/cloud/identity/identity.go
@@ -27,10 +27,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 )
 
 // AWSPrincipalTypeProvider defines the interface for AWS Principal Type Provider.
@@ -79,7 +79,7 @@ func GetAssumeRoleCredentials(roleIdentityProvider *AWSRolePrincipalTypeProvider
 }
 
 // NewAWSRolePrincipalTypeProvider will create a new AWSRolePrincipalTypeProvider from an AWSClusterRoleIdentity.
-func NewAWSRolePrincipalTypeProvider(identity *infrav1.AWSClusterRoleIdentity, sourceProvider *AWSPrincipalTypeProvider, log logr.Logger) *AWSRolePrincipalTypeProvider {
+func NewAWSRolePrincipalTypeProvider(identity *infrav1.AWSClusterRoleIdentity, sourceProvider *AWSPrincipalTypeProvider, log logger.Wrapper) *AWSRolePrincipalTypeProvider {
 	return &AWSRolePrincipalTypeProvider{
 		credentials:    nil,
 		stsClient:      nil,
@@ -130,7 +130,7 @@ type AWSRolePrincipalTypeProvider struct {
 	Principal      *infrav1.AWSClusterRoleIdentity
 	credentials    *credentials.Credentials
 	sourceProvider *AWSPrincipalTypeProvider
-	log            logr.Logger
+	log            logger.Wrapper
 	stsClient      stsiface.STSAPI
 }
 

--- a/pkg/cloud/interfaces.go
+++ b/pkg/cloud/interfaces.go
@@ -18,11 +18,11 @@ package cloud
 
 import (
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
@@ -44,52 +44,9 @@ type ClusterObject interface {
 	conditions.Setter
 }
 
-// Logger represents the ability to log messages, both errors and not.
-type Logger interface {
-	// Enabled tests whether this Logger is enabled.  For example, commandline
-	// flags might be used to set the logging verbosity and disable some info
-	// logs.
-	Enabled() bool
-
-	// Info logs a non-error message with the given key/value pairs as context.
-	//
-	// The msg argument should be used to add some constant description to
-	// the log line.  The key/value pairs can then be used to add additional
-	// variable information.  The key/value pairs should alternate string
-	// keys and arbitrary values.
-	Info(msg string, keysAndValues ...interface{})
-
-	// Error logs an error, with the given message and key/value pairs as context.
-	// It functions similarly to calling Info with the "error" named value, but may
-	// have unique behavior, and should be preferred for logging errors (see the
-	// package documentations for more information).
-	//
-	// The msg field should be used to add context to any underlying error,
-	// while the err field should be used to attach the actual error that
-	// triggered this log line, if present.
-	Error(err error, msg string, keysAndValues ...interface{})
-
-	// V returns a Logger value for a specific verbosity level, relative to
-	// this Logger.  In other words, V values are additive.  V higher verbosity
-	// level means a log message is less important.  It's illegal to pass a log
-	// level less than zero.
-	V(level int) logr.Logger
-
-	// WithValues adds some key-value pairs of context to a logger.
-	// See Info for documentation on how key/value pairs work.
-	WithValues(keysAndValues ...interface{}) logr.Logger
-
-	// WithName adds a new element to the logger's name.
-	// Successive calls with WithName continue to append
-	// suffixes to the logger's name.  It's strongly recommended
-	// that name segments contain only letters, digits, and hyphens
-	// (see the package documentation for more information).
-	WithName(name string) logr.Logger
-}
-
 // ClusterScoper is the interface for a cluster scope.
 type ClusterScoper interface {
-	Logger
+	logger.Wrapper
 	Session
 	ScopeUsage
 
@@ -97,7 +54,7 @@ type ClusterScoper interface {
 	Name() string
 	// Namespace returns the cluster namespace.
 	Namespace() string
-	// AWSClusterName returns the AWS cluster name.
+	// InfraClusterName returns the AWS infrastructure cluster name.
 	InfraClusterName() string
 	// Region returns the cluster region.
 	Region() string

--- a/pkg/cloud/logs/logs.go
+++ b/pkg/cloud/logs/logs.go
@@ -18,8 +18,7 @@ package logs
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
+	"github.com/go-logr/logr"
 )
 
 const (
@@ -28,7 +27,7 @@ const (
 )
 
 // GetAWSLogLevel will return the log level of an AWS Logger.
-func GetAWSLogLevel(logger cloud.Logger) aws.LogLevelType {
+func GetAWSLogLevel(logger logr.Logger) aws.LogLevelType {
 	if logger.V(logWithHTTPBody).Enabled() {
 		return aws.LogDebugWithHTTPBody
 	}
@@ -41,14 +40,14 @@ func GetAWSLogLevel(logger cloud.Logger) aws.LogLevelType {
 }
 
 // NewWrapLogr will create an AWS Logger wrapper.
-func NewWrapLogr(logger cloud.Logger) aws.Logger {
+func NewWrapLogr(logger logr.Logger) aws.Logger {
 	return &logrWrapper{
 		log: logger,
 	}
 }
 
 type logrWrapper struct {
-	log cloud.Logger
+	log logr.Logger
 }
 
 func (l *logrWrapper) Log(msgs ...interface{}) {
@@ -58,6 +57,9 @@ func (l *logrWrapper) Log(msgs ...interface{}) {
 	case 1:
 		l.log.Info(msgs[0].(string))
 	default:
+		// Even the previous implementation had this problem but because it wasn't a direct
+		// logr.Logger thing, it didn't say this...
+		//nolint: logrlint
 		l.log.Info(msgs[0].(string), msgs[:1]...)
 	}
 }

--- a/pkg/cloud/scope/clients.go
+++ b/pkg/cloud/scope/clients.go
@@ -51,13 +51,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	awslogs "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/logs"
 	awsmetrics "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/metrics"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/record"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/version"
 )
 
 // NewASGClient creates a new ASG API client for a given session.
-func NewASGClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) autoscalingiface.AutoScalingAPI {
-	asgClient := autoscaling.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewASGClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) autoscalingiface.AutoScalingAPI {
+	asgClient := autoscaling.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	asgClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	asgClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
 	asgClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))
@@ -66,8 +67,8 @@ func NewASGClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger clou
 }
 
 // NewEC2Client creates a new EC2 API client for a given session.
-func NewEC2Client(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) ec2iface.EC2API {
-	ec2Client := ec2.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewEC2Client(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) ec2iface.EC2API {
+	ec2Client := ec2.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	ec2Client.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	if session.ServiceLimiter(ec2.ServiceID) != nil {
 		ec2Client.Handlers.Sign.PushFront(session.ServiceLimiter(ec2.ServiceID).LimitRequest)
@@ -82,8 +83,8 @@ func NewEC2Client(scopeUser cloud.ScopeUsage, session cloud.Session, logger clou
 }
 
 // NewELBClient creates a new ELB API client for a given session.
-func NewELBClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) elbiface.ELBAPI {
-	elbClient := elb.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewELBClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) elbiface.ELBAPI {
+	elbClient := elb.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	elbClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	elbClient.Handlers.Sign.PushFront(session.ServiceLimiter(elb.ServiceID).LimitRequest)
 	elbClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
@@ -94,8 +95,8 @@ func NewELBClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger clou
 }
 
 // NewELBv2Client creates a new ELB v2 API client for a given session.
-func NewELBv2Client(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) elbv2iface.ELBV2API {
-	elbClient := elbv2.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewELBv2Client(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) elbv2iface.ELBV2API {
+	elbClient := elbv2.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	elbClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	elbClient.Handlers.Sign.PushFront(session.ServiceLimiter(elbv2.ServiceID).LimitRequest)
 	elbClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
@@ -135,8 +136,8 @@ func NewGlobalSQSClient(scopeUser cloud.ScopeUsage, session cloud.Session) sqsif
 }
 
 // NewResourgeTaggingClient creates a new Resource Tagging API client for a given session.
-func NewResourgeTaggingClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI {
-	resourceTagging := resourcegroupstaggingapi.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewResourgeTaggingClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI {
+	resourceTagging := resourcegroupstaggingapi.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	resourceTagging.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	resourceTagging.Handlers.Sign.PushFront(session.ServiceLimiter(resourceTagging.ServiceID).LimitRequest)
 	resourceTagging.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
@@ -147,8 +148,8 @@ func NewResourgeTaggingClient(scopeUser cloud.ScopeUsage, session cloud.Session,
 }
 
 // NewSecretsManagerClient creates a new Secrets API client for a given session..
-func NewSecretsManagerClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) secretsmanageriface.SecretsManagerAPI {
-	secretsClient := secretsmanager.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewSecretsManagerClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) secretsmanageriface.SecretsManagerAPI {
+	secretsClient := secretsmanager.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	secretsClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	secretsClient.Handlers.Sign.PushFront(session.ServiceLimiter(secretsClient.ServiceID).LimitRequest)
 	secretsClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
@@ -159,8 +160,8 @@ func NewSecretsManagerClient(scopeUser cloud.ScopeUsage, session cloud.Session, 
 }
 
 // NewEKSClient creates a new EKS API client for a given session.
-func NewEKSClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) eksiface.EKSAPI {
-	eksClient := eks.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewEKSClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) eksiface.EKSAPI {
+	eksClient := eks.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	eksClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	eksClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
 	eksClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))
@@ -169,8 +170,8 @@ func NewEKSClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger clou
 }
 
 // NewIAMClient creates a new IAM API client for a given session.
-func NewIAMClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) iamiface.IAMAPI {
-	iamClient := iam.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewIAMClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) iamiface.IAMAPI {
+	iamClient := iam.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	iamClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	iamClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
 	iamClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))
@@ -179,8 +180,8 @@ func NewIAMClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger clou
 }
 
 // NewSTSClient creates a new STS API client for a given session.
-func NewSTSClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) stsiface.STSAPI {
-	stsClient := sts.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewSTSClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) stsiface.STSAPI {
+	stsClient := sts.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	stsClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	stsClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
 	stsClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))
@@ -189,8 +190,8 @@ func NewSTSClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger clou
 }
 
 // NewSSMClient creates a new Secrets API client for a given session.
-func NewSSMClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) ssmiface.SSMAPI {
-	ssmClient := ssm.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewSSMClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) ssmiface.SSMAPI {
+	ssmClient := ssm.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	ssmClient.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	ssmClient.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
 	ssmClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))
@@ -199,8 +200,8 @@ func NewSSMClient(scopeUser cloud.ScopeUsage, session cloud.Session, logger clou
 }
 
 // NewS3Client creates a new S3 API client for a given session.
-func NewS3Client(scopeUser cloud.ScopeUsage, session cloud.Session, logger cloud.Logger, target runtime.Object) s3iface.S3API {
-	s3Client := s3.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger)).WithLogger(awslogs.NewWrapLogr(logger)))
+func NewS3Client(scopeUser cloud.ScopeUsage, session cloud.Session, logger logger.Wrapper, target runtime.Object) s3iface.S3API {
+	s3Client := s3.New(session.Session(), aws.NewConfig().WithLogLevel(awslogs.GetAWSLogLevel(logger.GetLogger())).WithLogger(awslogs.NewWrapLogr(logger.GetLogger())))
 	s3Client.Handlers.Build.PushFrontNamed(getUserAgentHandler())
 	s3Client.Handlers.CompleteAttempt.PushFront(awsmetrics.CaptureRequestMetrics(scopeUser.ControllerName()))
 	s3Client.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))

--- a/pkg/cloud/scope/fargate.go
+++ b/pkg/cloud/scope/fargate.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +29,7 @@ import (
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -38,7 +38,7 @@ import (
 // FargateProfileScopeParams defines the input parameters used to create a new Scope.
 type FargateProfileScopeParams struct {
 	Client         client.Client
-	Logger         *logr.Logger
+	Logger         *logger.Logger
 	Cluster        *clusterv1.Cluster
 	ControlPlane   *ekscontrolplanev1.AWSManagedControlPlane
 	FargateProfile *expinfrav1.AWSFargateProfile
@@ -57,7 +57,7 @@ func NewFargateProfileScope(params FargateProfileScopeParams) (*FargateProfileSc
 	}
 	if params.Logger == nil {
 		log := klog.Background()
-		params.Logger = &log
+		params.Logger = logger.NewLogger(log)
 	}
 
 	managedScope := &ManagedControlPlaneScope{
@@ -68,7 +68,7 @@ func NewFargateProfileScope(params FargateProfileScopeParams) (*FargateProfileSc
 		controllerName: params.ControllerName,
 	}
 
-	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, managedScope, params.ControlPlane.Spec.Region, params.Endpoints, *params.Logger)
+	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, managedScope, params.ControlPlane.Spec.Region, params.Endpoints, params.Logger)
 	if err != nil {
 		return nil, errors.Errorf("failed to create aws session: %v", err)
 	}
@@ -94,7 +94,7 @@ func NewFargateProfileScope(params FargateProfileScopeParams) (*FargateProfileSc
 
 // FargateProfileScope defines the basic context for an actuator to operate upon.
 type FargateProfileScope struct {
-	logr.Logger
+	logger.Logger
 	Client      client.Client
 	patchHelper *patch.Helper
 

--- a/pkg/cloud/scope/launchtemplate.go
+++ b/pkg/cloud/scope/launchtemplate.go
@@ -22,7 +22,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
@@ -47,7 +47,7 @@ type LaunchTemplateScope interface {
 	GetEC2Scope() EC2Scope
 
 	client.Client
-	cloud.Logger
+	logger.Wrapper
 }
 
 type ResourceServiceToUpdate struct {

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,6 +30,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -43,7 +43,7 @@ import (
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
 type MachineScopeParams struct {
 	Client       client.Client
-	Logger       *logr.Logger
+	Logger       *logger.Logger
 	Cluster      *clusterv1.Cluster
 	Machine      *clusterv1.Machine
 	InfraCluster EC2Scope
@@ -71,7 +71,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 
 	if params.Logger == nil {
 		log := klog.Background()
-		params.Logger = &log
+		params.Logger = logger.NewLogger(log)
 	}
 
 	helper, err := patch.NewHelper(params.AWSMachine, params.Client)
@@ -92,7 +92,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 
 // MachineScope defines a scope defined around a machine and its cluster.
 type MachineScope struct {
-	logr.Logger
+	logger.Logger
 	client      client.Client
 	patchHelper *patch.Helper
 

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +33,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -45,7 +45,7 @@ import (
 
 // MachinePoolScope defines a scope defined around a machine and its cluster.
 type MachinePoolScope struct {
-	logr.Logger
+	logger.Logger
 	client.Client
 	patchHelper *patch.Helper
 
@@ -58,7 +58,7 @@ type MachinePoolScope struct {
 // MachinePoolScopeParams defines a scope defined around a machine and its cluster.
 type MachinePoolScopeParams struct {
 	client.Client
-	Logger *logr.Logger
+	Logger *logger.Logger
 
 	Cluster        *clusterv1.Cluster
 	MachinePool    *expclusterv1.MachinePool
@@ -95,7 +95,7 @@ func NewMachinePoolScope(params MachinePoolScopeParams) (*MachinePoolScope, erro
 
 	if params.Logger == nil {
 		log := klog.Background()
-		params.Logger = &log
+		params.Logger = logger.NewLogger(log)
 	}
 
 	helper, err := patch.NewHelper(params.AWSMachinePool, params.Client)

--- a/pkg/cloud/scope/managednodegroup.go
+++ b/pkg/cloud/scope/managednodegroup.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +34,7 @@ import (
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -44,7 +44,7 @@ import (
 // ManagedMachinePoolScopeParams defines the input parameters used to create a new Scope.
 type ManagedMachinePoolScopeParams struct {
 	Client             client.Client
-	Logger             *logr.Logger
+	Logger             *logger.Logger
 	Cluster            *clusterv1.Cluster
 	ControlPlane       *ekscontrolplanev1.AWSManagedControlPlane
 	ManagedMachinePool *expinfrav1.AWSManagedMachinePool
@@ -73,7 +73,7 @@ func NewManagedMachinePoolScope(params ManagedMachinePoolScopeParams) (*ManagedM
 	}
 	if params.Logger == nil {
 		log := klog.Background()
-		params.Logger = &log
+		params.Logger = logger.NewLogger(log)
 	}
 
 	managedScope := &ManagedControlPlaneScope{
@@ -83,7 +83,7 @@ func NewManagedMachinePoolScope(params ManagedMachinePoolScopeParams) (*ManagedM
 		ControlPlane:   params.ControlPlane,
 		controllerName: params.ControllerName,
 	}
-	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, managedScope, params.ControlPlane.Spec.Region, params.Endpoints, *params.Logger)
+	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, managedScope, params.ControlPlane.Spec.Region, params.Endpoints, params.Logger)
 	if err != nil {
 		return nil, errors.Errorf("failed to create aws session: %v", err)
 	}
@@ -112,7 +112,7 @@ func NewManagedMachinePoolScope(params ManagedMachinePoolScopeParams) (*ManagedM
 
 // ManagedMachinePoolScope defines the basic context for an actuator to operate upon.
 type ManagedMachinePoolScope struct {
-	logr.Logger
+	logger.Logger
 	client.Client
 	patchHelper *patch.Helper
 

--- a/pkg/cloud/scope/session.go
+++ b/pkg/cloud/scope/session.go
@@ -30,7 +30,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +40,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/identity"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/throttle"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/util/system"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -104,9 +104,9 @@ func sessionForRegion(region string, endpoint []ServiceEndpoint) (*session.Sessi
 	return ns, sl, nil
 }
 
-func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.ClusterScoper, region string, endpoint []ServiceEndpoint, logger logr.Logger) (*session.Session, throttle.ServiceLimiters, error) {
-	log := logger.WithName("identity")
-	log.V(4).Info("Creating an AWS Session")
+func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.ClusterScoper, region string, endpoint []ServiceEndpoint, log logger.Wrapper) (*session.Session, throttle.ServiceLimiters, error) {
+	log = log.WithName("identity")
+	log.Trace("Creating an AWS Session")
 
 	resolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		for _, s := range endpoint {
@@ -140,7 +140,7 @@ func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.Cl
 			provider = cachedProvider.(identity.AWSPrincipalTypeProvider)
 		} else {
 			isChanged = true
-			// add this providers to the cache
+			// add this provider to the cache
 			providerCache.Store(providerHash, provider)
 		}
 		awsProviders[i] = provider.(credentials.Provider)
@@ -252,16 +252,16 @@ func buildProvidersForRef(
 	k8sClient client.Client,
 	clusterScoper cloud.ClusterScoper,
 	ref *infrav1.AWSIdentityReference,
-	log logr.Logger) ([]identity.AWSPrincipalTypeProvider, error) {
+	log logger.Wrapper) ([]identity.AWSPrincipalTypeProvider, error) {
 	if ref == nil {
-		log.V(4).Info("AWSCluster does not have a IdentityRef specified")
+		log.Trace("AWSCluster does not have a IdentityRef specified")
 		return providers, nil
 	}
 
 	var provider identity.AWSPrincipalTypeProvider
 	identityObjectKey := client.ObjectKey{Name: ref.Name}
 	log = log.WithValues("identityKey", identityObjectKey)
-	log.V(4).Info("Getting identity")
+	log.Trace("Getting identity")
 
 	switch ref.Kind {
 	case infrav1.ControllerIdentityKind:
@@ -283,7 +283,7 @@ func buildProvidersForRef(
 		if err != nil {
 			return providers, err
 		}
-		log.V(4).Info("Principal retrieved")
+		log.Trace("Principal retrieved")
 		canUse, err := isClusterPermittedToUsePrincipal(k8sClient, roleIdentity.Spec.AllowedNamespaces, clusterScoper.Namespace())
 		if err != nil {
 			return providers, err
@@ -404,7 +404,7 @@ func buildAWSClusterControllerIdentity(ctx context.Context, identityObjectKey cl
 	return nil
 }
 
-func getProvidersForCluster(ctx context.Context, k8sClient client.Client, clusterScoper cloud.ClusterScoper, log logr.Logger) ([]identity.AWSPrincipalTypeProvider, error) {
+func getProvidersForCluster(ctx context.Context, k8sClient client.Client, clusterScoper cloud.ClusterScoper, log logger.Wrapper) ([]identity.AWSPrincipalTypeProvider, error) {
 	providers := make([]identity.AWSPrincipalTypeProvider, 0)
 	providers, err := buildProvidersForRef(ctx, providers, k8sClient, clusterScoper, clusterScoper.IdentityRef(), log)
 	if err != nil {

--- a/pkg/cloud/scope/session_test.go
+++ b/pkg/cloud/scope/session_test.go
@@ -32,6 +32,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/identity"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/util/system"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -488,7 +489,7 @@ func TestPrincipalParsing(t *testing.T) {
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			tc.setup(t, k8sClient)
 			clusterScope.AWSCluster = &tc.awsCluster
-			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope, klog.Background())
+			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope, logger.NewLogger(klog.Background()))
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected an error but didn't get one")

--- a/pkg/cloud/scope/shared_test.go
+++ b/pkg/cloud/scope/shared_test.go
@@ -19,11 +19,11 @@ package scope
 import (
 	"testing"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	"k8s.io/klog/v2"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 )
 
 func TestSubnetPlacement(t *testing.T) {
@@ -33,7 +33,7 @@ func TestSubnetPlacement(t *testing.T) {
 		specAZs             []string
 		parentAZs           []string
 		controlPlaneSubnets infrav1.Subnets
-		logger              logr.Logger
+		logger              *logger.Logger
 		expectedSubnetIDs   []string
 		expectError         bool
 	}{
@@ -56,7 +56,7 @@ func TestSubnetPlacement(t *testing.T) {
 					AvailabilityZone: "eu-west-1c",
 				},
 			},
-			logger:            klog.Background(),
+			logger:            logger.NewLogger(klog.Background()),
 			expectedSubnetIDs: []string{"az1"},
 			expectError:       false,
 		},
@@ -79,7 +79,7 @@ func TestSubnetPlacement(t *testing.T) {
 					AvailabilityZone: "eu-west-1c",
 				},
 			},
-			logger:            klog.Background(),
+			logger:            logger.NewLogger(klog.Background()),
 			expectedSubnetIDs: []string{"az2"},
 			expectError:       false,
 		},
@@ -102,7 +102,7 @@ func TestSubnetPlacement(t *testing.T) {
 					AvailabilityZone: "eu-west-1c",
 				},
 			},
-			logger:            klog.Background(),
+			logger:            logger.NewLogger(klog.Background()),
 			expectedSubnetIDs: []string{"az3"},
 			expectError:       false,
 		},
@@ -128,7 +128,7 @@ func TestSubnetPlacement(t *testing.T) {
 					IsPublic:         true,
 				},
 			},
-			logger:            klog.Background(),
+			logger:            logger.NewLogger(klog.Background()),
 			expectedSubnetIDs: []string{"az1", "az2"},
 			expectError:       false,
 		},
@@ -138,7 +138,7 @@ func TestSubnetPlacement(t *testing.T) {
 			specAZs:             []string{},
 			parentAZs:           []string{},
 			controlPlaneSubnets: infrav1.Subnets{},
-			logger:              klog.Background(),
+			logger:              logger.NewLogger(klog.Background()),
 			expectedSubnetIDs:   []string{},
 			expectError:         true,
 		},
@@ -148,7 +148,7 @@ func TestSubnetPlacement(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			strategy, err := newDefaultSubnetPlacementStrategy(&tc.logger)
+			strategy, err := newDefaultSubnetPlacementStrategy(tc.logger)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			actualSubnetIDs, err := strategy.Place(&placementInput{

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -129,7 +129,7 @@ func (s *Service) ASGIfExists(name *string) (*expinfrav1.AutoScalingGroup, error
 
 // GetASGByName returns the existing ASG or nothing if it doesn't exist.
 func (s *Service) GetASGByName(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error) {
-	s.scope.V(2).Info("Looking for existing AutoScalingGroup by name")
+	s.scope.Debug("Looking for existing AutoScalingGroup by name")
 
 	input := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{
@@ -245,7 +245,7 @@ func (s *Service) DeleteASGAndWait(name string) error {
 		return err
 	}
 
-	s.scope.V(2).Info("Waiting for ASG to be deleted", "name", name)
+	s.scope.Debug("Waiting for ASG to be deleted", "name", name)
 
 	input := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: aws.StringSlice([]string{name}),
@@ -260,7 +260,7 @@ func (s *Service) DeleteASGAndWait(name string) error {
 
 // DeleteASG will delete the ASG of a service.
 func (s *Service) DeleteASG(name string) error {
-	s.scope.V(2).Info("Attempting to delete ASG", "name", name)
+	s.scope.Debug("Attempting to delete ASG", "name", name)
 
 	input := &autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(name),
@@ -271,7 +271,7 @@ func (s *Service) DeleteASG(name string) error {
 		return errors.Wrapf(err, "failed to delete ASG %q", name)
 	}
 
-	s.scope.V(2).Info("Deleted ASG", "name", name)
+	s.scope.Debug("Deleted ASG", "name", name)
 	return nil
 }
 
@@ -419,12 +419,12 @@ func BuildTagsFromMap(asgName string, inTags map[string]string) []*autoscaling.T
 // We may not always have to perform each action, so we check what we're
 // receiving to avoid calling AWS if we don't need to.
 func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[string]string) error {
-	s.scope.V(2).Info("Attempting to update tags on resource", "resource-id", *resourceID)
+	s.scope.Debug("Attempting to update tags on resource", "resource-id", *resourceID)
 	s.scope.Info("updating tags on resource", "resource-id", *resourceID, "create", create, "remove", remove)
 
 	// If we have anything to create or update
 	if len(create) > 0 {
-		s.scope.V(2).Info("Attempting to create tags on resource", "resource-id", *resourceID)
+		s.scope.Debug("Attempting to create tags on resource", "resource-id", *resourceID)
 
 		createOrUpdateTagsInput := &autoscaling.CreateOrUpdateTagsInput{}
 
@@ -437,7 +437,7 @@ func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[stri
 
 	// If we have anything to remove
 	if len(remove) > 0 {
-		s.scope.V(2).Info("Attempting to delete tags on resource", "resource-id", *resourceID)
+		s.scope.Debug("Attempting to delete tags on resource", "resource-id", *resourceID)
 
 		// Convert our remove map into an array of *ec2.Tag
 		removeTagsInput := mapToTags(remove, resourceID)

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -296,7 +296,7 @@ func (s *Service) deleteResource(ctx context.Context, remoteClient client.Client
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("deleting resource %s: %w", key, err)
 		}
-		s.scope.V(2).Info(fmt.Sprintf("resource %s was not found, no action", key))
+		s.scope.Debug(fmt.Sprintf("resource %s was not found, no action", key))
 	} else {
 		// resource found, delete if no label or not managed by helm
 		if val, ok := obj.GetLabels()[konfig.ManagedbyLabelKey]; !ok || val != "Helm" {
@@ -304,13 +304,13 @@ func (s *Service) deleteResource(ctx context.Context, remoteClient client.Client
 				if !apierrors.IsNotFound(err) {
 					return fmt.Errorf("deleting %s: %w", key, err)
 				}
-				s.scope.V(2).Info(fmt.Sprintf(
+				s.scope.Debug(fmt.Sprintf(
 					"resource %s was not found, not deleted", key))
 			} else {
-				s.scope.V(2).Info(fmt.Sprintf("resource %s was deleted", key))
+				s.scope.Debug(fmt.Sprintf("resource %s was deleted", key))
 			}
 		} else {
-			s.scope.V(2).Info(fmt.Sprintf("resource %s is managed by helm, not deleted", key))
+			s.scope.Debug(fmt.Sprintf("resource %s is managed by helm, not deleted", key))
 		}
 	}
 

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -158,7 +158,7 @@ func (s *Service) defaultAMIIDLookup(amiNameFormat, ownerID, baseOS, kubernetesV
 		return "", errors.Wrapf(err, "failed to find ami")
 	}
 
-	s.scope.V(2).Info("Found and using an existing AMI", "ami-id", aws.StringValue(latestImage.ImageId))
+	s.scope.Debug("Found and using an existing AMI", "ami-id", aws.StringValue(latestImage.ImageId))
 	return aws.StringValue(latestImage.ImageId), nil
 }
 

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -46,7 +46,7 @@ var (
 // ReconcileBastion ensures a bastion is created for the cluster.
 func (s *Service) ReconcileBastion() error {
 	if !s.scope.Bastion().Enabled {
-		s.scope.V(4).Info("Skipping bastion reconcile")
+		s.scope.Trace("Skipping bastion reconcile")
 		_, err := s.describeBastionInstance()
 		if err != nil {
 			if awserrors.IsNotFound(err) {
@@ -57,11 +57,11 @@ func (s *Service) ReconcileBastion() error {
 		return s.DeleteBastion()
 	}
 
-	s.scope.V(2).Info("Reconciling bastion host")
+	s.scope.Debug("Reconciling bastion host")
 
 	subnets := s.scope.Subnets()
 	if len(subnets.FilterPrivate()) == 0 {
-		s.scope.V(2).Info("No private subnets available, skipping bastion host")
+		s.scope.Debug("No private subnets available, skipping bastion host")
 		return nil
 	} else if len(subnets.FilterPublic()) == 0 {
 		return errors.New("failed to reconcile bastion host, no public subnets are available")
@@ -97,7 +97,7 @@ func (s *Service) ReconcileBastion() error {
 
 	s.scope.SetBastionInstance(instance.DeepCopy())
 	conditions.MarkTrue(s.scope.InfraCluster(), infrav1.BastionHostReadyCondition)
-	s.scope.V(2).Info("Reconcile bastion completed successfully")
+	s.scope.Debug("Reconcile bastion completed successfully")
 
 	return nil
 }
@@ -107,7 +107,7 @@ func (s *Service) DeleteBastion() error {
 	instance, err := s.describeBastionInstance()
 	if err != nil {
 		if awserrors.IsNotFound(err) {
-			s.scope.V(4).Info("bastion instance does not exist")
+			s.scope.Trace("bastion instance does not exist")
 			return nil
 		}
 		return errors.Wrap(err, "unable to describe bastion instance")

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -44,7 +44,7 @@ import (
 
 // GetRunningInstanceByTags returns the existing instance or nothing if it doesn't exist.
 func (s *Service) GetRunningInstanceByTags(scope *scope.MachineScope) (*infrav1.Instance, error) {
-	s.scope.V(2).Info("Looking for existing machine instance by tags")
+	s.scope.Debug("Looking for existing machine instance by tags")
 
 	input := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
@@ -84,7 +84,7 @@ func (s *Service) InstanceIfExists(id *string) (*infrav1.Instance, error) {
 		return nil, nil
 	}
 
-	s.scope.V(2).Info("Looking for instance by id", "instance-id", *id)
+	s.scope.Debug("Looking for instance by id", "instance-id", *id)
 
 	input := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{id},
@@ -111,7 +111,7 @@ func (s *Service) InstanceIfExists(id *string) (*infrav1.Instance, error) {
 
 // CreateInstance runs an ec2 instance.
 func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, userDataFormat string) (*infrav1.Instance, error) {
-	s.scope.V(2).Info("Creating an instance for a machine")
+	s.scope.Debug("Creating an instance for a machine")
 
 	input := &infrav1.Instance{
 		Type:              scope.AWSMachine.Spec.InstanceType,
@@ -229,7 +229,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, use
 
 	input.Tenancy = scope.AWSMachine.Spec.Tenancy
 
-	s.scope.V(2).Info("Running instance", "machine-role", scope.Role())
+	s.scope.Debug("Running instance", "machine-role", scope.Role())
 	out, err := s.runInstance(scope.Role(), input)
 	if err != nil {
 		// Only record the failure event if the error is not related to failed dependencies.
@@ -242,7 +242,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, use
 
 	if len(input.NetworkInterfaces) > 0 {
 		for _, id := range input.NetworkInterfaces {
-			s.scope.V(2).Info("Attaching security groups to provided network interface", "groups", input.SecurityGroupIDs, "interface", id)
+			s.scope.Debug("Attaching security groups to provided network interface", "groups", input.SecurityGroupIDs, "interface", id)
 			if err := s.attachSecurityGroupsToNetworkInterface(input.SecurityGroupIDs, id); err != nil {
 				return nil, err
 			}
@@ -436,7 +436,7 @@ func (s *Service) GetCoreNodeSecurityGroups(scope scope.LaunchTemplateScope) ([]
 // TerminateInstance terminates an EC2 instance.
 // Returns nil on success, error in all other cases.
 func (s *Service) TerminateInstance(instanceID string) error {
-	s.scope.V(2).Info("Attempting to terminate instance", "instance-id", instanceID)
+	s.scope.Debug("Attempting to terminate instance", "instance-id", instanceID)
 
 	input := &ec2.TerminateInstancesInput{
 		InstanceIds: aws.StringSlice([]string{instanceID}),
@@ -446,7 +446,7 @@ func (s *Service) TerminateInstance(instanceID string) error {
 		return errors.Wrapf(err, "failed to terminate instance with id %q", instanceID)
 	}
 
-	s.scope.V(2).Info("Terminated instance", "instance-id", instanceID)
+	s.scope.Debug("Terminated instance", "instance-id", instanceID)
 	return nil
 }
 
@@ -457,7 +457,7 @@ func (s *Service) TerminateInstanceAndWait(instanceID string) error {
 		return err
 	}
 
-	s.scope.V(2).Info("Waiting for EC2 instance to terminate", "instance-id", instanceID)
+	s.scope.Debug("Waiting for EC2 instance to terminate", "instance-id", instanceID)
 
 	input := &ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice([]string{instanceID}),
@@ -481,7 +481,7 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 		UserData:     i.UserData,
 	}
 
-	s.scope.V(2).Info("userData size", "bytes", len(*i.UserData), "role", role)
+	s.scope.Debug("userData size", "bytes", len(*i.UserData), "role", role)
 
 	if len(i.NetworkInterfaces) > 0 {
 		netInterfaces := make([]*ec2.InstanceNetworkInterfaceSpecification, 0, len(i.NetworkInterfaces))
@@ -572,16 +572,16 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 	}
 
 	waitTimeout := 1 * time.Minute
-	s.scope.V(2).Info("Waiting for instance to be in running state", "instance-id", *out.Instances[0].InstanceId, "timeout", waitTimeout.String())
+	s.scope.Debug("Waiting for instance to be in running state", "instance-id", *out.Instances[0].InstanceId, "timeout", waitTimeout.String())
 	ctx, cancel := context.WithTimeout(aws.BackgroundContext(), waitTimeout)
 	defer cancel()
 
 	if err := s.EC2Client.WaitUntilInstanceRunningWithContext(
 		ctx,
 		&ec2.DescribeInstancesInput{InstanceIds: []*string{out.Instances[0].InstanceId}},
-		request.WithWaiterLogger(awslogs.NewWrapLogr(s.scope)),
+		request.WithWaiterLogger(awslogs.NewWrapLogr(s.scope.GetLogger())),
 	); err != nil {
-		s.scope.V(2).Info("Could not determine if Machine is running. Machine state might be unavailable until next renconciliation.")
+		s.scope.Debug("Could not determine if Machine is running. Machine state might be unavailable until next renconciliation.")
 	}
 
 	return s.SDKToInstance(out.Instances[0])
@@ -639,14 +639,14 @@ func (s *Service) GetInstanceSecurityGroups(instanceID string) (map[string][]str
 // UpdateInstanceSecurityGroups modifies the security groups of the given
 // EC2 instance.
 func (s *Service) UpdateInstanceSecurityGroups(instanceID string, ids []string) error {
-	s.scope.V(2).Info("Attempting to update security groups on instance", "instance-id", instanceID)
+	s.scope.Debug("Attempting to update security groups on instance", "instance-id", instanceID)
 
 	enis, err := s.getInstanceENIs(instanceID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get ENIs for instance %q", instanceID)
 	}
 
-	s.scope.V(3).Info("Found ENIs on instance", "number-of-enis", len(enis), "instance-id", instanceID)
+	s.scope.Debug("Found ENIs on instance", "number-of-enis", len(enis), "instance-id", instanceID)
 
 	for _, eni := range enis {
 		if err := s.attachSecurityGroupsToNetworkInterface(ids, aws.StringValue(eni.NetworkInterfaceId)); err != nil {
@@ -662,11 +662,11 @@ func (s *Service) UpdateInstanceSecurityGroups(instanceID string, ids []string) 
 // We may not always have to perform each action, so we check what we're
 // receiving to avoid calling AWS if we don't need to.
 func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[string]string) error {
-	s.scope.V(2).Info("Attempting to update tags on resource", "resource-id", *resourceID)
+	s.scope.Debug("Attempting to update tags on resource", "resource-id", *resourceID)
 
 	// If we have anything to create or update
 	if len(create) > 0 {
-		s.scope.V(2).Info("Attempting to create tags on resource", "resource-id", *resourceID)
+		s.scope.Debug("Attempting to create tags on resource", "resource-id", *resourceID)
 
 		// Convert our create map into an array of *ec2.Tag
 		createTagsInput := converters.MapToTags(create)
@@ -685,7 +685,7 @@ func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[stri
 
 	// If we have anything to remove
 	if len(remove) > 0 {
-		s.scope.V(2).Info("Attempting to delete tags on resource", "resource-id", *resourceID)
+		s.scope.Debug("Attempting to delete tags on resource", "resource-id", *resourceID)
 
 		// Convert our remove map into an array of *ec2.Tag
 		removeTagsInput := converters.MapToTags(remove)

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -327,7 +327,7 @@ func (s *Service) GetLaunchTemplate(launchTemplateName string) (*expinfrav1.AWSL
 		return nil, "", nil
 	}
 
-	s.scope.V(2).Info("Looking for existing LaunchTemplates")
+	s.scope.Debug("Looking for existing LaunchTemplates")
 
 	input := &ec2.DescribeLaunchTemplateVersionsInput{
 		LaunchTemplateName: aws.String(launchTemplateName),
@@ -422,7 +422,7 @@ func (s *Service) CreateLaunchTemplate(scope scope.LaunchTemplateScope, imageID 
 
 // CreateLaunchTemplateVersion will create a launch template.
 func (s *Service) CreateLaunchTemplateVersion(id string, scope scope.LaunchTemplateScope, imageID *string, userData []byte) error {
-	s.scope.V(2).Info("creating new launch template version", "machine-pool", scope.LaunchTemplateName())
+	s.scope.Debug("creating new launch template version", "machine-pool", scope.LaunchTemplateName())
 
 	launchTemplateData, err := s.createLaunchTemplateData(scope, imageID, userData)
 	if err != nil {
@@ -547,7 +547,7 @@ func volumeToLaunchTemplateBlockDeviceMappingRequest(v *infrav1.Volume) *ec2.Lau
 
 // DeleteLaunchTemplate delete a launch template.
 func (s *Service) DeleteLaunchTemplate(id string) error {
-	s.scope.V(2).Info("Deleting launch template", "id", id)
+	s.scope.Debug("Deleting launch template", "id", id)
 
 	input := &ec2.DeleteLaunchTemplateInput{
 		LaunchTemplateId: aws.String(id),
@@ -557,7 +557,7 @@ func (s *Service) DeleteLaunchTemplate(id string) error {
 		return errors.Wrapf(err, "failed to delete launch template %q", id)
 	}
 
-	s.scope.V(2).Info("Deleted launch template", "id", id)
+	s.scope.Debug("Deleted launch template", "id", id)
 	return nil
 }
 
@@ -616,7 +616,7 @@ func (s *Service) GetLaunchTemplateLatestVersion(id string) (string, error) {
 }
 
 func (s *Service) deleteLaunchTemplateVersion(id string, version *int64) error {
-	s.scope.V(2).Info("Deleting launch template version", "id", id)
+	s.scope.Debug("Deleting launch template version", "id", id)
 
 	if version == nil {
 		return errors.New("version is a nil pointer")
@@ -633,7 +633,7 @@ func (s *Service) deleteLaunchTemplateVersion(id string, version *int64) error {
 		return err
 	}
 
-	s.scope.V(2).Info("Deleted launch template", "id", id, "version", *version)
+	s.scope.Debug("Deleted launch template", "id", id, "version", *version)
 	return nil
 }
 

--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -43,7 +43,7 @@ func (s *Service) reconcileAddons(ctx context.Context) error {
 	}
 
 	// Get installed addons for the cluster
-	s.scope.V(2).Info("getting installed eks addons", "cluster", eksClusterName)
+	s.scope.Debug("getting installed eks addons", "cluster", eksClusterName)
 	installed, err := s.getClusterAddonsInstalled(eksClusterName, addonNames)
 	if err != nil {
 		return fmt.Errorf("getting installed eks addons: %w", err)
@@ -59,18 +59,18 @@ func (s *Service) reconcileAddons(ctx context.Context) error {
 	}
 
 	//  Compute operations to move installed to desired
-	s.scope.V(2).Info("creating eks addons plan", "cluster", eksClusterName, "numdesired", len(desiredAddons), "numinstalled", len(installed))
+	s.scope.Debug("creating eks addons plan", "cluster", eksClusterName, "numdesired", len(desiredAddons), "numinstalled", len(installed))
 	addonsPlan := eksaddons.NewPlan(eksClusterName, desiredAddons, installed, s.EKSClient)
 	procedures, err := addonsPlan.Create(ctx)
 	if err != nil {
 		s.scope.Error(err, "failed creating eks addons plane")
 		return fmt.Errorf("creating eks addons plan: %w", err)
 	}
-	s.scope.V(2).Info("computed EKS addons plan", "numprocs", len(procedures))
+	s.scope.Debug("computed EKS addons plan", "numprocs", len(procedures))
 
 	// Perform required operations
 	for _, procedure := range procedures {
-		s.scope.V(2).Info("Executing addon procedure", "name", procedure.Name())
+		s.scope.Debug("Executing addon procedure", "name", procedure.Name())
 		if err := procedure.Do(ctx); err != nil {
 			s.scope.Error(err, "failed executing addon procedure", "name", procedure.Name())
 			return fmt.Errorf("%s: %w", procedure.Name(), err)
@@ -80,7 +80,7 @@ func (s *Service) reconcileAddons(ctx context.Context) error {
 	// Update status with addons installed details
 	// Note: we are not relying on the computed state from the operations as we still want
 	// to update the state even if there are no operations to capture things like status changes
-	s.scope.V(2).Info("getting installed eks addons to update status", "cluster", eksClusterName)
+	s.scope.Debug("getting installed eks addons to update status", "cluster", eksClusterName)
 	addonState, err := s.getInstalledState(eksClusterName, addonNames)
 	if err != nil {
 		return fmt.Errorf("getting installed state of eks addons: %w", err)
@@ -92,13 +92,13 @@ func (s *Service) reconcileAddons(ctx context.Context) error {
 		return fmt.Errorf("failed to update control plane: %w", err)
 	}
 	record.Eventf(s.scope.ControlPlane, "SuccessfulReconcileEKSClusterAddons", "Reconciled addons for EKS Cluster %s", s.scope.KubernetesClusterName())
-	s.scope.V(2).Info("Reconcile EKS addons completed successfully")
+	s.scope.Debug("Reconcile EKS addons completed successfully")
 
 	return nil
 }
 
 func (s *Service) getClusterAddonsInstalled(eksClusterName string, addonNames []*string) ([]*eksaddons.EKSAddon, error) {
-	s.V(2).Info("getting eks addons installed")
+	s.Debug("getting eks addons installed")
 
 	addonsInstalled := []*eksaddons.EKSAddon{}
 	if len(addonNames) == 0 {
@@ -119,7 +119,7 @@ func (s *Service) getClusterAddonsInstalled(eksClusterName string, addonNames []
 		if describeOutput.Addon == nil {
 			continue
 		}
-		s.scope.V(2).Info("describe output", "output", describeOutput.Addon)
+		s.scope.Debug("describe output", "output", describeOutput.Addon)
 
 		installedAddon := &eksaddons.EKSAddon{
 			Name:                  describeOutput.Addon.AddonName,
@@ -140,7 +140,7 @@ func (s *Service) getClusterAddonsInstalled(eksClusterName string, addonNames []
 }
 
 func (s *Service) getInstalledState(eksClusterName string, addonNames []*string) ([]ekscontrolplanev1.AddonState, error) {
-	s.V(2).Info("getting eks addons installed to create state")
+	s.Debug("getting eks addons installed to create state")
 
 	addonState := []ekscontrolplanev1.AddonState{}
 	if len(addonNames) == 0 {
@@ -161,7 +161,7 @@ func (s *Service) getInstalledState(eksClusterName string, addonNames []*string)
 		if describeOutput.Addon == nil {
 			continue
 		}
-		s.scope.V(2).Info("describe output", "output", describeOutput.Addon)
+		s.scope.Debug("describe output", "output", describeOutput.Addon)
 
 		installedAddonState := converters.AddonSDKToAddonState(describeOutput.Addon)
 		addonState = append(addonState, *installedAddonState)
@@ -171,7 +171,7 @@ func (s *Service) getInstalledState(eksClusterName string, addonNames []*string)
 }
 
 func (s *Service) listAddons(eksClusterName string) ([]*string, error) {
-	s.V(2).Info("getting list of eks addons")
+	s.Debug("getting list of eks addons")
 
 	input := &eks.ListAddonsInput{
 		ClusterName: &eksClusterName,

--- a/pkg/cloud/services/eks/config.go
+++ b/pkg/cloud/services/eks/config.go
@@ -45,7 +45,7 @@ const (
 )
 
 func (s *Service) reconcileKubeconfig(ctx context.Context, cluster *eks.Cluster) error {
-	s.scope.V(2).Info("Reconciling EKS kubeconfigs for cluster", "cluster-name", s.scope.KubernetesClusterName())
+	s.scope.Debug("Reconciling EKS kubeconfigs for cluster", "cluster-name", s.scope.KubernetesClusterName())
 
 	clusterRef := types.NamespacedName{
 		Name:      s.scope.Cluster.Name,
@@ -77,7 +77,7 @@ func (s *Service) reconcileKubeconfig(ctx context.Context, cluster *eks.Cluster)
 }
 
 func (s *Service) reconcileAdditionalKubeconfigs(ctx context.Context, cluster *eks.Cluster) error {
-	s.scope.V(2).Info("Reconciling additional EKS kubeconfigs for cluster", "cluster-name", s.scope.KubernetesClusterName())
+	s.scope.Debug("Reconciling additional EKS kubeconfigs for cluster", "cluster-name", s.scope.KubernetesClusterName())
 
 	clusterRef := types.NamespacedName{
 		Name:      s.scope.Cluster.Name + "-user",
@@ -141,7 +141,7 @@ func (s *Service) createCAPIKubeconfigSecret(ctx context.Context, cluster *eks.C
 }
 
 func (s *Service) updateCAPIKubeconfigSecret(ctx context.Context, configSecret *corev1.Secret, cluster *eks.Cluster) error {
-	s.scope.V(2).Info("Updating EKS kubeconfigs for cluster", "cluster-name", s.scope.KubernetesClusterName())
+	s.scope.Debug("Updating EKS kubeconfigs for cluster", "cluster-name", s.scope.KubernetesClusterName())
 
 	data, ok := configSecret.Data[secret.KubeconfigDataName]
 	if !ok {
@@ -265,7 +265,7 @@ func (s *Service) generateToken() (string, error) {
 
 	req, output := s.STSClient.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
 	req.HTTPRequest.Header.Add(clusterNameHeader, eksClusterName)
-	s.Logger.V(4).Info("generating token for AWS identity", "user", output.UserId, "account", output.Account, "arn", output.Arn)
+	s.Trace("generating token for AWS identity", "user", output.UserId, "account", output.Account, "arn", output.Arn)
 
 	presignedURL, err := req.Presign(tokenAgeMins * time.Minute)
 	if err != nil {

--- a/pkg/cloud/services/eks/eks.go
+++ b/pkg/cloud/services/eks/eks.go
@@ -32,7 +32,7 @@ import (
 
 // ReconcileControlPlane reconciles a EKS control plane.
 func (s *Service) ReconcileControlPlane(ctx context.Context) error {
-	s.scope.V(2).Info("Reconciling EKS control plane", "cluster", klog.KRef(s.scope.Cluster.Namespace, s.scope.Cluster.Name))
+	s.scope.Debug("Reconciling EKS control plane", "cluster", klog.KRef(s.scope.Cluster.Namespace, s.scope.Cluster.Name))
 
 	// Control Plane IAM Role
 	if err := s.reconcileControlPlaneIAMRole(); err != nil {
@@ -62,13 +62,13 @@ func (s *Service) ReconcileControlPlane(ctx context.Context) error {
 	}
 	conditions.MarkTrue(s.scope.ControlPlane, ekscontrolplanev1.EKSIdentityProviderConfiguredCondition)
 
-	s.scope.V(2).Info("Reconcile EKS control plane completed successfully")
+	s.scope.Debug("Reconcile EKS control plane completed successfully")
 	return nil
 }
 
 // DeleteControlPlane deletes the EKS control plane.
 func (s *Service) DeleteControlPlane() (err error) {
-	s.scope.V(2).Info("Deleting EKS control plane")
+	s.scope.Debug("Deleting EKS control plane")
 
 	// EKS Cluster
 	if err := s.deleteCluster(); err != nil {
@@ -85,13 +85,13 @@ func (s *Service) DeleteControlPlane() (err error) {
 		return err
 	}
 
-	s.scope.V(2).Info("Delete EKS control plane completed successfully")
+	s.scope.Debug("Delete EKS control plane completed successfully")
 	return nil
 }
 
 // ReconcilePool is the entrypoint for ManagedMachinePool reconciliation.
 func (s *NodegroupService) ReconcilePool() error {
-	s.scope.V(2).Info("Reconciling EKS nodegroup")
+	s.scope.Debug("Reconciling EKS nodegroup")
 
 	if err := s.reconcileNodegroupIAMRole(); err != nil {
 		conditions.MarkFalse(
@@ -123,14 +123,14 @@ func (s *NodegroupService) ReconcilePool() error {
 // ReconcilePoolDelete is the entrypoint for ManagedMachinePool deletion
 // reconciliation.
 func (s *NodegroupService) ReconcilePoolDelete() error {
-	s.scope.V(2).Info("Reconciling deletion of EKS nodegroup")
+	s.scope.Debug("Reconciling deletion of EKS nodegroup")
 
 	eksNodegroupName := s.scope.NodegroupName()
 
 	ng, err := s.describeNodegroup()
 	if err != nil {
 		if awserrors.IsNotFound(err) {
-			s.scope.V(4).Info("EKS nodegroup does not exist")
+			s.scope.Trace("EKS nodegroup does not exist")
 			return nil
 		}
 		return errors.Wrap(err, "failed to describe EKS nodegroup")

--- a/pkg/cloud/services/eks/fargate.go
+++ b/pkg/cloud/services/eks/fargate.go
@@ -45,7 +45,7 @@ func requeueRoleUpdating() reconcile.Result {
 
 // Reconcile is the entrypoint for FargateProfile reconciliation.
 func (s *FargateService) Reconcile() (reconcile.Result, error) {
-	s.scope.V(2).Info("Reconciling EKS fargate profile")
+	s.scope.Debug("Reconciling EKS fargate profile")
 
 	requeue, err := s.reconcileFargateIAMRole()
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *FargateService) reconcileFargateProfile() (requeue bool, err error) {
 		if ownedTag == nil {
 			return false, errors.New("owned tag not found for this cluster")
 		}
-		s.scope.V(2).Info("Found owned EKS fargate profile", "cluster-name", eksClusterName, "profile-name", profileName)
+		s.scope.Debug("Found owned EKS fargate profile", "cluster-name", eksClusterName, "profile-name", profileName)
 	}
 
 	if err := s.reconcileTags(profile); err != nil {
@@ -117,7 +117,7 @@ func (s *FargateService) reconcileFargateProfile() (requeue bool, err error) {
 }
 
 func (s *FargateService) handleStatus(profile *eks.FargateProfile) (requeue bool) {
-	s.V(2).Info("fargate profile", "status", *profile.Status)
+	s.Debug("fargate profile", "status", *profile.Status)
 	switch *profile.Status {
 	case eks.FargateProfileStatusCreating:
 		s.scope.FargateProfile.Status.Ready = false
@@ -160,7 +160,7 @@ func (s *FargateService) handleStatus(profile *eks.FargateProfile) (requeue bool
 
 // ReconcileDelete is the entrypoint for FargateProfile reconciliation.
 func (s *FargateService) ReconcileDelete() (reconcile.Result, error) {
-	s.scope.V(2).Info("Reconciling EKS fargate profile deletion")
+	s.scope.Debug("Reconciling EKS fargate profile deletion")
 
 	requeue, err := s.deleteFargateProfile()
 	if err != nil {

--- a/pkg/cloud/services/eks/identity_provider.go
+++ b/pkg/cloud/services/eks/identity_provider.go
@@ -49,11 +49,10 @@ func (s *Service) reconcileIdentityProvider(ctx context.Context) error {
 		return nil
 	}
 
-	s.scope.V(2).Info("creating oidc provider plan", "desired", desired, "current", current)
+	s.scope.Debug("creating oidc provider plan", "desired", desired, "current", current)
 	procedures, err := identityprovider.
-		NewPlan(clusterName, current, desired, s.EKSClient, s.scope.Logger).
+		NewPlan(clusterName, current, desired, s.EKSClient, s.scope).
 		Create(ctx)
-
 	if err != nil {
 		s.scope.Error(err, "failed creating eks identity provider plan")
 		return fmt.Errorf("creating eks identity provider plan: %w", err)
@@ -64,7 +63,7 @@ func (s *Service) reconcileIdentityProvider(ctx context.Context) error {
 		return nil
 	}
 
-	s.scope.V(2).Info("computed EKS identity provider plan", "numprocs", len(procedures))
+	s.scope.Debug("computed EKS identity provider plan", "numprocs", len(procedures))
 
 	// Perform required operations
 	for _, procedure := range procedures {

--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -124,11 +124,11 @@ func (s *Service) reconcileTrustPolicy() error {
 	if trustPolicyConfigMap.UID == "" {
 		trustPolicyConfigMap.Name = trustPolicyConfigMapName
 		trustPolicyConfigMap.Namespace = trustPolicyConfigMapNamespace
-		s.V(2).Info("Creating new Trust Policy ConfigMap", "cluster", s.scope.Name(), "configmap", trustPolicyConfigMapName)
+		s.Debug("Creating new Trust Policy ConfigMap", "cluster", s.scope.Name(), "configmap", trustPolicyConfigMapName)
 		return remoteClient.Create(ctx, trustPolicyConfigMap)
 	}
 
-	s.V(2).Info("Updating existing Trust Policy ConfigMap", "cluster", s.scope.Name(), "configmap", trustPolicyConfigMapName)
+	s.Debug("Updating existing Trust Policy ConfigMap", "cluster", s.scope.Name(), "configmap", trustPolicyConfigMapName)
 	return remoteClient.Update(ctx, trustPolicyConfigMap)
 }
 

--- a/pkg/cloud/services/eks/roles.go
+++ b/pkg/cloud/services/eks/roles.go
@@ -53,7 +53,7 @@ func FargateRolePolicies() []string {
 }
 
 func (s *Service) reconcileControlPlaneIAMRole() error {
-	s.scope.V(2).Info("Reconciling EKS Control Plane IAM Role")
+	s.scope.Debug("Reconciling EKS Control Plane IAM Role")
 
 	if s.scope.ControlPlane.Spec.RoleName == nil {
 		if !s.scope.EnableIAM() {
@@ -87,7 +87,7 @@ func (s *Service) reconcileControlPlaneIAMRole() error {
 	}
 
 	if s.IsUnmanaged(role, s.scope.Name()) {
-		s.scope.V(2).Info("Skipping, EKS control plane role policy assignment as role is unamanged")
+		s.scope.Debug("Skipping, EKS control plane role policy assignment as role is unamanged")
 		return nil
 	}
 
@@ -120,16 +120,16 @@ func (s *Service) deleteControlPlaneIAMRole() error {
 	}
 	roleName := *s.scope.ControlPlane.Spec.RoleName
 	if !s.scope.EnableIAM() {
-		s.scope.V(2).Info("EKS IAM disabled, skipping deleting EKS Control Plane IAM Role")
+		s.scope.Debug("EKS IAM disabled, skipping deleting EKS Control Plane IAM Role")
 		return nil
 	}
 
-	s.scope.V(2).Info("Deleting EKS Control Plane IAM Role")
+	s.scope.Debug("Deleting EKS Control Plane IAM Role")
 
 	role, err := s.GetIAMRole(roleName)
 	if err != nil {
 		if isNotFound(err) {
-			s.V(2).Info("EKS Control Plane IAM Role already deleted")
+			s.Debug("EKS Control Plane IAM Role already deleted")
 			return nil
 		}
 
@@ -137,7 +137,7 @@ func (s *Service) deleteControlPlaneIAMRole() error {
 	}
 
 	if s.IsUnmanaged(role, s.scope.Name()) {
-		s.V(2).Info("Skipping, EKS control plane iam role deletion as role is unamanged")
+		s.Debug("Skipping, EKS control plane iam role deletion as role is unamanged")
 		return nil
 	}
 
@@ -152,7 +152,7 @@ func (s *Service) deleteControlPlaneIAMRole() error {
 }
 
 func (s *NodegroupService) reconcileNodegroupIAMRole() error {
-	s.scope.V(2).Info("Reconciling EKS Nodegroup IAM Role")
+	s.scope.Debug("Reconciling EKS Nodegroup IAM Role")
 
 	if s.scope.RoleName() == "" {
 		var roleName string
@@ -194,7 +194,7 @@ func (s *NodegroupService) reconcileNodegroupIAMRole() error {
 	}
 
 	if s.IsUnmanaged(role, s.scope.ClusterName()) {
-		s.scope.V(2).Info("Skipping, EKS nodegroup role policy assignment as role is unamanged")
+		s.scope.Debug("Skipping, EKS nodegroup role policy assignment as role is unamanged")
 		return nil
 	}
 
@@ -238,16 +238,16 @@ func (s *NodegroupService) deleteNodegroupIAMRole() (reterr error) {
 	}()
 	roleName := s.scope.RoleName()
 	if !s.scope.EnableIAM() {
-		s.scope.V(2).Info("EKS IAM disabled, skipping deleting EKS Nodegroup IAM Role")
+		s.scope.Debug("EKS IAM disabled, skipping deleting EKS Nodegroup IAM Role")
 		return nil
 	}
 
-	s.scope.V(2).Info("Deleting EKS Nodegroup IAM Role")
+	s.scope.Debug("Deleting EKS Nodegroup IAM Role")
 
 	role, err := s.GetIAMRole(roleName)
 	if err != nil {
 		if isNotFound(err) {
-			s.V(2).Info("EKS Nodegroup IAM Role already deleted")
+			s.Debug("EKS Nodegroup IAM Role already deleted")
 			return nil
 		}
 
@@ -255,7 +255,7 @@ func (s *NodegroupService) deleteNodegroupIAMRole() (reterr error) {
 	}
 
 	if s.IsUnmanaged(role, s.scope.ClusterName()) {
-		s.V(2).Info("Skipping, EKS Nodegroup iam role deletion as role is unamanged")
+		s.Debug("Skipping, EKS Nodegroup iam role deletion as role is unamanged")
 		return nil
 	}
 
@@ -270,7 +270,7 @@ func (s *NodegroupService) deleteNodegroupIAMRole() (reterr error) {
 }
 
 func (s *FargateService) reconcileFargateIAMRole() (requeue bool, err error) {
-	s.scope.V(2).Info("Reconciling EKS Fargate IAM Role")
+	s.scope.Debug("Reconciling EKS Fargate IAM Role")
 
 	if s.scope.RoleName() == "" {
 		var roleName string
@@ -346,16 +346,16 @@ func (s *FargateService) deleteFargateIAMRole() (reterr error) {
 	}()
 	roleName := s.scope.RoleName()
 	if !s.scope.EnableIAM() {
-		s.scope.V(2).Info("EKS IAM disabled, skipping deleting EKS fargate IAM Role")
+		s.scope.Debug("EKS IAM disabled, skipping deleting EKS fargate IAM Role")
 		return nil
 	}
 
-	s.scope.V(2).Info("Deleting EKS fargate IAM Role")
+	s.scope.Debug("Deleting EKS fargate IAM Role")
 
 	_, err := s.GetIAMRole(roleName)
 	if err != nil {
 		if isNotFound(err) {
-			s.V(2).Info("EKS fargate IAM Role already deleted")
+			s.Debug("EKS fargate IAM Role already deleted")
 			return nil
 		}
 

--- a/pkg/cloud/services/eks/service.go
+++ b/pkg/cloud/services/eks/service.go
@@ -70,7 +70,7 @@ func NewService(controlPlaneScope *scope.ManagedControlPlaneScope, opts ...Servi
 			EKSAPI: scope.NewEKSClient(controlPlaneScope, controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
 		},
 		IAMService: iam.IAMService{
-			Logger:    controlPlaneScope.Logger,
+			Wrapper:   &controlPlaneScope.Logger,
 			IAMClient: scope.NewIAMClient(controlPlaneScope, controlPlaneScope, controlPlaneScope, controlPlaneScope.ControlPlane),
 			Client:    http.DefaultClient,
 		},
@@ -102,7 +102,7 @@ func NewNodegroupService(machinePoolScope *scope.ManagedMachinePoolScope) *Nodeg
 		AutoscalingClient: scope.NewASGClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
 		EKSClient:         scope.NewEKSClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
 		IAMService: iam.IAMService{
-			Logger:    machinePoolScope.Logger,
+			Wrapper:   &machinePoolScope.Logger,
 			IAMClient: scope.NewIAMClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
 		},
 		STSClient: scope.NewSTSClient(machinePoolScope, machinePoolScope, machinePoolScope, machinePoolScope.ManagedMachinePool),
@@ -124,7 +124,7 @@ func NewFargateService(fargatePoolScope *scope.FargateProfileScope) *FargateServ
 		scope:     fargatePoolScope,
 		EKSClient: scope.NewEKSClient(fargatePoolScope, fargatePoolScope, fargatePoolScope, fargatePoolScope.FargateProfile),
 		IAMService: iam.IAMService{
-			Logger:    fargatePoolScope.Logger,
+			Wrapper:   &fargatePoolScope.Logger,
 			IAMClient: scope.NewIAMClient(fargatePoolScope, fargatePoolScope, fargatePoolScope, fargatePoolScope.FargateProfile),
 		},
 		STSClient: scope.NewSTSClient(fargatePoolScope, fargatePoolScope, fargatePoolScope, fargatePoolScope.FargateProfile),

--- a/pkg/cloud/services/eks/tags.go
+++ b/pkg/cloud/services/eks/tags.go
@@ -130,7 +130,7 @@ func (s *NodegroupService) reconcileASGTags(ng *eks.Nodegroup) error {
 	}
 
 	tagsToDelete, tagsToAdd := getASGTagUpdates(s.scope.ClusterName(), tagDescriptionsToMap(asg.Tags), s.scope.AdditionalTags())
-	s.scope.V(2).Info("Tags", "tagsToAdd", tagsToAdd, "tagsToDelete", tagsToDelete)
+	s.scope.Debug("Tags", "tagsToAdd", tagsToAdd, "tagsToDelete", tagsToDelete)
 
 	if len(tagsToAdd) > 0 {
 		input := &autoscaling.CreateOrUpdateTagsInput{}

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -52,7 +52,7 @@ const maxELBsDescribeTagsRequest = 20
 
 // ReconcileLoadbalancers reconciles the load balancers for the given cluster.
 func (s *Service) ReconcileLoadbalancers() error {
-	s.scope.V(2).Info("Reconciling load balancers")
+	s.scope.Debug("Reconciling load balancers")
 
 	// If ELB scheme is set to Internet-facing due to an API bug in versions > v0.6.6 and v0.7.0, change it to internet-facing and patch.
 	if s.scope.ControlPlaneLoadBalancerScheme().String() == infrav1.ClassicELBSchemeIncorrectInternetFacing.String() {
@@ -60,7 +60,7 @@ func (s *Service) ReconcileLoadbalancers() error {
 		if err := s.scope.PatchObject(); err != nil {
 			return err
 		}
-		s.scope.V(4).Info("Patched control plane load balancer scheme")
+		s.scope.Trace("Patched control plane load balancer scheme")
 	}
 
 	// Generate a default control plane load balancer name. The load balancer name cannot be
@@ -87,7 +87,7 @@ func (s *Service) ReconcileLoadbalancers() error {
 		if err != nil {
 			return err
 		}
-		s.scope.V(2).Info("Created new classic load balancer for apiserver", "api-server-elb-name", apiELB.Name)
+		s.scope.Debug("Created new classic load balancer for apiserver", "api-server-elb-name", apiELB.Name)
 	case err != nil:
 		// Failed to describe the classic ELB
 		return err
@@ -131,19 +131,19 @@ func (s *Service) ReconcileLoadbalancers() error {
 			}
 		}
 	} else {
-		s.scope.V(4).Info("Unmanaged control plane load balancer, skipping load balancer configuration", "api-server-elb", apiELB)
+		s.scope.Trace("Unmanaged control plane load balancer, skipping load balancer configuration", "api-server-elb", apiELB)
 	}
 
 	// TODO(vincepri): check if anything has changed and reconcile as necessary.
 	apiELB.DeepCopyInto(&s.scope.Network().APIServerELB)
-	s.scope.V(4).Info("Control plane load balancer", "api-server-elb", apiELB)
+	s.scope.Trace("Control plane load balancer", "api-server-elb", apiELB)
 
-	s.scope.V(2).Info("Reconcile load balancers completed successfully")
+	s.scope.Debug("Reconcile load balancers completed successfully")
 	return nil
 }
 
 func (s *Service) deleteAPIServerELB() error {
-	s.scope.V(2).Info("Deleting control plane load balancer")
+	s.scope.Debug("Deleting control plane load balancer")
 
 	elbName, err := ELBName(s.scope)
 	if err != nil {
@@ -164,11 +164,11 @@ func (s *Service) deleteAPIServerELB() error {
 	}
 
 	if apiELB.IsUnmanaged(s.scope.Name()) {
-		s.scope.V(2).Info("Found unmanaged classic load balancer for apiserver, skipping deletion", "api-server-elb-name", apiELB.Name)
+		s.scope.Debug("Found unmanaged classic load balancer for apiserver, skipping deletion", "api-server-elb-name", apiELB.Name)
 		return nil
 	}
 
-	s.scope.V(3).Info("deleting load balancer", "name", elbName)
+	s.scope.Debug("deleting load balancer", "name", elbName)
 	if err := s.deleteClassicELB(elbName); err != nil {
 		conditions.MarkFalse(s.scope.InfraCluster(), infrav1.LoadBalancerReadyCondition, "DeletingFailed", clusterv1.ConditionSeverityWarning, err.Error())
 		return err
@@ -192,7 +192,7 @@ func (s *Service) deleteAPIServerELB() error {
 // cluster is deleted, its ELB is deleted; the ELBs found in this function will typically be for
 // Services that were not deleted before the cluster was deleted.
 func (s *Service) deleteAWSCloudProviderELBs() error {
-	s.scope.V(2).Info("Deleting AWS cloud provider load balancers (created for LoadBalancer-type Services)")
+	s.scope.Debug("Deleting AWS cloud provider load balancers (created for LoadBalancer-type Services)")
 
 	elbs, err := s.listAWSCloudProviderOwnedELBs()
 	if err != nil {
@@ -200,7 +200,7 @@ func (s *Service) deleteAWSCloudProviderELBs() error {
 	}
 
 	for _, elb := range elbs {
-		s.scope.V(3).Info("Deleting AWS cloud provider load balancer", "arn", elb)
+		s.scope.Debug("Deleting AWS cloud provider load balancer", "arn", elb)
 		if err := s.deleteClassicELB(elb); err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func (s *Service) deleteAWSCloudProviderELBs() error {
 
 // DeleteLoadbalancers deletes the load balancers for the given cluster.
 func (s *Service) DeleteLoadbalancers() error {
-	s.scope.V(2).Info("Deleting load balancers")
+	s.scope.Debug("Deleting load balancers")
 
 	if err := s.deleteAPIServerELB(); err != nil {
 		return errors.Wrap(err, "failed to delete control plane load balancer")
@@ -769,14 +769,14 @@ func (s *Service) reconcileELBTags(lb *infrav1.ClassicELB, desiredTags map[strin
 
 	for k, v := range desiredTags {
 		if val, ok := currentTags[k]; !ok || val != v {
-			s.scope.V(4).Info("adding tag to load balancer", "elb-name", lb.Name, "key", k, "value", v)
+			s.scope.Trace("adding tag to load balancer", "elb-name", lb.Name, "key", k, "value", v)
 			addTagsInput.Tags = append(addTagsInput.Tags, &elb.Tag{Key: aws.String(k), Value: aws.String(v)})
 		}
 	}
 
 	for k := range currentTags {
 		if _, ok := desiredTags[k]; !ok {
-			s.scope.V(4).Info("removing tag from load balancer", "elb-name", lb.Name, "key", k)
+			s.scope.Trace("removing tag from load balancer", "elb-name", lb.Name, "key", k)
 			removeTagsInput.Tags = append(removeTagsInput.Tags, &elb.TagKeyOnly{Key: aws.String(k)})
 		}
 	}

--- a/pkg/cloud/services/gc/cleanup.go
+++ b/pkg/cloud/services/gc/cleanup.go
@@ -109,11 +109,11 @@ func (s *Service) deleteResources(ctx context.Context) error {
 
 func (s *Service) isMatchingResource(resource *AWSResource, serviceName, resourceName string) bool {
 	if resource.ARN.Service != serviceName {
-		s.scope.V(5).Info("Resource not for service", "arn", resource.ARN.String(), "service_name", serviceName, "resource_name", resourceName)
+		s.scope.Debug("Resource not for service", "arn", resource.ARN.String(), "service_name", serviceName, "resource_name", resourceName)
 		return false
 	}
 	if !strings.HasPrefix(resource.ARN.Resource, resourceName+"/") {
-		s.scope.V(5).Info("Resource type does not match", "arn", resource.ARN.String(), "service_name", serviceName, "resource_name", resourceName)
+		s.scope.Debug("Resource type does not match", "arn", resource.ARN.String(), "service_name", serviceName, "resource_name", resourceName)
 		return false
 	}
 

--- a/pkg/cloud/services/gc/ec2.go
+++ b/pkg/cloud/services/gc/ec2.go
@@ -28,7 +28,7 @@ import (
 func (s *Service) deleteSecurityGroups(ctx context.Context, resources []*AWSResource) error {
 	for _, resource := range resources {
 		if !s.isSecurityGroupToDelete(resource) {
-			s.scope.V(5).Info("Resource not a security group for deletion", "arn", resource.ARN.String())
+			s.scope.Debug("Resource not a security group for deletion", "arn", resource.ARN.String())
 			continue
 		}
 
@@ -37,7 +37,7 @@ func (s *Service) deleteSecurityGroups(ctx context.Context, resources []*AWSReso
 			return fmt.Errorf("deleting security group %s: %w", groupID, err)
 		}
 	}
-	s.scope.V(2).Info("Finished processing resources for security group deletion")
+	s.scope.Debug("Finished processing resources for security group deletion")
 
 	return nil
 }
@@ -47,10 +47,10 @@ func (s *Service) isSecurityGroupToDelete(resource *AWSResource) bool {
 		return false
 	}
 	if eksClusterName := resource.Tags[eksClusterNameTag]; eksClusterName != "" {
-		s.scope.V(5).Info("Security group was created by EKS directly", "arn", resource.ARN.String(), "check", "securitygroup", "cluster_name", eksClusterName)
+		s.scope.Debug("Security group was created by EKS directly", "arn", resource.ARN.String(), "check", "securitygroup", "cluster_name", eksClusterName)
 		return false
 	}
-	s.scope.V(5).Info("Resource is a security group to delete", "arn", resource.ARN.String(), "check", "securitygroup")
+	s.scope.Debug("Resource is a security group to delete", "arn", resource.ARN.String(), "check", "securitygroup")
 
 	return true
 }
@@ -60,7 +60,7 @@ func (s *Service) deleteSecurityGroup(ctx context.Context, securityGroupID strin
 		GroupId: aws.String(securityGroupID),
 	}
 
-	s.scope.V(2).Info("Deleting security group", "group_id", securityGroupID)
+	s.scope.Debug("Deleting security group", "group_id", securityGroupID)
 	if _, err := s.ec2Client.DeleteSecurityGroupWithContext(ctx, &input); err != nil {
 		return fmt.Errorf("deleting security group: %w", err)
 	}

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -57,22 +57,22 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 			Groups:   NodeGroups,
 		},
 	}
-	s.scope.V(2).Info("Mapping node IAM role", "iam-role", nodesRoleMapping.RoleARN, "user", nodesRoleMapping.UserName)
+	s.scope.Debug("Mapping node IAM role", "iam-role", nodesRoleMapping.RoleARN, "user", nodesRoleMapping.UserName)
 	if err := authBackend.MapRole(nodesRoleMapping); err != nil {
 		return fmt.Errorf("mapping iam node role: %w", err)
 	}
 
-	s.scope.V(2).Info("Mapping additional IAM roles and users")
+	s.scope.Debug("Mapping additional IAM roles and users")
 	iamCfg := s.scope.IAMAuthConfig()
 	for _, roleMapping := range iamCfg.RoleMappings {
-		s.scope.V(2).Info("Mapping IAM role", "iam-role", roleMapping.RoleARN, "user", roleMapping.UserName)
+		s.scope.Debug("Mapping IAM role", "iam-role", roleMapping.RoleARN, "user", roleMapping.UserName)
 		if err := authBackend.MapRole(roleMapping); err != nil {
 			return fmt.Errorf("mapping iam role: %w", err)
 		}
 	}
 
 	for _, userMapping := range iamCfg.UserMappings {
-		s.scope.V(2).Info("Mapping IAM user", "iam-user", userMapping.UserARN, "user", userMapping.UserName)
+		s.scope.Debug("Mapping IAM user", "iam-user", userMapping.UserARN, "user", userMapping.UserName)
 		if err := authBackend.MapUser(userMapping); err != nil {
 			return fmt.Errorf("mapping iam user: %w", err)
 		}

--- a/pkg/cloud/services/kubeproxy/reconcile.go
+++ b/pkg/cloud/services/kubeproxy/reconcile.go
@@ -59,16 +59,16 @@ func (s *Service) deleteKubeProxy(ctx context.Context, remoteClient client.Clien
 	ds := &appsv1.DaemonSet{}
 	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: kubeProxyNamespace, Name: kubeProxyName}, ds); err != nil {
 		if apierrors.IsNotFound(err) {
-			s.scope.V(2).Info("The kube-proxy DaemonSet is not found, no action")
+			s.scope.Debug("The kube-proxy DaemonSet is not found, no action")
 			return nil
 		}
 		return fmt.Errorf("getting kube-proxy daemonset: %w", err)
 	}
 
-	s.scope.V(2).Info("The kube-proxy DaemonSet found, deleting")
+	s.scope.Debug("The kube-proxy DaemonSet found, deleting")
 	if err := remoteClient.Delete(ctx, ds, &client.DeleteOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			s.scope.V(2).Info("The kube-proxy DaemonSet is not found, not deleted")
+			s.scope.Debug("The kube-proxy DaemonSet is not found, not deleted")
 			return nil
 		}
 		return fmt.Errorf("deleting kube-proxy DaemonSet: %w", err)

--- a/pkg/cloud/services/network/egress_only_gateways.go
+++ b/pkg/cloud/services/network/egress_only_gateways.go
@@ -36,11 +36,11 @@ import (
 
 func (s *Service) reconcileEgressOnlyInternetGateways() error {
 	if !s.scope.VPC().IsIPv6Enabled() {
-		s.scope.V(4).Info("Skipping egress only internet gateways reconcile in not ipv6 mode")
+		s.scope.Trace("Skipping egress only internet gateways reconcile in not ipv6 mode")
 		return nil
 	}
 
-	s.scope.V(2).Info("Reconciling egress only internet gateways")
+	s.scope.Debug("Reconciling egress only internet gateways")
 
 	eigws, err := s.describeEgressOnlyVpcInternetGateways()
 	if awserrors.IsNotFound(err) {
@@ -78,7 +78,7 @@ func (s *Service) reconcileEgressOnlyInternetGateways() error {
 
 func (s *Service) deleteEgressOnlyInternetGateways() error {
 	if !s.scope.VPC().IsIPv6Enabled() {
-		s.scope.V(4).Info("Skipping egress only internet gateway deletion in none ipv6 mode")
+		s.scope.Trace("Skipping egress only internet gateway deletion in none ipv6 mode")
 		return nil
 	}
 

--- a/pkg/cloud/services/network/gateways.go
+++ b/pkg/cloud/services/network/gateways.go
@@ -36,11 +36,11 @@ import (
 
 func (s *Service) reconcileInternetGateways() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping internet gateways reconcile in unmanaged mode")
+		s.scope.Trace("Skipping internet gateways reconcile in unmanaged mode")
 		return nil
 	}
 
-	s.scope.V(2).Info("Reconciling internet gateways")
+	s.scope.Debug("Reconciling internet gateways")
 
 	igs, err := s.describeVpcInternetGateways()
 	if awserrors.IsNotFound(err) {
@@ -78,7 +78,7 @@ func (s *Service) reconcileInternetGateways() error {
 
 func (s *Service) deleteInternetGateways() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping internet gateway deletion in unmanaged mode")
+		s.scope.Trace("Skipping internet gateway deletion in unmanaged mode")
 		return nil
 	}
 
@@ -101,7 +101,7 @@ func (s *Service) deleteInternetGateways() error {
 		}
 
 		record.Eventf(s.scope.InfraCluster(), "SuccessfulDetachInternetGateway", "Detached Internet Gateway %q from VPC %q", *ig.InternetGatewayId, s.scope.VPC().ID)
-		s.scope.V(2).Info("Detached internet gateway from VPC", "internet-gateway-id", *ig.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
+		s.scope.Debug("Detached internet gateway from VPC", "internet-gateway-id", *ig.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 
 		deleteReq := &ec2.DeleteInternetGatewayInput{
 			InternetGatewayId: ig.InternetGatewayId,
@@ -145,7 +145,7 @@ func (s *Service) createInternetGateway() (*ec2.InternetGateway, error) {
 		return nil, errors.Wrapf(err, "failed to attach internet gateway %q to vpc %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
 	}
 	record.Eventf(s.scope.InfraCluster(), "SuccessfulAttachInternetGateway", "Internet Gateway %q attached to VPC %q", *ig.InternetGateway.InternetGatewayId, s.scope.VPC().ID)
-	s.scope.V(2).Info("attached internet gateway to VPC", "internet-gateway-id", *ig.InternetGateway.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
+	s.scope.Debug("attached internet gateway to VPC", "internet-gateway-id", *ig.InternetGateway.InternetGatewayId, "vpc-id", s.scope.VPC().ID)
 
 	return ig.InternetGateway, nil
 }

--- a/pkg/cloud/services/network/natgateways.go
+++ b/pkg/cloud/services/network/natgateways.go
@@ -38,14 +38,14 @@ import (
 
 func (s *Service) reconcileNatGateways() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping NAT gateway reconcile in unmanaged mode")
+		s.scope.Trace("Skipping NAT gateway reconcile in unmanaged mode")
 		return nil
 	}
 
-	s.scope.V(2).Info("Reconciling NAT gateways")
+	s.scope.Debug("Reconciling NAT gateways")
 
 	if len(s.scope.Subnets().FilterPrivate()) == 0 {
-		s.scope.V(2).Info("No private subnets available, skipping NAT gateways")
+		s.scope.Debug("No private subnets available, skipping NAT gateways")
 		conditions.MarkFalse(
 			s.scope.InfraCluster(),
 			infrav1.NatGatewaysReadyCondition,
@@ -54,7 +54,7 @@ func (s *Service) reconcileNatGateways() error {
 			"No private subnets available, skipping NAT gateways")
 		return nil
 	} else if len(s.scope.Subnets().FilterPublic()) == 0 {
-		s.scope.V(2).Info("No public subnets available. Cannot create NAT gateways for private subnets, this might be a configuration error.")
+		s.scope.Debug("No public subnets available. Cannot create NAT gateways for private subnets, this might be a configuration error.")
 		conditions.MarkFalse(
 			s.scope.InfraCluster(),
 			infrav1.NatGatewaysReadyCondition,
@@ -123,15 +123,15 @@ func (s *Service) reconcileNatGateways() error {
 
 func (s *Service) deleteNatGateways() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping NAT gateway deletion in unmanaged mode")
+		s.scope.Trace("Skipping NAT gateway deletion in unmanaged mode")
 		return nil
 	}
 
 	if len(s.scope.Subnets().FilterPrivate()) == 0 {
-		s.scope.V(2).Info("No private subnets available, skipping NAT gateways")
+		s.scope.Debug("No private subnets available, skipping NAT gateways")
 		return nil
 	} else if len(s.scope.Subnets().FilterPublic()) == 0 {
-		s.scope.V(2).Info("No public subnets available. Cannot create NAT gateways for private subnets, this might be a configuration error.")
+		s.scope.Debug("No public subnets available. Cannot create NAT gateways for private subnets, this might be a configuration error.")
 		return nil
 	}
 

--- a/pkg/cloud/services/network/network.go
+++ b/pkg/cloud/services/network/network.go
@@ -28,7 +28,7 @@ import (
 
 // ReconcileNetwork reconciles the network of the given cluster.
 func (s *Service) ReconcileNetwork() (err error) {
-	s.scope.V(2).Info("Reconciling network for cluster", "cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()))
+	s.scope.Debug("Reconciling network for cluster", "cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()))
 
 	// VPC.
 	if err := s.reconcileVPC(); err != nil {
@@ -73,13 +73,13 @@ func (s *Service) ReconcileNetwork() (err error) {
 		return err
 	}
 
-	s.scope.V(2).Info("Reconcile network completed successfully")
+	s.scope.Debug("Reconcile network completed successfully")
 	return nil
 }
 
 // DeleteNetwork deletes the network of the given cluster.
 func (s *Service) DeleteNetwork() (err error) {
-	s.scope.V(2).Info("Deleting network")
+	s.scope.Debug("Deleting network")
 
 	vpc := &infrav1.VPCSpec{}
 	// Get VPC used for the cluster
@@ -183,6 +183,6 @@ func (s *Service) DeleteNetwork() (err error) {
 	}
 	conditions.MarkFalse(s.scope.InfraCluster(), infrav1.VpcReadyCondition, clusterv1.DeletedReason, clusterv1.ConditionSeverityInfo, "")
 
-	s.scope.V(2).Info("Delete network completed successfully")
+	s.scope.Debug("Delete network completed successfully")
 	return nil
 }

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -40,11 +40,11 @@ const (
 
 func (s *Service) reconcileRouteTables() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping routing tables reconcile in unmanaged mode")
+		s.scope.Trace("Skipping routing tables reconcile in unmanaged mode")
 		return nil
 	}
 
-	s.scope.V(2).Info("Reconciling routing tables")
+	s.scope.Debug("Reconciling routing tables")
 
 	subnetRouteMap, err := s.describeVpcRouteTablesBySubnet()
 	if err != nil {
@@ -82,7 +82,7 @@ func (s *Service) reconcileRouteTables() error {
 		}
 
 		if rt, ok := subnetRouteMap[sn.ID]; ok {
-			s.scope.V(2).Info("Subnet is already associated with route table", "subnet-id", sn.ID, "route-table-id", *rt.RouteTableId)
+			s.scope.Debug("Subnet is already associated with route table", "subnet-id", sn.ID, "route-table-id", *rt.RouteTableId)
 			// TODO(vincepri): check that everything is in order, e.g. routes match the subnet type.
 
 			// For managed environments we need to reconcile the routes of our tables if there is a mistmatch.
@@ -132,7 +132,7 @@ func (s *Service) reconcileRouteTables() error {
 			return err
 		}
 
-		s.scope.V(2).Info("Subnet has been associated with route table", "subnet-id", sn.ID, "route-table-id", rt.ID)
+		s.scope.Debug("Subnet has been associated with route table", "subnet-id", sn.ID, "route-table-id", rt.ID)
 		sn.RouteTableID = aws.String(rt.ID)
 	}
 	conditions.MarkTrue(s.scope.InfraCluster(), infrav1.RouteTablesReadyCondition)
@@ -210,7 +210,7 @@ func (s *Service) describeVpcRouteTablesBySubnet() (map[string]*ec2.RouteTable, 
 
 func (s *Service) deleteRouteTables() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping routing tables deletion in unmanaged mode")
+		s.scope.Trace("Skipping routing tables deletion in unmanaged mode")
 		return nil
 	}
 
@@ -231,7 +231,7 @@ func (s *Service) deleteRouteTables() error {
 			}
 
 			record.Eventf(s.scope.InfraCluster(), "SuccessfulDisassociateRouteTable", "Disassociated managed RouteTable %q from subnet %q", *rt.RouteTableId, *as.SubnetId)
-			s.scope.V(2).Info("Deleted association between route table and subnet", "route-table-id", *rt.RouteTableId, "subnet-id", *as.SubnetId)
+			s.scope.Debug("Deleted association between route table and subnet", "route-table-id", *rt.RouteTableId, "subnet-id", *as.SubnetId)
 		}
 
 		if _, err := s.EC2Client.DeleteRouteTable(&ec2.DeleteRouteTableInput{RouteTableId: rt.RouteTableId}); err != nil {

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -178,7 +178,7 @@ func (s *Service) reconcileSubnets() error {
 		}
 	}
 
-	s.scope.V(2).Info("reconciled subnets", "subnets", subnets)
+	s.scope.Debug("reconciled subnets", "subnets", subnets)
 	conditions.MarkTrue(s.scope.InfraCluster(), infrav1.SubnetsReadyCondition)
 	return nil
 }
@@ -199,7 +199,7 @@ func (s *Service) getDefaultSubnets() (infrav1.Subnets, error) {
 	}
 
 	if len(zones) > maxZones {
-		s.scope.V(2).Info("region has more than AvailabilityZoneUsageLimit availability zones, picking zones to use", "region", s.scope.Region(), "AvailabilityZoneUsageLimit", maxZones)
+		s.scope.Debug("region has more than AvailabilityZoneUsageLimit availability zones, picking zones to use", "region", s.scope.Region(), "AvailabilityZoneUsageLimit", maxZones)
 		if selectionScheme == infrav1.AZSelectionSchemeRandom {
 			rand.Shuffle(len(zones), func(i, j int) {
 				zones[i], zones[j] = zones[j], zones[i]
@@ -209,7 +209,7 @@ func (s *Service) getDefaultSubnets() (infrav1.Subnets, error) {
 			sort.Strings(zones)
 		}
 		zones = zones[:maxZones]
-		s.scope.V(2).Info("zones selected", "region", s.scope.Region(), "zones", zones)
+		s.scope.Debug("zones selected", "region", s.scope.Region(), "zones", zones)
 	}
 
 	// 1 private subnet for each AZ plus 1 other subnet that will be further sub-divided for the public subnets
@@ -276,7 +276,7 @@ func (s *Service) getDefaultSubnets() (infrav1.Subnets, error) {
 
 func (s *Service) deleteSubnets() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
-		s.scope.V(4).Info("Skipping subnets deletion in unmanaged mode")
+		s.scope.Trace("Skipping subnets deletion in unmanaged mode")
 		return nil
 	}
 
@@ -462,7 +462,7 @@ func (s *Service) createSubnet(sn *infrav1.SubnetSpec) (*infrav1.SubnetSpec, err
 		}
 	}
 
-	s.scope.V(2).Info("Created new subnet in VPC with cidr and availability zone ",
+	s.scope.Debug("Created new subnet in VPC with cidr and availability zone ",
 		"subnet-id", *out.Subnet.SubnetId,
 		"vpc-id", *out.Subnet.VpcId,
 		"cidr-block", *out.Subnet.CidrBlock,

--- a/pkg/cloud/services/s3/s3.go
+++ b/pkg/cloud/services/s3/s3.go
@@ -224,7 +224,7 @@ func (s *Service) ensureBucketPolicy(bucketName string) error {
 		return errors.Wrap(err, "creating S3 bucket policy")
 	}
 
-	s.scope.V(4).Info("Updated bucket policy", "bucket_name", bucketName)
+	s.scope.Trace("Updated bucket policy", "bucket_name", bucketName)
 
 	return nil
 }

--- a/pkg/eks/identityprovider/plan.go
+++ b/pkg/eks/identityprovider/plan.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
-	"github.com/go-logr/logr"
 
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/planner"
 )
 
 // NewPlan creates plan to manage EKS OIDC identity provider association.
-func NewPlan(clusterName string, currentIdentityProvider, desiredIdentityProvider *OidcIdentityProviderConfig, client eksiface.EKSAPI, log logr.Logger) planner.Plan {
+func NewPlan(clusterName string, currentIdentityProvider, desiredIdentityProvider *OidcIdentityProviderConfig, client eksiface.EKSAPI, log logger.Wrapper) planner.Plan {
 	return &plan{
 		currentIdentityProvider: currentIdentityProvider,
 		desiredIdentityProvider: desiredIdentityProvider,
@@ -42,7 +42,7 @@ type plan struct {
 	currentIdentityProvider *OidcIdentityProviderConfig
 	desiredIdentityProvider *OidcIdentityProviderConfig
 	eksClient               eksiface.EKSAPI
-	log                     logr.Logger
+	log                     logger.Wrapper
 	clusterName             string
 }
 

--- a/pkg/eks/identityprovider/plan_test.go
+++ b/pkg/eks/identityprovider/plan_test.go
@@ -28,13 +28,14 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/eks/mock_eksiface"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 )
 
 func TestEKSAddonPlan(t *testing.T) {
 	clusterName := "default.cluster"
 	identityProviderARN := "aws:mock:provider:arn"
 	idnetityProviderName := "IdentityProviderConfigName"
-	log := klog.Background()
+	log := logger.NewLogger(klog.Background())
 
 	testCases := []struct {
 		name                    string

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,83 @@
+// Package logger
+//nolint: logrlint
+package logger
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	logLevelDebug = 2
+	logLevelWarn  = 3
+	logLevelTrace = 4
+)
+
+// Wrapper defines a convenient interface to use to log things.
+type Wrapper interface {
+	Info(msg string, keysAndValues ...any)
+	Debug(msg string, keysAndValues ...any)
+	Warn(msg string, keysAndValues ...any)
+	Trace(msg string, keysAndValues ...any)
+	Error(err error, msg string, keysAndValues ...any)
+	WithValues(keysAndValues ...any) *Logger
+	WithName(name string) *Logger
+	GetLogger() logr.Logger
+}
+
+// Logger is a concrete logger using logr underneath.
+type Logger struct {
+	logger logr.Logger
+}
+
+// NewLogger creates a logger with a passed in logr.Logger implementation directly.
+func NewLogger(log logr.Logger) *Logger {
+	return &Logger{
+		logger: log,
+	}
+}
+
+// FromContext retrieves the logr implementation from Context and uses it as underlying logger.
+func FromContext(ctx context.Context) *Logger {
+	log := logr.FromContextOrDiscard(ctx)
+	return &Logger{
+		logger: log,
+	}
+}
+
+var _ Wrapper = &Logger{}
+
+func (c *Logger) Info(msg string, keysAndValues ...any) {
+	c.logger.Info(msg, keysAndValues...)
+}
+
+func (c *Logger) Debug(msg string, keysAndValues ...any) {
+	c.logger.V(logLevelDebug).Info(msg, keysAndValues...)
+}
+
+func (c *Logger) Warn(msg string, keysAndValues ...any) {
+	c.logger.V(logLevelWarn).Info(msg, keysAndValues...)
+}
+
+func (c *Logger) Trace(msg string, keysAndValues ...any) {
+	c.logger.V(logLevelTrace).Info(msg, keysAndValues...)
+}
+
+func (c *Logger) Error(err error, msg string, keysAndValues ...any) {
+	c.logger.Error(err, msg, keysAndValues...)
+}
+
+func (c *Logger) GetLogger() logr.Logger {
+	return c.logger
+}
+
+func (c *Logger) WithValues(keysAndValues ...any) *Logger {
+	c.logger = c.logger.WithValues(keysAndValues...)
+	return c
+}
+
+func (c *Logger) WithName(name string) *Logger {
+	c.logger = c.logger.WithName(name)
+	return c
+}

--- a/test/mocks/capa_clusterscoper_mock.go
+++ b/test/mocks/capa_clusterscoper_mock.go
@@ -29,6 +29,7 @@ import (
 	v1beta2 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	cloud "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	throttle "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/throttle"
+	logger "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	client0 "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -126,18 +127,21 @@ func (mr *MockClusterScoperMockRecorder) ControllerName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerName", reflect.TypeOf((*MockClusterScoper)(nil).ControllerName))
 }
 
-// Enabled mocks base method.
-func (m *MockClusterScoper) Enabled() bool {
+// Debug mocks base method.
+func (m *MockClusterScoper) Debug(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Enabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Debug", varargs...)
 }
 
-// Enabled indicates an expected call of Enabled.
-func (mr *MockClusterScoperMockRecorder) Enabled() *gomock.Call {
+// Debug indicates an expected call of Debug.
+func (mr *MockClusterScoperMockRecorder) Debug(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enabled", reflect.TypeOf((*MockClusterScoper)(nil).Enabled))
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debug", reflect.TypeOf((*MockClusterScoper)(nil).Debug), varargs...)
 }
 
 // Error mocks base method.
@@ -155,6 +159,20 @@ func (mr *MockClusterScoperMockRecorder) Error(arg0, arg1 interface{}, arg2 ...i
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockClusterScoper)(nil).Error), varargs...)
+}
+
+// GetLogger mocks base method.
+func (m *MockClusterScoper) GetLogger() logr.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogger")
+	ret0, _ := ret[0].(logr.Logger)
+	return ret0
+}
+
+// GetLogger indicates an expected call of GetLogger.
+func (mr *MockClusterScoperMockRecorder) GetLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockClusterScoper)(nil).GetLogger))
 }
 
 // IdentityRef mocks base method.
@@ -340,25 +358,45 @@ func (mr *MockClusterScoperMockRecorder) SetFailureDomain(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFailureDomain", reflect.TypeOf((*MockClusterScoper)(nil).SetFailureDomain), arg0, arg1)
 }
 
-// V mocks base method.
-func (m *MockClusterScoper) V(arg0 int) logr.Logger {
+// Trace mocks base method.
+func (m *MockClusterScoper) Trace(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "V", arg0)
-	ret0, _ := ret[0].(logr.Logger)
-	return ret0
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Trace", varargs...)
 }
 
-// V indicates an expected call of V.
-func (mr *MockClusterScoperMockRecorder) V(arg0 interface{}) *gomock.Call {
+// Trace indicates an expected call of Trace.
+func (mr *MockClusterScoperMockRecorder) Trace(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V", reflect.TypeOf((*MockClusterScoper)(nil).V), arg0)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trace", reflect.TypeOf((*MockClusterScoper)(nil).Trace), varargs...)
+}
+
+// Warn mocks base method.
+func (m *MockClusterScoper) Warn(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Warn", varargs...)
+}
+
+// Warn indicates an expected call of Warn.
+func (mr *MockClusterScoperMockRecorder) Warn(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warn", reflect.TypeOf((*MockClusterScoper)(nil).Warn), varargs...)
 }
 
 // WithName mocks base method.
-func (m *MockClusterScoper) WithName(arg0 string) logr.Logger {
+func (m *MockClusterScoper) WithName(arg0 string) *logger.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithName", arg0)
-	ret0, _ := ret[0].(logr.Logger)
+	ret0, _ := ret[0].(*logger.Logger)
 	return ret0
 }
 
@@ -369,14 +407,14 @@ func (mr *MockClusterScoperMockRecorder) WithName(arg0 interface{}) *gomock.Call
 }
 
 // WithValues mocks base method.
-func (m *MockClusterScoper) WithValues(arg0 ...interface{}) logr.Logger {
+func (m *MockClusterScoper) WithValues(arg0 ...interface{}) *logger.Logger {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "WithValues", varargs...)
-	ret0, _ := ret[0].(logr.Logger)
+	ret0, _ := ret[0].(*logger.Logger)
 	return ret0
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Create a unified Logger interface which developers can use to log debug and trace information. It's just a soft wrapper around logr.Logger.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3152

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
