### PR TITLE
e2e: add elasticfilesystem:TagResource action

### DIFF
--- a/test/e2e/shared/template.go
+++ b/test/e2e/shared/template.go
@@ -133,6 +133,7 @@ func newBootstrapTemplate(e2eCtx *E2EContext) *cfn_bootstrap.Template {
 				"elasticfilesystem:DescribeAccessPoints",
 				"elasticfilesystem:DescribeFileSystems",
 				"elasticfilesystem:CreateAccessPoint",
+				"elasticfilesystem:TagResource",
 				"ec2:DescribeAvailabilityZones",
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

We're trying to migrate the `periodic-cluster-api-provider-aws-e2e` job from Prow build cluster running on GKE to Prow build cluster running on EKS. As part of that, we added [a new job `periodic-cluster-api-provider-aws-e2e-eks-canary`](https://github.com/kubernetes/test-infra/blob/f5f92ef685cfad2108bc5e266313c0f9636e79a7/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml#L43-L91). However, the job is consistently failing with:

```
capa-e2e: [It] [unmanaged] [functional] Workload cluster with EFS driver should pass dynamic provisioning test
```

After some investigation, we found out that `efs-claim` PVC is not getting provisioned and `efs-csi-controller` is logging to following error:

```
E0517 09:28:04.011078       1 driver.go:103] GRPC error: rpc error: code = Unauthenticated desc = Access Denied. Please ensure you have the right AWS permissions: Access denied
```

After some additional investigation, we found out that adding `elasticfilesystem:TagResource` action to the node policy solves the problem. We're not 100% sure why that solves the issue, but upstream EFS CSI driver added it relatively recently as well: https://github.com/kubernetes-sigs/aws-efs-csi-driver/commit/cd41c38c9902505e14337d4967f929027ce6c417

We're also not 100% sure why we see this issue only in the new cluster, but we assume it might be related to the fact that we're using brand new boskos accounts, so maybe some account settings are different.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref https://github.com/kubernetes/k8s.io/issues/5048

**Checklist**:
- [x] squashed commits
- [x] adds or updates e2e tests

**Release note**:
```release-note
NONE
```

cc @dims @pkprzekwas 