### PR TITLE
Remove CAPA tagging from unmanaged network resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - args:
         - "--leader-elect"
-        - "--feature-gates=EKS=${CAPA_EKS:=true},EKSEnableIAM=${CAPA_EKS_IAM:=false},EKSAllowAddRoles=${CAPA_EKS_ADD_ROLES:=false},EKSFargate=${EXP_EKS_FARGATE:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true},BootstrapFormatIgnition=${EXP_BOOTSTRAP_FORMAT_IGNITION:=false},ExternalResourceGC=${EXP_EXTERNAL_RESOURCE_GC:=false},AlternativeGCStrategy=${EXP_ALTERNATIVE_GC_STRATEGY:=false},TagUnmanagedNetworkResources=${TAG_UNMANAGED_NETWORK_RESOURCES:=false}"
+        - "--feature-gates=EKS=${CAPA_EKS:=true},EKSEnableIAM=${CAPA_EKS_IAM:=false},EKSAllowAddRoles=${CAPA_EKS_ADD_ROLES:=false},EKSFargate=${EXP_EKS_FARGATE:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true},BootstrapFormatIgnition=${EXP_BOOTSTRAP_FORMAT_IGNITION:=false},ExternalResourceGC=${EXP_EXTERNAL_RESOURCE_GC:=false},AlternativeGCStrategy=${EXP_ALTERNATIVE_GC_STRATEGY:=false},TagUnmanagedNetworkResources=${TAG_UNMANAGED_NETWORK_RESOURCES:=true}"
         - "--v=${CAPA_LOGLEVEL:=0}"
         - "--metrics-bind-addr=0.0.0.0:8080"
         image: controller:latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - args:
         - "--leader-elect"
-        - "--feature-gates=EKS=${CAPA_EKS:=true},EKSEnableIAM=${CAPA_EKS_IAM:=false},EKSAllowAddRoles=${CAPA_EKS_ADD_ROLES:=false},EKSFargate=${EXP_EKS_FARGATE:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true},BootstrapFormatIgnition=${EXP_BOOTSTRAP_FORMAT_IGNITION:=false},ExternalResourceGC=${EXP_EXTERNAL_RESOURCE_GC:=false},AlternativeGCStrategy=${EXP_ALTERNATIVE_GC_STRATEGY:=false}"
+        - "--feature-gates=EKS=${CAPA_EKS:=true},EKSEnableIAM=${CAPA_EKS_IAM:=false},EKSAllowAddRoles=${CAPA_EKS_ADD_ROLES:=false},EKSFargate=${EXP_EKS_FARGATE:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true},BootstrapFormatIgnition=${EXP_BOOTSTRAP_FORMAT_IGNITION:=false},ExternalResourceGC=${EXP_EXTERNAL_RESOURCE_GC:=false},AlternativeGCStrategy=${EXP_ALTERNATIVE_GC_STRATEGY:=false},TagUnmanagedNetworkResources=${TAG_UNMANAGED_NETWORK_RESOURCES:=false}"
         - "--v=${CAPA_LOGLEVEL:=0}"
         - "--metrics-bind-addr=0.0.0.0:8080"
         image: controller:latest

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -68,15 +68,16 @@ var defaultAWSSecurityGroupRoles = []infrav1.SecurityGroupRole{
 // AWSClusterReconciler reconciles a AwsCluster object.
 type AWSClusterReconciler struct {
 	client.Client
-	Recorder              record.EventRecorder
-	ec2ServiceFactory     func(scope.EC2Scope) services.EC2Interface
-	networkServiceFactory func(scope.ClusterScope) services.NetworkInterface
-	elbServiceFactory     func(scope.ELBScope) services.ELBInterface
-	securityGroupFactory  func(scope.ClusterScope) services.SecurityGroupInterface
-	Endpoints             []scope.ServiceEndpoint
-	WatchFilterValue      string
-	ExternalResourceGC    bool
-	AlternativeGCStrategy bool
+	Recorder                     record.EventRecorder
+	ec2ServiceFactory            func(scope.EC2Scope) services.EC2Interface
+	networkServiceFactory        func(scope.ClusterScope) services.NetworkInterface
+	elbServiceFactory            func(scope.ELBScope) services.ELBInterface
+	securityGroupFactory         func(scope.ClusterScope) services.SecurityGroupInterface
+	Endpoints                    []scope.ServiceEndpoint
+	WatchFilterValue             string
+	ExternalResourceGC           bool
+	AlternativeGCStrategy        bool
+	TagUnmanagedNetworkResources bool
 }
 
 // getEC2Service factory func is added for testing purpose so that we can inject mocked EC2Service to the AWSClusterReconciler.
@@ -169,12 +170,13 @@ func (r *AWSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Create the scope.
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
-		Client:         r.Client,
-		Logger:         log,
-		Cluster:        cluster,
-		AWSCluster:     awsCluster,
-		ControllerName: "awscluster",
-		Endpoints:      r.Endpoints,
+		Client:                       r.Client,
+		Logger:                       log,
+		Cluster:                      cluster,
+		AWSCluster:                   awsCluster,
+		ControllerName:               "awscluster",
+		Endpoints:                    r.Endpoints,
+		TagUnmanagedNetworkResources: r.TagUnmanagedNetworkResources,
 	})
 	if err != nil {
 		return reconcile.Result{}, errors.Errorf("failed to create scope: %+v", err)

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -79,6 +79,7 @@ type AWSMachineReconciler struct {
 	objectStoreServiceFactory    func(cloud.ClusterScoper) services.ObjectStoreInterface
 	Endpoints                    []scope.ServiceEndpoint
 	WatchFilterValue             string
+	TagUnmanagedNetworkResources bool
 }
 
 const (
@@ -1032,12 +1033,13 @@ func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log *logger.
 		}
 
 		managedControlPlaneScope, err = scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
-			Client:         r.Client,
-			Logger:         log,
-			Cluster:        cluster,
-			ControlPlane:   controlPlane,
-			ControllerName: "awsManagedControlPlane",
-			Endpoints:      r.Endpoints,
+			Client:                       r.Client,
+			Logger:                       log,
+			Cluster:                      cluster,
+			ControlPlane:                 controlPlane,
+			ControllerName:               "awsManagedControlPlane",
+			Endpoints:                    r.Endpoints,
+			TagUnmanagedNetworkResources: r.TagUnmanagedNetworkResources,
 		})
 		if err != nil {
 			return nil, err
@@ -1060,11 +1062,12 @@ func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log *logger.
 
 	// Create the cluster scope
 	clusterScope, err = scope.NewClusterScope(scope.ClusterScopeParams{
-		Client:         r.Client,
-		Logger:         log,
-		Cluster:        cluster,
-		AWSCluster:     awsCluster,
-		ControllerName: "awsmachine",
+		Client:                       r.Client,
+		Logger:                       log,
+		Cluster:                      cluster,
+		AWSCluster:                   awsCluster,
+		ControllerName:               "awsmachine",
+		TagUnmanagedNetworkResources: r.TagUnmanagedNetworkResources,
 	})
 	if err != nil {
 		return nil, err

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -87,12 +87,13 @@ type AWSManagedControlPlaneReconciler struct {
 	Recorder  record.EventRecorder
 	Endpoints []scope.ServiceEndpoint
 
-	EnableIAM             bool
-	AllowAdditionalRoles  bool
-	WatchFilterValue      string
-	ExternalResourceGC    bool
-	AlternativeGCStrategy bool
-	WaitInfraPeriod       time.Duration
+	EnableIAM                    bool
+	AllowAdditionalRoles         bool
+	WatchFilterValue             string
+	ExternalResourceGC           bool
+	AlternativeGCStrategy        bool
+	WaitInfraPeriod              time.Duration
+	TagUnmanagedNetworkResources bool
 }
 
 // SetupWithManager is used to setup the controller.
@@ -173,13 +174,14 @@ func (r *AWSManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	managedScope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
-		Client:               r.Client,
-		Cluster:              cluster,
-		ControlPlane:         awsControlPlane,
-		ControllerName:       strings.ToLower(awsManagedControlPlaneKind),
-		EnableIAM:            r.EnableIAM,
-		AllowAdditionalRoles: r.AllowAdditionalRoles,
-		Endpoints:            r.Endpoints,
+		Client:                       r.Client,
+		Cluster:                      cluster,
+		ControlPlane:                 awsControlPlane,
+		ControllerName:               strings.ToLower(awsManagedControlPlaneKind),
+		EnableIAM:                    r.EnableIAM,
+		AllowAdditionalRoles:         r.AllowAdditionalRoles,
+		Endpoints:                    r.Endpoints,
+		TagUnmanagedNetworkResources: r.TagUnmanagedNetworkResources,
 	})
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)

--- a/docs/book/src/topics/bring-your-own-aws-infrastructure.md
+++ b/docs/book/src/topics/bring-your-own-aws-infrastructure.md
@@ -44,9 +44,10 @@ Cluster API itself does tag AWS resources it creates. The `sigs.k8s.io/cluster-a
 When consuming existing AWS infrastructure, the Cluster API AWS provider does not require any tags to be present. The absence of the tags on an AWS resource indicates to Cluster API that it should not modify the resource or attempt to manage the lifecycle of the resource.
 
 However, the built-in Kubernetes AWS cloud provider _does_ require certain tags in order to function properly. Specifically, all subnets where Kubernetes nodes reside should have the `kubernetes.io/cluster/<cluster-name>` tag present. Private subnets should also have the `kubernetes.io/role/internal-elb` tag with a value of 1, and public subnets should have the `kubernetes.io/role/elb` tag with a value of 1. These latter two tags help the cloud provider understand which subnets to use when creating load balancers.
-> **Note**: The subnet tagging above is taken care by the CAPA controllers but additionalTags provided by users won't be propagated to the unmanaged VPC subnets.
 
 Finally, if the controller manager isn't started with the `--configure-cloud-routes: "false"` parameter, the route table(s) will also need the `kubernetes.io/cluster/<cluster-name>` tag. (This parameter can be added by customizing the `KubeadmConfigSpec` object of the `KubeadmControlPlane` object.)
+
+> **Note**: All the tagging of resources should be the responsibility of the users and are not managed by CAPA controllers.
 
 ### Configuring the AWSCluster Specification
 

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -57,10 +57,11 @@ import (
 // AWSMachinePoolReconciler reconciles a AWSMachinePool object.
 type AWSMachinePoolReconciler struct {
 	client.Client
-	Recorder          record.EventRecorder
-	WatchFilterValue  string
-	asgServiceFactory func(cloud.ClusterScoper) services.ASGInterface
-	ec2ServiceFactory func(scope.EC2Scope) services.EC2Interface
+	Recorder                     record.EventRecorder
+	WatchFilterValue             string
+	asgServiceFactory            func(cloud.ClusterScoper) services.ASGInterface
+	ec2ServiceFactory            func(scope.EC2Scope) services.EC2Interface
+	TagUnmanagedNetworkResources bool
 }
 
 func (r *AWSMachinePoolReconciler) getASGService(scope cloud.ClusterScoper) services.ASGInterface {
@@ -594,11 +595,12 @@ func (r *AWSMachinePoolReconciler) getInfraCluster(ctx context.Context, log *log
 		}
 
 		managedControlPlaneScope, err = scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
-			Client:         r.Client,
-			Logger:         log,
-			Cluster:        cluster,
-			ControlPlane:   controlPlane,
-			ControllerName: "awsManagedControlPlane",
+			Client:                       r.Client,
+			Logger:                       log,
+			Cluster:                      cluster,
+			ControlPlane:                 controlPlane,
+			ControllerName:               "awsManagedControlPlane",
+			TagUnmanagedNetworkResources: r.TagUnmanagedNetworkResources,
 		})
 		if err != nil {
 			return nil, err
@@ -621,11 +623,12 @@ func (r *AWSMachinePoolReconciler) getInfraCluster(ctx context.Context, log *log
 
 	// Create the cluster scope
 	clusterScope, err = scope.NewClusterScope(scope.ClusterScopeParams{
-		Client:         r.Client,
-		Logger:         log,
-		Cluster:        cluster,
-		AWSCluster:     awsCluster,
-		ControllerName: "awsmachine",
+		Client:                       r.Client,
+		Logger:                       log,
+		Cluster:                      cluster,
+		AWSCluster:                   awsCluster,
+		ControllerName:               "awsmachine",
+		TagUnmanagedNetworkResources: r.TagUnmanagedNetworkResources,
 	})
 	if err != nil {
 		return nil, err

--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -53,11 +53,12 @@ import (
 // AWSManagedMachinePoolReconciler reconciles a AWSManagedMachinePool object.
 type AWSManagedMachinePoolReconciler struct {
 	client.Client
-	Recorder             record.EventRecorder
-	Endpoints            []scope.ServiceEndpoint
-	EnableIAM            bool
-	AllowAdditionalRoles bool
-	WatchFilterValue     string
+	Recorder                     record.EventRecorder
+	Endpoints                    []scope.ServiceEndpoint
+	EnableIAM                    bool
+	AllowAdditionalRoles         bool
+	WatchFilterValue             string
+	TagUnmanagedNetworkResources bool
 }
 
 // SetupWithManager is used to setup the controller.
@@ -138,11 +139,12 @@ func (r *AWSManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	managedControlPlaneScope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
-		Client:         r.Client,
-		Logger:         log,
-		Cluster:        cluster,
-		ControlPlane:   controlPlane,
-		ControllerName: "awsManagedControlPlane",
+		Client:                       r.Client,
+		Logger:                       log,
+		Cluster:                      cluster,
+		ControlPlane:                 controlPlane,
+		ControllerName:               "awsManagedControlPlane",
+		TagUnmanagedNetworkResources: r.TagUnmanagedNetworkResources,
 	})
 	if err != nil {
 		return ctrl.Result{}, errors.New("error getting managed control plane scope")

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -75,6 +75,11 @@ const (
 	// owner: @wyike
 	// alpha: v2.0
 	AlternativeGCStrategy featuregate.Feature = "AlternativeGCStrategy"
+
+	// TagUnmanagedNetworkResources is used to disable tagging unmanaged networking resources.
+	// owner: @skarlso
+	// alpha: v2.0
+	TagUnmanagedNetworkResources featuregate.Feature = "TagUnmanagedNetworkResources"
 )
 
 func init() {
@@ -95,4 +100,5 @@ var defaultCAPAFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	BootstrapFormatIgnition:       {Default: false, PreRelease: featuregate.Alpha},
 	ExternalResourceGC:            {Default: false, PreRelease: featuregate.Alpha},
 	AlternativeGCStrategy:         {Default: false, PreRelease: featuregate.Alpha},
+	TagUnmanagedNetworkResources:  {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -100,5 +100,5 @@ var defaultCAPAFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	BootstrapFormatIgnition:       {Default: false, PreRelease: featuregate.Alpha},
 	ExternalResourceGC:            {Default: false, PreRelease: featuregate.Alpha},
 	AlternativeGCStrategy:         {Default: false, PreRelease: featuregate.Alpha},
-	TagUnmanagedNetworkResources:  {Default: false, PreRelease: featuregate.Alpha},
+	TagUnmanagedNetworkResources:  {Default: true, PreRelease: featuregate.Alpha},
 }

--- a/main.go
+++ b/main.go
@@ -226,23 +226,25 @@ func setupReconcilersAndWebhooks(ctx context.Context, mgr ctrl.Manager, awsServi
 	externalResourceGC, alternativeGCStrategy bool,
 ) {
 	if err := (&controllers.AWSMachineReconciler{
-		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("controllers").WithName("AWSMachine"),
-		Recorder:         mgr.GetEventRecorderFor("awsmachine-controller"),
-		Endpoints:        awsServiceEndpoints,
-		WatchFilterValue: watchFilterValue,
+		Client:                       mgr.GetClient(),
+		Log:                          ctrl.Log.WithName("controllers").WithName("AWSMachine"),
+		Recorder:                     mgr.GetEventRecorderFor("awsmachine-controller"),
+		Endpoints:                    awsServiceEndpoints,
+		WatchFilterValue:             watchFilterValue,
+		TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsMachineConcurrency, RecoverPanic: pointer.Bool(true)}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AWSMachine")
 		os.Exit(1)
 	}
 
 	if err := (&controllers.AWSClusterReconciler{
-		Client:                mgr.GetClient(),
-		Recorder:              mgr.GetEventRecorderFor("awscluster-controller"),
-		Endpoints:             awsServiceEndpoints,
-		WatchFilterValue:      watchFilterValue,
-		ExternalResourceGC:    externalResourceGC,
-		AlternativeGCStrategy: alternativeGCStrategy,
+		Client:                       mgr.GetClient(),
+		Recorder:                     mgr.GetEventRecorderFor("awscluster-controller"),
+		Endpoints:                    awsServiceEndpoints,
+		WatchFilterValue:             watchFilterValue,
+		ExternalResourceGC:           externalResourceGC,
+		AlternativeGCStrategy:        alternativeGCStrategy,
+		TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsClusterConcurrency, RecoverPanic: pointer.Bool(true)}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AWSCluster")
 		os.Exit(1)
@@ -251,9 +253,10 @@ func setupReconcilersAndWebhooks(ctx context.Context, mgr ctrl.Manager, awsServi
 	if feature.Gates.Enabled(feature.MachinePool) {
 		setupLog.Debug("enabling machine pool controller and webhook")
 		if err := (&expcontrollers.AWSMachinePoolReconciler{
-			Client:           mgr.GetClient(),
-			Recorder:         mgr.GetEventRecorderFor("awsmachinepool-controller"),
-			WatchFilterValue: watchFilterValue,
+			Client:                       mgr.GetClient(),
+			Recorder:                     mgr.GetEventRecorderFor("awsmachinepool-controller"),
+			WatchFilterValue:             watchFilterValue,
+			TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: instanceStateConcurrency, RecoverPanic: pointer.Bool(true)}); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AWSMachinePool")
 			os.Exit(1)
@@ -395,12 +398,13 @@ func setupEKSReconcilersAndWebhooks(ctx context.Context, mgr ctrl.Manager, awsSe
 	if feature.Gates.Enabled(feature.MachinePool) {
 		setupLog.Debug("enabling EKS managed machine pool controller")
 		if err := (&expcontrollers.AWSManagedMachinePoolReconciler{
-			AllowAdditionalRoles: allowAddRoles,
-			Client:               mgr.GetClient(),
-			EnableIAM:            enableIAM,
-			Endpoints:            awsServiceEndpoints,
-			Recorder:             mgr.GetEventRecorderFor("awsmanagedmachinepool-reconciler"),
-			WatchFilterValue:     watchFilterValue,
+			AllowAdditionalRoles:         allowAddRoles,
+			Client:                       mgr.GetClient(),
+			EnableIAM:                    enableIAM,
+			Endpoints:                    awsServiceEndpoints,
+			Recorder:                     mgr.GetEventRecorderFor("awsmanagedmachinepool-reconciler"),
+			WatchFilterValue:             watchFilterValue,
+			TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: instanceStateConcurrency, RecoverPanic: pointer.Bool(true)}); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AWSManagedMachinePool")
 			os.Exit(1)

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -37,13 +37,14 @@ import (
 
 // ClusterScopeParams defines the input parameters used to create a new Scope.
 type ClusterScopeParams struct {
-	Client         client.Client
-	Logger         *logger.Logger
-	Cluster        *clusterv1.Cluster
-	AWSCluster     *infrav1.AWSCluster
-	ControllerName string
-	Endpoints      []ServiceEndpoint
-	Session        awsclient.ConfigProvider
+	Client                       client.Client
+	Logger                       *logger.Logger
+	Cluster                      *clusterv1.Cluster
+	AWSCluster                   *infrav1.AWSCluster
+	ControllerName               string
+	Endpoints                    []ServiceEndpoint
+	Session                      awsclient.ConfigProvider
+	TagUnmanagedNetworkResources bool
 }
 
 // NewClusterScope creates a new Scope from the supplied parameters.
@@ -62,11 +63,12 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 	}
 
 	clusterScope := &ClusterScope{
-		Logger:         *params.Logger,
-		client:         params.Client,
-		Cluster:        params.Cluster,
-		AWSCluster:     params.AWSCluster,
-		controllerName: params.ControllerName,
+		Logger:                       *params.Logger,
+		client:                       params.Client,
+		Cluster:                      params.Cluster,
+		AWSCluster:                   params.AWSCluster,
+		controllerName:               params.ControllerName,
+		tagUnmanagedNetworkResources: params.TagUnmanagedNetworkResources,
 	}
 
 	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, clusterScope, params.AWSCluster.Spec.Region, params.Endpoints, params.Logger)
@@ -98,6 +100,8 @@ type ClusterScope struct {
 	session         awsclient.ConfigProvider
 	serviceLimiters throttle.ServiceLimiters
 	controllerName  string
+
+	tagUnmanagedNetworkResources bool
 }
 
 // Network returns the cluster network object.
@@ -321,6 +325,11 @@ func (s *ClusterScope) ServiceLimiter(service string) *throttle.ServiceLimiter {
 // Bastion returns the bastion details.
 func (s *ClusterScope) Bastion() *infrav1.Bastion {
 	return &s.AWSCluster.Spec.Bastion
+}
+
+// TagUnmanagedNetworkResources returns if the feature flag tag unmanaged network resources is set.
+func (s *ClusterScope) TagUnmanagedNetworkResources() bool {
+	return s.tagUnmanagedNetworkResources
 }
 
 // SetBastionInstance sets the bastion instance in the status of the cluster.

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -63,8 +63,9 @@ type ManagedControlPlaneScopeParams struct {
 	Endpoints      []ServiceEndpoint
 	Session        awsclient.ConfigProvider
 
-	EnableIAM            bool
-	AllowAdditionalRoles bool
+	EnableIAM                    bool
+	AllowAdditionalRoles         bool
+	TagUnmanagedNetworkResources bool
 }
 
 // NewManagedControlPlaneScope creates a new Scope from the supplied parameters.
@@ -82,16 +83,17 @@ func NewManagedControlPlaneScope(params ManagedControlPlaneScopeParams) (*Manage
 	}
 
 	managedScope := &ManagedControlPlaneScope{
-		Logger:               *params.Logger,
-		Client:               params.Client,
-		Cluster:              params.Cluster,
-		ControlPlane:         params.ControlPlane,
-		patchHelper:          nil,
-		session:              nil,
-		serviceLimiters:      nil,
-		controllerName:       params.ControllerName,
-		allowAdditionalRoles: params.AllowAdditionalRoles,
-		enableIAM:            params.EnableIAM,
+		Logger:                       *params.Logger,
+		Client:                       params.Client,
+		Cluster:                      params.Cluster,
+		ControlPlane:                 params.ControlPlane,
+		patchHelper:                  nil,
+		session:                      nil,
+		serviceLimiters:              nil,
+		controllerName:               params.ControllerName,
+		allowAdditionalRoles:         params.AllowAdditionalRoles,
+		enableIAM:                    params.EnableIAM,
+		tagUnmanagedNetworkResources: params.TagUnmanagedNetworkResources,
 	}
 	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, managedScope, params.ControlPlane.Spec.Region, params.Endpoints, params.Logger)
 	if err != nil {
@@ -123,8 +125,9 @@ type ManagedControlPlaneScope struct {
 	serviceLimiters throttle.ServiceLimiters
 	controllerName  string
 
-	enableIAM            bool
-	allowAdditionalRoles bool
+	enableIAM                    bool
+	allowAdditionalRoles         bool
+	tagUnmanagedNetworkResources bool
 }
 
 // RemoteClient returns the Kubernetes client for connecting to the workload cluster.
@@ -292,6 +295,11 @@ func (s *ManagedControlPlaneScope) Session() awsclient.ConfigProvider {
 // Bastion returns the bastion details.
 func (s *ManagedControlPlaneScope) Bastion() *infrav1.Bastion {
 	return &s.ControlPlane.Spec.Bastion
+}
+
+// TagUnmanagedNetworkResources returns if the feature flag tag unmanaged network resources is set.
+func (s *ManagedControlPlaneScope) TagUnmanagedNetworkResources() bool {
+	return s.tagUnmanagedNetworkResources
 }
 
 // SetBastionInstance sets the bastion instance in the status of the cluster.

--- a/pkg/cloud/scope/network.go
+++ b/pkg/cloud/scope/network.go
@@ -42,4 +42,7 @@ type NetworkScope interface {
 
 	// Bastion returns the bastion details for the cluster.
 	Bastion() *infrav1.Bastion
+
+	// TagUnmanagedNetworkResources returns is tagging unmanaged network resources is set.
+	TagUnmanagedNetworkResources() bool
 }

--- a/pkg/cloud/services/network/egress_only_gateways.go
+++ b/pkg/cloud/services/network/egress_only_gateways.go
@@ -40,6 +40,11 @@ func (s *Service) reconcileEgressOnlyInternetGateways() error {
 		return nil
 	}
 
+	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
+		s.scope.Trace("Skipping egress only internet gateway reconcile in unmanaged mode")
+		return nil
+	}
+
 	s.scope.Debug("Reconciling egress only internet gateways")
 
 	eigws, err := s.describeEgressOnlyVpcInternetGateways()

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -53,12 +53,6 @@ func (s *Service) reconcileSubnets() error {
 		s.scope.SetSubnets(subnets)
 	}()
 
-	// Describe subnets in the vpc.
-	existing, err := s.describeVpcSubnets()
-	if err != nil {
-		return err
-	}
-
 	unmanagedVPC := s.scope.VPC().IsUnmanaged(s.scope.Name())
 
 	if len(subnets) == 0 {
@@ -70,6 +64,7 @@ func (s *Service) reconcileSubnets() error {
 		}
 		// If we a managed VPC and have no subnets then create subnets. There will be 1 public and 1 private subnet
 		// for each az in a region up to a maximum of 3 azs
+		var err error
 		s.scope.Info("no subnets specified, setting defaults")
 		subnets, err = s.getDefaultSubnets()
 		if err != nil {
@@ -81,6 +76,12 @@ func (s *Service) reconcileSubnets() error {
 			s.scope.Error(err, "failed to patch object to save subnets")
 			return err
 		}
+	}
+
+	// Describe subnets in the vpc.
+	existing, err := s.describeVpcSubnets()
+	if err != nil {
+		return err
 	}
 
 	if s.scope.SecondaryCidrBlock() != nil {

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -501,56 +501,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 				Subnets: []infrav1.SubnetSpec{},
 			}),
-			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
-					Filters: []*ec2.Filter{
-						{
-							Name:   aws.String("state"),
-							Values: []*string{aws.String("pending"), aws.String("available")},
-						},
-						{
-							Name:   aws.String("vpc-id"),
-							Values: []*string{aws.String(subnetsVPCID)},
-						},
-					},
-				})).
-					Return(&ec2.DescribeSubnetsOutput{
-						Subnets: []*ec2.Subnet{
-							{
-								VpcId:               aws.String(subnetsVPCID),
-								SubnetId:            aws.String("subnet-1"),
-								AvailabilityZone:    aws.String("us-east-1a"),
-								CidrBlock:           aws.String("10.0.10.0/24"),
-								MapPublicIpOnLaunch: aws.Bool(false),
-							},
-							{
-								VpcId:               aws.String(subnetsVPCID),
-								SubnetId:            aws.String("subnet-2"),
-								AvailabilityZone:    aws.String("us-east-1a"),
-								CidrBlock:           aws.String("10.0.20.0/24"),
-								MapPublicIpOnLaunch: aws.Bool(false),
-							},
-						},
-					}, nil)
-
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
-					Return(&ec2.DescribeRouteTablesOutput{}, nil)
-
-				m.DescribeNatGatewaysPages(
-					gomock.Eq(&ec2.DescribeNatGatewaysInput{
-						Filter: []*ec2.Filter{
-							{
-								Name:   aws.String("vpc-id"),
-								Values: []*string{aws.String(subnetsVPCID)},
-							},
-							{
-								Name:   aws.String("state"),
-								Values: []*string{aws.String("pending"), aws.String("available")},
-							},
-						},
-					}),
-					gomock.Any()).Return(nil)
-			},
+			expect:        func(m *mocks.MockEC2APIMockRecorder) {},
 			errorExpected: true,
 		},
 		{

--- a/pkg/cloud/services/network/vpc.go
+++ b/pkg/cloud/services/network/vpc.go
@@ -54,6 +54,9 @@ func (s *Service) reconcileVPC() error {
 		if s.scope.VPC().IsIPv6Enabled() {
 			s.scope.VPC().IPv6 = vpc.IPv6
 		}
+		if s.scope.TagUnmanagedNetworkResources() {
+			s.scope.VPC().Tags = vpc.Tags
+		}
 
 		// If VPC is unmanaged, return early.
 		if vpc.IsUnmanaged(s.scope.Name()) {
@@ -65,7 +68,9 @@ func (s *Service) reconcileVPC() error {
 			return nil
 		}
 
-		s.scope.VPC().Tags = vpc.Tags
+		if !s.scope.TagUnmanagedNetworkResources() {
+			s.scope.VPC().Tags = vpc.Tags
+		}
 
 		// Make sure tags are up-to-date.
 		// **Only** do this for managed VPCs. Make sure this logic is below the above `vpc.IsUnmanaged` check.

--- a/pkg/cloud/services/network/vpc.go
+++ b/pkg/cloud/services/network/vpc.go
@@ -51,7 +51,6 @@ func (s *Service) reconcileVPC() error {
 		}
 
 		s.scope.VPC().CidrBlock = vpc.CidrBlock
-		s.scope.VPC().Tags = vpc.Tags
 		if s.scope.VPC().IsIPv6Enabled() {
 			s.scope.VPC().IPv6 = vpc.IPv6
 		}
@@ -65,6 +64,8 @@ func (s *Service) reconcileVPC() error {
 			record.Eventf(s.scope.InfraCluster(), "SuccessfulSetVPCAttributes", "Set managed VPC attributes for %q", vpc.ID)
 			return nil
 		}
+
+		s.scope.VPC().Tags = vpc.Tags
 
 		// Make sure tags are up-to-date.
 		// **Only** do this for managed VPCs. Make sure this logic is below the above `vpc.IsUnmanaged` check.

--- a/pkg/cloud/services/network/vpc_test.go
+++ b/pkg/cloud/services/network/vpc_test.go
@@ -427,10 +427,7 @@ func TestReconcileVPC(t *testing.T) {
 			want: &infrav1.VPCSpec{
 				ID:        "unmanaged-vpc-exists",
 				CidrBlock: "10.0.0.0/8",
-				Tags: map[string]string{
-					"sigs.k8s.io/cluster-api-provider-aws/role": "common",
-					"Name": "test-cluster-vpc",
-				},
+				Tags:      nil,
 				IPv6: &infrav1.IPv6{
 					PoolID:    "my-pool",
 					CidrBlock: "2001:db8:1234:1a03::/56",
@@ -453,16 +450,6 @@ func TestReconcileVPC(t *testing.T) {
 										State: aws.String(ec2.SubnetCidrBlockStateCodeAssociated),
 									},
 									Ipv6Pool: aws.String("my-pool"),
-								},
-							},
-							Tags: []*ec2.Tag{
-								{
-									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
-									Value: aws.String("common"),
-								},
-								{
-									Key:   aws.String("Name"),
-									Value: aws.String("test-cluster-vpc"),
 								},
 							},
 						},
@@ -492,12 +479,9 @@ func TestReconcileVPC(t *testing.T) {
 			name:  "Should patch vpc spec successfully, if unmanaged vpc exists",
 			input: &infrav1.VPCSpec{ID: "unmanaged-vpc-exists", AvailabilityZoneUsageLimit: &usageLimit, AvailabilityZoneSelection: &selection},
 			want: &infrav1.VPCSpec{
-				ID:        "unmanaged-vpc-exists",
-				CidrBlock: "10.0.0.0/8",
-				Tags: map[string]string{
-					"sigs.k8s.io/cluster-api-provider-aws/role": "common",
-					"Name": "test-cluster-vpc",
-				},
+				ID:                         "unmanaged-vpc-exists",
+				CidrBlock:                  "10.0.0.0/8",
+				Tags:                       nil,
 				AvailabilityZoneUsageLimit: &usageLimit,
 				AvailabilityZoneSelection:  &selection,
 			},
@@ -508,16 +492,6 @@ func TestReconcileVPC(t *testing.T) {
 							State:     aws.String("available"),
 							VpcId:     aws.String("unmanaged-vpc-exists"),
 							CidrBlock: aws.String("10.0.0.0/8"),
-							Tags: []*ec2.Tag{
-								{
-									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
-									Value: aws.String("common"),
-								},
-								{
-									Key:   aws.String("Name"),
-									Value: aws.String("test-cluster-vpc"),
-								},
-							},
 						},
 					},
 				}, nil)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR removed tagging from unmanaged network resources such that the unmanaged resource tagging is taken care by the users themselves.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3948 
Fixes #3919 
Fixes #3692 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required
If the **TagUnmanagedNetworkResources** feature flag is set to false then CAPA tagging of unmanaged network resources will be disabled.
```
