### PR TITLE
fix(#3980): save the API ELB AZ to NetworkStatus

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -443,9 +443,6 @@ func (s *Service) reconcileClassicLoadBalancer() error {
 				return errors.Wrapf(err, "failed to attach apiserver load balancer %q to subnets", apiELB.Name)
 			}
 		}
-		if len(apiELB.AvailabilityZones) != len(spec.AvailabilityZones) {
-			apiELB.AvailabilityZones = spec.AvailabilityZones
-		}
 
 		// Reconcile the security groups from the spec and the ones currently attached to the load balancer
 		if !sets.NewString(apiELB.SecurityGroupIDs...).Equal(sets.NewString(spec.SecurityGroupIDs...)) {
@@ -459,6 +456,10 @@ func (s *Service) reconcileClassicLoadBalancer() error {
 		}
 	} else {
 		s.scope.Trace("Unmanaged control plane load balancer, skipping load balancer configuration", "api-server-elb", apiELB)
+	}
+
+	if len(apiELB.AvailabilityZones) != len(spec.AvailabilityZones) {
+		apiELB.AvailabilityZones = spec.AvailabilityZones
 	}
 
 	// TODO(vincepri): check if anything has changed and reconcile as necessary.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

In the case of a BYO load balancer, CAPA does not discover what AZs the LoadBalancer is a part of automatically. A downstream consequence is that control plane nodes are unable to target multiple AZs for placement, leading to all nodes being placed in a single AZ. Instead, CAPA should always be able to determine the AZs in which a load balancer is available and select the proper AZs accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3980

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
