### PR TITLE
fix: remove set nodes role

### DIFF
--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -30,7 +30,6 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
-	iamv1 "sigs.k8s.io/cluster-api-provider-aws/v2/iam/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
@@ -105,11 +104,7 @@ func (s *Service) getARNForRole(role string) (string, error) {
 }
 
 func (s *Service) getRolesForWorkers(ctx context.Context) (map[string]struct{}, error) {
-	// previously this was the default role always added to the IAM authenticator config
-	// we'll keep this to not break existing behavior for users
-	allRoles := map[string]struct{}{
-		fmt.Sprintf("nodes%s", iamv1.DefaultNameSuffix): {},
-	}
+	allRoles := map[string]struct{}{}
 	if err := s.getRolesForMachineDeployments(ctx, allRoles); err != nil {
 		return nil, fmt.Errorf("failed to get roles from machine deployments %w", err)
 	}

--- a/test/e2e/suites/managed/cluster.go
+++ b/test/e2e/suites/managed/cluster.go
@@ -101,10 +101,13 @@ func ManagedClusterSpec(ctx context.Context, inputGetter func() ManagedClusterSp
 	verifySecretExists(ctx, fmt.Sprintf("%s-kubeconfig", input.ClusterName), input.Namespace.Name, bootstrapClient)
 	verifySecretExists(ctx, fmt.Sprintf("%s-user-kubeconfig", input.ClusterName), input.Namespace.Name, bootstrapClient)
 
-	ginkgo.By("Checking that aws-iam-authenticator config map exists")
-	workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
-	workloadClient := workloadClusterProxy.GetClient()
-	verifyConfigMapExists(ctx, "aws-auth", metav1.NamespaceSystem, workloadClient)
+	// this will not be created unless there are worker machines or set by IAMAuthenticatorConfig on the managed control plane spec
+	if input.WorkerMachineCount > 0 {
+		ginkgo.By("Checking that aws-iam-authenticator config map exists")
+		workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+		workloadClient := workloadClusterProxy.GetClient()
+		verifyConfigMapExists(ctx, "aws-auth", metav1.NamespaceSystem, workloadClient)
+	}
 }
 
 // DeleteClusterSpecInput is the input to DeleteClusterSpec.

--- a/test/e2e/suites/managed/eks_ipv6_test.go
+++ b/test/e2e/suites/managed/eks_ipv6_test.go
@@ -72,7 +72,7 @@ var _ = ginkgo.Describe("[managed] [general] [ipv6] EKS cluster tests", func() {
 				ClusterName:              clusterName,
 				Flavour:                  EKSIPv6ClusterFlavor,
 				ControlPlaneMachineCount: 1, //NOTE: this cannot be zero as clusterctl returns an error
-				WorkerMachineCount:       1,
+				WorkerMachineCount:       0,
 			}
 		})
 

--- a/test/e2e/suites/managed/upgrade_test.go
+++ b/test/e2e/suites/managed/upgrade_test.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("EKS Cluster upgrade test", func() {
 				ClusterName:              clusterName,
 				Flavour:                  EKSControlPlaneOnlyFlavor, // TODO (richardcase) - change in the future when upgrades to machinepools work
 				ControlPlaneMachineCount: 1,                         // NOTE: this cannot be zero as clusterctl returns an error
-				WorkerMachineCount:       1,
+				WorkerMachineCount:       0,
 				KubernetesVersion:        initialVersion,
 			}
 		})


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
removes the node role arn lookup automatically being added on to the iamconfig. 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4291 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
removes always adding nodes role to iamauth config for EKS clusters 
```
