### PR TITLE
Fix `make test` for Apple M1 (darwin-arm64), fail if kubebuilder assets cannot be found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,8 @@ E2E_SKIP_EKS_UPGRADE ?= "false"
 EKS_SOURCE_TEMPLATE ?= eks/cluster-template-eks-control-plane-only.yaml
 
 # set up `setup-envtest` to install kubebuilder dependency
-export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.23.3
-SETUP_ENVTEST_VER := v0.0.0-20211110210527-619e6b92dab9
+export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.24.2
+SETUP_ENVTEST_VER := v0.0.0-20230131074648-f5014c077fc3
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest
@@ -385,13 +385,9 @@ install-setup-envtest: # Install setup-envtest so that setup-envtest's eval is e
 
 .PHONY: setup-envtest
 setup-envtest: install-setup-envtest # Build setup-envtest from tools folder.
-	@if [ $(shell go env GOOS) == "darwin" ]; then \
-		$(eval KUBEBUILDER_ASSETS := $(shell $(SETUP_ENVTEST) use --use-env -p path --arch amd64 $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))) \
-		echo "kube-builder assets set using darwin OS"; \
-	else \
-		$(eval KUBEBUILDER_ASSETS := $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))) \
-		echo "kube-builder assets set using other OS"; \
-	fi
+	@$(eval KUBEBUILDER_ASSETS := $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))) \
+	if [ -z "$(KUBEBUILDER_ASSETS)" ]; then echo "Failed to find kubebuilder assets, see errors above"; exit 1; fi; \
+	echo "kube-builder assets: $(KUBEBUILDER_ASSETS)"
 
 .PHONY: test
 test: setup-envtest ## Run tests


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

- Fail if the specified Kubernetes version binaries cannot be found. Otherwise the test starts and tries to use system-installed binaries by mistake, which it typically wouldn't find. The actual download error is then hidden at the beginning of the test output.
- Bump envtest to Kubernetes 1.24 because then it will work for [kubebuilder on Apple M1 as of this comment](https://github.com/kubernetes-sigs/kubebuilder/issues/2664#issuecomment-1183351948). With this, I found that the `--arch amd64` workaround isn't needed anymore (I'm on Apple M1 and it's working), so I removed the OS/arch distinction.
- Use latest envtest commit because the Makefile used a version from 2021

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

n/a

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
