### PR TITLE
Support specifying subnet filters for API ELB subnets

### DIFF
--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1200,6 +1200,7 @@ func autoConvert_v1beta2_AWSLoadBalancerSpec_To_v1beta1_AWSLoadBalancerSpec(in *
 	out.Scheme = (*ClassicELBScheme)(unsafe.Pointer(in.Scheme))
 	out.CrossZoneLoadBalancing = in.CrossZoneLoadBalancing
 	out.Subnets = *(*[]string)(unsafe.Pointer(&in.Subnets))
+	// WARNING: in.SubnetFilter requires manual conversion: does not exist in peer-type
 	out.HealthCheckProtocol = (*ClassicELBProtocol)(unsafe.Pointer(in.HealthCheckProtocol))
 	out.AdditionalSecurityGroups = *(*[]string)(unsafe.Pointer(&in.AdditionalSecurityGroups))
 	// WARNING: in.LoadBalancerType requires manual conversion: does not exist in peer-type

--- a/api/v1beta2/awscluster_types.go
+++ b/api/v1beta2/awscluster_types.go
@@ -194,9 +194,9 @@ type AWSLoadBalancerSpec struct {
 	// Deprecated: This field is being replaced by `SubnetSpec`
 	Subnets []string `json:"subnets,omitempty"`
 
-	// SubnetSpec is an array of subnet configurations that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)
+	// SubnetFilter is an array of subnet configurations that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)
 	// +optional
-	SubnetSpec []AWSResourceReference `json:"subnetSpec,omitempty"`
+	SubnetFilter []AWSResourceReference `json:"subnetSpec,omitempty"`
 
 	// HealthCheckProtocol sets the protocol type for ELB health check target
 	// default value is ELBProtocolSSL

--- a/api/v1beta2/awscluster_types.go
+++ b/api/v1beta2/awscluster_types.go
@@ -191,7 +191,12 @@ type AWSLoadBalancerSpec struct {
 
 	// Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)
 	// +optional
+	// Deprecated: This field is being replaced by `SubnetSpec`
 	Subnets []string `json:"subnets,omitempty"`
+
+	// SubnetSpec is an array of subnet configurations that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)
+	// +optional
+	SubnetSpec []AWSResourceReference `json:"subnetSpec,omitempty"`
 
 	// HealthCheckProtocol sets the protocol type for ELB health check target
 	// default value is ELBProtocolSSL

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -564,6 +564,13 @@ func (in *AWSLoadBalancerSpec) DeepCopyInto(out *AWSLoadBalancerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SubnetFilter != nil {
+		in, out := &in.SubnetFilter, &out.SubnetFilter
+		*out = make([]AWSResourceReference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.HealthCheckProtocol != nil {
 		in, out := &in.HealthCheckProtocol, &out.HealthCheckProtocol
 		*out = new(ELBProtocol)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1024,10 +1024,50 @@ spec:
                     - internet-facing
                     - internal
                     type: string
+                  subnetSpec:
+                    description: SubnetFilter is an array of subnet configurations
+                      that should be applied to the control plane load balancer (defaults
+                      to discovered subnets for managed VPCs or an empty set for unmanaged
+                      VPCs)
+                    items:
+                      description: AWSResourceReference is a reference to a specific
+                        AWS resource by ID or filters. Only one of ID or Filters may
+                        be specified. Specifying more than one will result in a validation
+                        error.
+                      properties:
+                        filters:
+                          description: 'Filters is a set of key/value pairs used to
+                            identify a resource They are applied according to the
+                            rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                          items:
+                            description: Filter is a filter used to identify an AWS
+                              resource.
+                            properties:
+                              name:
+                                description: Name of the filter. Filter names are
+                                  case-sensitive.
+                                type: string
+                              values:
+                                description: Values includes one or more filter values.
+                                  Filter values are case-sensitive.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - name
+                            - values
+                            type: object
+                          type: array
+                        id:
+                          description: ID of resource
+                          type: string
+                      type: object
+                    type: array
                   subnets:
-                    description: Subnets sets the subnets that should be applied to
-                      the control plane load balancer (defaults to discovered subnets
-                      for managed VPCs or an empty set for unmanaged VPCs)
+                    description: 'Subnets sets the subnets that should be applied
+                      to the control plane load balancer (defaults to discovered subnets
+                      for managed VPCs or an empty set for unmanaged VPCs) Deprecated:
+                      This field is being replaced by `SubnetSpec`'
                     items:
                       type: string
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -620,11 +620,51 @@ spec:
                             - internet-facing
                             - internal
                             type: string
+                          subnetSpec:
+                            description: SubnetFilter is an array of subnet configurations
+                              that should be applied to the control plane load balancer
+                              (defaults to discovered subnets for managed VPCs or
+                              an empty set for unmanaged VPCs)
+                            items:
+                              description: AWSResourceReference is a reference to
+                                a specific AWS resource by ID or filters. Only one
+                                of ID or Filters may be specified. Specifying more
+                                than one will result in a validation error.
+                              properties:
+                                filters:
+                                  description: 'Filters is a set of key/value pairs
+                                    used to identify a resource They are applied according
+                                    to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                                  items:
+                                    description: Filter is a filter used to identify
+                                      an AWS resource.
+                                    properties:
+                                      name:
+                                        description: Name of the filter. Filter names
+                                          are case-sensitive.
+                                        type: string
+                                      values:
+                                        description: Values includes one or more filter
+                                          values. Filter values are case-sensitive.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - name
+                                    - values
+                                    type: object
+                                  type: array
+                                id:
+                                  description: ID of resource
+                                  type: string
+                              type: object
+                            type: array
                           subnets:
-                            description: Subnets sets the subnets that should be applied
-                              to the control plane load balancer (defaults to discovered
-                              subnets for managed VPCs or an empty set for unmanaged
-                              VPCs)
+                            description: 'Subnets sets the subnets that should be
+                              applied to the control plane load balancer (defaults
+                              to discovered subnets for managed VPCs or an empty set
+                              for unmanaged VPCs) Deprecated: This field is being
+                              replaced by `SubnetSpec`'
                             items:
                               type: string
                             type: array

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1507,10 +1507,10 @@ func (s *Service) SubnetIDs(scope *scope.ELBScope) ([]string, error) {
 
 	if s.scope.ControlPlaneLoadBalancer() != nil {
 		// Handle migration from `.Subnets` to `.SubnetSpec`
-		if len(s.scope.ControlPlaneLoadBalancer().Subnets) > 0 && len(s.scope.ControlPlaneLoadBalancer().SubnetSpec) == 0 {
+		if len(s.scope.ControlPlaneLoadBalancer().Subnets) > 0 && len(s.scope.ControlPlaneLoadBalancer().SubnetFilter) == 0 {
 			for _, subnet := range s.scope.ControlPlaneLoadBalancer().Subnets {
-				s.scope.ControlPlaneLoadBalancer().SubnetSpec = append(
-					s.scope.ControlPlaneLoadBalancer().SubnetSpec,
+				s.scope.ControlPlaneLoadBalancer().SubnetFilter = append(
+					s.scope.ControlPlaneLoadBalancer().SubnetFilter,
 					infrav1.AWSResourceReference{
 						ID: &subnet,
 					},
@@ -1518,7 +1518,7 @@ func (s *Service) SubnetIDs(scope *scope.ELBScope) ([]string, error) {
 			}
 		}
 
-		for _, subnet := range s.scope.ControlPlaneLoadBalancer().SubnetSpec {
+		for _, subnet := range s.scope.ControlPlaneLoadBalancer().SubnetFilter {
 			switch {
 			case subnet.ID != nil:
 				subnetIDs = append(subnetIDs, aws.StringValue(subnet.ID))

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1500,7 +1500,7 @@ func chunkELBs(names []string) [][]string {
 	return chunked
 }
 
-// SubnetIDs return subnet IDs defined for the Control Plane LoadBalancer
+// SubnetIDs return subnet IDs defined for the Control Plane LoadBalancer.
 func (s *Service) SubnetIDs(scope *scope.ELBScope) ([]string, error) {
 	subnetIDs := make([]string, 0)
 	var inputFilters = make([]*ec2.Filter, 0)

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1512,7 +1512,7 @@ func (s *Service) SubnetIDs(scope *scope.ELBScope) ([]string, error) {
 				s.scope.ControlPlaneLoadBalancer().SubnetFilter = append(
 					s.scope.ControlPlaneLoadBalancer().SubnetFilter,
 					infrav1.AWSResourceReference{
-						ID: &subnet,
+						ID: aws.String(subnet),
 					},
 				)
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

The subnets for the control plane load balancer can currently only be specified by providing their subnet ID. This is only possible when the subnets are created ahead of the cluster and running in VPC-unmanaged mode.

This change introduces a new `SubnetSpec` field (that would ideally just be called `Subnets` in the next API version) that allows providing subnet filters like we already have on AWSMachine and AWSMachinePool. This means we can create the subnets in CAPA (by defining them on the NetworkSpec of the AWSCluster CR) and still specify which to use for the control plane ELB.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3979

**Special notes for your reviewer**:

At this point, I'd like to just get some thoughts on the approach as I'm not 100% sure how API changes are handled.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
