### PR TITLE
Revert creating instance with wait blocking

### DIFF
--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -593,6 +593,8 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil)
+	m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil)
 	m.DescribeNetworkInterfaces(gomock.Eq(&ec2.DescribeNetworkInterfacesInput{Filters: []*ec2.Filter{
 		{
 			Name:   aws.String("attachment.instance-id"),

--- a/pkg/cloud/services/ec2/bastion_test.go
+++ b/pkg/cloud/services/ec2/bastion_test.go
@@ -366,6 +366,8 @@ func TestServiceReconcileBastion(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 			},
 			bastionEnabled: true,
 			expectError:    false,
@@ -600,6 +602,8 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 			},
 			bastionEnabled: true,
 			expectError:    false,

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -17,12 +17,15 @@ limitations under the License.
 package ec2
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"k8s.io/utils/pointer"
@@ -31,6 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/converters"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/filter"
+	awslogs "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/logs"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/userdata"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/record"
@@ -604,6 +608,19 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 
 	if len(out.Instances) == 0 {
 		return nil, errors.Errorf("no instance returned for reservation %v", out.GoString())
+	}
+
+	waitTimeout := 1 * time.Minute
+	s.scope.Debug("Waiting for instance to be in running state", "instance-id", *out.Instances[0].InstanceId, "timeout", waitTimeout.String())
+	ctx, cancel := context.WithTimeout(aws.BackgroundContext(), waitTimeout)
+	defer cancel()
+
+	if err := s.EC2Client.WaitUntilInstanceRunningWithContext(
+		ctx,
+		&ec2.DescribeInstancesInput{InstanceIds: []*string{out.Instances[0].InstanceId}},
+		request.WithWaiterLogger(awslogs.NewWrapLogr(s.scope.GetLogger())),
+	); err != nil {
+		s.scope.Debug("Could not determine if Machine is running. Machine state might be unavailable until next renconciliation.")
 	}
 
 	return s.SDKToInstance(out.Instances[0])

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -402,6 +402,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -529,6 +531,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -683,6 +687,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -833,6 +839,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -984,6 +992,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1112,6 +1122,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1239,6 +1251,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1458,6 +1472,8 @@ func TestCreateInstance(t *testing.T) {
 							SubnetId: aws.String("matching-subnet"),
 						}},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -1769,6 +1785,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2006,6 +2024,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2124,6 +2144,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2330,6 +2352,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2486,6 +2510,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2642,6 +2668,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2802,6 +2830,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -2931,6 +2961,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -3061,6 +3093,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -3192,6 +3226,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -3320,6 +3356,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -3448,6 +3486,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
@@ -3576,6 +3616,8 @@ func TestCreateInstance(t *testing.T) {
 							},
 						}, nil
 					})
+				m.WaitUntilInstanceRunningWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
 				m.
 					DescribeNetworkInterfaces(gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4092 is a very good performance enhancement to do concurrent work in large scale deployment. But in the awsmachine reconcile (creation part)workflow, it lacks proper requeue mechanism to requeue pending or even other necessary status instance for next loop reconciliation.
As a result, a very basic self-host management cluster upgrade scenario is experiencing a great performance downgrade because of no too much object changes in such scenario, and no aws machine requeue with only having to rely on the fixed 10min resync period.

To be safer for capa v2.1.x, I just revert previous behavior on awsmachine creation that has been verified during releases. In future major/minor release, we can add the enhancement (creation part)of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4092 back. In the meanwhile redesign the requeue behavior for awsmachine reconcile(creation part), and do fully testing and validations.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4293

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Revert creating an instance with previous waiting until it's running
```
