### PR TITLE
Fix awsmanagedcontrolplane doesn’t get reconciled

### DIFF
--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -92,6 +92,7 @@ type AWSManagedControlPlaneReconciler struct {
 	WatchFilterValue      string
 	ExternalResourceGC    bool
 	AlternativeGCStrategy bool
+	WaitInfraPeriod       time.Duration
 }
 
 // SetupWithManager is used to setup the controller.
@@ -236,7 +237,7 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 		// Wait for the cluster infrastructure to be ready before creating machines
 		if !managedScope.Cluster.Status.InfrastructureReady {
 			managedScope.Info("Cluster infrastructure is not ready yet")
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: r.WaitInfraPeriod}, nil
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Provider infrastructure is not ready when AWS Managed Control Plane is reconciled for the first time and the cluster creation get stuck for 15 minutes until the reconciliation is forced.

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release Notes**:
```
Fix AWSManagedControlPlane reconciliation
```
