### PR TITLE
Adding tags to OIDC providers

### DIFF
--- a/pkg/cloud/converters/tags.go
+++ b/pkg/cloud/converters/tags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/ssm"
 
@@ -142,6 +143,22 @@ func MapToSSMTags(src infrav1.Tags) []*ssm.Tag {
 
 	for k, v := range src {
 		tag := &ssm.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		tags = append(tags, tag)
+	}
+
+	return tags
+}
+
+// MapToIAMTags converts a infrav1.Tags to a []*iam.Tag.
+func MapToIAMTags(src infrav1.Tags) []*iam.Tag {
+	tags := make([]*iam.Tag, 0, len(src))
+
+	for k, v := range src {
+		tag := &iam.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}

--- a/pkg/cloud/services/eks/oidc_test.go
+++ b/pkg/cloud/services/eks/oidc_test.go
@@ -69,6 +69,10 @@ func TestOIDCReconcile(t *testing.T) {
 				}).Return(&iam.CreateOpenIDConnectProviderOutput{
 					OpenIDConnectProviderArn: aws.String("arn::oidc"),
 				}, nil)
+				m.TagOpenIDConnectProvider(&iam.TagOpenIDConnectProviderInput{
+					OpenIDConnectProviderArn: aws.String("arn::oidc"),
+					Tags:                     []*iam.Tag{},
+				}).Return(&iam.TagOpenIDConnectProviderOutput{}, nil)
 			},
 		},
 		{
@@ -101,6 +105,10 @@ func TestOIDCReconcile(t *testing.T) {
 					ThumbprintList: aws.StringSlice([]string{"15dbd260c7465ecca6de2c0b2181187f66ee0d1a"}),
 					Url:            &url,
 				}, nil)
+				m.TagOpenIDConnectProvider(&iam.TagOpenIDConnectProviderInput{
+					OpenIDConnectProviderArn: aws.String("arn::oidc"),
+					Tags:                     []*iam.Tag{},
+				}).Return(&iam.TagOpenIDConnectProviderOutput{}, nil)
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?** /kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**: Currently while creating an EKS cluster, its respective OIDC provider gets created and reconciled. However it didn't have the same tags as of the cluster. This PR adds the code for the OIDC provider to also have same tags as of cluster.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

Proof of OIDC getting tagged:
![Pasted Graphic](https://user-images.githubusercontent.com/54012750/212041392-ee7f9c30-5a94-469b-a415-6db845fe89b9.jpg)
