### PR TITLE
[Release-1.5] Removed io/ioutil import

### DIFF
--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -19,7 +19,7 @@ package s3_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"reflect"
 	"strings"
@@ -405,7 +405,7 @@ func Test_Create_object(t *testing.T) {
 			t.Run("puts_given_bootstrap_data_untouched", func(t *testing.T) {
 				t.Parallel()
 
-				data, err := ioutil.ReadAll(putObjectInput.Body)
+				data, err := io.ReadAll(putObjectInput.Body)
 				if err != nil {
 					t.Fatalf("Reading put object body: %v", err)
 				}


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Linting currently fails on any backported PRs due to the use of `io/ioutil` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

See failing test on this PR: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3988/

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
