### PR TITLE
Add back RBAC for controller identities

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -143,6 +143,7 @@ rules:
   resources:
   - awsclustercontrolleridentities
   verbs:
+  - create
   - get
   - list
   - watch

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -127,7 +127,7 @@ func (r *AWSClusterReconciler) getSecurityGroupService(scope scope.ClusterScope)
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusterroleidentities;awsclusterstaticidentities,verbs=get;list;watch
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclustercontrolleridentities,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclustercontrolleridentities,verbs=get;list;watch;create
 
 func (r *AWSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := logger.FromContext(ctx)

--- a/exp/controlleridentitycreator/awscontrolleridentity_controller.go
+++ b/exp/controlleridentitycreator/awscontrolleridentity_controller.go
@@ -48,7 +48,7 @@ type AWSControllerIdentityReconciler struct {
 	WatchFilterValue string
 }
 
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclustercontrolleridentities,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclustercontrolleridentities,verbs=get;list;watch;create
 
 func (r *AWSControllerIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logger.FromContext(ctx)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package logger
-//nolint: logrlint
 package logger
 
 import (


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds back RBAC for controller identities which was deleted mistakenly in #3907 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
