### PR TITLE
fix: resolve secrets when generating eks userdata (backport #4285 to 2.1)

### DIFF
--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -229,9 +229,9 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 	log.Info("Generating userdata")
 	files, err := r.resolveFiles(ctx, config)
 	if err != nil {
-		log.Info("Control Plane has not yet been initialized")
+		log.Info("Failed to resolve files for user data")
 		conditions.MarkFalse(config, eksbootstrapv1.DataSecretAvailableCondition, eksbootstrapv1.DataSecretGenerationFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	nodeInput := &userdata.NodeInput{

--- a/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
+++ b/bootstrap/eks/controllers/eksconfig_controller_reconciler_test.go
@@ -203,6 +203,78 @@ func TestEKSConfigReconciler(t *testing.T) {
 			gomega.Expect(string(secret.Data["value"])).To(Not(Equal(string(expectedUserData))))
 		}).Should(Succeed())
 	})
+	t.Run("Should Reconcile an EKSConfig with a secret file reference", func(t *testing.T) {
+		g := NewWithT(t)
+		amcp := newAMCP("test-cluster")
+		//nolint: gosec // these are not credentials
+		secretPath := "/etc/secret.txt"
+		secretContent := "secretValue"
+		cluster := newCluster(amcp.Name)
+		machine := newMachine(cluster, "test-machine")
+		config := newEKSConfig(machine)
+		config.Spec.Files = append(config.Spec.Files, eksbootstrapv1.File{
+			ContentFrom: &eksbootstrapv1.FileSource{
+				Secret: eksbootstrapv1.SecretFileSource{
+					Name: "my-secret",
+					Key:  "secretKey",
+				},
+			},
+			Path: secretPath,
+		})
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "my-secret",
+			},
+			Data: map[string][]byte{
+				"secretKey": []byte(secretContent),
+			},
+		}
+		t.Logf(dump("amcp", amcp))
+		t.Logf(dump("config", config))
+		t.Logf(dump("machine", machine))
+		t.Logf(dump("cluster", cluster))
+		t.Logf(dump("secret", secret))
+		g.Expect(testEnv.Client.Create(ctx, secret)).To(Succeed())
+		g.Expect(testEnv.Client.Create(ctx, amcp)).To(Succeed())
+
+		// create a userData with the secret content and check if reconile.joinWorker
+		// resolves the userdata properly
+		expectedUserData, err := userdata.NewNode(&userdata.NodeInput{
+			ClusterName: amcp.Name,
+			Files: []eksbootstrapv1.File{
+				{
+					Content: secretContent,
+					Path:    secretPath,
+				},
+			},
+			KubeletExtraArgs: map[string]string{
+				"test-arg": "test-value",
+			},
+		})
+		g.Expect(err).To(BeNil())
+		reconciler := EKSConfigReconciler{
+			Client: testEnv.Client,
+		}
+		t.Logf(fmt.Sprintf("Calling reconcile on cluster '%s' and config '%s' should requeue", cluster.Name, config.Name))
+		g.Eventually(func(gomega Gomega) {
+			result, err := reconciler.joinWorker(ctx, cluster, config, configOwner("Machine"))
+			gomega.Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(result.Requeue).To(BeFalse())
+		}).Should(Succeed())
+
+		secretList := &corev1.SecretList{}
+		testEnv.Client.List(ctx, secretList)
+		t.Logf(dump("secrets", secretList))
+		gotSecret := &corev1.Secret{}
+		g.Eventually(func(gomega Gomega) {
+			gomega.Expect(testEnv.Client.Get(ctx, client.ObjectKey{
+				Name:      config.Name,
+				Namespace: "default",
+			}, gotSecret)).To(Succeed())
+		}).Should(Succeed())
+		g.Expect(string(gotSecret.Data["value"])).To(Equal(string(expectedUserData)))
+	})
 }
 
 // newCluster return a CAPI cluster object.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
resolves ContentFrom for eksconfig userdata
```
