### PR TITLE
Fix AWS CloudFormation dump after failed suit when there is no bootstrap cluster

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -859,7 +859,11 @@ func (s *ServiceQuota) updateServiceQuotaRequestStatus(serviceQuotasClient *serv
 }
 
 func DumpEKSClusters(ctx context.Context, e2eCtx *E2EContext) {
-	logPath := filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", e2eCtx.Environment.BootstrapClusterProxy.GetName(), "aws-resources")
+	name := "no-bootstrap-cluster"
+	if e2eCtx.Environment.BootstrapClusterProxy != nil {
+		name = e2eCtx.Environment.BootstrapClusterProxy.GetName()
+	}
+	logPath := filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", name, "aws-resources")
 	if err := os.MkdirAll(logPath, os.ModePerm); err != nil {
 		fmt.Fprintf(GinkgoWriter, "couldn't create directory: path=%s, err=%s", logPath, err)
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

This will help a lot in figuring out test failures such as these: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-eks-e2e/1617752246580154368

The cloudFormation stack failed but we have no idea why because we don't have any output of it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4001

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
