### PR TITLE
fix: Replace misleading wording used for security group overrides

### DIFF
--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -193,7 +193,7 @@ func (s *ManagedControlPlaneScope) SecondaryCidrBlock() *string {
 	return s.ControlPlane.Spec.SecondaryCidrBlock
 }
 
-// SecurityGroupOverrides returns the security groups that are overridden in the ControlPlane spec.
+// SecurityGroupOverrides returns the security groups that are overrides in the ControlPlane spec.
 func (s *ManagedControlPlaneScope) SecurityGroupOverrides() map[infrav1.SecurityGroupRole]string {
 	return s.ControlPlane.Spec.NetworkSpec.SecurityGroupOverrides
 }

--- a/pkg/cloud/scope/sg.go
+++ b/pkg/cloud/scope/sg.go
@@ -31,7 +31,7 @@ type SGScope interface {
 	// SecurityGroups returns the cluster security groups as a map, it creates the map if empty.
 	SecurityGroups() map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
 
-	// SecurityGroupOverrides returns the security groups that are overridden in the cluster spec
+	// SecurityGroupOverrides returns the security groups that are used as overrides in the cluster spec
 	SecurityGroupOverrides() map[infrav1.SecurityGroupRole]string
 
 	// VPC returns the cluster VPC.

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -119,7 +119,7 @@ func (s *Service) ReconcileSecurityGroups() error {
 			continue
 		}
 
-		if !s.securityGroupIsOverridden(existing.ID) {
+		if !s.securityGroupIsAnOverride(existing.ID) {
 			// Make sure tags are up to date.
 			if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
 				buildParams := s.getSecurityGroupTagParams(existing.Name, existing.ID, role)
@@ -140,8 +140,8 @@ func (s *Service) ReconcileSecurityGroups() error {
 		sg := s.scope.SecurityGroups()[i]
 		s.scope.Debug("second pass security group reconciliation", "group-id", sg.ID, "name", sg.Name, "role", i)
 
-		if s.securityGroupIsOverridden(sg.ID) {
-			// skip rule/tag reconciliation on security groups that are overridden, assuming they're managed by another process
+		if s.securityGroupIsAnOverride(sg.ID) {
+			// skip rule/tag reconciliation on security groups that are overrides, assuming they're managed by another process
 			continue
 		}
 
@@ -188,7 +188,7 @@ func (s *Service) ReconcileSecurityGroups() error {
 	return nil
 }
 
-func (s *Service) securityGroupIsOverridden(securityGroupID string) bool {
+func (s *Service) securityGroupIsAnOverride(securityGroupID string) bool {
 	for _, overrideID := range s.scope.SecurityGroupOverrides() {
 		if overrideID == securityGroupID {
 			return true

--- a/pkg/cloud/services/securitygroup/securitygroups_test.go
+++ b/pkg/cloud/services/securitygroup/securitygroups_test.go
@@ -247,7 +247,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 			},
 		},
 		{
-			name: "all overridden, do not tag",
+			name: "all overrides defined, do not tag",
 			input: &infrav1.NetworkSpec{
 				VPC: infrav1.VPCSpec{
 					ID:                "vpc-securitygroups",
@@ -412,7 +412,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "do not delete overridden security groups",
+			name: "do not delete security groups provided as overrides",
 			input: &infrav1.NetworkSpec{
 				VPC: infrav1.VPCSpec{
 					ID:                "vpc-securitygroups",


### PR DESCRIPTION
The wording "overridden" is misleading. In every case where the wording is used to reference a security group, the security group is being overridden. Instead, it is the security group provided as an override.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The wording "overridden" is misleading. In every case where the wording is used to reference a security group, the security group is being overridden. Instead, it is the security group provided as an override.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
