### PR TITLE
Fail creation of machine pool if no subnets matching filters found

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -526,6 +526,12 @@ func (s *Service) SubnetIDs(scope *scope.MachinePoolScope) ([]string, error) {
 		for _, subnet := range out.Subnets {
 			subnetIDs = append(subnetIDs, *subnet.SubnetId)
 		}
+
+		if len(subnetIDs) == 0 {
+			errMessage := fmt.Sprintf("failed to create ASG %q, no subnets available matching criteria %q", scope.Name(), inputFilters)
+			record.Warnf(scope.AWSMachinePool, "FailedCreate", errMessage)
+			return subnetIDs, awserrors.NewFailedDependency(errMessage)
+		}
 	}
 
 	return scope.SubnetIDs(subnetIDs)

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -644,6 +644,26 @@ func TestServiceUpdateASGWithSubnetFilters(t *testing.T) {
 			},
 		},
 		{
+			name:            "should return an error if no matching subnets found",
+			machinePoolName: "update-asg-fail",
+			wantErr:         true,
+			awsResourceReference: []infrav1.AWSResourceReference{
+				{
+					Filters: []infrav1.Filter{
+						{
+							Name:   "tag:subnet-role",
+							Values: []string{"non-existent"},
+						},
+					},
+				},
+			},
+			expect: func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
+				e.DescribeSubnets(gomock.AssignableToTypeOf(&ec2.DescribeSubnetsInput{})).Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{},
+				}, nil)
+			},
+		},
+		{
 			name:            "should return error if update ASG fails",
 			machinePoolName: "update-asg-fail",
 			wantErr:         true,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Currently if when using subnet filters with an AWSMachinePool no subnets are found to match the code will fallback to using any matching the AZs specified on the CR. This is unexpected and in contrast to how AWSMachine is handled in the same situation. 
This PR causes an error to be raised if the filters provided result in no subnets matching.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3977

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
