### PR TITLE
docs: restore comment describing specific envsubst usage

### DIFF
--- a/config/rbac/serviceaccount.yaml
+++ b/config/rbac/serviceaccount.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     control-plane: controller-manager
   annotations:
+    # The following uses the prefix substitution functionality of envsubst (https://github.com/drone/envsubst)
+    # Not compatible with GNU envsubst
     ${AWS_CONTROLLER_IAM_ROLE/#arn/eks.amazonaws.com/role-arn: arn}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

I ran into an issue using the published manifests because there was an envsubst directive that is only compatible with a specific distribution of envsubst (github.com/drone/envsubst). I found [context in an old PR](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2100/files#r534228348). This PR restores an explanatory comment that got lost in a subsequent change.