### PR TITLE
E2E tests for AlternativeGCStrategy

### DIFF
--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/addons/csi/data/aws-ebs-csi-external.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/addons/csi/data/aws-ebs-csi-external.yaml
@@ -4,8 +4,8 @@ metadata:
   name: aws-secret
   namespace: kube-system
 stringData:
-  key_id: ${AWS_ACCESS_KEY_ID}
-  access_key: ${AWS_SECRET_ACCESS_KEY}
+  key_id: ""
+  access_key: ""
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -381,6 +381,14 @@ spec:
     spec:
       affinity:
         nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
           preferredDuringSchedulingIgnoredDuringExecution:
             - preference:
                 matchExpressions:
@@ -590,6 +598,10 @@ spec:
         - effect: NoExecute
           operator: Exists
           tolerationSeconds: 300
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
       volumes:
         - emptyDir: {}
           name: socket-dir


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Add two e2e for AlternativeGCStrategy feature
- [managed] [gc] should cleanup a cluster that has ELB/NLB load balancers using AlternativeGCStrategy
- [unmanaged] [gc] should cleanup a cluster that has ELB/NLB load balancers using AlternativeGCStrategy

They have exact same test steps with ` [managed] [gc] should cleanup a cluster that has ELB/NLB load balancers` and `[unmanaged] [gc] should cleanup a cluster that has ELB/NLB load balancers`, except that before creating workload cluster, `shared.ReconfigureDeployment` is executed to reconfigure capa deployment with `AlternativeGCStrategy` feature flag set to true and will recover capa after test is done

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4161 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add E2E tests for AlternativeGCStrategy
```
