### PR TITLE
Remove ARN field from AWSResourceReference

### DIFF
--- a/api/v1beta1/awsmachine_conversion.go
+++ b/api/v1beta1/awsmachine_conversion.go
@@ -65,7 +65,7 @@ func (dst *AWSMachineList) ConvertFrom(srcRaw conversion.Hub) error {
 	return Convert_v1beta2_AWSMachineList_To_v1beta1_AWSMachineList(src, dst, nil)
 }
 
-// ConvertTo converts the v1beta1 AWSCluster receiver to a v1beta2 AWSCluster.
+// ConvertTo converts the v1beta1 AWSMachineTemplate receiver to a v1beta2 AWSMachineTemplate.
 func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*infrav1.AWSMachineTemplate)
 
@@ -113,4 +113,3 @@ func (dst *AWSMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 
 	return Convert_v1beta2_AWSMachineTemplateList_To_v1beta1_AWSMachineTemplateList(src, dst, nil)
 }
-

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -24,3 +24,7 @@ import (
 func Convert_v1beta2_AWSClusterSpec_To_v1beta1_AWSClusterSpec(in *v1beta2.AWSClusterSpec, out *AWSClusterSpec, s conversion.Scope) error {
 	return autoConvert_v1beta2_AWSClusterSpec_To_v1beta1_AWSClusterSpec(in, out, s)
 }
+
+func Convert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(in *AWSResourceReference, out *v1beta2.AWSResourceReference, s conversion.Scope) error {
+	return autoConvert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(in, out, s)
+}

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -21,10 +21,50 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	v1beta2 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	fuzz "github.com/google/gofuzz"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+func fuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		AWSMachineFuzzer,
+		AWSMachineTemplateFuzzer,
+	}
+}
+
+func AWSMachineFuzzer(obj *AWSMachine, c fuzz.Continue) {
+	c.FuzzNoCustom(obj)
+	
+	// AWSMachine.Spec.Subnet.ARN and AWSMachine.Spec.AdditionalSecurityGroups.ARN has been removed in v1beta2, so setting it to nil in order to avoid v1beta1 --> v1beta2 --> v1beta1 round trip errors.
+	if obj.Spec.Subnet != nil {
+		obj.Spec.Subnet.ARN = nil
+	}
+	restored := make([]AWSResourceReference, len(obj.Spec.AdditionalSecurityGroups))
+	for _, sg := range obj.Spec.AdditionalSecurityGroups {
+		sg.ARN = nil
+		restored = append(restored, sg)
+	}
+	obj.Spec.AdditionalSecurityGroups = restored
+}
+
+func AWSMachineTemplateFuzzer(obj *AWSMachineTemplate, c fuzz.Continue) {
+	c.FuzzNoCustom(obj)
+	
+	// AWSMachineTemplate.Spec.Template.Spec.FailureDomain, AWSMachineTemplate.Spec.Template.Spec.Subnet.ARN and AWSMachineTemplate.Spec.Template.Spec.AdditionalSecurityGroups.ARN has been removed in v1beta2, so setting it to nil in order to avoid  v1beta1 --> v1beta2 --> v1beta round trip errors.
+	if obj.Spec.Template.Spec.Subnet != nil {
+		obj.Spec.Template.Spec.Subnet.ARN = nil
+	}
+	restored := make([]AWSResourceReference, len(obj.Spec.Template.Spec.AdditionalSecurityGroups))
+	for _, sg := range obj.Spec.Template.Spec.AdditionalSecurityGroups {
+		sg.ARN = nil
+		restored = append(restored, sg)
+	}
+	obj.Spec.Template.Spec.AdditionalSecurityGroups = restored
+}
 
 func TestFuzzyConversion(t *testing.T) {
 	g := NewWithT(t)
@@ -42,12 +82,14 @@ func TestFuzzyConversion(t *testing.T) {
 		Scheme: scheme,
 		Hub:    &v1beta2.AWSMachine{},
 		Spoke:  &AWSMachine{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzFuncs},
 	}))
 
 	t.Run("for AWSMachineTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Scheme: scheme,
 		Hub:    &v1beta2.AWSMachineTemplate{},
 		Spoke:  &AWSMachineTemplate{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzFuncs},
 	}))
 
 	t.Run("for AWSClusterStaticIdentity", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -335,11 +335,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*AWSResourceReference)(nil), (*v1beta2.AWSResourceReference)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(a.(*AWSResourceReference), b.(*v1beta2.AWSResourceReference), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*v1beta2.AWSResourceReference)(nil), (*AWSResourceReference)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_AWSResourceReference_To_v1beta1_AWSResourceReference(a.(*v1beta2.AWSResourceReference), b.(*AWSResourceReference), scope)
 	}); err != nil {
@@ -592,6 +587,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*v1beta2.Volume)(nil), (*Volume)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_Volume_To_v1beta1_Volume(a.(*v1beta2.Volume), b.(*Volume), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*AWSResourceReference)(nil), (*v1beta2.AWSResourceReference)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(a.(*AWSResourceReference), b.(*v1beta2.AWSResourceReference), scope)
 	}); err != nil {
 		return err
 	}
@@ -1228,7 +1228,17 @@ func Convert_v1beta2_AWSMachine_To_v1beta1_AWSMachine(in *v1beta2.AWSMachine, ou
 
 func autoConvert_v1beta1_AWSMachineList_To_v1beta2_AWSMachineList(in *AWSMachineList, out *v1beta2.AWSMachineList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1beta2.AWSMachine)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1beta2.AWSMachine, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_AWSMachine_To_v1beta2_AWSMachine(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1239,7 +1249,17 @@ func Convert_v1beta1_AWSMachineList_To_v1beta2_AWSMachineList(in *AWSMachineList
 
 func autoConvert_v1beta2_AWSMachineList_To_v1beta1_AWSMachineList(in *v1beta2.AWSMachineList, out *AWSMachineList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]AWSMachine)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]AWSMachine, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_AWSMachine_To_v1beta1_AWSMachine(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1261,9 +1281,27 @@ func autoConvert_v1beta1_AWSMachineSpec_To_v1beta2_AWSMachineSpec(in *AWSMachine
 	out.AdditionalTags = *(*v1beta2.Tags)(unsafe.Pointer(&in.AdditionalTags))
 	out.IAMInstanceProfile = in.IAMInstanceProfile
 	out.PublicIP = (*bool)(unsafe.Pointer(in.PublicIP))
-	out.AdditionalSecurityGroups = *(*[]v1beta2.AWSResourceReference)(unsafe.Pointer(&in.AdditionalSecurityGroups))
+	if in.AdditionalSecurityGroups != nil {
+		in, out := &in.AdditionalSecurityGroups, &out.AdditionalSecurityGroups
+		*out = make([]v1beta2.AWSResourceReference, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AdditionalSecurityGroups = nil
+	}
 	out.FailureDomain = (*string)(unsafe.Pointer(in.FailureDomain))
-	out.Subnet = (*v1beta2.AWSResourceReference)(unsafe.Pointer(in.Subnet))
+	if in.Subnet != nil {
+		in, out := &in.Subnet, &out.Subnet
+		*out = new(v1beta2.AWSResourceReference)
+		if err := Convert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Subnet = nil
+	}
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))
 	out.RootVolume = (*v1beta2.Volume)(unsafe.Pointer(in.RootVolume))
 	out.NonRootVolumes = *(*[]v1beta2.Volume)(unsafe.Pointer(&in.NonRootVolumes))
@@ -1296,9 +1334,27 @@ func autoConvert_v1beta2_AWSMachineSpec_To_v1beta1_AWSMachineSpec(in *v1beta2.AW
 	out.AdditionalTags = *(*Tags)(unsafe.Pointer(&in.AdditionalTags))
 	out.IAMInstanceProfile = in.IAMInstanceProfile
 	out.PublicIP = (*bool)(unsafe.Pointer(in.PublicIP))
-	out.AdditionalSecurityGroups = *(*[]AWSResourceReference)(unsafe.Pointer(&in.AdditionalSecurityGroups))
+	if in.AdditionalSecurityGroups != nil {
+		in, out := &in.AdditionalSecurityGroups, &out.AdditionalSecurityGroups
+		*out = make([]AWSResourceReference, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_AWSResourceReference_To_v1beta1_AWSResourceReference(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AdditionalSecurityGroups = nil
+	}
 	out.FailureDomain = (*string)(unsafe.Pointer(in.FailureDomain))
-	out.Subnet = (*AWSResourceReference)(unsafe.Pointer(in.Subnet))
+	if in.Subnet != nil {
+		in, out := &in.Subnet, &out.Subnet
+		*out = new(AWSResourceReference)
+		if err := Convert_v1beta2_AWSResourceReference_To_v1beta1_AWSResourceReference(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Subnet = nil
+	}
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))
 	out.RootVolume = (*Volume)(unsafe.Pointer(in.RootVolume))
 	out.NonRootVolumes = *(*[]Volume)(unsafe.Pointer(&in.NonRootVolumes))
@@ -1384,7 +1440,17 @@ func Convert_v1beta2_AWSMachineTemplate_To_v1beta1_AWSMachineTemplate(in *v1beta
 
 func autoConvert_v1beta1_AWSMachineTemplateList_To_v1beta2_AWSMachineTemplateList(in *AWSMachineTemplateList, out *v1beta2.AWSMachineTemplateList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1beta2.AWSMachineTemplate)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1beta2.AWSMachineTemplate, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_AWSMachineTemplate_To_v1beta2_AWSMachineTemplate(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1395,7 +1461,17 @@ func Convert_v1beta1_AWSMachineTemplateList_To_v1beta2_AWSMachineTemplateList(in
 
 func autoConvert_v1beta2_AWSMachineTemplateList_To_v1beta1_AWSMachineTemplateList(in *v1beta2.AWSMachineTemplateList, out *AWSMachineTemplateList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]AWSMachineTemplate)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]AWSMachineTemplate, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_AWSMachineTemplate_To_v1beta1_AWSMachineTemplate(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1476,19 +1552,13 @@ func Convert_v1beta2_AWSMachineTemplateStatus_To_v1beta1_AWSMachineTemplateStatu
 
 func autoConvert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(in *AWSResourceReference, out *v1beta2.AWSResourceReference, s conversion.Scope) error {
 	out.ID = (*string)(unsafe.Pointer(in.ID))
-	out.ARN = (*string)(unsafe.Pointer(in.ARN))
+	// WARNING: in.ARN requires manual conversion: does not exist in peer-type
 	out.Filters = *(*[]v1beta2.Filter)(unsafe.Pointer(&in.Filters))
 	return nil
 }
 
-// Convert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference is an autogenerated conversion function.
-func Convert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(in *AWSResourceReference, out *v1beta2.AWSResourceReference, s conversion.Scope) error {
-	return autoConvert_v1beta1_AWSResourceReference_To_v1beta2_AWSResourceReference(in, out, s)
-}
-
 func autoConvert_v1beta2_AWSResourceReference_To_v1beta1_AWSResourceReference(in *v1beta2.AWSResourceReference, out *AWSResourceReference, s conversion.Scope) error {
 	out.ID = (*string)(unsafe.Pointer(in.ID))
-	out.ARN = (*string)(unsafe.Pointer(in.ARN))
 	out.Filters = *(*[]Filter)(unsafe.Pointer(&in.Filters))
 	return nil
 }

--- a/api/v1beta2/awsmachine_webhook.go
+++ b/api/v1beta2/awsmachine_webhook.go
@@ -252,9 +252,6 @@ func (r *AWSMachine) validateAdditionalSecurityGroups() field.ErrorList {
 		if len(additionalSecurityGroup.Filters) > 0 && additionalSecurityGroup.ID != nil {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.additionalSecurityGroups"), "only one of ID or Filters may be specified, specifying both is forbidden"))
 		}
-		if additionalSecurityGroup.ARN != nil {
-			log.Info("ARN field is deprecated and is no operation function.")
-		}
 	}
 	return allErrs
 }

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -30,11 +30,6 @@ type AWSResourceReference struct {
 	// +optional
 	ID *string `json:"id,omitempty"`
 
-	// ARN of resource.
-	// +optional
-	// Deprecated: This field has no function and is going to be removed in the next release.
-	ARN *string `json:"arn,omitempty"`
-
 	// Filters is a set of key/value pairs used to identify a resource
 	// They are applied according to the rules defined by the AWS API:
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -902,11 +902,6 @@ func (in *AWSResourceReference) DeepCopyInto(out *AWSResourceReference) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.ARN != nil {
-		in, out := &in.ARN, &out.ARN
-		*out = new(string)
-		**out = **in
-	}
 	if in.Filters != nil {
 		in, out := &in.Filters, &out.Filters
 		*out = make([]Filter, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -87,10 +87,6 @@ spec:
                         be specified. Specifying more than one will result in a validation
                         error.
                       properties:
-                        arn:
-                          description: 'ARN of resource. Deprecated: This field has
-                            no function and is going to be removed in the next release.'
-                          type: string
                         filters:
                           description: 'Filters is a set of key/value pairs used to
                             identify a resource They are applied according to the
@@ -341,10 +337,6 @@ spec:
                     resource by ID or filters. Only one of ID or Filters may be specified.
                     Specifying more than one will result in a validation error.
                   properties:
-                    arn:
-                      description: 'ARN of resource. Deprecated: This field has no
-                        function and is going to be removed in the next release.'
-                      type: string
                     filters:
                       description: 'Filters is a set of key/value pairs used to identify
                         a resource They are applied according to the rules defined
@@ -562,10 +554,6 @@ spec:
                         be specified. Specifying more than one will result in a validation
                         error.
                       properties:
-                        arn:
-                          description: 'ARN of resource. Deprecated: This field has
-                            no function and is going to be removed in the next release.'
-                          type: string
                         filters:
                           description: 'Filters is a set of key/value pairs used to
                             identify a resource They are applied according to the
@@ -821,10 +809,6 @@ spec:
                     resource by ID or filters. Only one of ID or Filters may be specified.
                     Specifying more than one will result in a validation error.
                   properties:
-                    arn:
-                      description: 'ARN of resource. Deprecated: This field has no
-                        function and is going to be removed in the next release.'
-                      type: string
                     filters:
                       description: 'Filters is a set of key/value pairs used to identify
                         a resource They are applied according to the rules defined

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -545,10 +545,6 @@ spec:
                     resource by ID or filters. Only one of ID or Filters may be specified.
                     Specifying more than one will result in a validation error.
                   properties:
-                    arn:
-                      description: 'ARN of resource. Deprecated: This field has no
-                        function and is going to be removed in the next release.'
-                      type: string
                     filters:
                       description: 'Filters is a set of key/value pairs used to identify
                         a resource They are applied according to the rules defined
@@ -799,10 +795,6 @@ spec:
                 description: Subnet is a reference to the subnet to use for this instance.
                   If not specified, the cluster subnet will be used.
                 properties:
-                  arn:
-                    description: 'ARN of resource. Deprecated: This field has no function
-                      and is going to be removed in the next release.'
-                    type: string
                   filters:
                     description: 'Filters is a set of key/value pairs used to identify
                       a resource They are applied according to the rules defined by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -487,11 +487,6 @@ spec:
                             may be specified. Specifying more than one will result
                             in a validation error.
                           properties:
-                            arn:
-                              description: 'ARN of resource. Deprecated: This field
-                                has no function and is going to be removed in the
-                                next release.'
-                              type: string
                             filters:
                               description: 'Filters is a set of key/value pairs used
                                 to identify a resource They are applied according
@@ -754,11 +749,6 @@ spec:
                           this instance. If not specified, the cluster subnet will
                           be used.
                         properties:
-                          arn:
-                            description: 'ARN of resource. Deprecated: This field
-                              has no function and is going to be removed in the next
-                              release.'
-                            type: string
                           filters:
                             description: 'Filters is a set of key/value pairs used
                               to identify a resource They are applied according to

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -94,10 +94,6 @@ spec:
                         be specified. Specifying more than one will result in a validation
                         error.
                       properties:
-                        arn:
-                          description: 'ARN of resource. Deprecated: This field has
-                            no function and is going to be removed in the next release.'
-                          type: string
                         filters:
                           description: 'Filters is a set of key/value pairs used to
                             identify a resource They are applied according to the
@@ -546,10 +542,6 @@ spec:
                         be specified. Specifying more than one will result in a validation
                         error.
                       properties:
-                        arn:
-                          description: 'ARN of resource. Deprecated: This field has
-                            no function and is going to be removed in the next release.'
-                          type: string
                         filters:
                           description: 'Filters is a set of key/value pairs used to
                             identify a resource They are applied according to the

--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -89,9 +89,6 @@ func (r *AWSMachinePool) validateSubnets() field.ErrorList {
 	}
 
 	for _, subnet := range r.Spec.Subnets {
-		if subnet.ARN != nil {
-			log.Info("ARN field is deprecated and is no operation function.")
-		}
 		if subnet.ID != nil && subnet.Filters != nil {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.subnets.filters"), "providing either subnet ID or filter is supported, should not provide both"))
 			break
@@ -106,9 +103,6 @@ func (r *AWSMachinePool) validateAdditionalSecurityGroups() field.ErrorList {
 	for _, sg := range r.Spec.AWSLaunchTemplate.AdditionalSecurityGroups {
 		if sg.ID != nil && sg.Filters != nil {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.awsLaunchTemplate.AdditionalSecurityGroups"), "either ID or filters should be used"))
-		}
-		if sg.ARN != nil {
-			log.Info("ARN field is deprecated and is no operation function.")
 		}
 	}
 	return allErrs

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f
+	github.com/google/gofuzz v1.2.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.22.1
 	github.com/pkg/errors v0.9.1
@@ -87,7 +88,6 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-github/v45 v45.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package logger
 //nolint: logrlint
 package logger


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We deprecated ARN field from AWSResourceReference in this [PR](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3257) and decided to remove it once v1beta2 API changes are in. This PR removes that field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes Part of #2355 

**Special notes for your reviewer**:

**Checklist**:
- [x] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests
