### PR TITLE
fix: correct the enum types for protocol values

### DIFF
--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -94,7 +94,7 @@ var (
 	TargetGroupAttributeEnablePreserveClientIP = "preserve_client_ip.enabled"
 )
 
-// LoadBalancerAttribute defines a set of attributes for a V2 load balancer
+// LoadBalancerAttribute defines a set of attributes for a V2 load balancer.
 type LoadBalancerAttribute string
 
 var (
@@ -110,7 +110,7 @@ type TargetGroupSpec struct {
 	Name string `json:"name"`
 	// Port is the exposed port
 	Port int64 `json:"port"`
-	// +kubebuilder:validation:Enum=tcp;tls;upd
+	// +kubebuilder:validation:Enum=tcp;tls;udp;TCP;TLS;UDP
 	Protocol ELBProtocol `json:"protocol"`
 	VpcID    string      `json:"vpcId"`
 	// HealthCheck is the elb health check associated with the load balancer.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1213,7 +1213,10 @@ spec:
                                   enum:
                                   - tcp
                                   - tls
-                                  - upd
+                                  - udp
+                                  - TCP
+                                  - TLS
+                                  - UDP
                                   type: string
                                 targetGroupHealthCheck:
                                   description: HealthCheck is the elb health check
@@ -2639,7 +2642,10 @@ spec:
                                   enum:
                                   - tcp
                                   - tls
-                                  - upd
+                                  - udp
+                                  - TCP
+                                  - TLS
+                                  - UDP
                                   type: string
                                 targetGroupHealthCheck:
                                   description: HealthCheck is the elb health check

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1677,7 +1677,10 @@ spec:
                                   enum:
                                   - tcp
                                   - tls
-                                  - upd
+                                  - udp
+                                  - TCP
+                                  - TLS
+                                  - UDP
                                   type: string
                                 targetGroupHealthCheck:
                                   description: HealthCheck is the elb health check


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Field validation should be case-insensitive. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4284

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the webhook validation for Protocol types.
```
