### PR TITLE
🐛 Allow the defaulting of InstanceMetadataOptions to go through for AWSMachineTemplates

### DIFF
--- a/api/v1beta2/awsmachinetemplate_webhook.go
+++ b/api/v1beta2/awsmachinetemplate_webhook.go
@@ -227,7 +227,15 @@ func (r *AWSMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw r
 	var allErrs field.ErrorList
 
 	if !topology.ShouldSkipImmutabilityChecks(req, newAWSMachineTemplate) && !cmp.Equal(newAWSMachineTemplate.Spec, oldAWSMachineTemplate.Spec) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), newAWSMachineTemplate, "AWSMachineTemplate.Spec is immutable"))
+		if oldAWSMachineTemplate.Spec.Template.Spec.InstanceMetadataOptions == nil {
+			oldAWSMachineTemplate.Spec.Template.Spec.InstanceMetadataOptions = newAWSMachineTemplate.Spec.Template.Spec.InstanceMetadataOptions
+		}
+
+		if !cmp.Equal(newAWSMachineTemplate.Spec.Template.Spec, oldAWSMachineTemplate.Spec.Template.Spec) {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("AWSMachineTemplate", "spec", "template", "spec"), newAWSMachineTemplate, "AWSMachineTemplate.Spec is immutable"),
+			)
+		}
 	}
 
 	return aggregateObjErrors(newAWSMachineTemplate.GroupVersionKind().GroupKind(), newAWSMachineTemplate.Name, allErrs)

--- a/api/v1beta2/awsmachinetemplate_webhook.go
+++ b/api/v1beta2/awsmachinetemplate_webhook.go
@@ -233,7 +233,7 @@ func (r *AWSMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw r
 
 		if !cmp.Equal(newAWSMachineTemplate.Spec.Template.Spec, oldAWSMachineTemplate.Spec.Template.Spec) {
 			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("AWSMachineTemplate", "spec", "template", "spec"), newAWSMachineTemplate, "AWSMachineTemplate.Spec is immutable"),
+				field.Invalid(field.NewPath("spec", "template", "spec"), newAWSMachineTemplate, "AWSMachineTemplate.Spec is immutable"),
 			)
 		}
 	}

--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -116,6 +116,27 @@ func TestAWSMachineTemplateValidateUpdate(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			name: "allow defaulted values to update",
+			modifiedTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							CloudInit:    CloudInit{},
+							InstanceType: "test",
+							InstanceMetadataOptions: &InstanceMetadataOptions{
+								HTTPEndpoint:            InstanceMetadataEndpointStateEnabled,
+								HTTPPutResponseHopLimit: 1,
+								HTTPTokens:              HTTPTokensStateRequired,
+								InstanceMetadataTags:    InstanceMetadataEndpointStateDisabled,
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**: In https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4037 we introduced `InstanceMetadataOptions`, but we didn't deal with upgrading from `2.0.x` to `>= 2.1.0`.

In the `2.0.x` we didn't have `InstanceMetadataOptions`, so when upgrading to `2.1.0` or more, defaulting kicks in, but gets rejected. This is because of missing changes to `ValidateUpdate`, to detect this and allow defaulted changes. This PR fixes that.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

@richardcase @Skarlso @Ankitasw - we should probably recommend using 2.1.1

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow the defaulting of InstanceMetadataOptions to go through for AWSMachineTemplates
```
