### PR TITLE
Update ASG if subnet changes

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -47,6 +47,10 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 		//TODO: determine what additional values go here and what else should be in the struct
 	}
 
+	if v.VPCZoneIdentifier != nil {
+		i.Subnets = strings.Split(*v.VPCZoneIdentifier, ",")
+	}
+
 	if v.MixedInstancesPolicy != nil {
 		i.MixedInstancesPolicy = &expinfrav1.MixedInstancesPolicy{
 			InstancesDistribution: &expinfrav1.InstancesDistribution{
@@ -286,7 +290,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 		AutoScalingGroupName: aws.String(scope.Name()), //TODO: define dynamically - borrow logic from ec2
 		MaxSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MaxSize)),
 		MinSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MinSize)),
-		VPCZoneIdentifier:    aws.String(strings.Join(subnetIDs, ", ")),
+		VPCZoneIdentifier:    aws.String(strings.Join(subnetIDs, ",")),
 		CapacityRebalance:    aws.Bool(scope.AWSMachinePool.Spec.CapacityRebalance),
 	}
 

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -44,6 +44,7 @@ type ASGInterface interface {
 	DeleteASGAndWait(id string) error
 	SuspendProcesses(name string, processes []string) error
 	ResumeProcesses(name string, processes []string) error
+	SubnetIDs(scope *scope.MachinePoolScope) ([]string, error)
 }
 
 // EC2Interface encapsulates the methods exposed to the machine

--- a/pkg/cloud/services/mock_services/autoscaling_interface_mock.go
+++ b/pkg/cloud/services/mock_services/autoscaling_interface_mock.go
@@ -153,6 +153,21 @@ func (mr *MockASGInterfaceMockRecorder) StartASGInstanceRefresh(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartASGInstanceRefresh", reflect.TypeOf((*MockASGInterface)(nil).StartASGInstanceRefresh), arg0)
 }
 
+// SubnetIDs mocks base method.
+func (m *MockASGInterface) SubnetIDs(arg0 *scope.MachinePoolScope) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubnetIDs", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubnetIDs indicates an expected call of SubnetIDs.
+func (mr *MockASGInterfaceMockRecorder) SubnetIDs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetIDs", reflect.TypeOf((*MockASGInterface)(nil).SubnetIDs), arg0)
+}
+
 // SuspendProcesses mocks base method.
 func (m *MockASGInterface) SuspendProcesses(arg0 string, arg1 []string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
After aws machine pool deployed, CAPA creates asg with subnets （[code](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/c59945258adfcf08b7a2ddd4c5190c0456db9fb4/pkg/cloud/services/autoscaling/autoscalinggroup.go#L157)）. The subnets are either from AWSMachinePoolSpec.Subnets, or derived from AWSMachinePoolSpec.AvailabilityZones, or MachinePool.Spec.FailureDomains, or ControlplaneSubnets.FilterPrivate().

User is possible to update the subnets or AvailabilityZones defined in AWSMachinePool. CAPA should update asg accordingly.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3315 

**Special notes for your reviewer**:
Manual testing:
1. AWSMachinePool has only AvailabilityZones AZ1 defined.  Update AWSMachinePool with AZ2, and check asg using `aws autoscaling describe-auto-scaling-groups --auto-scaling-group-name c4-mp-0`:  AvailabilityZones is updated to AZ2 and VPCZoneIdentifier is updated to subnet list in AZ2.
2. AWSMachinePool has Subnets subnet1 defined. Update AWSMachinePool Subnets with subnet1,subnet2, and check asg using `aws autoscaling describe-auto-scaling-groups --auto-scaling-group-name c4-mp-0`: VPCZoneIdentifier is updated to `subnet1,subnet2`

Notes:
If updating asg from using subnet1 to subnet2 while they are in same AZ, the existing instance in subnet1 won't be terminated and redeployed to new subnet2. It seems the expected behavior of default terminating policy for asg.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
