### PR TITLE
[release-1.5] Fix ProviderIDList in managed machinepool

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 )
 
 func (s *NodegroupService) describeNodegroup() (*eks.Nodegroup, error) {
@@ -573,12 +572,7 @@ func (s *NodegroupService) setStatus(ng *eks.Nodegroup) error {
 		for _, group := range groups.AutoScalingGroups {
 			replicas += int32(len(group.Instances))
 			for _, instance := range group.Instances {
-				id, err := noderefutil.NewProviderID(fmt.Sprintf("aws://%s/%s", *instance.AvailabilityZone, *instance.InstanceId))
-				if err != nil {
-					s.Error(err, "couldn't create provider ID for instance", "id", *instance.InstanceId)
-					continue
-				}
-				providerIDList = append(providerIDList, id.String())
+				providerIDList = append(providerIDList, fmt.Sprintf("aws:///%s/%s", *instance.AvailabilityZone, *instance.InstanceId))
 			}
 		}
 		managedPool.Spec.ProviderIDList = providerIDList


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Due to provider ID matching logic changes in core CAPI, ProviderIdList need to be populated correctly.
Fix for unmanaged machine pools is https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3743 and this PR does the same for managed machine pools.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
