### PR TITLE
Make overwrite the default behaviour for conflict resolution in addons

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1355,7 +1355,7 @@ spec:
                   description: Addon represents a EKS addon.
                   properties:
                     conflictResolution:
-                      default: none
+                      default: overwrite
                       description: ConflictResolution is used to declare what should
                         happen if there are parameter conflicts. Defaults to none
                       enum:

--- a/controlplane/eks/api/v1beta2/types.go
+++ b/controlplane/eks/api/v1beta2/types.go
@@ -132,7 +132,7 @@ type Addon struct {
 	Version string `json:"version"`
 	// ConflictResolution is used to declare what should happen if there
 	// are parameter conflicts. Defaults to none
-	// +kubebuilder:default=none
+	// +kubebuilder:default=overwrite
 	// +kubebuilder:validation:Enum=overwrite;none
 	ConflictResolution *AddonResolution `json:"conflictResolution,omitempty"`
 	// ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account

--- a/docs/book/src/topics/eks/addons.md
+++ b/docs/book/src/topics/eks/addons.md
@@ -23,6 +23,9 @@ spec:
       conflictResolution: "overwrite"
 ```
 
+_Note_: For `conflictResolution` `overwrite` is the **default** behaviour. That means, if not otherwise specified, it's
+set to `overwrite`.
+
 Additionally, there is a cluster [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors)
 called [eks-managedmachinepool-vpccni](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template-eks-managedmachinepool-vpccni.yaml) that you can use with **clusterctl**:
 

--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -208,12 +208,8 @@ func (s *Service) translateAPIToAddon(addons []ekscontrolplanev1.Addon) []*eksad
 }
 
 func convertConflictResolution(conflict ekscontrolplanev1.AddonResolution) *string {
-	switch conflict {
-	case ekscontrolplanev1.AddonResolutionNone:
+	if conflict == ekscontrolplanev1.AddonResolutionNone {
 		return aws.String(eks.ResolveConflictsNone)
-	case ekscontrolplanev1.AddonResolutionOverwrite:
-		return aws.String(eks.ResolveConflictsOverwrite)
-	default:
-		return nil
 	}
+	return aws.String(eks.ResolveConflictsOverwrite)
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

After the IPv6 discussion there was this comment from Richard: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3513#discussion_r917737084

There is no scenario in which you wouldn't want to overwrite, so we set it up as default behaviour.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
