### PR TITLE
Allow external autoscaler for EKS managed node groups

### DIFF
--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -85,7 +85,7 @@ func (r *AWSManagedMachinePoolReconciler) SetupWithManager(ctx context.Context, 
 		Complete(r)
 }
 
-// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=awsmanagedcontrolplanes;awsmanagedcontrolplanes/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmanagedmachinepools,verbs=get;list;watch;update;patch;delete
@@ -193,7 +193,7 @@ func (r *AWSManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 func (r *AWSManagedMachinePoolReconciler) reconcileNormal(
-	_ context.Context,
+	ctx context.Context,
 	machinePoolScope *scope.ManagedMachinePoolScope,
 	ec2Scope scope.EC2Scope,
 ) (ctrl.Result, error) {
@@ -235,7 +235,7 @@ func (r *AWSManagedMachinePoolReconciler) reconcileNormal(
 		conditions.MarkTrue(machinePoolScope.ManagedMachinePool, expinfrav1.LaunchTemplateReadyCondition)
 	}
 
-	if err := ekssvc.ReconcilePool(); err != nil {
+	if err := ekssvc.ReconcilePool(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile machine pool for AWSManagedMachinePool %s/%s", machinePoolScope.ManagedMachinePool.Namespace, machinePoolScope.ManagedMachinePool.Name)
 	}
 

--- a/pkg/cloud/services/eks/eks.go
+++ b/pkg/cloud/services/eks/eks.go
@@ -90,7 +90,7 @@ func (s *Service) DeleteControlPlane() (err error) {
 }
 
 // ReconcilePool is the entrypoint for ManagedMachinePool reconciliation.
-func (s *NodegroupService) ReconcilePool() error {
+func (s *NodegroupService) ReconcilePool(ctx context.Context) error {
 	s.scope.Debug("Reconciling EKS nodegroup")
 
 	if err := s.reconcileNodegroupIAMRole(); err != nil {
@@ -105,7 +105,7 @@ func (s *NodegroupService) ReconcilePool() error {
 	}
 	conditions.MarkTrue(s.scope.ManagedMachinePool, expinfrav1.IAMNodegroupRolesReadyCondition)
 
-	if err := s.reconcileNodegroup(); err != nil {
+	if err := s.reconcileNodegroup(ctx); err != nil {
 		conditions.MarkFalse(
 			s.scope.ManagedMachinePool,
 			expinfrav1.EKSNodegroupReadyCondition,


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The `AWSManagedMachinePool` controller should respect the annotation for externally managed autoscaler.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4134

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

```release-note
The `AWSManagedMachinePool` controller should respect the annotation for the externally managed autoscaler.
```