### PR TITLE
fix: remove check for root volume device name on create

### DIFF
--- a/api/v1beta2/awsmachine_webhook.go
+++ b/api/v1beta2/awsmachine_webhook.go
@@ -193,7 +193,7 @@ func (r *AWSMachine) validateRootVolume() field.ErrorList {
 	}
 
 	if r.Spec.RootVolume.DeviceName != "" {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.rootVolume.deviceName"), "root volume shouldn't have device name"))
+		log.Info("root volume shouldn't have a device name (this can be ignored if performing a `clusterctl move`)")
 	}
 
 	return allErrs

--- a/api/v1beta2/awsmachine_webhook_test.go
+++ b/api/v1beta2/awsmachine_webhook_test.go
@@ -80,16 +80,18 @@ func TestAWSMachine_Create(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "ensure root volume has no device name",
+			name: "ensure root volume with device name works (for clusterctl move)",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					RootVolume: &Volume{
 						DeviceName: "name",
+						Type:       "gp2",
+						Size:       *aws.Int64(8),
 					},
 					InstanceType: "test",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "ensure non root volume have device names",

--- a/api/v1beta2/awsmachinetemplate_webhook.go
+++ b/api/v1beta2/awsmachinetemplate_webhook.go
@@ -68,7 +68,7 @@ func (r *AWSMachineTemplate) validateRootVolume() field.ErrorList {
 	}
 
 	if spec.RootVolume.DeviceName != "" {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.rootVolume.deviceName"), "root volume shouldn't have device name"))
+		log.Info("root volume shouldn't have a device name (this can be ignored if performing a `clusterctl move`)")
 	}
 
 	return allErrs

--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -59,6 +60,25 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 				},
 			},
 			wantError: true,
+		},
+		{
+			name: "ensure RootVolume DeviceName can be set for use with clusterctl move",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							RootVolume: &Volume{
+								DeviceName: "name",
+								Type:       "gp2",
+								Size:       *aws.Int64(8),
+							},
+							InstanceType: "test",
+						},
+					},
+				},
+			},
+			wantError: false,
 		},
 	}
 	for _, tt := range tests {

--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -75,7 +75,7 @@ func (r *AWSMachinePool) validateRootVolume() field.ErrorList {
 	}
 
 	if r.Spec.AWSLaunchTemplate.RootVolume.DeviceName != "" {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.awsLaunchTemplate.rootVolume.deviceName"), "root volume shouldn't have device name"))
+		log.Info("root volume shouldn't have a device name (this can be ignored if performing a `clusterctl move`)")
 	}
 
 	return allErrs

--- a/exp/api/v1beta2/awsmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook_test.go
@@ -124,6 +124,21 @@ func TestAWSMachinePool_ValidateCreate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Ensure root volume with device name works (for clusterctl move)",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						RootVolume: &infrav1.Volume{
+							DeviceName: "name",
+							Type:       "gp2",
+							Size:       *aws.Int64(8),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`clusterctl move` currently fails if trying to move an `AWSMachinePool` that have it's `rootVolume` already populated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3624

**Special notes for your reviewer**:

From what I can tell, the RootVolume device name is actually retrieved from the AMI image and the value in the `Spec` isn't used (only populated after creating).

See: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/7440d3ed110540432a7aed1ea165aaea79157a9c/pkg/cloud/services/ec2/instances.go#L926-L942

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
