### PR TITLE
fix: malformed s3 arn due to incorrect string formatting

### DIFF
--- a/pkg/cloud/services/s3/s3.go
+++ b/pkg/cloud/services/s3/s3.go
@@ -244,7 +244,7 @@ func (s *Service) bucketPolicy(bucketName string) (string, error) {
 			Sid:    "control-plane",
 			Effect: iam.EffectAllow,
 			Principal: map[iam.PrincipalType]iam.PrincipalID{
-				iam.PrincipalAWS: []string{fmt.Sprintf("arn:%s:iam::%s:role/%s", s.scope, *accountID.Account, bucket.ControlPlaneIAMInstanceProfile)},
+				iam.PrincipalAWS: []string{fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, *accountID.Account, bucket.ControlPlaneIAMInstanceProfile)},
 			},
 			Action:   []string{"s3:GetObject"},
 			Resource: []string{fmt.Sprintf("arn:%s:s3:::%s/control-plane/*", partition, bucketName)},

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -172,6 +172,10 @@ func TestReconcileBucket(t *testing.T) {
 			if !strings.Contains(policy, fmt.Sprintf("%s/node/*", bucketName)) {
 				t.Errorf("At least one policy should apply for all objects with %q prefix, got: %v", "node", policy)
 			}
+
+			if !strings.Contains(policy, "arn:aws:iam::foo:role/control-plane.cluster-api-provider-aws.sigs.k8s.io") {
+				t.Errorf("Expected arn to contain the right principal; got: %v", policy)
+			}
 		}).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes a problem introduced by merging https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4010

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix incorrect s3 bucket ARN formatting.
```
