### PR TITLE
cleaning up unnecessary object patches

### DIFF
--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -241,9 +241,10 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 
 	awsManagedControlPlane := managedScope.ControlPlane
 
-	controllerutil.AddFinalizer(managedScope.ControlPlane, ekscontrolplanev1.ManagedControlPlaneFinalizer)
-	if err := managedScope.PatchObject(); err != nil {
-		return ctrl.Result{}, err
+	if controllerutil.AddFinalizer(managedScope.ControlPlane, ekscontrolplanev1.ManagedControlPlaneFinalizer) {
+		if err := managedScope.PatchObject(); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	ec2Service := ec2.NewService(managedScope)

--- a/exp/controllers/awsfargatepool_controller.go
+++ b/exp/controllers/awsfargatepool_controller.go
@@ -147,9 +147,10 @@ func (r *AWSFargateProfileReconciler) reconcileNormal(
 ) (ctrl.Result, error) {
 	fargateProfileScope.Info("Reconciling AWSFargateProfile")
 
-	controllerutil.AddFinalizer(fargateProfileScope.FargateProfile, expinfrav1.FargateProfileFinalizer)
-	if err := fargateProfileScope.PatchObject(); err != nil {
-		return ctrl.Result{}, err
+	if controllerutil.AddFinalizer(fargateProfileScope.FargateProfile, expinfrav1.FargateProfileFinalizer) {
+		if err := fargateProfileScope.PatchObject(); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	ekssvc := eks.NewFargateService(fargateProfileScope)

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -203,11 +203,11 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(ctx context.Context, machineP
 	}
 
 	// If the AWSMachinepool doesn't have our finalizer, add it
-	controllerutil.AddFinalizer(machinePoolScope.AWSMachinePool, expinfrav1.MachinePoolFinalizer)
-
-	// Register finalizer immediately to avoid orphaning AWS resources
-	if err := machinePoolScope.PatchObject(); err != nil {
-		return ctrl.Result{}, err
+	if controllerutil.AddFinalizer(machinePoolScope.AWSMachinePool, expinfrav1.MachinePoolFinalizer) {
+		// Register finalizer immediately to avoid orphaning AWS resources
+		if err := machinePoolScope.PatchObject(); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if !machinePoolScope.Cluster.Status.InfrastructureReady {

--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -199,9 +199,10 @@ func (r *AWSManagedMachinePoolReconciler) reconcileNormal(
 ) (ctrl.Result, error) {
 	machinePoolScope.Info("Reconciling AWSManagedMachinePool")
 
-	controllerutil.AddFinalizer(machinePoolScope.ManagedMachinePool, expinfrav1.ManagedMachinePoolFinalizer)
-	if err := machinePoolScope.PatchObject(); err != nil {
-		return ctrl.Result{}, err
+	if controllerutil.AddFinalizer(machinePoolScope.ManagedMachinePool, expinfrav1.ManagedMachinePoolFinalizer) {
+		if err := machinePoolScope.PatchObject(); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	ekssvc := eks.NewNodegroupService(machinePoolScope)

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -260,6 +260,7 @@ func (s *ClusterScope) PatchObject() error {
 			infrav1.BastionHostReadyCondition,
 			infrav1.LoadBalancerReadyCondition,
 			infrav1.PrincipalUsageAllowedCondition,
+			infrav1.PrincipalCredentialRetrievedCondition,
 		}})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: 
- The AWSCluster reconciler has an additional defer which included a patch in it which is ignoring the existing existing Close happening in a defer about 10 lines further down. During reconciliation you'll get a double Patch call and the only difference in the two was the list of conditions. I merged the conditions and deleted the unneeded Patch.
- All finalizers are being added by `controllerutil.AddFinalizer` which returns a bool if the finalizer was actually added to the object. It will return true on the first reconciliation and the patch will be called and false from then on, wrapping the AddFinalizer call with an if and gating the Patch will avoid the patch logic when it's obviously not necessary.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4093

**Special notes for your reviewer**:
yo dog i got a patch for your patch when you want patches!

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove extra object patching from AWSCluster to decrease the overwhelming number of kube API calls.
```
