### PR TITLE
Fix EKSControlPlaneReconciliationFailed when OIDC already exists

### DIFF
--- a/pkg/cloud/services/eks/iam/iam.go
+++ b/pkg/cloud/services/eks/iam/iam.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
@@ -461,7 +462,7 @@ func (s *IAMService) FindAndVerifyOIDCProvider(cluster *eks.Cluster) (string, er
 			return "", errors.Wrap(err, "error getting provider")
 		}
 		// URL should always contain `https`.
-		if *provider.Url != issuerURL.String() {
+		if *provider.Url != issuerURL.String() && *provider.Url != strings.Replace(issuerURL.String(), "https://", "", 1) {
 			continue
 		}
 		if len(provider.ThumbprintList) != 1 || *provider.ThumbprintList[0] != thumbprint {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Avoid "failed to create OIDC provider: error creating provider: EntityAlreadyExists" and "EKSControlPlaneReconciliationFailed" errors when provider.Url do not contain https

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3972 

**Special notes for your reviewer**:

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
