### PR TITLE
PROPOSAL: move Daniel to maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,9 +27,9 @@ aliases:
     - sedefsavas
     - Skarlso
     - Ankitasw
+    - dlipovetsky
   cluster-api-aws-reviewers:
     - dthorsen
-    - dlipovetsky
     - pydctw
     - shivi28
     - AverageMarcus

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ Thank you to all contributors and a special thanks to our current maintainers & 
 | -------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | [@richardcase](https://github.com/richardcase) (from 2020-12-04)     | [@shivi28](https://github.com/shivi28) (from 2021-08-27)             |
 | [@sedefsavas](https://github.com/sedefsavas) (from 2021-03-21)       | [@dthorsen](https://github.com/dthorsen) (from 2020-12-04)           |
-| [@Skarlso](https://github.com/Skarlso) (from 2022-10-19)             | [@dlipovetsky](https://github.com/dlipovetsky) (from 2021-08-27)     |
-| [@Ankitasw](https://github.com/Ankitasw) (from 2022-10-19)           | [@pydctw](https://github.com/pydctw) (from 2021-12-09)               |
-|                                                                      | [@AverageMarcus](https://github.com/AverageMarcus) (from 2022-10-19) |
+| [@Skarlso](https://github.com/Skarlso) (from 2022-10-19)             | [@pydctw](https://github.com/pydctw) (from 2021-12-09)               |
+| [@Ankitasw](https://github.com/Ankitasw) (from 2022-10-19)           | [@AverageMarcus](https://github.com/AverageMarcus) (from 2022-10-19) |
+| [@dlipovetsky](https://github.com/dlipovetsky) (from 2021-10-31)     |                                                                      |
 
 and the previous/emeritus maintainers & reviewers:
 


### PR DESCRIPTION
Signed-off-by: Richard Case <richard.case@suse.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This change will move to Daniel from review to maintainer. Daniel has been a long term user and contributor to CAPA. He provides thoughtful and insightful reviews. 

Holding for lazy consensus until after the office hours on 31st October 2022

/hold

