### PR TITLE
fix: invalid yaml in multi-tenancy example

### DIFF
--- a/docs/book/src/topics/multitenancy.md
+++ b/docs/book/src/topics/multitenancy.md
@@ -56,7 +56,7 @@ kind: AWSClusterControllerIdentity
 metadata:
   name: "default"
 spec:
-  allowedNamespaces:{}  # matches all namespaces
+  allowedNamespaces: {}  # matches all namespaces
 ```
 `AWSClusterControllerIdentity` is immutable to avoid any unwanted overrides to the allowed namespaces, especially during upgrading clusters.
 
@@ -231,7 +231,7 @@ kind: AWSClusterControllerIdentity
 metadata:
   name: "default"
 spec:
-  allowedNamespaces:{}  # matches all namespaces
+  allowedNamespaces: {}  # matches all namespaces
 ```
 
 ```yaml


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind documentation

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
The YAML provided within the example is missing a space, this makes it invalid if a user wishes to place it into a file and apply it without editing the manifest directly.

```bash
kubectl apply -f default-controller-identity.yaml
error: error validating "default-controller-identity.yaml": error validating data: ValidationError(AWSClusterControllerIdentity.spec): invalid type for io.x-k8s.cluster.infrastructure.v1beta1.AWSClusterControllerIdentity.spec: got "string", expected "map"; if you choose to ignore these errors, turn validation off with --validate=false
```

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
