### PR TITLE
Reconcile EKSConfig correctly for MachinePool and other Owner kinds

### DIFF
--- a/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
+++ b/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/bootstrap/eks/internal/userdata"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
@@ -55,7 +56,7 @@ func TestEKSConfigReconciler(t *testing.T) {
 		}
 		t.Logf(fmt.Sprintf("Calling reconcile on cluster '%s' and config '%s' should requeue", cluster.Name, config.Name))
 		g.Eventually(func(gomega Gomega) {
-			result, err := reconciler.joinWorker(ctx, cluster, config)
+			result, err := reconciler.joinWorker(ctx, cluster, config, configOwner("Machine"))
 			gomega.Expect(err).NotTo(HaveOccurred())
 			gomega.Expect(result.Requeue).To(BeFalse())
 		}).Should(Succeed())
@@ -74,16 +75,26 @@ func TestEKSConfigReconciler(t *testing.T) {
 
 		g.Expect(string(secret.Data["value"])).To(Equal(string(expectedUserData)))
 	})
-
 	t.Run("Should reconcile an EKSConfig and update data Secret", func(t *testing.T) {
 		g := NewWithT(t)
 		amcp := newAMCP("test-cluster")
 		cluster := newCluster(amcp.Name)
-		machine := newMachine(cluster, "test-machine")
-		config := newEKSConfig(machine)
+		mp := newMachinePool(cluster, "test-machine")
+		config := newEKSConfig(nil)
+		config.ObjectMeta.Name = mp.Name
+		config.ObjectMeta.UID = types.UID(fmt.Sprintf("%s uid", mp.Name))
+		config.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{
+				Kind:       "MachinePool",
+				APIVersion: v1beta1.GroupVersion.String(),
+				Name:       mp.Name,
+				UID:        types.UID(fmt.Sprintf("%s uid", mp.Name)),
+			},
+		}
+		config.Status.DataSecretName = &mp.Name
 		t.Logf(dump("amcp", amcp))
 		t.Logf(dump("config", config))
-		t.Logf(dump("machine", machine))
+		t.Logf(dump("machinepool", mp))
 		t.Logf(dump("cluster", cluster))
 		oldUserData, err := newUserData(cluster.Name, map[string]string{"test-arg": "test-value"})
 		g.Expect(err).To(BeNil())
@@ -100,7 +111,7 @@ func TestEKSConfigReconciler(t *testing.T) {
 		}
 		t.Logf(fmt.Sprintf("Calling reconcile on cluster '%s' and config '%s' should requeue", cluster.Name, config.Name))
 		g.Eventually(func(gomega Gomega) {
-			result, err := reconciler.joinWorker(ctx, cluster, config)
+			result, err := reconciler.joinWorker(ctx, cluster, config, configOwner("MachinePool"))
 			gomega.Expect(err).NotTo(HaveOccurred())
 			gomega.Expect(result.Requeue).To(BeFalse())
 		}).Should(Succeed())
@@ -125,7 +136,7 @@ func TestEKSConfigReconciler(t *testing.T) {
 		}
 		t.Logf(dump("config", config))
 		g.Eventually(func(gomega Gomega) {
-			result, err := reconciler.joinWorker(ctx, cluster, config)
+			result, err := reconciler.joinWorker(ctx, cluster, config, configOwner("MachinePool"))
 			gomega.Expect(err).NotTo(HaveOccurred())
 			gomega.Expect(result.Requeue).To(BeFalse())
 		}).Should(Succeed())
@@ -139,6 +150,57 @@ func TestEKSConfigReconciler(t *testing.T) {
 				Namespace: "default",
 			}, secret)).To(Succeed())
 			gomega.Expect(string(secret.Data["value"])).To(Equal(string(expectedUserData)))
+		}).Should(Succeed())
+	})
+
+	t.Run("Should reconcile an EKSConfig and not update data if secret exists and config owner is Machine kind", func(t *testing.T) {
+		g := NewWithT(t)
+		amcp := newAMCP("test-cluster")
+		cluster := newCluster(amcp.Name)
+		machine := newMachine(cluster, "test-machine")
+		config := newEKSConfig(machine)
+		t.Logf(dump("amcp", amcp))
+		t.Logf(dump("config", config))
+		t.Logf(dump("machine", machine))
+		t.Logf(dump("cluster", cluster))
+		expectedUserData, err := newUserData(cluster.Name, map[string]string{"test-arg": "test-value"})
+		g.Expect(err).To(BeNil())
+		g.Expect(testEnv.Client.Create(ctx, amcp)).To(Succeed())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      machine.Name,
+			},
+		}
+		g.Expect(testEnv.Client.Create(ctx, secret)).To(Succeed())
+
+		amcpList := &ekscontrolplanev1.AWSManagedControlPlaneList{}
+		testEnv.Client.List(ctx, amcpList)
+		t.Logf(dump("stored-amcps", amcpList))
+
+		reconciler := EKSConfigReconciler{
+			Client: testEnv.Client,
+		}
+		t.Logf(fmt.Sprintf("Calling reconcile on cluster '%s' and config '%s' should requeue", cluster.Name, config.Name))
+		g.Eventually(func(gomega Gomega) {
+			result, err := reconciler.joinWorker(ctx, cluster, config, configOwner("Machine"))
+			gomega.Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(result.Requeue).To(BeFalse())
+		}).Should(Succeed())
+
+		t.Logf(fmt.Sprintf("Secret '%s' should exist and be out of date", config.Name))
+		secretList := &corev1.SecretList{}
+		testEnv.Client.List(ctx, secretList)
+		t.Logf(dump("secrets", secretList))
+
+		secret = &corev1.Secret{}
+		g.Eventually(func(gomega Gomega) {
+			gomega.Expect(testEnv.Client.Get(ctx, client.ObjectKey{
+				Name:      config.Name,
+				Namespace: "default",
+			}, secret)).To(Succeed())
+			gomega.Expect(string(secret.Data["value"])).To(Not(Equal(string(expectedUserData))))
 		}).Should(Succeed())
 	})
 }
@@ -204,6 +266,40 @@ func newMachine(cluster *clusterv1.Cluster, name string) *clusterv1.Machine {
 	return machine
 }
 
+// newMachinePool returns a CAPI machine object; if cluster is not nil, the MachinePool  is linked to the cluster as well.
+func newMachinePool(cluster *clusterv1.Cluster, name string) *v1beta1.MachinePool {
+	generatedName := fmt.Sprintf("%s-%s", name, util.RandomString(5))
+	mp := &v1beta1.MachinePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachinePool",
+			APIVersion: v1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      generatedName,
+		},
+		Spec: v1beta1.MachinePoolSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							Kind:       "EKSConfig",
+							APIVersion: eksbootstrapv1.GroupVersion.String(),
+						},
+					},
+				},
+			},
+		},
+	}
+	if cluster != nil {
+		mp.Spec.ClusterName = cluster.Name
+		mp.ObjectMeta.Labels = map[string]string{
+			clusterv1.ClusterLabelName: cluster.Name,
+		}
+	}
+	return mp
+}
+
 // newEKSConfig return an EKSConfig object; if machine is not nil, the EKSConfig is linked to the machine as well.
 func newEKSConfig(machine *clusterv1.Machine) *eksbootstrapv1.EKSConfig {
 	config := &eksbootstrapv1.EKSConfig{
@@ -219,6 +315,7 @@ func newEKSConfig(machine *clusterv1.Machine) *eksbootstrapv1.EKSConfig {
 				"test-arg": "test-value",
 			},
 		},
+		Status: eksbootstrapv1.EKSConfigStatus{},
 	}
 	if machine != nil {
 		config.ObjectMeta.Name = machine.Name
@@ -231,6 +328,7 @@ func newEKSConfig(machine *clusterv1.Machine) *eksbootstrapv1.EKSConfig {
 				UID:        types.UID(fmt.Sprintf("%s uid", machine.Name)),
 			},
 		}
+		config.Status.DataSecretName = &machine.Name
 		machine.Spec.Bootstrap.ConfigRef.Name = config.Name
 		machine.Spec.Bootstrap.ConfigRef.Namespace = config.Namespace
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Fixes EKSConfig reconciliation handling for non-Machine kind owner resources, such as MachinePools. Previously EKSConfig reconciliation stopped after the secret was created. However, the secret may need to be updated if the LaunchTemplate changes.

Additional logging and error handling improvements included alongside.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3848

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed EKSConfig reconciliation handling for non-Machine kind owner resources, such as MachinePools.
```
