### PR TITLE
Fix lastAppliedTags annotations naming

### DIFF
--- a/controllers/awsmachine_security_groups.go
+++ b/controllers/awsmachine_security_groups.go
@@ -31,7 +31,7 @@ const (
 	// the AdditionalSecurityGroups in the Machine Provider Config.
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
-	SecurityGroupsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws/v2-last-applied-security-groups"
+	SecurityGroupsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws-last-applied-security-groups"
 )
 
 // Ensures that the security groups of the machine are correct

--- a/controllers/awsmachine_tags.go
+++ b/controllers/awsmachine_tags.go
@@ -26,7 +26,7 @@ const (
 	// which tracks the AdditionalTags in the Machine Provider Config.
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
-	TagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws/v2-last-applied-tags"
+	TagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws-last-applied-tags"
 
 	// VolumeTagsLastAppliedAnnotation is the key for the ebs volumes annotation
 	// which tracks the AdditionalTags in the Machine Provider Config.

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -47,7 +47,7 @@ const (
 	// AdditionalTags in the AWSMachinePool Provider Config.
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
-	TagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws/v2-last-applied-tags"
+	TagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws-last-applied-tags"
 )
 
 func (s *Service) ReconcileLaunchTemplate(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Valid annotation keys have two segments: an optional prefix and name, separated by a slash (/). 
In this commit, we fix the ones that include two slashes that couldn't be parsed as valid structs.

**Which issue(s) this PR fixes**:
Fixes #3863

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
