### PR TITLE
Allow user to specify the Name tag value for AWS tags

### DIFF
--- a/api/v1beta2/tags.go
+++ b/api/v1beta2/tags.go
@@ -243,6 +243,12 @@ func (b BuildParams) WithCloudProvider(name string) BuildParams {
 // Build builds tags including the cluster tag and returns them in map form.
 func Build(params BuildParams) Tags {
 	tags := make(Tags)
+
+	// Add the name tag first so that it can be overwritten by a user-provided tag in the `Additional` tags.
+	if params.Name != nil {
+		tags["Name"] = *params.Name
+	}
+
 	for k, v := range params.Additional {
 		tags[k] = v
 	}
@@ -252,10 +258,6 @@ func Build(params BuildParams) Tags {
 	}
 	if params.Role != nil {
 		tags[NameAWSClusterAPIRole] = *params.Role
-	}
-
-	if params.Name != nil {
-		tags["Name"] = *params.Name
 	}
 
 	return tags

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -510,12 +510,17 @@ func (s *Service) getSubnetTagParams(unmanagedVPC bool, id string, public bool, 
 			additionalTags[k] = v
 		}
 
+		// Prefer `Name` tag if given, else generate a name
 		var name strings.Builder
-		name.WriteString(s.scope.Name())
-		name.WriteString("-subnet-")
-		name.WriteString(role)
-		name.WriteString("-")
-		name.WriteString(zone)
+		if manualTagName, ok := manualTags["Name"]; ok {
+			name.WriteString(manualTagName)
+		} else {
+			name.WriteString(s.scope.Name())
+			name.WriteString("-subnet-")
+			name.WriteString(role)
+			name.WriteString("-")
+			name.WriteString(zone)
+		}
 
 		return infrav1.BuildParams{
 			ClusterName: s.scope.Name(),


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Prevents CAPA from overwriting any user-provided `Name` tags.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3989

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
