### PR TITLE
Fix AWS Cluster Tags Deletion & Re-addition issue

### DIFF
--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -119,6 +119,7 @@ func (s *Service) reconcileSubnets() error {
 			if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
 				buildParams := s.getSubnetTagParams(unmanagedVPC, existingSubnet.ID, existingSubnet.IsPublic, existingSubnet.AvailabilityZone, subnetTags)
 				tagsBuilder := tags.New(&buildParams, tags.WithEC2(s.EC2Client))
+				s.removeNonClusterSharedTags(subnetTags, existingSubnet.Tags)
 				if err := tagsBuilder.Ensure(existingSubnet.Tags); err != nil {
 					return false, err
 				}
@@ -275,7 +276,45 @@ func (s *Service) getDefaultSubnets() (infrav1.Subnets, error) {
 }
 
 func (s *Service) deleteSubnets() error {
+	s.scope.V(0).Info("Deleting subnets")
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
+
+		s.scope.V(0).Info("Deleting subnet tags if vpc is unmanaged")
+
+		// For deletion of the subnet tag while the static placement cluster is getting deleted:
+		// for all the subnets, the specific tag of key and value is fetched (in this case it will be equal to one's of the cluster getting deleted)
+		// If the tag is found, it will be deleted. If not found, an error will be returned.
+		// The fetching of tags is done in the same way tags are described using AWS CLI.
+		existing, err := s.describeSubnets()
+		if err != nil {
+			return err
+		}
+
+		for i := range existing.Subnets {
+
+			describeTagsInput := &ec2.DescribeTagsInput{Filters: []*ec2.Filter{
+				{Name: aws.String("resource-type"), Values: []*string{aws.String("subnet")}},
+				{Name: aws.String("key"), Values: []*string{aws.String(infrav1.NameKubernetesAWSCloudProviderPrefix + s.scope.KubernetesClusterName())}},
+				{Name: aws.String("value"), Values: []*string{aws.String(string(infrav1.ResourceLifecycleShared))}},
+			},
+			}
+
+			if fetchedTags, err := s.EC2Client.DescribeTags(describeTagsInput); err != nil {
+				return errors.Wrapf(err, "failed to delete tags for resource %q", *existing.Subnets[i].SubnetId)
+			} else if len(fetchedTags.Tags) > 0 {
+				s.scope.V(0).Info("Found a tag for deletion")
+				// Create the DeleteTags input
+				deleteTagsInput := &ec2.DeleteTagsInput{
+					Resources: []*string{existing.Subnets[i].SubnetId},
+					Tags:      []*ec2.Tag{{Key: aws.String(infrav1.NameKubernetesAWSCloudProviderPrefix + s.scope.KubernetesClusterName()), Value: aws.String(string(infrav1.ResourceLifecycleShared))}},
+				}
+
+				// Delete tags in AWS.
+				if _, err = s.EC2Client.DeleteTags(deleteTagsInput); err != nil {
+					return errors.Wrapf(err, "failed to delete tags for resource %q", *existing.Subnets[i].SubnetId)
+				}
+			}
+		}
 		s.scope.Trace("Skipping subnets deletion in unmanaged mode")
 		return nil
 	}
@@ -531,4 +570,20 @@ func (s *Service) getSubnetTagParams(unmanagedVPC bool, id string, public bool, 
 			Additional: additionalTags,
 		}
 	}
+}
+
+func (s *Service) removeNonClusterSharedTags(clusterSubnetTags, VPCSubnetTags infrav1.Tags) {
+
+	for key, value := range clusterSubnetTags {
+		if key != infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName()) && value == string(infrav1.ResourceLifecycleShared) {
+			delete(clusterSubnetTags, key)
+		}
+	}
+
+	for key, value := range VPCSubnetTags {
+		if key != infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName()) && value == string(infrav1.ResourceLifecycleShared) {
+			delete(VPCSubnetTags, key)
+		}
+	}
+
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?** Bug Fix PR

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**: This PR fixes the AWS tags deletion and re-addition issue. So, when the cluster is deleted, the subnet will no longer have the tag of that cluster and will also not re-populate those tags while restarting the pod/deployment of controller.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
