### PR TITLE
[E2E] Use k8s version 1.24.4 in conformance test and increase control plane wait timeout for conformance and EKS tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -156,7 +156,7 @@ variables:
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_MACHINE_TYPE_VCPU_USAGE: 2
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.24.0"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.24.4"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
   ETCD_VERSION_UPGRADE_TO: "3.5.3-0"
@@ -180,7 +180,7 @@ intervals:
   default/wait-cluster: ["30m", "10s"]
   default/wait-control-plane: ["25m", "10s"]
   default/wait-worker-nodes: ["20m", "10s"]
-  conformance/wait-control-plane: ["30m", "10s"]
+  conformance/wait-control-plane: ["35m", "10s"]
   conformance/wait-worker-nodes: ["35m", "10s"]
   default/wait-controllers: ["5m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -136,7 +136,7 @@ variables:
 
 intervals:
   default/wait-cluster: ["30m", "10s"]
-  default/wait-control-plane: ["30m", "10s"]
+  default/wait-control-plane: ["35m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-controllers: ["5m", "10s"]
   default/wait-delete-cluster: ["35m", "30s"]

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -758,8 +758,7 @@ func DumpCloudTrailEvents(e2eCtx *E2EContext) {
 // Kubernetes version in the e2econfig.
 func conformanceImageID(e2eCtx *E2EContext) string {
 	ver := e2eCtx.E2EConfig.GetVariable("CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION")
-	strippedVer := strings.Replace(ver, "v", "", 1)
-	amiName := AMIPrefix + strippedVer + "*"
+	amiName := AMIPrefix + ver + "*"
 
 	Byf("Searching for AMI: name=%s", amiName)
 	ec2Svc := ec2.New(e2eCtx.AWSSession)


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind regression

**What this PR does / why we need it**:
This PR upgrades the conformance tests k8s version to 1.24.4 so as to pick up the corrected AMIs with containerd version 1.6.6, which fixes failing conformance tests.
This PR also increases the control plane wait timeout such that conformance test passes.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/113449

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
