### PR TITLE
Modify AWSMachine reconciliation behavior to terminate and create instances without blocking

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -352,7 +352,7 @@ func (r *AWSMachineReconciler) reconcileDelete(machineScope *scope.MachineScope,
 			return ctrl.Result{}, err
 		}
 
-		if err := ec2Service.TerminateInstanceAndWait(instance.ID); err != nil {
+		if err := ec2Service.TerminateInstance(instance.ID); err != nil {
 			machineScope.Error(err, "failed to terminate instance")
 			conditions.MarkFalse(machineScope.AWSMachine, infrav1.InstanceReadyCondition, "DeletingFailed", clusterv1.ConditionSeverityWarning, err.Error())
 			r.Recorder.Eventf(machineScope.AWSMachine, corev1.EventTypeWarning, "FailedTerminate", "Failed to terminate instance %q: %v", instance.ID, err)

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -581,8 +581,6 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil)
-	m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil)
 	m.DescribeNetworkInterfaces(gomock.Eq(&ec2.DescribeNetworkInterfacesInput{Filters: []*ec2.Filter{
 		{
 			Name:   aws.String("attachment.instance-id"),

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -1536,9 +1536,8 @@ func TestAWSMachineReconciler(t *testing.T) {
 			_, err := reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			g.Expect(err).To(BeNil())
 			g.Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
-			g.Expect(ms.AWSMachine.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
 		})
-		t.Run("should ignore instances in terminated down state", func(t *testing.T) {
+		t.Run("should ignore instances in terminated state", func(t *testing.T) {
 			g := NewWithT(t)
 			awsMachine := getAWSMachine()
 			setup(t, g, awsMachine)
@@ -1555,7 +1554,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 			_, err := reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			g.Expect(err).To(BeNil())
-			g.Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
+			g.Expect(buf.String()).To(ContainSubstring("EC2 instance terminated successfully"))
 			g.Expect(ms.AWSMachine.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
 		})
 		t.Run("instance not shutting down yet", func(t *testing.T) {
@@ -1665,7 +1664,6 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 					_, err := reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 					g.Expect(err).To(BeNil())
-					g.Expect(ms.AWSMachine.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
 				})
 
 				t.Run("should fail to detach control plane ELB from instance", func(t *testing.T) {

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -391,6 +391,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 					secretSvc.EXPECT().UserData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 					instance.State = infrav1.InstanceStatePending
 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs, cs)
+
 					g.Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStatePending)))
 					g.Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
 					g.Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
@@ -410,6 +411,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 					secretSvc.EXPECT().UserData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 					instance.State = infrav1.InstanceStateRunning
 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs, cs, cs, cs)
+
 					g.Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateRunning)))
 					g.Expect(ms.AWSMachine.Status.Ready).To(Equal(true))
 					g.Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
@@ -1081,7 +1083,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				instance.State = infrav1.InstanceStateRunning
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
 
@@ -1094,7 +1096,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				ms.AWSMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
 			t.Run("should not attempt to delete the secret if InsecureSkipSecretsManager is set on CloudInit", func(t *testing.T) {
@@ -1107,7 +1109,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				ms.AWSMachine.Spec.CloudInit.InsecureSkipSecretsManager = true
 
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(0)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
@@ -1167,7 +1169,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				instance.State = infrav1.InstanceStateRunning
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
 
@@ -1180,7 +1182,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				ms.AWSMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
 		})
@@ -1348,7 +1350,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				instance.State = infrav1.InstanceStateRunning
 				objectStoreSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
@@ -1365,7 +1367,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				ms.AWSMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 
 				objectStoreSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
@@ -1429,7 +1431,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				instance.State = infrav1.InstanceStateRunning
 				objectStoreSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
 
@@ -1444,7 +1446,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				// TODO: This seems to have no effect on the test result.
 				ms.AWSMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 				objectStoreSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil).AnyTimes()
 				_, _ = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 			})
 		})
@@ -1572,7 +1574,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 				getRunningInstance(t, g)
 
 				expected := errors.New("can't reach AWS to terminate machine")
-				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(expected)
+				ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(expected)
 
 				buf := new(bytes.Buffer)
 				klog.SetOutput(buf)
@@ -1585,7 +1587,7 @@ func TestAWSMachineReconciler(t *testing.T) {
 			t.Run("when instance can be shut down", func(t *testing.T) {
 				terminateInstance := func(t *testing.T, g *WithT) {
 					t.Helper()
-					ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil)
+					ec2Svc.EXPECT().TerminateInstance(gomock.Any()).Return(nil)
 					secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).AnyTimes()
 				}
 

--- a/pkg/cloud/services/ec2/bastion_test.go
+++ b/pkg/cloud/services/ec2/bastion_test.go
@@ -366,8 +366,6 @@ func TestServiceReconcileBastion(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 			},
 			bastionEnabled: true,
 			expectError:    false,

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -385,8 +385,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -497,9 +495,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -637,9 +632,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -773,9 +765,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -910,9 +899,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1024,8 +1010,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1136,8 +1120,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1323,8 +1305,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1585,8 +1565,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1790,8 +1768,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1893,8 +1869,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2067,8 +2041,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2208,8 +2180,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2351,8 +2321,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2465,8 +2433,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2580,8 +2546,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2696,8 +2660,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2809,8 +2771,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2922,8 +2882,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -3035,8 +2993,6 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
-				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The existing AWSMachine reconciliation loop blocks on terminating an ec2 instance and waits for it to confirm the termination with AWS, as well as blocking on ec2 instance creation and waits up to one minute, for no discernible reason I could detect. This PR removes the blocking behavior, proceeding with reconciliation immediately after the AWS sdk confirms success on the API call. 

As a result, this change greatly speeds up large machine deployment rollouts. Previously, very large Machine Deployments (> 100 machines) would take several hours for the machine sets to provision new nodes and tear down machines. This was mostly a result of the reconciliation blocking for each instance creation and delete, and while blocked, prevented additional concurrent work from proceeding, as there is a fixed number of concurrent AWSMachine reconcile workers allowed (controlled by `--awsmachine-concurrency`).

We tested this change in one of our clusters - timing it with 600 nodes, split into 3 node groups (really, 1 node group, duplicated for 3 az's in us-east-2). We were testing with t3.small instances which have just enough CPU to run kubelet and the daemonset pods we deploy. 

We captured metrics from both the CAPI and CAPA controllers as well as metrics about the state of the CAPI resources in the kubernetes cluster. The most meaningful thing to note in the metrics is the time scale. The rollout took ~2 hours to complete on the mainline version and < 45 minutes on this branch. The CAPA unfinished workqueue metric is also significantly different before and after this change.

This is metrics without the change (running on capi v1.3.2, capa v2.0.2 official release):

![Screenshot 2023-02-23 at 10-30-51 Kubernetes Cluster Autoscaling Datadog](https://user-images.githubusercontent.com/13153715/220970210-a4c2f291-e770-4104-a342-cc1a572cd420.png)

This is the metrics from the same cluster after this change (running on capi v1.3.2, this PR branch):

![Screenshot 2023-02-23 at 10-31-38 Kubernetes Cluster Autoscaling Datadog](https://user-images.githubusercontent.com/13153715/220970242-e87b0d43-69ec-4fe9-bf76-439de9f23865.png)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Split into two commits for review, first commit is the modified behavior. The second commit is updating the e2e test sites for the new reconciliation behavior.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Modifies the AWSMachine reconciliation to no longer block on ec2 termination or creation, resulting in faster rollouts for large Machine Deployments.
```
