### PR TITLE
e2e: remove Subnet CCM tags

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -1243,27 +1243,9 @@ func CreateSubnet(e2eCtx *E2EContext, clusterName string, cidrBlock string, az s
 						Key:   aws.String("Name"),
 						Value: aws.String(clusterName + "-subnet-" + st),
 					},
-					{
-						Key:   aws.String("kubernetes.io/cluster/" + clusterName),
-						Value: aws.String("shared"),
-					},
 				},
 			},
 		},
-	}
-
-	// Tag subnet based on type(st)
-	switch st {
-	case "private":
-		input.TagSpecifications[0].Tags = append(input.TagSpecifications[0].Tags, &ec2.Tag{
-			Key:   aws.String("kubernetes.io/role/internal-elb"),
-			Value: aws.String("1"),
-		})
-	case "public":
-		input.TagSpecifications[0].Tags = append(input.TagSpecifications[0].Tags, &ec2.Tag{
-			Key:   aws.String("kubernetes.io/role/elb"),
-			Value: aws.String("1"),
-		})
 	}
 
 	if az != "" {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
Removes CCM tags from unmanaged Subnets in e2e helper functions and test https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2715.

This PR https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3251 modified the e2e functions to tag unmanaged Subnets, instead the e2e tests should rely on CAPA to do the correct tagging.

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
@dlipovetsky and I noticed this while looking at https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3481

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
