### PR TITLE
Always populate Load balancer type as classic if not provided by user

### DIFF
--- a/api/v1beta2/defaults.go
+++ b/api/v1beta2/defaults.go
@@ -63,9 +63,11 @@ func SetDefaults_AWSClusterSpec(s *AWSClusterSpec) { //nolint:golint,stylecheck
 	}
 	if s.ControlPlaneLoadBalancer == nil {
 		s.ControlPlaneLoadBalancer = &AWSLoadBalancerSpec{
-			Scheme:           &ELBSchemeInternetFacing,
-			LoadBalancerType: LoadBalancerTypeClassic,
+			Scheme: &ELBSchemeInternetFacing,
 		}
+	}
+	if s.ControlPlaneLoadBalancer.LoadBalancerType == "" {
+		s.ControlPlaneLoadBalancer.LoadBalancerType = LoadBalancerTypeClassic
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
/kind failing-test
/kind regression

**What this PR does / why we need it**:
This PR adds default value for Load balancer type as `Classic` in `ControlPlaneLoadBalancer`. It was initially set only in case ControlPlaneLoadBalancer spec was not provided by the user. If any of the parameter in ControlPlaneLoadBalancer is provided, the `loadBalancerType` was not set to classic. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3916 

**Special notes for your reviewer**:

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
