### PR TITLE
[E2E] Increase service quota for VPC

### DIFF
--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -146,7 +146,7 @@ func getLimitedResources() map[string]*ServiceQuota {
 		ServiceCode:         "vpc",
 		QuotaName:           "VPCs per Region",
 		QuotaCode:           "L-F678F1CE",
-		DesiredMinimumValue: 20,
+		DesiredMinimumValue: 25,
 	}
 
 	serviceQuotas["ec2-normal"] = &ServiceQuota{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind failing-test
/kind regression


**What this PR does / why we need it**:
This PR increases service quota for VPC to 25, as current quota is not sufficient for running E2E tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests
