### PR TITLE
Set ASG DesiredCapacity value only if MachinePool replicas is between min and max size of the AWSMachinePool

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -157,45 +157,45 @@ func (s *Service) GetASGByName(scope *scope.MachinePoolScope) (*expinfrav1.AutoS
 }
 
 // CreateASG runs an autoscaling group.
-func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error) {
-	subnets, err := s.SubnetIDs(scope)
+func (s *Service) CreateASG(machinePoolScope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error) {
+	subnets, err := s.SubnetIDs(machinePoolScope)
 	if err != nil {
 		return nil, fmt.Errorf("getting subnets for ASG: %w", err)
 	}
 
 	input := &expinfrav1.AutoScalingGroup{
-		Name:                 scope.Name(),
-		MaxSize:              scope.AWSMachinePool.Spec.MaxSize,
-		MinSize:              scope.AWSMachinePool.Spec.MinSize,
+		Name:                 machinePoolScope.Name(),
+		MaxSize:              machinePoolScope.AWSMachinePool.Spec.MaxSize,
+		MinSize:              machinePoolScope.AWSMachinePool.Spec.MinSize,
 		Subnets:              subnets,
-		DefaultCoolDown:      scope.AWSMachinePool.Spec.DefaultCoolDown,
-		CapacityRebalance:    scope.AWSMachinePool.Spec.CapacityRebalance,
-		MixedInstancesPolicy: scope.AWSMachinePool.Spec.MixedInstancesPolicy,
+		DefaultCoolDown:      machinePoolScope.AWSMachinePool.Spec.DefaultCoolDown,
+		CapacityRebalance:    machinePoolScope.AWSMachinePool.Spec.CapacityRebalance,
+		MixedInstancesPolicy: machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy,
 	}
 
-	if scope.MachinePool.Spec.Replicas != nil {
-		input.DesiredCapacity = scope.MachinePool.Spec.Replicas
+	if machinePoolScope.MachinePool.Spec.Replicas != nil {
+		input.DesiredCapacity = machinePoolScope.MachinePool.Spec.Replicas
 	}
 
-	if scope.AWSMachinePool.Status.LaunchTemplateID == "" {
+	if machinePoolScope.AWSMachinePool.Status.LaunchTemplateID == "" {
 		return nil, errors.New("AWSMachinePool has no LaunchTemplateID for some reason")
 	}
 
 	// Make sure to use the MachinePoolScope here to get the merger of AWSCluster and AWSMachinePool tags
-	additionalTags := scope.AdditionalTags()
+	additionalTags := machinePoolScope.AdditionalTags()
 	// Set the cloud provider tag
 	additionalTags[infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName())] = string(infrav1.ResourceLifecycleOwned)
 
 	input.Tags = infrav1.Build(infrav1.BuildParams{
 		ClusterName: s.scope.KubernetesClusterName(),
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
-		Name:        aws.String(scope.Name()),
+		Name:        aws.String(machinePoolScope.Name()),
 		Role:        aws.String("node"),
 		Additional:  additionalTags,
 	})
 
 	s.scope.Info("Running instance")
-	if err := s.runPool(input, scope.AWSMachinePool.Status.LaunchTemplateID); err != nil {
+	if err := s.runPool(input, machinePoolScope.AWSMachinePool.Status.LaunchTemplateID); err != nil {
 		// Only record the failure event if the error is not related to failed dependencies.
 		// This is to avoid spamming failure events since the machine will be requeued by the actuator.
 		// if !awserrors.IsFailedDependency(errors.Cause(err)) {
@@ -204,7 +204,7 @@ func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScal
 		s.scope.Error(err, "unable to create AutoScalingGroup")
 		return nil, err
 	}
-	record.Eventf(scope.AWSMachinePool, "SuccessfulCreate", "Created new ASG: %s", scope.Name())
+	record.Eventf(machinePoolScope.AWSMachinePool, "SuccessfulCreate", "Created new ASG: %s", machinePoolScope.Name())
 
 	return nil, nil
 }

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -449,8 +449,9 @@ func TestServiceCreateASG(t *testing.T) {
 							},
 						},
 					},
-					MaxSize: aws.Int64(0),
-					MinSize: aws.Int64(0),
+					DesiredCapacity: aws.Int64(1),
+					MaxSize:         aws.Int64(2),
+					MinSize:         aws.Int64(1),
 					Tags: []*autoscaling.Tag{
 						{
 							Key:               aws.String("kubernetes.io/cluster/test"),
@@ -502,6 +503,72 @@ func TestServiceCreateASG(t *testing.T) {
 			},
 		},
 		{
+			name:            "should not fail if MachinePool replicas number is less than AWSMachinePool MinSize for externally managed replicas",
+			machinePoolName: "create-asg-success",
+			setupMachinePoolScope: func(mps *scope.MachinePoolScope) {
+				mps.AWSMachinePool.Spec.MinSize = 2
+				mps.AWSMachinePool.Spec.MaxSize = 5
+				mps.MachinePool.Spec.Replicas = aws.Int32(1)
+				mps.MachinePool.Annotations = map[string]string{
+					scope.ReplicasManagedByAnnotation: scope.ExternalAutoscalerReplicasManagedByAnnotationValue,
+				}
+			},
+			wantErr: false,
+			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
+				m.CreateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
+					func(actual *autoscaling.CreateAutoScalingGroupInput) (*autoscaling.CreateAutoScalingGroupOutput, error) {
+						if actual.DesiredCapacity != nil {
+							t.Fatalf("Actual DesiredCapacity did not match expected, Actual: %d, Expected: <nil>", *actual.DesiredCapacity)
+						}
+						return &autoscaling.CreateAutoScalingGroupOutput{}, nil
+					})
+			},
+		},
+		{
+			name:            "should not fail if MachinePool replicas number is greater than AWSMachinePool MaxSize for externally managed replicas",
+			machinePoolName: "create-asg-success",
+			setupMachinePoolScope: func(mps *scope.MachinePoolScope) {
+				mps.AWSMachinePool.Spec.MinSize = 2
+				mps.AWSMachinePool.Spec.MaxSize = 5
+				mps.MachinePool.Spec.Replicas = aws.Int32(6)
+				mps.MachinePool.Annotations = map[string]string{
+					scope.ReplicasManagedByAnnotation: scope.ExternalAutoscalerReplicasManagedByAnnotationValue,
+				}
+			},
+			wantErr: false,
+			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
+				m.CreateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
+					func(actual *autoscaling.CreateAutoScalingGroupInput) (*autoscaling.CreateAutoScalingGroupOutput, error) {
+						if actual.DesiredCapacity != nil {
+							t.Fatalf("Actual DesiredCapacity did not match expected, Actual: %d, Expected: <nil>", *actual.DesiredCapacity)
+						}
+						return &autoscaling.CreateAutoScalingGroupOutput{}, nil
+					})
+			},
+		},
+		{
+			name:            "should return error if MachinePool replicas number is less than AWSMachinePool MinSize",
+			machinePoolName: "create-asg-fail",
+			setupMachinePoolScope: func(mps *scope.MachinePoolScope) {
+				mps.AWSMachinePool.Spec.MinSize = 2
+				mps.AWSMachinePool.Spec.MaxSize = 3
+				mps.MachinePool.Spec.Replicas = aws.Int32(1)
+			},
+			wantErr: true,
+			expect:  func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {},
+		},
+		{
+			name:            "should return error if MachinePool replicas number is greater than AWSMachinePool MaxSize",
+			machinePoolName: "create-asg-fail",
+			setupMachinePoolScope: func(mps *scope.MachinePoolScope) {
+				mps.AWSMachinePool.Spec.MinSize = 2
+				mps.AWSMachinePool.Spec.MaxSize = 3
+				mps.MachinePool.Spec.Replicas = aws.Int32(4)
+			},
+			wantErr: true,
+			expect:  func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {},
+		},
+		{
 			name:            "should return error if subnet not found for asg",
 			machinePoolName: "create-asg-fail",
 			setupMachinePoolScope: func(mps *scope.MachinePoolScope) {
@@ -551,6 +618,10 @@ func TestServiceCreateASG(t *testing.T) {
 			mps, err := getMachinePoolScope(fakeClient, clusterScope)
 			g.Expect(err).ToNot(HaveOccurred())
 			mps.AWSMachinePool.Name = tt.machinePoolName
+
+			// Default MachinePool replicas to 1, like it's done in CAPI.
+			mps.MachinePool.Spec.Replicas = aws.Int32(1)
+
 			tt.setupMachinePoolScope(mps)
 			asg, err := s.CreateASG(mps)
 			checkErr(tt.wantErr, err, g)
@@ -1137,6 +1208,8 @@ func getClusterScope(client client.Client) (*scope.ClusterScope, error) {
 func getMachinePoolScope(client client.Client, clusterScope *scope.ClusterScope) (*scope.MachinePoolScope, error) {
 	awsMachinePool := &expinfrav1.AWSMachinePool{
 		Spec: expinfrav1.AWSMachinePoolSpec{
+			MinSize: 1,
+			MaxSize: 2,
 			Subnets: []infrav1.AWSResourceReference{
 				{
 					ID: aws.String("subnet1"),


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Now if we don't define replicas value in MachinePool spec, it is [defaulted](https://github.com/kubernetes-sigs/cluster-api/blob/main/exp/api/v1beta1/machinepool_webhook.go#L54-L56) to 1 by the webhook. Unfortunately, if minimum size of AWSMachinePool is greater than that, ASG creation fails with 400 error from AWS.

To prevent this, we ensure that the desired number of replicas for ASG is set only if MachinePool replicas is between min and max size of the AWSMachinePool, otherwise we return an error.

For clusters with externally managed replicas we can ignore this problem and do not set desired replicas during ASG creation at all. In this case MachinePool replicas value will be defaulted to AWSMachinePool MinSize by AWS and then updated by external autoscaler to the right value.

<!-- Enter a description of the change and why this change is needed -->

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set ASG DesiredCapacity value only if MachinePool replicas is between min and max size of the AWSMachinePool.
```
