### PR TITLE
Remove suspend process flow from create ASG

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -404,6 +404,7 @@ func (r *AWSMachinePoolReconciler) updatePool(machinePoolScope *scope.MachinePoo
 
 	suspendedProcessesSlice := machinePoolScope.AWSMachinePool.Spec.SuspendProcesses.ConvertSetValuesToStringSlice()
 	if !cmp.Equal(existingASG.CurrentlySuspendProcesses, suspendedProcessesSlice) {
+		clusterScope.Info("reconciling processes", "suspend-processes", suspendedProcessesSlice)
 		var (
 			toBeSuspended []string
 			toBeResumed   []string
@@ -431,7 +432,7 @@ func (r *AWSMachinePoolReconciler) updatePool(machinePoolScope *scope.MachinePoo
 			delete(currentlySuspended, k)
 		}
 
-		// Convert them back into lists so
+		// Convert them back into lists to pass them to resume/suspend.
 		for k := range desiredSuspended {
 			toBeSuspended = append(toBeSuspended, k)
 		}
@@ -441,11 +442,13 @@ func (r *AWSMachinePoolReconciler) updatePool(machinePoolScope *scope.MachinePoo
 		}
 
 		if len(toBeSuspended) > 0 {
+			clusterScope.Info("suspending processes", "processes", toBeSuspended)
 			if err := asgSvc.SuspendProcesses(existingASG.Name, toBeSuspended); err != nil {
 				return errors.Wrapf(err, "failed to suspend processes while trying update pool")
 			}
 		}
 		if len(toBeResumed) > 0 {
+			clusterScope.Info("resuming processes", "processes", toBeResumed)
 			if err := asgSvc.ResumeProcesses(existingASG.Name, toBeResumed); err != nil {
 				return errors.Wrapf(err, "failed to resume processes while trying update pool")
 			}


### PR DESCRIPTION
/kind bug


**What this PR does / why we need it**:

The suspend flow in the create ASG process is failing because during the ASG creation, we never return the actual ASG. That's because the CreateAutoscalingGroup flow is not returning an ASG so we reconcile it.

I just removed the suspend during creation, the update flow should still suspend or unsuspend anything that is different.

I'll try adding some more tests to this part of the code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
