### PR TITLE
[E2E] Fix test flavor generation make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,9 +369,6 @@ $(ARTIFACTS):
 .PHONY: generate-test-flavors
 generate-test-flavors: $(KUSTOMIZE)  ## Generate test template flavors
 	./hack/gen-test-flavors.sh withoutclusterclass
-
-.PHONY: generate-clusterclass-test-flavors
-generate-clusterclass-test-flavors: $(KUSTOMIZE)  ## Generate ClusterClass test template flavors
 	./hack/gen-test-flavors.sh withclusterclass
 
 .PHONY: e2e-image
@@ -401,7 +398,7 @@ test-verbose: setup-envtest ## Run tests with verbose settings.
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -v ./...
 
 .PHONY: test-e2e ## Run e2e tests using clusterctl
-test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) generate-test-flavors generate-clusterclass-test-flavors e2e-image ## Run e2e tests
+test-e2e: $(GINKGO) $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) generate-test-flavors e2e-image ## Run e2e tests
 	time $(GINKGO) -tags=e2e $(GINKGO_ARGS) -p ./test/e2e/suites/unmanaged/... -- -config-path="$(E2E_CONF_PATH)" $(E2E_ARGS)
 
 .PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind regression

**What this PR does / why we need it**:
This PR unifies the make target for generating test flavors for tests with and without using ClusterClass, as it was not much of a value-add to separate both, as both are used in almost all the tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
