### PR TITLE
Feature: add default behaviour for clusterawsadm bootstrap iam print-policy

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/iam.go
@@ -71,6 +71,18 @@ func (t Template) policyFunctionMap() map[PolicyName]func() *iamv1.PolicyDocumen
 	}
 }
 
+func (t Template) PrintPolicyDocs() error {
+	for _, name := range ManagedIAMPolicyNames {
+		policyDoc := t.GetPolicyDocFromPolicyName(name)
+		value, err := converters.IAMPolicyDocumentToJSON(*policyDoc)
+		if err != nil {
+			return err
+		}
+		fmt.Println(name, value)
+	}
+	return nil
+}
+
 // GetPolicyDocFromPolicyName returns a Template's policy document.
 func (t Template) GetPolicyDocFromPolicyName(policyName PolicyName) *iamv1.PolicyDocument {
 	return t.policyFunctionMap()[policyName]()

--- a/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
+++ b/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
@@ -64,6 +64,10 @@ func printPolicyCmd() *cobra.Command {
 				return err
 			}
 
+			if policyName == "" {
+				return template.PrintPolicyDocs()
+			}
+
 			policyDocument := template.GetPolicyDocFromPolicyName(policyName)
 			str, err := converters.IAMPolicyDocumentToJSON(*policyDocument)
 			if err != nil {
@@ -81,6 +85,11 @@ func printPolicyCmd() *cobra.Command {
 
 func getDocumentName(cmd *cobra.Command) (bootstrap.PolicyName, error) {
 	val := bootstrap.PolicyName(cmd.Flags().Lookup("document").Value.String())
+
+	if val == "" {
+		return "", nil
+	}
+
 	if !val.IsValid() {
 		return "", errInvalidDocumentName
 	}

--- a/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
+++ b/cmd/clusterawsadm/cmd/bootstrap/iam/iam_doc.go
@@ -37,6 +37,9 @@ func printPolicyCmd() *cobra.Command {
 			Kubernetes Cluster API Provider AWS.
 		`),
 		Example: cmd.Examples(`
+		# Print out all the IAM policies for the Kubernetes CLuster API Provider AWS.
+		clusterawsadm bootstrap iam print-policy
+
 		# Print out the IAM policy for the Kubernetes Cluster API Provider AWS Controller.
 		clusterawsadm bootstrap iam print-policy --document AWSIAMManagedPolicyControllers
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Currently clusterawsadm doesn't support execution of "clusterawsadm bootstrap iam print-policy", it needs "--document" flag to specify the policy documents we want to see.

This PR introduces the "clusterawsadm bootstrap iam print-policy" as an individual command to list all those policy documents at once.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update clusterawsadm to include a full list of policies when omitting `--document` parameter.
```
