### PR TITLE
[E2E] Increase test timeout in Ginkgo args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ifeq ($(findstring \[PR-Blocking\],$(E2E_FOCUS)),\[PR-Blocking\])
 endif
 
 override E2E_ARGS += -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" -use-existing-cluster=$(USE_EXISTING_CLUSTER)
-override GINKGO_ARGS += -v --trace --timeout=3h --output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.xml"
+override GINKGO_ARGS += -v --trace --timeout=4h --output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.xml"
 
 ifdef GINKGO_SKIP
 	override GINKGO_ARGS += -skip "$(GINKGO_SKIP)"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind flake
/kind support

**What this PR does / why we need it**:
Sometimes EKS E2E tests takes more than 3 hrs to complete test runs. This PR increases the E2E tests timeout in Ginkgo args to accommodate the above requirement.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests
