### PR TITLE
Remove Equals() from v1beta2 Tags API

### DIFF
--- a/api/v1beta2/tags.go
+++ b/api/v1beta2/tags.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -29,12 +28,6 @@ import (
 
 // Tags defines a map of tags.
 type Tags map[string]string
-
-// Equals returns true if the tags are equal.
-// This func is deprecated and should not be used.
-func (t Tags) Equals(other Tags) bool {
-	return cmp.Equal(t, other)
-}
 
 // HasOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of this management tooling.
 func (t Tags) HasOwned(cluster string) bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up the `Equals` func from `Tags` as it is deprecated and not used anywhere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes Part of #2355 

**Special notes for your reviewer**:

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
