### PR TITLE
Update scan action

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,7 +2,7 @@ name: scan-images
 
 on:
   schedule:
-    # every Monday at 12:00PM
+    # every Monday at 12:00AM
     - cron: "0 12 * * 1"
 
 # Remove all permissions from GITHUB_TOKEN except metadata.
@@ -14,12 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3.1.0
-      - name: Make images
-        run:  make REGISTRY=gcr.io/k8s-staging-cluster-api-aws PULL_POLICY=IfNotPresent TAG=dev ARCH=amd64 docker-build
-      - name: Run Trivy vulnerability scanner on CAPA image
-        uses: aquasecurity/trivy-action@v0.8.0
+        uses: actions/checkout@v3.2.0
+      - name: Setup go
+        uses: actions/setup-go@v3.5.0
         with:
-          image-ref: 'gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller-arm64:dev'
-          format: 'table'
-          exit-code: '1'
+          go-version: 1.19
+      - name: Run verify container script
+        run: make verify-container-images

--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,10 @@ verify-gen: generate ## Verify generated files
 		echo "generated files are out of date, run make generate"; exit 1; \
 	fi
 
+.PHONY: verify-container-images
+verify-container-images: ## Verify container images
+	TRACE=$(TRACE) ./hack/verify-container-images.sh
+
 .PHONY: apidiff
 apidiff: APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 apidiff: $(GO_APIDIFF) ## Check for API differences


### PR DESCRIPTION
1. update scan workflow action
2. update verify-container-images script
3. add `make verify-container-images` tool

This is a follow up PR of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3921.

A test result by temporarily add
```
push:
    branches: [ action ]
```
to scan.yaml: https://github.com/wyike/cluster-api-provider-aws/actions/runs/3828313468/jobs/6513758507 

Fixes #3894 

