### PR TITLE
4046 - Add AssumeRole and update appropriate tests

### DIFF
--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/zz_generated.conversion.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/zz_generated.conversion.go
@@ -207,6 +207,7 @@ func autoConvert_v1beta1_AWSIAMConfigurationSpec_To_v1alpha1_AWSIAMConfiguration
 	out.Partition = in.Partition
 	out.SecureSecretsBackends = *(*[]v1beta2.SecretBackend)(unsafe.Pointer(&in.SecureSecretsBackends))
 	// WARNING: in.S3Buckets requires manual conversion: does not exist in peer-type
+	// WARNING: in.AllowAssumeRole requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/cmd/clusterawsadm/api/bootstrap/v1beta1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1beta1/types.go
@@ -224,6 +224,9 @@ type AWSIAMConfigurationSpec struct {
 	// TODO: This field could be a pointer, but it seems it breaks setting default values?
 	// +optional
 	S3Buckets S3Buckets `json:"s3Buckets,omitempty"`
+
+	// AllowAssumeRole enables the sts:AssumeRole permission within the CAPA policies
+	AllowAssumeRole bool `json:"allowAssumeRole,omitempty"`
 }
 
 // GetObjectKind returns the AAWSIAMConfiguration's TypeMeta.

--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -252,6 +252,15 @@ func (t Template) ControllersPolicy() *iamv1.PolicyDocument {
 			})
 		}
 	}
+	if t.Spec.AllowAssumeRole {
+		statement = append(statement, iamv1.StatementEntry{
+			Effect:   iamv1.EffectAllow,
+			Resource: t.allowedEC2InstanceProfiles(),
+			Action: iamv1.Actions{
+				"sts:AssumeRole",
+			},
+		})
+	}
 	if t.Spec.S3Buckets.Enable {
 		statement = append(statement, iamv1.StatementEntry{
 			Effect: iamv1.EffectAllow,

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -1,0 +1,445 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  AWSIAMInstanceProfileControlPlane:
+    Properties:
+      InstanceProfileName: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      Roles:
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::InstanceProfile
+  AWSIAMInstanceProfileControllers:
+    Properties:
+      InstanceProfileName: controllers.cluster-api-provider-aws.sigs.k8s.io
+      Roles:
+      - Ref: AWSIAMRoleControllers
+    Type: AWS::IAM::InstanceProfile
+  AWSIAMInstanceProfileNodes:
+    Properties:
+      InstanceProfileName: nodes.cluster-api-provider-aws.sigs.k8s.io
+      Roles:
+      - Ref: AWSIAMRoleNodes
+    Type: AWS::IAM::InstanceProfile
+  AWSIAMManagedPolicyCloudProviderControlPlane:
+    Properties:
+      Description: For the Kubernetes Cloud Provider AWS Control Plane
+      ManagedPolicyName: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeLaunchConfigurations
+          - autoscaling:DescribeTags
+          - ec2:AssignIpv6Addresses
+          - ec2:DescribeInstances
+          - ec2:DescribeImages
+          - ec2:DescribeRegions
+          - ec2:DescribeRouteTables
+          - ec2:DescribeSecurityGroups
+          - ec2:DescribeSubnets
+          - ec2:DescribeVolumes
+          - ec2:CreateSecurityGroup
+          - ec2:CreateTags
+          - ec2:CreateVolume
+          - ec2:ModifyInstanceAttribute
+          - ec2:ModifyVolume
+          - ec2:AttachVolume
+          - ec2:AuthorizeSecurityGroupIngress
+          - ec2:CreateRoute
+          - ec2:DeleteRoute
+          - ec2:DeleteSecurityGroup
+          - ec2:DeleteVolume
+          - ec2:DetachVolume
+          - ec2:RevokeSecurityGroupIngress
+          - ec2:DescribeVpcs
+          - elasticloadbalancing:AddTags
+          - elasticloadbalancing:AttachLoadBalancerToSubnets
+          - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
+          - elasticloadbalancing:CreateLoadBalancer
+          - elasticloadbalancing:CreateLoadBalancerPolicy
+          - elasticloadbalancing:CreateLoadBalancerListeners
+          - elasticloadbalancing:ConfigureHealthCheck
+          - elasticloadbalancing:DeleteLoadBalancer
+          - elasticloadbalancing:DeleteLoadBalancerListeners
+          - elasticloadbalancing:DescribeLoadBalancers
+          - elasticloadbalancing:DescribeLoadBalancerAttributes
+          - elasticloadbalancing:DetachLoadBalancerFromSubnets
+          - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+          - elasticloadbalancing:ModifyLoadBalancerAttributes
+          - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+          - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
+          - elasticloadbalancing:CreateListener
+          - elasticloadbalancing:CreateTargetGroup
+          - elasticloadbalancing:DeleteListener
+          - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
+          - elasticloadbalancing:DescribeListeners
+          - elasticloadbalancing:DescribeLoadBalancerPolicies
+          - elasticloadbalancing:DescribeTargetGroups
+          - elasticloadbalancing:DescribeTargetHealth
+          - elasticloadbalancing:ModifyListener
+          - elasticloadbalancing:ModifyTargetGroup
+          - elasticloadbalancing:RegisterTargets
+          - elasticloadbalancing:SetLoadBalancerPoliciesOfListener
+          - iam:CreateServiceLinkedRole
+          - kms:DescribeKey
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyCloudProviderNodes:
+    Properties:
+      Description: For the Kubernetes Cloud Provider AWS nodes
+      ManagedPolicyName: nodes.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - ec2:AssignIpv6Addresses
+          - ec2:DescribeInstances
+          - ec2:DescribeRegions
+          - ec2:CreateTags
+          - ec2:DescribeTags
+          - ec2:DescribeNetworkInterfaces
+          - ec2:DescribeInstanceTypes
+          - ecr:GetAuthorizationToken
+          - ecr:BatchCheckLayerAvailability
+          - ecr:GetDownloadUrlForLayer
+          - ecr:GetRepositoryPolicy
+          - ecr:DescribeRepositories
+          - ecr:ListImages
+          - ecr:BatchGetImage
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - secretsmanager:DeleteSecret
+          - secretsmanager:GetSecretValue
+          Effect: Allow
+          Resource:
+          - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        - Action:
+          - ssm:UpdateInstanceInformation
+          - ssmmessages:CreateControlChannel
+          - ssmmessages:CreateDataChannel
+          - ssmmessages:OpenControlChannel
+          - ssmmessages:OpenDataChannel
+          - s3:GetEncryptionConfiguration
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControlPlane
+      - Ref: AWSIAMRoleNodes
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllers:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - ec2:AttachNetworkInterface
+          - ec2:DetachNetworkInterface
+          - ec2:AllocateAddress
+          - ec2:AssignIpv6Addresses
+          - ec2:AssignPrivateIpAddresses
+          - ec2:UnassignPrivateIpAddresses
+          - ec2:AssociateRouteTable
+          - ec2:AttachInternetGateway
+          - ec2:AuthorizeSecurityGroupIngress
+          - ec2:CreateInternetGateway
+          - ec2:CreateEgressOnlyInternetGateway
+          - ec2:CreateNatGateway
+          - ec2:CreateNetworkInterface
+          - ec2:CreateRoute
+          - ec2:CreateRouteTable
+          - ec2:CreateSecurityGroup
+          - ec2:CreateSubnet
+          - ec2:CreateTags
+          - ec2:CreateVpc
+          - ec2:ModifyVpcAttribute
+          - ec2:DeleteInternetGateway
+          - ec2:DeleteEgressOnlyInternetGateway
+          - ec2:DeleteNatGateway
+          - ec2:DeleteRouteTable
+          - ec2:ReplaceRoute
+          - ec2:DeleteSecurityGroup
+          - ec2:DeleteSubnet
+          - ec2:DeleteTags
+          - ec2:DeleteVpc
+          - ec2:DescribeAccountAttributes
+          - ec2:DescribeAddresses
+          - ec2:DescribeAvailabilityZones
+          - ec2:DescribeInstances
+          - ec2:DescribeInternetGateways
+          - ec2:DescribeEgressOnlyInternetGateways
+          - ec2:DescribeInstanceTypes
+          - ec2:DescribeImages
+          - ec2:DescribeNatGateways
+          - ec2:DescribeNetworkInterfaces
+          - ec2:DescribeNetworkInterfaceAttribute
+          - ec2:DescribeRouteTables
+          - ec2:DescribeSecurityGroups
+          - ec2:DescribeSubnets
+          - ec2:DescribeVpcs
+          - ec2:DescribeVpcAttribute
+          - ec2:DescribeVolumes
+          - ec2:DescribeTags
+          - ec2:DetachInternetGateway
+          - ec2:DisassociateRouteTable
+          - ec2:DisassociateAddress
+          - ec2:ModifyInstanceAttribute
+          - ec2:ModifyNetworkInterfaceAttribute
+          - ec2:ModifySubnetAttribute
+          - ec2:ReleaseAddress
+          - ec2:RevokeSecurityGroupIngress
+          - ec2:RunInstances
+          - ec2:TerminateInstances
+          - tag:GetResources
+          - elasticloadbalancing:AddTags
+          - elasticloadbalancing:CreateLoadBalancer
+          - elasticloadbalancing:ConfigureHealthCheck
+          - elasticloadbalancing:DeleteLoadBalancer
+          - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DescribeLoadBalancers
+          - elasticloadbalancing:DescribeLoadBalancerAttributes
+          - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
+          - elasticloadbalancing:DescribeTags
+          - elasticloadbalancing:ModifyLoadBalancerAttributes
+          - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+          - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+          - elasticloadbalancing:RemoveTags
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
+          - ec2:CreateLaunchTemplate
+          - ec2:CreateLaunchTemplateVersion
+          - ec2:DescribeLaunchTemplates
+          - ec2:DescribeLaunchTemplateVersions
+          - ec2:DeleteLaunchTemplate
+          - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - autoscaling:CreateAutoScalingGroup
+          - autoscaling:UpdateAutoScalingGroup
+          - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
+          - autoscaling:DeleteAutoScalingGroup
+          - autoscaling:DeleteTags
+          Effect: Allow
+          Resource:
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: elasticloadbalancing.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: spot.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot
+        - Action:
+          - iam:PassRole
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/*.cluster-api-provider-aws.sigs.k8s.io
+        - Action:
+          - secretsmanager:CreateSecret
+          - secretsmanager:DeleteSecret
+          - secretsmanager:TagResource
+          Effect: Allow
+          Resource:
+          - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/*.cluster-api-provider-aws.sigs.k8s.io
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - ssm:GetParameter
+          Effect: Allow
+          Resource:
+          - arn:*:ssm:*:*:parameter/aws/service/eks/optimized-ami/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: eks.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: eks-nodegroup.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: eks-fargate.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
+        - Action:
+          - iam:GetRole
+          - iam:ListAttachedRolePolicies
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/*
+        - Action:
+          - iam:GetPolicy
+          Effect: Allow
+          Resource:
+          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+        - Action:
+          - eks:DescribeCluster
+          - eks:ListClusters
+          - eks:CreateCluster
+          - eks:TagResource
+          - eks:UpdateClusterVersion
+          - eks:DeleteCluster
+          - eks:UpdateClusterConfig
+          - eks:UntagResource
+          - eks:UpdateNodegroupVersion
+          - eks:DescribeNodegroup
+          - eks:DeleteNodegroup
+          - eks:UpdateNodegroupConfig
+          - eks:CreateNodegroup
+          - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
+          Effect: Allow
+          Resource:
+          - arn:*:eks:*:*:cluster/*
+          - arn:*:eks:*:*:nodegroup/*/*/*
+        - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
+          - eks:ListAddons
+          - eks:CreateAddon
+          - eks:DescribeAddonVersions
+          - eks:DescribeAddon
+          - eks:DeleteAddon
+          - eks:UpdateAddon
+          - eks:TagResource
+          - eks:DescribeFargateProfile
+          - eks:CreateFargateProfile
+          - eks:DeleteFargateProfile
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - iam:PassRole
+          Condition:
+            StringEquals:
+              iam:PassedToService: eks.amazonaws.com
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - kms:CreateGrant
+          - kms:DescribeKey
+          Condition:
+            ForAnyValue:StringLike:
+              kms:ResourceAliases: alias/cluster-api-provider-aws-*
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMRoleControlPlane:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: 2012-10-17
+      RoleName: control-plane.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role
+  AWSIAMRoleControllers:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: 2012-10-17
+      RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role
+  AWSIAMRoleEKSControlPlane:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - eks.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+      RoleName: eks-controlplane.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role
+  AWSIAMRoleNodes:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+      RoleName: nodes.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -173,6 +173,7 @@ Resources:
           - ec2:DescribeAddresses
           - ec2:DescribeAvailabilityZones
           - ec2:DescribeInstances
+          - ec2:DescribeInstanceTypes
           - ec2:DescribeInternetGateways
           - ec2:DescribeEgressOnlyInternetGateways
           - ec2:DescribeInstanceTypes
@@ -205,6 +206,7 @@ Resources:
           - elasticloadbalancing:DeleteTargetGroup
           - elasticloadbalancing:DescribeLoadBalancers
           - elasticloadbalancing:DescribeLoadBalancerAttributes
+          - elasticloadbalancing:DescribeTargetGroups
           - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
           - elasticloadbalancing:DescribeTags
           - elasticloadbalancing:ModifyLoadBalancerAttributes

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -222,6 +222,7 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
+          - ec2:ModifyInstanceMetadataOptions
           Effect: Allow
           Resource:
           - '*'

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
@@ -174,6 +174,14 @@ func TestRenderCloudformation(t *testing.T) {
 				return t
 			},
 		},
+		{
+			fixture: "with_allow_assume_role",
+			template: func() Template {
+				t := NewTemplate()
+				t.Spec.AllowAssumeRole = true
+				return t
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/docs/book/src/topics/multitenancy.md
+++ b/docs/book/src/topics/multitenancy.md
@@ -213,6 +213,9 @@ There are multiple AWS assume role permissions that need to be configured in ord
   }
   ```
 
+Both of these permissions can be enabled via clusterawsadm as documented [here](using-clusterawsadm-to-fulfill-prerequisites.md#cross-account-role-assumption).
+
+
 ### Examples
 
 This is a deployable example which uses the `AWSClusterRoleIdentity` "test-account-role" to assume into the `arn:aws:iam::123456789:role/CAPARole` role in the target account.

--- a/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
+++ b/docs/book/src/topics/using-clusterawsadm-to-fulfill-prerequisites.md
@@ -106,6 +106,36 @@ spec:
   ...
 ```
 
+#### Cross Account Role Assumption
+
+CAPA, by default, does not provide the necessary permissions to allow cross-account role assumption, which can be used to manage clusters in other environments. This is documented [here](multitenancy.md#necessary-permissions-for-assuming-a-role). The 'sts:AssumeRole' permissions can be added via the following configuration on the manager account configuration:
+
+```yaml
+apiVersion: bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSIAMConfiguration
+spec:
+  ...
+  allowAssumeRole: true
+  ...
+```
+
+The above will give the controller to have the necessary permissions needed in order for it to manage clusters in other accounts using the AWSClusterRoleIdentity. Please note, the above should only be applied to the account where CAPA is running. To allow CAPA to assume the roles in the managed/target accounts, the following configuration needs to be used:
+```yaml
+apiVersion: bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSIAMConfiguration
+spec:
+  ...
+  clusterAPIControllers:
+    disabled: false
+    trustStatements:
+    - Action:
+      - "sts:AssumeRole"
+      Effect: "Allow"
+      Principal:
+        AWS:
+        - "arn:aws:iam::<manager account>:role/controllers.cluster-api-provider-aws.sigs.k8s.io"
+  ...
+```
 
 
 ### Without `clusterawsadm`


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows CAPA policy to have an AssumeRole policy which allows it to perform cross account assume roles used by the AwsClusterRoleIdentity

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4046 

**Special notes for your reviewer**:

**Checklist**:
- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Adds option to enable sts:AssumeRole policy in CAPA allowing it to perform cross account role assumes.  (#4046)
```
