### PR TITLE
Change naming format of AMIs while searching for AMIs

### DIFF
--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -229,7 +229,7 @@ func getAllImages(ec2Client ec2iface.EC2API, ownerID string) (map[string][]*ec2.
 }
 
 func findAMI(imagesMap map[string][]*ec2.Image, baseOS, kubernetesVersion string) (*ec2.Image, error) {
-	amiNameFormat := "capa-ami-{{.BaseOS}}-{{.K8sVersion}}"
+	amiNameFormat := "capa-ami-{{.BaseOS}}-{{.K8sVersion}}-*"
 	amiName, err := ec2service.GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to process ami format: %q", amiNameFormat)

--- a/cmd/clusterawsadm/ami/helper_test.go
+++ b/cmd/clusterawsadm/ami/helper_test.go
@@ -19,7 +19,10 @@ package ami
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
 )
 
 func TestAllPatchVersions(t *testing.T) {
@@ -48,6 +51,53 @@ func TestAllPatchVersions(t *testing.T) {
 			if !cmp.Equal(got, tt.want) {
 				t.Errorf("allPatchesForVersion() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestFindAMI(t *testing.T) {
+	tests := []struct {
+		name      string
+		imagesMap map[string][]*ec2.Image
+		want      *ec2.Image
+	}{
+		{
+			name: "find AMI based on the latest ami format",
+			imagesMap: map[string][]*ec2.Image{
+				"capa-ami-amazon-2-v1.23.5-*": {
+					{
+						ImageId:      aws.String("capa-ami-amazon-2-v1.25.3-1664536077"),
+						CreationDate: aws.String("2011-02-08T17:02:31.000Z"),
+					},
+				},
+			},
+			want: &ec2.Image{
+				ImageId:      aws.String("capa-ami-amazon-2-v1.25.3-1664536077"),
+				CreationDate: aws.String("2011-02-08T17:02:31.000Z"),
+			},
+		},
+		{
+			name: "find AMI based on the old ami format",
+			imagesMap: map[string][]*ec2.Image{
+				"capa-ami-amazon-2-1.23.5": {
+					{
+						ImageId:      aws.String("capa-ami-amazon-2-1.25.3-00-1664536077"),
+						CreationDate: aws.String("2011-02-08T17:02:31.000Z"),
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := findAMI(tt.imagesMap, "amazon-2", "v1.23.5")
+			if err != nil {
+				t.Fatalf("error while finding AMI %+v", err)
+			}
+			g.Expect(got).Should(Equal(tt.want))
 		})
 	}
 }

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strings"
 	"text/template"
 	"time"
 
@@ -77,7 +76,7 @@ type AMILookup struct {
 
 // GenerateAmiName will generate an AMI name.
 func GenerateAmiName(amiNameFormat, baseOS, kubernetesVersion string) (string, error) {
-	amiNameParameters := AMILookup{baseOS, strings.TrimPrefix(kubernetesVersion, "v")}
+	amiNameParameters := AMILookup{baseOS, kubernetesVersion}
 	// revert to default if not specified
 	if amiNameFormat == "" {
 		amiNameFormat = DefaultAmiNameFormat

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -265,7 +265,7 @@ func TestGenerateAmiName(t *testing.T) {
 			args: args{
 				kubernetesVersion: "v1.23.3",
 			},
-			want: "capa-ami--?1.23.3-*",
+			want: "capa-ami--?v1.23.3-*",
 		},
 		{
 			name: "Should return valid amiName if default AMI name format passed",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The old AMIs were generated with following pattern: `capa-ami-amazon-2-1.25.2-00-1664536077`. From the recent releases, the new AMIs are getting generated as `capa-ami-amazon-2-v1.25.3-1665727783`(observe prefix v to the k8s version)). Because of this mismatch, the newly generated AMIs are not getting published in S3, as the AMIs are filtered based on the convention `capa-ami-{{.BaseOS}}-{{.K8sVersion}}`.
This PR fixes the AMI naming format from `capa-ami-{{.BaseOS}}-{{.K8sVersion}}` to `capa-ami-{{.BaseOS}}-{{.K8sVersion}}-*`, such that all the new AMIs are also published to the S3 amis.json.
[Ref](https://kubernetes.slack.com/archives/C01E0Q35A8J/p1666969997721009) slack thread.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
