### PR TITLE
Fix session surviving cluster purge and recreate through cache

### DIFF
--- a/pkg/cloud/scope/session.go
+++ b/pkg/cloud/scope/session.go
@@ -162,6 +162,10 @@ func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.Cl
 		_, err := providers[0].Retrieve()
 		if err != nil {
 			conditions.MarkUnknown(clusterScoper.InfraCluster(), infrav1.PrincipalCredentialRetrievedCondition, infrav1.CredentialProviderBuildFailedReason, err.Error())
+
+			// delete the existing session from cache. Otherwise, we give back a defective session on next method invocation with same cluster scope
+			sessionCache.Delete(getSessionName(region, clusterScoper))
+
 			return nil, nil, errors.Wrap(err, "Failed to retrieve identity credentials")
 		}
 		awsConfig = awsConfig.WithCredentials(credentials.NewChainCredentials(awsProviders))


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

AWS sessions need to be removed from cache in case of faulty retrieval from credentials providers. Otherwise a defective session can survive a delete of a cluster and recreate with same name but new credentials. 

Steps to reproduce:

1. Create credentials for AWS account 
2. Create a cluster with name XYZ using multi-tenancy for these AWS credentials
3. Delete this cluster with name XYZ
4. Create new credentials for AWS account 
5. Create a cluster with same name XYZ using multi-tenancy for these new AWS credentials

Result: Due to the two-layered caching approach in `sessionForClusterWithRegion()`(`pkg/cloud/scope/session.go:108`) the session created using the credentials from step #1 is able to survive and still be used for the newly created cluster, which results in various 401/403 errors from AWS API.

This PR makes sure that the old session is explcitly evicted from cache as soon as it is no longer possible to retrieve the credentials from cached credential providers. 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Fix surviving defective session on cluster recreate with new AWS credentials
```

<sub>Jan Röhrich <[jan.roehrich@mercedes-benz.com](mailto:jan.roehrich@mercedes-benz.com)>, Mercedes-Benz Tech Innovation GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>