### PR TITLE
[release-1.5] fix: wrong EKS tag when upgrading older clusters

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -68,7 +68,7 @@ func (s *Service) reconcileCluster(ctx context.Context) error {
 		oldOwnedTag := cluster.Tags[oldTagKey]
 
 		if ownedTag == nil && oldOwnedTag == nil {
-			return fmt.Errorf("cluster is not tagged with neither %s nor %s", tagKey, oldTagKey)
+			return fmt.Errorf("EKS cluster resource %q must have a tag with key %q or %q", eksClusterName, oldTagKey, tagKey)
 		}
 
 		s.scope.V(2).Info("Found owned EKS cluster in AWS", "cluster-name", eksClusterName)


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3783.

The automated cherry-pick [failed](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3783#issuecomment-1284493507).