### PR TITLE
[E2E] Update CAPA version in tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -84,14 +84,14 @@ providers:
   - name: aws
     type: InfrastructureProvider
     versions:
-      - name: v1.5.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> v1beta2 clusterctl upgrades test only.
-        value: "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v1.5.0/infrastructure-components.yaml"
+      - name: v1.5.2 # latest published release in the v1beta1 series; this is used for v1beta1 --> v1beta2 clusterctl upgrades test only.
+        value: "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v1.5.2/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
         files:
           - sourcePath: "./shared/v1beta1_provider/metadata.yaml"
           - sourcePath: "./infrastructure-aws/capi-upgrades/v1beta1/cluster-template.yaml"
-      - name: v1.6.99
+      - name: v2.0.99
         # Use manifest from source files
         value: ../../../config/default
         # Do not add contract field for v1beta1 --> v1beta2 clusterctl upgrades test to work.
@@ -142,9 +142,9 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.24.0"
-  KUBERNETES_VERSION: "v1.24.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.24.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.24.4"
+  KUBERNETES_VERSION: "v1.24.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.24.4"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.23.6"
   # Pre and post 1.23 Kubernetes versions are being used for CSI upgrade tests
   PRE_1_23_KUBERNETES_VERSION: "v1.22.4"

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -80,7 +80,7 @@ providers:
   - name: aws
     type: InfrastructureProvider
     versions:
-      - name: v1.6.99
+      - name: v2.0.99
         # Use manifest from source files
         value: ../../../config/default
         contract: v1beta1
@@ -116,8 +116,8 @@ providers:
         targetName: "cluster-template-eks-control-plane-only-legacy.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.22.9"
-  KUBERNETES_VERSION_MANAGEMENT: "v1.22.9" # Kind bootstrap
+  KUBERNETES_VERSION: "v1.24.4"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.24.4" # Kind bootstrap
   EXP_MACHINE_POOL: "true"
   EXP_CLUSTER_RESOURCE_SET: "true"
   EVENT_BRIDGE_INSTANCE_STATE: "true"
@@ -126,10 +126,10 @@ variables:
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
   EXP_EKS_IAM: "false"
   EXP_EKS_ADD_ROLES: "false"
-  VPC_ADDON_VERSION: "v1.11.0-eksbuild.1"
-  COREDNS_ADDON_VERSION: "v1.8.7-eksbuild.1"
-  KUBE_PROXY_ADDON_VERSION: "v1.22.6-eksbuild.1"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "1.22.9"
+  VPC_ADDON_VERSION: "v1.11.4-eksbuild.1"
+  COREDNS_ADDON_VERSION: "v1.8.7-eksbuild.3"
+  KUBE_PROXY_ADDON_VERSION: "v1.24.7-eksbuild.2"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "1.24.4"
   AUTO_CONTROLLER_IDENTITY_CREATOR: "false"
   IP_FAMILY: "IPv4"
   CAPA_LOGLEVEL: "4"

--- a/test/e2e/data/shared/v1beta2_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta2_provider/metadata.yaml
@@ -38,3 +38,6 @@ releaseSeries:
   - major: 1
     minor: 6
     contract: v1beta1
+  - major: 2
+    minor: 0
+    contract: v1beta1

--- a/test/e2e/suites/managed/cluster.go
+++ b/test/e2e/suites/managed/cluster.go
@@ -101,8 +101,6 @@ func ManagedClusterSpec(ctx context.Context, inputGetter func() ManagedClusterSp
 	verifySecretExists(ctx, fmt.Sprintf("%s-kubeconfig", input.ClusterName), input.Namespace.Name, bootstrapClient)
 	verifySecretExists(ctx, fmt.Sprintf("%s-user-kubeconfig", input.ClusterName), input.Namespace.Name, bootstrapClient)
 
-	time.Sleep(2 * time.Minute) //TODO: replace with an eventually on the aws-iam-auth check
-
 	shared.Byf("Checking that aws-iam-authenticator config map exists")
 	workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
 	workloadClient := workloadClusterProxy.GetClient()

--- a/test/e2e/suites/managed/helpers.go
+++ b/test/e2e/suites/managed/helpers.go
@@ -22,6 +22,7 @@ package managed
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -118,9 +119,9 @@ func verifySecretExists(ctx context.Context, secretName, namespace string, k8scl
 
 func verifyConfigMapExists(ctx context.Context, name, namespace string, k8sclient crclient.Client) {
 	cm := &corev1.ConfigMap{}
-	err := k8sclient.Get(ctx, apimachinerytypes.NamespacedName{Name: name, Namespace: namespace}, cm)
-
-	Expect(err).ShouldNot(HaveOccurred())
+	Eventually(func() error {
+		return k8sclient.Get(ctx, apimachinerytypes.NamespacedName{Name: name, Namespace: namespace}, cm)
+	}, 2*time.Minute, 5*time.Second).Should(Succeed())
 }
 
 func VerifyRoleExistsAndOwned(roleName string, eksClusterName string, checkOwned bool, sess client.ConfigProvider) {

--- a/test/e2e/suites/managed/upgrade_test.go
+++ b/test/e2e/suites/managed/upgrade_test.go
@@ -36,8 +36,8 @@ import (
 // EKS cluster upgrade tests.
 var _ = ginkgo.Describe("EKS Cluster upgrade test", func() {
 	const (
-		initialVersion   = "v1.21.0"
-		upgradeToVersion = "v1.22.0"
+		initialVersion   = "v1.22.4"
+		upgradeToVersion = "v1.24.4"
 	)
 	var (
 		namespace   *corev1.Namespace


### PR DESCRIPTION
**What type of PR is this?**
/area testing
/kind support

**What this PR does / why we need it**:
This PR updates the CAPA version used to v2.0.x. It also updates k8s versions used in the tests to v1.24.4.
For EKS upgrade tests, the upgrade path is updated from 1.22.4 to 1.24.4


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3879 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
