### PR TITLE
fix: remove modification of networkinterface for ipv6

### DIFF
--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -461,17 +461,6 @@ func (s *Service) createLaunchTemplateData(scope scope.LaunchTemplateScope, imag
 			Name: aws.String(lt.IamInstanceProfile),
 		}
 	}
-	if s.scope.VPC().IsIPv6Enabled() {
-		data.NetworkInterfaces = []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
-			{
-				Ipv6Prefixes: []*ec2.Ipv6PrefixSpecificationRequest{
-					{
-						Ipv6Prefix: aws.String("auto"),
-					},
-				},
-			},
-		}
-	}
 
 	ids, err := s.GetCoreNodeSecurityGroups(scope)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Eventually, AWS' ipv6 docs aren't quite sure and eksctl completely removed dabbling with the network interface in launch templates. We are going to follow suit.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2420#issuecomment-1542812102

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove setting `Ipv6Prefix: aws.String("auto")` for network interfaces when IPv6 is enabled.
```
