### PR TITLE
test: save original aws resource quotas as returned by API

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -798,9 +798,11 @@ type ServiceQuota struct {
 	RequestStatus       string
 }
 
-func EnsureServiceQuotas(sess client.ConfigProvider) map[string]*ServiceQuota {
+func EnsureServiceQuotas(sess client.ConfigProvider) (map[string]*ServiceQuota, map[string]*servicequotas.ServiceQuota) {
 	limitedResources := getLimitedResources()
 	serviceQuotasClient := servicequotas.New(sess)
+
+	originalQuotas := map[string]*servicequotas.ServiceQuota{}
 
 	for k, v := range limitedResources {
 		out, err := serviceQuotasClient.GetServiceQuota(&servicequotas.GetServiceQuotaInput{
@@ -808,6 +810,7 @@ func EnsureServiceQuotas(sess client.ConfigProvider) map[string]*ServiceQuota {
 			ServiceCode: aws.String(v.ServiceCode),
 		})
 		Expect(err).NotTo(HaveOccurred())
+		originalQuotas[k] = out.Quota
 		v.Value = int(aws.Float64Value(out.Quota.Value))
 		limitedResources[k] = v
 		if v.Value < v.DesiredMinimumValue {
@@ -815,7 +818,7 @@ func EnsureServiceQuotas(sess client.ConfigProvider) map[string]*ServiceQuota {
 		}
 	}
 
-	return limitedResources
+	return limitedResources, originalQuotas
 }
 
 func (s *ServiceQuota) attemptRaiseServiceQuotaRequest(serviceQuotasClient *servicequotas.ServiceQuotas) {

--- a/test/e2e/shared/resource.go
+++ b/test/e2e/shared/resource.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/gofrs/flock"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
@@ -60,6 +61,19 @@ func WriteResourceQuotesToFile(logPath string, serviceQuotas map[string]*Service
 		VolumeGP2: serviceQuotas["volume-GP2"].Value,
 	}
 	data, err := yaml.Marshal(resources)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = os.WriteFile(logPath, data, 0644) //nolint:gosec
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func WriteAWSResourceQuotesToFile(logPath string, serviceQuotas map[string]*servicequotas.ServiceQuota) {
+	if _, err := os.Stat(logPath); err == nil {
+		// If resource-quotas file exists, remove it. Should not fail on error, another ginkgo node might have already deleted it.
+		os.Remove(logPath)
+	}
+
+	data, err := yaml.Marshal(serviceQuotas)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = os.WriteFile(logPath, data, 0644) //nolint:gosec

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -158,9 +158,10 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 
 	if !e2eCtx.Settings.SkipQuotas {
 		By("Writing AWS service quotas to a file for parallel tests")
-		quotas := EnsureServiceQuotas(e2eCtx.BootstrapUserAWSSession)
+		quotas, originalQuotas := EnsureServiceQuotas(e2eCtx.BootstrapUserAWSSession)
 		WriteResourceQuotesToFile(ResourceQuotaFilePath, quotas)
 		WriteResourceQuotesToFile(path.Join(e2eCtx.Settings.ArtifactFolder, "initial-resource-quotas.yaml"), quotas)
+		WriteAWSResourceQuotesToFile(path.Join(e2eCtx.Settings.ArtifactFolder, "initial-aws-resource-quotas.yaml"), originalQuotas)
 	}
 
 	e2eCtx.Settings.InstanceVCPU, err = strconv.Atoi(e2eCtx.E2EConfig.GetVariable(InstanceVcpu))


### PR DESCRIPTION
Signed-off-by: Richard Case <richard.case@outlook.com>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support

**What this PR does / why we need it**:

This adds saving of the original quotas from AWS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
