### PR TITLE
Do not return error if secret does not exist

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -763,7 +763,7 @@ func (r *AWSMachineReconciler) deleteIgnitionBootstrapDataFromS3(machineScope *s
 	}
 
 	_, userDataFormat, err := machineScope.GetRawBootstrapDataWithFormat()
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		r.Recorder.Eventf(machineScope.AWSMachine, corev1.EventTypeWarning, "FailedGetBootstrapData", err.Error())
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
The non existence of the bootstrap secret should not prevent an awsMachine from being deleted

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This change in behaviour was most likely introduced during the ignition support introduction 
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2271/files#diff-4f8240f4e7ff07dcfa9627342b62772c1fe6ae0943021abe53fbb966db88886e

https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2271/files#diff-0b559bbd149f0e6d54d789235423f66fa8906fdc6ee9c99b9e85db912912011e

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
deleteIgnitionBootstrapDataFromS3 do not return error if secret is not found
```
