### PR TITLE
test: increased cluster creation timeout for eks e2e

### DIFF
--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -135,7 +135,7 @@ variables:
   CAPA_LOGLEVEL: "4"
 
 intervals:
-  default/wait-cluster: ["30m", "10s"]
+  default/wait-cluster: ["40m", "10s"]
   default/wait-control-plane: ["35m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/suites/managed/cluster.go
+++ b/test/e2e/suites/managed/cluster.go
@@ -74,11 +74,14 @@ func ManagedClusterSpec(ctx context.Context, inputGetter func() ManagedClusterSp
 	Expect(err).ShouldNot(HaveOccurred())
 
 	shared.Byf("Waiting for the cluster to be provisioned")
+	start := time.Now()
 	cluster := framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
 		Getter:    input.BootstrapClusterProxy.GetClient(),
 		Namespace: configCluster.Namespace,
 		Name:      configCluster.ClusterName,
 	}, input.E2EConfig.GetIntervals("", "wait-cluster")...)
+	duration := time.Since(start)
+	shared.Byf("Finished waiting for cluster after: %s", duration)
 	Expect(cluster).NotTo(BeNil())
 
 	shared.Byf("Checking EKS cluster is active")


### PR DESCRIPTION
**What type of PR is this?**

/kind flake
/kind support


**What this PR does / why we need it**:

Increased the eks e2e timeout for cluster creation. Also added logging to time the wait for sucessful creations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
