### PR TITLE
chore: Update k8s version to 1.25 in E2E tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -142,9 +142,9 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.24.4"
-  KUBERNETES_VERSION: "v1.24.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.24.4"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.25.4"
+  KUBERNETES_VERSION: "v1.25.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.25.4"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.23.6"
   # Pre and post 1.23 Kubernetes versions are being used for CSI upgrade tests
   PRE_1_23_KUBERNETES_VERSION: "v1.22.4"
@@ -156,7 +156,7 @@ variables:
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_MACHINE_TYPE_VCPU_USAGE: 2
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.24.4"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.25.4"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "3"
   ETCD_VERSION_UPGRADE_TO: "3.5.3-0"
@@ -172,7 +172,7 @@ variables:
   INIT_WITH_BINARY_V1BETA1: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/clusterctl-{OS}-{ARCH}"
   # INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_KUBERNETES_VERSION: "v1.24.0"
+  INIT_WITH_KUBERNETES_VERSION: "v1.25.0"
   EXP_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
 

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -116,8 +116,8 @@ providers:
         targetName: "cluster-template-eks-control-plane-only-legacy.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.24.4"
-  KUBERNETES_VERSION_MANAGEMENT: "v1.24.4" # Kind bootstrap
+  KUBERNETES_VERSION: "v1.25.4"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.25.4" # Kind bootstrap
   EXP_MACHINE_POOL: "true"
   EXP_CLUSTER_RESOURCE_SET: "true"
   EVENT_BRIDGE_INSTANCE_STATE: "true"
@@ -129,7 +129,7 @@ variables:
   VPC_ADDON_VERSION: "v1.11.4-eksbuild.1"
   COREDNS_ADDON_VERSION: "v1.8.7-eksbuild.3"
   KUBE_PROXY_ADDON_VERSION: "v1.24.7-eksbuild.2"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "1.24.4"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "1.25.4"
   AUTO_CONTROLLER_IDENTITY_CREATOR: "false"
   IP_FAMILY: "IPv4"
   CAPA_LOGLEVEL: "4"

--- a/test/e2e/suites/managed/upgrade_test.go
+++ b/test/e2e/suites/managed/upgrade_test.go
@@ -36,8 +36,8 @@ import (
 // EKS cluster upgrade tests.
 var _ = ginkgo.Describe("EKS Cluster upgrade test", func() {
 	const (
-		initialVersion   = "v1.22.4"
-		upgradeToVersion = "v1.24.4"
+		initialVersion   = "v1.23.10"
+		upgradeToVersion = "v1.25.4"
 	)
 	var (
 		namespace   *corev1.Namespace


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support

**What this PR does / why we need it**:
This PR updates k8s version in CAPA to v1.25.4.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR should merge before #3920 as this is a pre-requisite for that PR.
This PR should be merged post https://github.com/kubernetes/test-infra/pull/28222

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests
