### PR TITLE
Verify container images

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,25 @@
+name: scan-images
+
+on:
+  schedule:
+    # every Monday at 12:00PM
+    - cron: "0 12 * * 1"
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  scan:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.1.0
+      - name: Make images
+        run:  make REGISTRY=gcr.io/k8s-staging-cluster-api-aws PULL_POLICY=IfNotPresent TAG=dev ARCH=amd64 docker-build
+      - name: Run Trivy vulnerability scanner on CAPA image
+        uses: aquasecurity/trivy-action@v0.8.0
+        with:
+          image-ref: 'gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller-arm64:dev'
+          format: 'table'
+          exit-code: '1'

--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TRIVY_VERSION=0.34.0
+
+GO_OS="$(go env GOOS)"
+if [[ "${GO_OS}" == "linux" ]]; then
+  TRIVY_OS="Linux"
+elif [[ "${GO_OS}" == "darwin"* ]]; then
+  TRIVY_OS="macOS"
+fi
+
+GO_ARCH="$(go env GOARCH)"
+if [[ "${GO_ARCH}" == "amd" ]]; then
+  TRIVY_ARCH="32bit"
+elif [[ "${GO_ARCH}" == "amd64"* ]]; then
+  TRIVY_ARCH="64bit"
+elif [[ "${GO_ARCH}" == "arm" ]]; then
+  TRIVY_ARCH="ARM"
+elif [[ "${GO_ARCH}" == "arm64" ]]; then
+  TRIVY_ARCH="ARM64"
+fi
+
+TOOL_BIN=hack/tools/bin
+mkdir -p ${TOOL_BIN}
+
+# Downloads trivy scanner
+curl -L -o ${TOOL_BIN}/trivy.tar.gz \
+    https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz \
+
+tar xfO ${TOOL_BIN}/trivy.tar.gz trivy > ${TOOL_BIN}/trivy
+chmod +x ${TOOL_BIN}/trivy
+rm ${TOOL_BIN}/trivy.tar.gz
+
+## Builds the container images to be scanned
+make REGISTRY=gcr.io/k8s-staging-cluster-api-aws PULL_POLICY=IfNotPresent TAG=dev docker-build
+
+# Scan the images
+${TOOL_BIN}/trivy image -q gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller-${GO_ARCH}:dev


### PR DESCRIPTION
It allows to scan the controller manager image locally

This script is referring hack/verify-container-images.sh from cluster-api

Fixes #3894

