### PR TITLE
Add missing configuration to enable the awsmachinetemplate validating webhook

### DIFF
--- a/api/v1beta2/awsmachinetemplate_webhook.go
+++ b/api/v1beta2/awsmachinetemplate_webhook.go
@@ -40,6 +40,7 @@ func (r *AWSMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) er
 }
 
 // AWSMachineTemplateWebhook implements a custom validation webhook for AWSMachineTemplate.
+// Note: we use a custom validator to access the request context for SSA of AWSMachineTemplate.
 // +kubebuilder:object:generate=false
 type AWSMachineTemplateWebhook struct{}
 
@@ -224,11 +225,6 @@ func (r *AWSMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw r
 	}
 
 	var allErrs field.ErrorList
-
-	// Allow setting of cloudInit.secureSecretsBackend to "secrets-manager" only to handle v1alpha3 upgrade
-	if oldAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend == "" && newAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend == SecretBackendSecretsManager {
-		newAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend = ""
-	}
 
 	if !topology.ShouldSkipImmutabilityChecks(req, newAWSMachineTemplate) && !cmp.Equal(newAWSMachineTemplate.Spec, oldAWSMachineTemplate.Spec) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), newAWSMachineTemplate, "AWSMachineTemplate.Spec is immutable"))

--- a/api/v1beta2/awsmachinetemplate_webhook.go
+++ b/api/v1beta2/awsmachinetemplate_webhook.go
@@ -43,7 +43,8 @@ func (r *AWSMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) er
 // +kubebuilder:object:generate=false
 type AWSMachineTemplateWebhook struct{}
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=awsmachinetemplates,versions=v1beta2,name=validation.awsmachinetemplate.infrastructure.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=awsmachinetemplates,versions=v1beta2,name=validation.awsmachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
 var _ webhook.CustomValidator = &AWSMachineTemplateWebhook{}
 
 func (r *AWSMachineTemplate) validateRootVolume() field.ErrorList {
@@ -224,8 +225,8 @@ func (r *AWSMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw r
 
 	var allErrs field.ErrorList
 
-	// Allow setting of cloudInit.secureSecretsBackend to "secrets-manager" only to handle v1beta2 upgrade
-	if oldAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend == "" && newAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend == SecretBackendSSMParameterStore {
+	// Allow setting of cloudInit.secureSecretsBackend to "secrets-manager" only to handle v1alpha3 upgrade
+	if oldAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend == "" && newAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend == SecretBackendSecretsManager {
 		newAWSMachineTemplate.Spec.Template.Spec.CloudInit.SecureSecretsBackend = ""
 	}
 

--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -117,7 +117,7 @@ func TestAWSMachineTemplateValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			wantError: false,
+			wantError: true,
 		},
 		{
 			name: "allow secrets manager",
@@ -135,6 +135,20 @@ func TestAWSMachineTemplateValidateUpdate(t *testing.T) {
 				},
 			},
 			wantError: false,
+		},
+		{
+			name: "don't allow updates",
+			modifiedTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test2",
+						},
+					},
+				},
+			},
+			wantError: true,
 		},
 	}
 	for _, tt := range tests {

--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -103,40 +103,6 @@ func TestAWSMachineTemplateValidateUpdate(t *testing.T) {
 		wantError        bool
 	}{
 		{
-			name: "don't allow ssm parameter store",
-			modifiedTemplate: &AWSMachineTemplate{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: AWSMachineTemplateSpec{
-					Template: AWSMachineTemplateResource{
-						Spec: AWSMachineSpec{
-							CloudInit: CloudInit{
-								SecureSecretsBackend: SecretBackendSSMParameterStore,
-							},
-							InstanceType: "test",
-						},
-					},
-				},
-			},
-			wantError: true,
-		},
-		{
-			name: "allow secrets manager",
-			modifiedTemplate: &AWSMachineTemplate{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: AWSMachineTemplateSpec{
-					Template: AWSMachineTemplateResource{
-						Spec: AWSMachineSpec{
-							CloudInit: CloudInit{
-								SecureSecretsBackend: SecretBackendSecretsManager,
-							},
-							InstanceType: "test",
-						},
-					},
-				},
-			},
-			wantError: false,
-		},
-		{
 			name: "don't allow updates",
 			modifiedTemplate: &AWSMachineTemplate{
 				ObjectMeta: metav1.ObjectMeta{},

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -414,6 +414,28 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsfargateprofile
   failurePolicy: Fail
   matchPolicy: Equivalent


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Enables the AWSMachineTemplate validating webhook. Unclear why it was not previously configured.

~~The CloudInit behavior was removed, as it was copied from the v1alpha4 resources in [c09f55f8f2249d9fde6d7878a6595bf1c4672ff2](https://github.com/kubernetes-sigs/cluster-api-provider-aws/commit/c09f55f8f2249d9fde6d7878a6595bf1c4672ff2#diff-d85ef380a29a05566d8f529b89c7746d5ce4b257400061fe52be4a9ef0647668R65-R68) and kept being dragged forward, but the comment indicates it was only needed for one resource version upgrade, so I _think_ it's no longer necessary.~~

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4116

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed bug which resulted in the AWSMachineTemplate validating webhook not being enabled as expected.
```
