### PR TITLE
fix: use instance profiles of nodepools and machine deployments for mapping roles

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -72,6 +71,14 @@ rules:
   - clusters
   - machinepools
   - machines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
   verbs:
   - get
   - list

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -119,6 +119,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 						Name: "test",
 					},
 					Spec: clusterv1.MachineSpec{
+						ClusterName: "capi-test",
 						Bootstrap: clusterv1.Bootstrap{
 							DataSecretName: pointer.StringPtr("bootstrap-data"),
 						},
@@ -149,6 +150,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				},
 				Machine: &clusterv1.Machine{
 					Spec: clusterv1.MachineSpec{
+						ClusterName: "capi-test",
 						Bootstrap: clusterv1.Bootstrap{
 							DataSecretName: pointer.StringPtr("bootstrap-data"),
 						},
@@ -1813,6 +1815,7 @@ func TestAWSMachineReconciler_AWSClusterToAWSMachines(t *testing.T) {
 					},
 				},
 				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "AWSMachine",
 						Name:       "aws-machine-6",
@@ -1852,6 +1855,7 @@ func TestAWSMachineReconciler_AWSClusterToAWSMachines(t *testing.T) {
 					Name: "aws-test-1",
 				},
 				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "AWSMachine",
 						Name:       "aws-machine-1",
@@ -1883,6 +1887,7 @@ func TestAWSMachineReconciler_AWSClusterToAWSMachines(t *testing.T) {
 					Name: "aws-test-2",
 				},
 				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "AWSMachine",
 						Name:       "aws-machine-2",
@@ -1911,6 +1916,7 @@ func TestAWSMachineReconciler_AWSClusterToAWSMachines(t *testing.T) {
 					Name: "aws-test-3",
 				},
 				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "AWSMachine",
 						Name:       "aws-machine-3",
@@ -1947,6 +1953,7 @@ func TestAWSMachineReconciler_AWSClusterToAWSMachines(t *testing.T) {
 					Kind: "Machine",
 				},
 				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "Machine",
 						Name:       "aws-machine-4",
@@ -1979,6 +1986,7 @@ func TestAWSMachineReconciler_AWSClusterToAWSMachines(t *testing.T) {
 					},
 				},
 				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "AWSMachine",
 						APIVersion: infrav1.GroupVersion.String(),
@@ -2152,7 +2160,14 @@ func TestAWSMachineReconciler_Reconcile(t *testing.T) {
 					},
 				}, Spec: infrav1.AWSMachineSpec{InstanceType: "test"},
 			},
-			ownerMachine: &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "capi-test-machine"}},
+			ownerMachine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "capi-test-machine",
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
+				},
+			},
 			ownerCluster: &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "capi-test-1"}},
 			expectError:  false,
 		},
@@ -2170,12 +2185,17 @@ func TestAWSMachineReconciler_Reconcile(t *testing.T) {
 					},
 				}, Spec: infrav1.AWSMachineSpec{InstanceType: "test"},
 			},
-			ownerMachine: &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					clusterv1.ClusterLabelName: "capi-test-1",
+			ownerMachine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterv1.ClusterLabelName: "capi-test-1",
+					},
+					Name: "capi-test-machine", Namespace: "default",
 				},
-				Name: "capi-test-machine", Namespace: "default",
-			}},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
+				},
+			},
 			ownerCluster: &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "capi-test-1"}},
 			expectError:  false,
 		},
@@ -2193,12 +2213,16 @@ func TestAWSMachineReconciler_Reconcile(t *testing.T) {
 					},
 				}, Spec: infrav1.AWSMachineSpec{InstanceType: "test"},
 			},
-			ownerMachine: &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					clusterv1.ClusterLabelName: "capi-test-1",
+			ownerMachine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterv1.ClusterLabelName: "capi-test-1",
+					},
+					Name: "capi-test-machine", Namespace: "default",
+				}, Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
 				},
-				Name: "capi-test-machine", Namespace: "default",
-			}},
+			},
 			ownerCluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "capi-test-1"},
 				Spec: clusterv1.ClusterSpec{
@@ -2221,12 +2245,17 @@ func TestAWSMachineReconciler_Reconcile(t *testing.T) {
 					},
 				}, Spec: infrav1.AWSMachineSpec{InstanceType: "test"},
 			},
-			ownerMachine: &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					clusterv1.ClusterLabelName: "capi-test-1",
+			ownerMachine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterv1.ClusterLabelName: "capi-test-1",
+					},
+					Name: "capi-test-machine", Namespace: "default",
 				},
-				Name: "capi-test-machine", Namespace: "default",
-			}},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
+				},
+			},
 			ownerCluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "capi-test-1"},
 				Spec: clusterv1.ClusterSpec{
@@ -2249,12 +2278,17 @@ func TestAWSMachineReconciler_Reconcile(t *testing.T) {
 					},
 				}, Spec: infrav1.AWSMachineSpec{InstanceType: "test"},
 			},
-			ownerMachine: &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					clusterv1.ClusterLabelName: "capi-test-1",
+			ownerMachine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterv1.ClusterLabelName: "capi-test-1",
+					},
+					Name: "capi-test-machine", Namespace: "default",
 				},
-				Name: "capi-test-machine", Namespace: "default",
-			}},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "capi-test",
+				},
+			},
 			ownerCluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "capi-test-1"},
 				Spec: clusterv1.ClusterSpec{

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -116,7 +116,10 @@ func (r *AWSManagedControlPlaneReconciler) SetupWithManager(ctx context.Context,
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachines;awsmachines/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinetemplates,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmanagedmachinepools;awsmanagedmachinepools/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinepools;awsmachinepools/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=awsmanagedcontrolplanes,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -21,21 +21,23 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/pkg/errors"
 
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
 	iamv1 "sigs.k8s.io/cluster-api-provider-aws/iam/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
 // ReconcileIAMAuthenticator is used to create the aws-iam-authenticator in a cluster.
 func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	s.scope.Info("Reconciling aws-iam-authenticator configuration", "cluster-name", s.scope.Name())
-
-	accountID, err := s.getAccountID()
-	if err != nil {
-		return fmt.Errorf("getting account id: %w", err)
-	}
 
 	remoteClient, err := s.scope.RemoteClient()
 	if err != nil {
@@ -47,18 +49,27 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("getting aws-iam-authenticator backend: %w", err)
 	}
-
-	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/nodes%s", accountID, iamv1.DefaultNameSuffix)
-	nodesRoleMapping := ekscontrolplanev1.RoleMapping{
-		RoleARN: roleARN,
-		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
-			UserName: EC2NodeUserName,
-			Groups:   NodeGroups,
-		},
+	nodeRoles, err := s.getRolesForWorkers(ctx)
+	if err != nil {
+		s.scope.Error(err, "getting roles for remote workers")
+		return fmt.Errorf("getting roles for remote workers: %w", err)
 	}
-	s.scope.V(2).Info("Mapping node IAM role", "iam-role", nodesRoleMapping.RoleARN, "user", nodesRoleMapping.UserName)
-	if err := authBackend.MapRole(nodesRoleMapping); err != nil {
-		return fmt.Errorf("mapping iam node role: %w", err)
+	for roleName := range nodeRoles {
+		roleARN, err := s.getARNForRole(roleName)
+		if err != nil {
+			return fmt.Errorf("failed to get ARN for role %s: %w", roleARN, err)
+		}
+		nodesRoleMapping := ekscontrolplanev1.RoleMapping{
+			RoleARN: roleARN,
+			KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+				UserName: EC2NodeUserName,
+				Groups:   NodeGroups,
+			},
+		}
+		s.scope.V(2).Info("Mapping node IAM role", "iam-role", nodesRoleMapping.RoleARN, "user", nodesRoleMapping.UserName)
+		if err := authBackend.MapRole(nodesRoleMapping); err != nil {
+			return fmt.Errorf("mapping iam node role: %w", err)
+		}
 	}
 
 	s.scope.V(2).Info("Mapping additional IAM roles and users")
@@ -82,13 +93,123 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) getAccountID() (string, error) {
-	input := &sts.GetCallerIdentityInput{}
-
-	out, err := s.STSClient.GetCallerIdentity(input)
+func (s *Service) getARNForRole(role string) (string, error) {
+	input := &iam.GetRoleInput{
+		RoleName: aws.String(role),
+	}
+	out, err := s.IAMClient.GetRole(input)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to get caller identity")
+		return "", errors.Wrap(err, "unable to get role")
+	}
+	return aws.StringValue(out.Role.Arn), nil
+}
+
+func (s *Service) getRolesForWorkers(ctx context.Context) (map[string]struct{}, error) {
+	// previously this was the default role always added to the IAM authenticator config
+	// we'll keep this to not break existing behavior for users
+	allRoles := map[string]struct{}{
+		fmt.Sprintf("nodes%s", iamv1.DefaultNameSuffix): {},
+	}
+	if err := s.getRolesForMachineDeployments(ctx, allRoles); err != nil {
+		return nil, fmt.Errorf("failed to get roles from machine deployments %w", err)
+	}
+	if err := s.getRolesForMachinePools(ctx, allRoles); err != nil {
+		return nil, fmt.Errorf("failed to get roles from machine pools %w", err)
+	}
+	return allRoles, nil
+}
+
+func (s *Service) getRolesForMachineDeployments(ctx context.Context, allRoles map[string]struct{}) error {
+	deploymentList := &clusterv1.MachineDeploymentList{}
+	selectors := []client.ListOption{
+		client.InNamespace(s.scope.Namespace()),
+		client.MatchingLabels{
+			clusterv1.ClusterLabelName: s.scope.Name(),
+		},
+	}
+	err := s.client.List(ctx, deploymentList, selectors...)
+	if err != nil {
+		return fmt.Errorf("failed to list machine deployments for cluster %s/%s: %w", s.scope.Namespace(), s.scope.Name(), err)
 	}
 
-	return aws.StringValue(out.Account), nil
+	for _, deployment := range deploymentList.Items {
+		ref := deployment.Spec.Template.Spec.InfrastructureRef
+		if ref.Kind != "AWSMachineTemplate" {
+			continue
+		}
+		awsMachineTemplate := &infrav1.AWSMachineTemplate{}
+		err := s.client.Get(ctx, client.ObjectKey{
+			Name:      ref.Name,
+			Namespace: s.scope.Namespace(),
+		}, awsMachineTemplate)
+		if err != nil {
+			return fmt.Errorf("failed to get AWSMachine %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+		instanceProfile := awsMachineTemplate.Spec.Template.Spec.IAMInstanceProfile
+		if _, ok := allRoles[instanceProfile]; !ok && instanceProfile != "" {
+			allRoles[instanceProfile] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func (s *Service) getRolesForMachinePools(ctx context.Context, allRoles map[string]struct{}) error {
+	machinePoolList := &expclusterv1.MachinePoolList{}
+	selectors := []client.ListOption{
+		client.InNamespace(s.scope.Namespace()),
+		client.MatchingLabels{
+			clusterv1.ClusterLabelName: s.scope.Name(),
+		},
+	}
+	err := s.client.List(ctx, machinePoolList, selectors...)
+	if err != nil {
+		return fmt.Errorf("failed to list machine pools for cluster %s/%s: %w", s.scope.Namespace(), s.scope.Name(), err)
+	}
+	for _, pool := range machinePoolList.Items {
+		ref := pool.Spec.Template.Spec.InfrastructureRef
+		switch ref.Kind {
+		case "AWSMachinePool":
+			if err := s.getRolesForAWSMachinePool(ctx, ref, allRoles); err != nil {
+				return err
+			}
+		case "AWSManagedMachinePool":
+			if err := s.getRolesForAWSManagedMachinePool(ctx, ref, allRoles); err != nil {
+				return err
+			}
+		default:
+		}
+	}
+	return nil
+}
+
+func (s *Service) getRolesForAWSMachinePool(ctx context.Context, ref corev1.ObjectReference, allRoles map[string]struct{}) error {
+	awsMachinePool := &expinfrav1.AWSMachinePool{}
+	err := s.client.Get(ctx, client.ObjectKey{
+		Name:      ref.Name,
+		Namespace: s.scope.Namespace(),
+	}, awsMachinePool)
+	if err != nil {
+		return fmt.Errorf("failed to get AWSMachine %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+	instanceProfile := awsMachinePool.Spec.AWSLaunchTemplate.IamInstanceProfile
+	if _, ok := allRoles[instanceProfile]; !ok && instanceProfile != "" {
+		allRoles[instanceProfile] = struct{}{}
+	}
+	return nil
+}
+
+func (s *Service) getRolesForAWSManagedMachinePool(ctx context.Context, ref corev1.ObjectReference, allRoles map[string]struct{}) error {
+	awsManagedMachinePool := &expinfrav1.AWSManagedMachinePool{}
+	err := s.client.Get(ctx, client.ObjectKey{
+		Name:      ref.Name,
+		Namespace: s.scope.Namespace(),
+	}, awsManagedMachinePool)
+	if err != nil {
+		return fmt.Errorf("failed to get AWSMachine %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+	instanceProfile := awsManagedMachinePool.Spec.RoleName
+	if _, ok := allRoles[instanceProfile]; !ok && instanceProfile != "" {
+		allRoles[instanceProfile] = struct{}{}
+	}
+	return nil
 }

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -23,7 +23,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/cloud/services/iamauth/reconcile_test.go
+++ b/pkg/cloud/services/iamauth/reconcile_test.go
@@ -1,0 +1,217 @@
+package iamauth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+func TestReconcileIAMAuth(t *testing.T) {
+	var (
+		mockCtrl *gomock.Controller
+		ctx      context.Context
+	)
+	setup := func(t *testing.T) {
+		t.Helper()
+		mockCtrl = gomock.NewController(t)
+		ctx = context.TODO()
+	}
+
+	teardown := func() {
+		mockCtrl.Finish()
+	}
+	t.Run("Should successfully find roles for MachineDeployments and MachinePools", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		namespace, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("integ-test-%s", util.RandomString(5)))
+		g.Expect(err).To(BeNil())
+		ns := namespace.Name
+		name := "default"
+		eksCluster := createEKSCluster(name, ns)
+		g.Expect(testEnv.Create(ctx, eksCluster)).To(Succeed())
+		awsMP := createAWSMachinePoolForClusterWithInstanceProfile(name, ns, eksCluster.Name, "nodes.cluster-api-provider-aws.sigs.k8s.io")
+		infraRef := corev1.ObjectReference{
+			Kind:       awsMP.TypeMeta.Kind,
+			Name:       awsMP.Name,
+			Namespace:  awsMP.Namespace,
+			APIVersion: awsMP.TypeMeta.APIVersion,
+		}
+		g.Expect(testEnv.Create(ctx, awsMP)).To(Succeed())
+		mp := createMachinepoolForCluster(name, ns, eksCluster.Name, infraRef)
+		g.Expect(testEnv.Create(ctx, mp)).To(Succeed())
+
+		awsMachineTemplate := createAWSMachineTemplateForClusterWithInstanceProfile(name, ns, eksCluster.Name, "eks-nodes.cluster-api-provider-aws.sigs.k8s.io")
+		infraRefForMD := corev1.ObjectReference{
+			Kind:       awsMachineTemplate.TypeMeta.Kind,
+			Name:       awsMachineTemplate.Name,
+			Namespace:  awsMachineTemplate.Namespace,
+			APIVersion: awsMachineTemplate.TypeMeta.APIVersion,
+		}
+		g.Expect(testEnv.Create(ctx, awsMachineTemplate)).To(Succeed())
+		md := createMachineDeploymentForCluster(name, ns, eksCluster.Name, infraRefForMD)
+		g.Expect(testEnv.Create(ctx, md)).To(Succeed())
+
+		expectedRoles := map[string]struct{}{
+			"nodes.cluster-api-provider-aws.sigs.k8s.io":     {},
+			"eks-nodes.cluster-api-provider-aws.sigs.k8s.io": {},
+		}
+
+		controllerIdentity := createControllerIdentity()
+		g.Expect(testEnv.Create(ctx, controllerIdentity)).To(Succeed())
+		managedScope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
+			Client:       testEnv,
+			ControlPlane: eksCluster,
+			Cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+			},
+		})
+		g.Expect(err).To(BeNil(), "failed to create managedScope")
+		authService := NewService(managedScope, BackendTypeConfigMap, managedScope.Client)
+		gotRoles, err := authService.getRolesForWorkers(ctx)
+		g.Expect(err).To(BeNil(), "failed to get roles for workers")
+		g.Expect(gotRoles).To(BeEquivalentTo(expectedRoles), "did not get correct roles for workers")
+		defer teardown()
+		defer t.Cleanup(func() {
+			g.Expect(testEnv.Cleanup(ctx, namespace, eksCluster, awsMP, mp, awsMachineTemplate, md, controllerIdentity)).To(Succeed())
+		})
+	})
+}
+
+func createEKSCluster(name, namespace string) *ekscontrolplanev1.AWSManagedControlPlane {
+	eksCluster := &ekscontrolplanev1.AWSManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: name,
+			},
+		},
+		Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{},
+	}
+	return eksCluster
+}
+
+func createAWSMachinePoolForClusterWithInstanceProfile(name, namespace, clusterName, instanceProfile string) *expinfrav1.AWSMachinePool {
+	awsMP := &expinfrav1.AWSMachinePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "AWSMachinePool",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: clusterName,
+			},
+		},
+		Spec: expinfrav1.AWSMachinePoolSpec{
+			AWSLaunchTemplate: expinfrav1.AWSLaunchTemplate{
+				IamInstanceProfile: instanceProfile,
+			},
+			MaxSize: 1,
+		},
+	}
+	return awsMP
+}
+
+func createMachinepoolForCluster(name, namespace, clusterName string, infrastructureRef corev1.ObjectReference) *expclusterv1.MachinePool {
+	mp := &expclusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: clusterName,
+			},
+		},
+		Spec: expclusterv1.MachinePoolSpec{
+			ClusterName: clusterName,
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName:       clusterName,
+					InfrastructureRef: infrastructureRef,
+				},
+			},
+		},
+	}
+	return mp
+}
+
+func createAWSMachineTemplateForClusterWithInstanceProfile(name, namespace, clusterName, instanceProfile string) *infrav1.AWSMachineTemplate {
+	mt := &infrav1.AWSMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "AWSMachineTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: clusterName,
+			},
+		},
+		Spec: infrav1.AWSMachineTemplateSpec{
+			Template: infrav1.AWSMachineTemplateResource{
+				Spec: infrav1.AWSMachineSpec{
+					IAMInstanceProfile: instanceProfile,
+					InstanceType:       "m5.xlarge",
+				},
+			},
+		},
+	}
+	return mt
+}
+
+func createMachineDeploymentForCluster(name, namespace, clusterName string, infrastructureRef corev1.ObjectReference) *clusterv1.MachineDeployment {
+	md := &clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: clusterName,
+			},
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: clusterName,
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName:       clusterName,
+					InfrastructureRef: infrastructureRef,
+				},
+			},
+			Replicas: pointer.Int32(2),
+		},
+	}
+	return md
+}
+
+func createControllerIdentity() *infrav1.AWSClusterControllerIdentity {
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		TypeMeta: metav1.TypeMeta{
+			Kind: string(infrav1.ControllerIdentityKind),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	return controllerIdentity
+}

--- a/pkg/cloud/services/iamauth/service.go
+++ b/pkg/cloud/services/iamauth/service.go
@@ -17,7 +17,7 @@ limitations under the License.
 package iamauth
 
 import (
-	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
@@ -28,7 +28,7 @@ type Service struct {
 	scope     scope.IAMAuthScope
 	backend   BackendType
 	client    client.Client
-	STSClient stsiface.STSAPI
+	IAMClient iamiface.IAMAPI
 }
 
 // NewService will create a new Service object.
@@ -37,6 +37,6 @@ func NewService(iamScope scope.IAMAuthScope, backend BackendType, client client.
 		scope:     iamScope,
 		backend:   backend,
 		client:    client,
-		STSClient: scope.NewSTSClient(iamScope, iamScope, iamScope, iamScope.InfraCluster()),
+		IAMClient: scope.NewIAMClient(iamScope, iamScope, iamScope, iamScope.InfraCluster()),
 	}
 }

--- a/pkg/cloud/services/iamauth/suite_test.go
+++ b/pkg/cloud/services/iamauth/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package iamauth
 
 import (
 	"fmt"
@@ -25,16 +25,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	// +kubebuilder:scaffold:imports
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1beta1"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/test/helpers"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
 	testEnv *helpers.TestEnvironment
@@ -49,9 +46,11 @@ func TestMain(m *testing.M) {
 
 func setup() {
 	utilruntime.Must(infrav1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(ekscontrolplanev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(expinfrav1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(expclusterv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
+
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
 		path.Join("config", "crd", "bases"),
 	},
@@ -61,24 +60,22 @@ func setup() {
 	if err != nil {
 		panic(err)
 	}
-	if err := (&infrav1.AWSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Unable to setup AWSCluster webhook: %v", err))
-	}
-	if err := (&infrav1.AWSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Unable to setup AWSMachine webhook: %v", err))
+	if err := (&ekscontrolplanev1.AWSManagedControlPlane{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup  AWSManagedControlPlane webhook: %v", err))
 	}
 	if err := (&infrav1.AWSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSMachineTemplate webhook: %v", err))
 	}
 	if err := (&expinfrav1.AWSMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Unable to setup AWSMachinePool webhook: %v", err))
+		panic(fmt.Sprintf("Unable to setup AWSMachineTemplate webhook: %v", err))
 	}
-	if err := (&expinfrav1.AWSManagedMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Unable to setup AWSManagedMachinePool webhook: %v", err))
+	if err := (&infrav1.AWSClusterControllerIdentity{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSMachineTemplate webhook: %v", err))
 	}
 	if err := (&expclusterv1.MachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup MachinePool webhook: %v", err))
 	}
+
 	go func() {
 		fmt.Println("Starting the manager")
 		if err := testEnv.StartManager(ctx); err != nil {

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -422,6 +422,7 @@ func createCloudFormationStack(prov client.ConfigProvider, t *cfn_bootstrap.Temp
 
 	err := cfnSvc.ReconcileBootstrapStack(t.Spec.StackName, *renderCustomCloudFormation(t), tags)
 	if err != nil {
+		By(fmt.Sprintf("Error reconciling Cloud formation stack %v", err))
 		stack, err := CFN.DescribeStacks(&cfn.DescribeStacksInput{StackName: aws.String(t.Spec.StackName)})
 		if err == nil && len(stack.Stacks) > 0 {
 			deleteMultitenancyRoles(prov)

--- a/test/e2e/shared/template.go
+++ b/test/e2e/shared/template.go
@@ -116,7 +116,7 @@ func newBootstrapTemplate(e2eCtx *E2EContext) *cfn_bootstrap.Template {
 	Expect(err).NotTo(HaveOccurred())
 	t.Spec.Region = region
 	t.Spec.EKS.Disable = false
-	t.Spec.EKS.AllowIAMRoleCreation = true
+	t.Spec.EKS.AllowIAMRoleCreation = false
 	t.Spec.EKS.DefaultControlPlaneRole.Disable = false
 	t.Spec.EKS.ManagedMachinePool.Disable = false
 	t.Spec.S3Buckets.Enable = true

--- a/test/e2e/shared/template.go
+++ b/test/e2e/shared/template.go
@@ -116,7 +116,7 @@ func newBootstrapTemplate(e2eCtx *E2EContext) *cfn_bootstrap.Template {
 	Expect(err).NotTo(HaveOccurred())
 	t.Spec.Region = region
 	t.Spec.EKS.Disable = false
-	t.Spec.EKS.AllowIAMRoleCreation = false
+	t.Spec.EKS.AllowIAMRoleCreation = true
 	t.Spec.EKS.DefaultControlPlaneRole.Disable = false
 	t.Spec.EKS.ManagedMachinePool.Disable = false
 	t.Spec.S3Buckets.Enable = true


### PR DESCRIPTION
chore: refactor getting roles to be inline with PR review

test: adds an integration test to test getting roles logic

Also backports the following commit to 1.5 https://github.com/kubernetes-sigs/cluster-api-provider-aws/commit/e0fc4de3bc5f4008b214a8cab6c72a5fe51c6960#diff-6ff1d74b482f5f7e1c2727b17204096fe4bf243e8b7bbb0099b5701b7d3f77b1L53-L54

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug 
backports https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4011

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
