### PR TITLE
Set httpPutResponseHopLimit to 2 when creating instances

### DIFF
--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -127,7 +127,7 @@ func TestAWSMachineTemplateValidateUpdate(t *testing.T) {
 							InstanceType: "test",
 							InstanceMetadataOptions: &InstanceMetadataOptions{
 								HTTPEndpoint:            InstanceMetadataEndpointStateEnabled,
-								HTTPPutResponseHopLimit: 1,
+								HTTPPutResponseHopLimit: 2,
 								HTTPTokens:              HTTPTokensStateRequired,
 								InstanceMetadataTags:    InstanceMetadataEndpointStateDisabled,
 							},

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -285,7 +285,7 @@ func (obj *InstanceMetadataOptions) SetDefaults() {
 		obj.HTTPEndpoint = InstanceMetadataEndpointStateEnabled
 	}
 	if obj.HTTPPutResponseHopLimit == 0 {
-		obj.HTTPPutResponseHopLimit = 1
+		obj.HTTPPutResponseHopLimit = 2 // Defaults to 2 in container environment
 	}
 	if obj.HTTPTokens == "" {
 		obj.HTTPTokens = HTTPTokensStateRequired // Defaults to IMDSv2

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -2551,7 +2551,7 @@ func TestAWSMachineReconcilerReconcileDefaultsToLoadBalancerTypeClassic(t *testi
 						},
 						MetadataOptions: &ec2.InstanceMetadataOptionsResponse{
 							HttpEndpoint:            aws.String(string(infrav1.InstanceMetadataEndpointStateEnabled)),
-							HttpPutResponseHopLimit: aws.Int64(1),
+							HttpPutResponseHopLimit: aws.Int64(2),
 							HttpTokens:              aws.String(string(infrav1.HTTPTokensStateRequired)),
 							InstanceMetadataTags:    aws.String(string(infrav1.InstanceMetadataEndpointStateDisabled)),
 						},

--- a/docs/book/src/topics/instance-metadata.md
+++ b/docs/book/src/topics/instance-metadata.md
@@ -6,6 +6,7 @@ Instance metadata is data about your instance that you can use to configure or m
 * Instance Metadata Service Version 2 (IMDSv2) – a session-oriented method
 
 CAPA defaults to IMDSv2 when creating instances, as it provides a [better level of security](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).
+CAPA defaults to 2 hot limit when creating instances with IMDSv2, as it is recommended in container environment according to [AWS document](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations).
 
 It is possible to configure the instance metadata options using the field called `instanceMetadataOptions` in the `AWSMachineTemplate`.
 
@@ -21,7 +22,7 @@ spec:
     spec:
       instanceMetadataOptions:
         httpEndpoint: enabled
-        httpPutResponseHopLimit: 1
+        httpPutResponseHopLimit: 2
         httpTokens: required
         instanceMetadataTags: disabled
 ```


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4247

**Special notes for your reviewer**:
Set default httpPutResponseHopLimit as 2 when creating instances
Keep crd default value as 1, in case that customers want to set it as 1 for some machine deployment

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set default httpPutResponseHopLimit to 2 in IMDSv2 enablement when creating instances
```
