### PR TITLE
fix: wrong EKS tag when upgrading older clusters

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -69,7 +69,7 @@ func (s *Service) reconcileCluster(ctx context.Context) error {
 		oldOwnedTag := cluster.Tags[oldTagKey]
 
 		if ownedTag == nil && oldOwnedTag == nil {
-			return fmt.Errorf("cluster is not tagged with neither %s nor %s", tagKey, oldTagKey)
+			return fmt.Errorf("EKS cluster resource %q must have a tag with key %q or %q", eksClusterName, oldTagKey, tagKey)
 		}
 
 		s.scope.V(2).Info("Found owned EKS cluster in AWS", "cluster", klog.KRef("", eksClusterName))

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -62,8 +62,14 @@ func (s *Service) reconcileCluster(ctx context.Context) error {
 	} else {
 		tagKey := infrav1.ClusterAWSCloudProviderTagKey(eksClusterName)
 		ownedTag := cluster.Tags[tagKey]
-		if ownedTag == nil {
-			return fmt.Errorf("checking owner of %s is %s: %w", s.scope.KubernetesClusterName(), eksClusterName, err)
+		// Prior to https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3573,
+		// Clusters were tagged using s.scope.Name()
+		// To support upgrading older clusters, check for both tags
+		oldTagKey := infrav1.ClusterAWSCloudProviderTagKey(s.scope.Name())
+		oldOwnedTag := cluster.Tags[oldTagKey]
+
+		if ownedTag == nil && oldOwnedTag == nil {
+			return fmt.Errorf("cluster is not tagged with neither %s nor %s", tagKey, oldTagKey)
 		}
 
 		s.scope.V(2).Info("Found owned EKS cluster in AWS", "cluster", klog.KRef("", eksClusterName))


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
After https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3573, the AWS tag on a EKS cluster was changed. This was a good change to make everything more consistent, but it broke upgrading EKS clusters that were created with CAPA < v1.5.0.

In this PR, both the new and the previous tag formats will be checked and only fail if both are nil.

I also took the opportunity to clean up the error message, here is what it looked like before. It wasn't very clear what it was looking for and printed a nil error.
```
    - lastTransitionTime: "2022-09-22T10:01:30Z"
      message: 'checking owner of default_e2e-eks-upgrade-test-3618755-control-plane
        is e2e-eks-upgrade-test-3618755: %!!(MISSING)w(<nil>)'
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
