### PR TITLE
Allow customization of ingress rules in control plane LB security group

### DIFF
--- a/api/v1beta1/awscluster_conversion.go
+++ b/api/v1beta1/awscluster_conversion.go
@@ -74,7 +74,7 @@ func restoreControlPlaneLoadBalancer(restored, dst *infrav2.AWSLoadBalancerSpec)
 	dst.LoadBalancerType = restored.LoadBalancerType
 	dst.DisableHostsRewrite = restored.DisableHostsRewrite
 	dst.PreserveClientIP = restored.PreserveClientIP
-	dst.AdditionalIngressRules = restored.AdditionalIngressRules
+	dst.IngressRules = restored.IngressRules
 }
 
 // ConvertFrom converts the v1beta1 AWSCluster receiver to a v1beta1 AWSCluster.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1219,7 +1219,7 @@ func autoConvert_v1beta2_AWSLoadBalancerSpec_To_v1beta1_AWSLoadBalancerSpec(in *
 	out.Subnets = *(*[]string)(unsafe.Pointer(&in.Subnets))
 	out.HealthCheckProtocol = (*ClassicELBProtocol)(unsafe.Pointer(in.HealthCheckProtocol))
 	out.AdditionalSecurityGroups = *(*[]string)(unsafe.Pointer(&in.AdditionalSecurityGroups))
-	// WARNING: in.AdditionalIngressRules requires manual conversion: does not exist in peer-type
+	// WARNING: in.IngressRules requires manual conversion: does not exist in peer-type
 	// WARNING: in.LoadBalancerType requires manual conversion: does not exist in peer-type
 	// WARNING: in.DisableHostsRewrite requires manual conversion: does not exist in peer-type
 	// WARNING: in.PreserveClientIP requires manual conversion: does not exist in peer-type

--- a/api/v1beta2/awscluster_types.go
+++ b/api/v1beta2/awscluster_types.go
@@ -208,10 +208,9 @@ type AWSLoadBalancerSpec struct {
 	// +optional
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 
-	// AdditionalIngressRules sets the additional ingress rules for the control plane load balancer. If no source security group ids are specified, the
-	// default control plane security group will be used.
+	// IngressRules sets the ingress rules for the control plane load balancer.
 	// +optional
-	AdditionalIngressRules []IngressRule `json:"additionalIngressRules,omitempty"`
+	IngressRules []IngressRule `json:"ingressRules,omitempty"`
 
 	// LoadBalancerType sets the type for a load balancer. The default type is classic.
 	// +kubebuilder:default=classic

--- a/api/v1beta2/awscluster_webhook.go
+++ b/api/v1beta2/awscluster_webhook.go
@@ -199,9 +199,9 @@ func (r *AWSCluster) validateAdditionalIngressRules() field.ErrorList {
 		return allErrs
 	}
 
-	for _, rule := range r.Spec.ControlPlaneLoadBalancer.AdditionalIngressRules {
+	for _, rule := range r.Spec.ControlPlaneLoadBalancer.IngressRules {
 		if (rule.CidrBlocks != nil || rule.IPv6CidrBlocks != nil) && (rule.SourceSecurityGroupIDs != nil || rule.SourceSecurityGroupRoles != nil) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("additionalIngressRules"), r.Spec.ControlPlaneLoadBalancer.AdditionalIngressRules, "CIDR blocks and security group IDs or security group roles cannot be used together"))
+			allErrs = append(allErrs, field.Invalid(field.NewPath("additionalIngressRules"), r.Spec.ControlPlaneLoadBalancer.IngressRules, "CIDR blocks and security group IDs or security group roles cannot be used together"))
 		}
 	}
 

--- a/api/v1beta2/awscluster_webhook_test.go
+++ b/api/v1beta2/awscluster_webhook_test.go
@@ -252,11 +252,11 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "rejects additional ingress rules with cidr block and source security group id",
+			name: "rejects ingress rules with cidr block and source security group id",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
-						AdditionalIngressRules: []IngressRule{
+						IngressRules: []IngressRule{
 							{
 								Protocol:               SecurityGroupProtocolTCP,
 								CidrBlocks:             []string{"test"},
@@ -269,11 +269,11 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "rejects additional ingress rules with cidr block and source security group id and role",
+			name: "rejects ingress rules with cidr block and source security group id and role",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
-						AdditionalIngressRules: []IngressRule{
+						IngressRules: []IngressRule{
 							{
 								Protocol:                 SecurityGroupProtocolTCP,
 								IPv6CidrBlocks:           []string{"test"},
@@ -287,11 +287,11 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "accepts additional ingress rules with cidr block",
+			name: "accepts ingress rules with cidr block",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
-						AdditionalIngressRules: []IngressRule{
+						IngressRules: []IngressRule{
 							{
 								Protocol:   SecurityGroupProtocolTCP,
 								CidrBlocks: []string{"test"},
@@ -303,11 +303,11 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "accepts additional ingress rules with source security group role",
+			name: "accepts ingress rules with source security group role",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
-						AdditionalIngressRules: []IngressRule{
+						IngressRules: []IngressRule{
 							{
 								Protocol:                 SecurityGroupProtocolTCP,
 								SourceSecurityGroupRoles: []SecurityGroupRole{SecurityGroupBastion},
@@ -319,11 +319,11 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "accepts additional ingress rules with source security group id and role",
+			name: "accepts ingress rules with source security group id and role",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
-						AdditionalIngressRules: []IngressRule{
+						IngressRules: []IngressRule{
 							{
 								Protocol:                 SecurityGroupProtocolTCP,
 								SourceSecurityGroupIDs:   []string{"test"},

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -574,8 +574,8 @@ func (in *AWSLoadBalancerSpec) DeepCopyInto(out *AWSLoadBalancerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.AdditionalIngressRules != nil {
-		in, out := &in.AdditionalIngressRules, &out.AdditionalIngressRules
+	if in.IngressRules != nil {
+		in, out := &in.IngressRules, &out.IngressRules
 		*out = make([]IngressRule, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -966,11 +966,43 @@ spec:
                 description: ControlPlaneLoadBalancer is optional configuration for
                   customizing control plane behavior.
                 properties:
-                  additionalIngressRules:
-                    description: AdditionalIngressRules sets the additional ingress
-                      rules for the control plane load balancer. If no source security
-                      group ids are specified, the default control plane security
-                      group will be used.
+                  additionalSecurityGroups:
+                    description: AdditionalSecurityGroups sets the security groups
+                      used by the load balancer. Expected to be security group IDs
+                      This is optional - if not provided new security groups will
+                      be created for the load balancer
+                    items:
+                      type: string
+                    type: array
+                  crossZoneLoadBalancing:
+                    description: "CrossZoneLoadBalancing enables the classic ELB cross
+                      availability zone balancing. \n With cross-zone load balancing,
+                      each load balancer node for your Classic Load Balancer distributes
+                      requests evenly across the registered instances in all enabled
+                      Availability Zones. If cross-zone load balancing is disabled,
+                      each load balancer node distributes requests evenly across the
+                      registered instances in its Availability Zone only. \n Defaults
+                      to false."
+                    type: boolean
+                  disableHostsRewrite:
+                    description: DisableHostsRewrite disabled the hair pinning issue
+                      solution that adds the NLB's address as 127.0.0.1 to the hosts
+                      file of each instance. This is by default, false.
+                    type: boolean
+                  healthCheckProtocol:
+                    description: HealthCheckProtocol sets the protocol type for ELB
+                      health check target default value is ELBProtocolSSL
+                    enum:
+                    - TCP
+                    - SSL
+                    - HTTP
+                    - HTTPS
+                    - TLS
+                    - UDP
+                    type: string
+                  ingressRules:
+                    description: IngressRules sets the ingress rules for the control
+                      plane load balancer.
                     items:
                       description: IngressRule defines an AWS ingress rule for security
                         groups.
@@ -1040,40 +1072,6 @@ spec:
                       - toPort
                       type: object
                     type: array
-                  additionalSecurityGroups:
-                    description: AdditionalSecurityGroups sets the security groups
-                      used by the load balancer. Expected to be security group IDs
-                      This is optional - if not provided new security groups will
-                      be created for the load balancer
-                    items:
-                      type: string
-                    type: array
-                  crossZoneLoadBalancing:
-                    description: "CrossZoneLoadBalancing enables the classic ELB cross
-                      availability zone balancing. \n With cross-zone load balancing,
-                      each load balancer node for your Classic Load Balancer distributes
-                      requests evenly across the registered instances in all enabled
-                      Availability Zones. If cross-zone load balancing is disabled,
-                      each load balancer node distributes requests evenly across the
-                      registered instances in its Availability Zone only. \n Defaults
-                      to false."
-                    type: boolean
-                  disableHostsRewrite:
-                    description: DisableHostsRewrite disabled the hair pinning issue
-                      solution that adds the NLB's address as 127.0.0.1 to the hosts
-                      file of each instance. This is by default, false.
-                    type: boolean
-                  healthCheckProtocol:
-                    description: HealthCheckProtocol sets the protocol type for ELB
-                      health check target default value is ELBProtocolSSL
-                    enum:
-                    - TCP
-                    - SSL
-                    - HTTP
-                    - HTTPS
-                    - TLS
-                    - UDP
-                    type: string
                   loadBalancerType:
                     default: classic
                     description: LoadBalancerType sets the type for a load balancer.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -559,11 +559,45 @@ spec:
                         description: ControlPlaneLoadBalancer is optional configuration
                           for customizing control plane behavior.
                         properties:
-                          additionalIngressRules:
-                            description: AdditionalIngressRules sets the additional
-                              ingress rules for the control plane load balancer. If
-                              no source security group ids are specified, the default
-                              control plane security group will be used.
+                          additionalSecurityGroups:
+                            description: AdditionalSecurityGroups sets the security
+                              groups used by the load balancer. Expected to be security
+                              group IDs This is optional - if not provided new security
+                              groups will be created for the load balancer
+                            items:
+                              type: string
+                            type: array
+                          crossZoneLoadBalancing:
+                            description: "CrossZoneLoadBalancing enables the classic
+                              ELB cross availability zone balancing. \n With cross-zone
+                              load balancing, each load balancer node for your Classic
+                              Load Balancer distributes requests evenly across the
+                              registered instances in all enabled Availability Zones.
+                              If cross-zone load balancing is disabled, each load
+                              balancer node distributes requests evenly across the
+                              registered instances in its Availability Zone only.
+                              \n Defaults to false."
+                            type: boolean
+                          disableHostsRewrite:
+                            description: DisableHostsRewrite disabled the hair pinning
+                              issue solution that adds the NLB's address as 127.0.0.1
+                              to the hosts file of each instance. This is by default,
+                              false.
+                            type: boolean
+                          healthCheckProtocol:
+                            description: HealthCheckProtocol sets the protocol type
+                              for ELB health check target default value is ELBProtocolSSL
+                            enum:
+                            - TCP
+                            - SSL
+                            - HTTP
+                            - HTTPS
+                            - TLS
+                            - UDP
+                            type: string
+                          ingressRules:
+                            description: IngressRules sets the ingress rules for the
+                              control plane load balancer.
                             items:
                               description: IngressRule defines an AWS ingress rule
                                 for security groups.
@@ -634,42 +668,6 @@ spec:
                               - toPort
                               type: object
                             type: array
-                          additionalSecurityGroups:
-                            description: AdditionalSecurityGroups sets the security
-                              groups used by the load balancer. Expected to be security
-                              group IDs This is optional - if not provided new security
-                              groups will be created for the load balancer
-                            items:
-                              type: string
-                            type: array
-                          crossZoneLoadBalancing:
-                            description: "CrossZoneLoadBalancing enables the classic
-                              ELB cross availability zone balancing. \n With cross-zone
-                              load balancing, each load balancer node for your Classic
-                              Load Balancer distributes requests evenly across the
-                              registered instances in all enabled Availability Zones.
-                              If cross-zone load balancing is disabled, each load
-                              balancer node distributes requests evenly across the
-                              registered instances in its Availability Zone only.
-                              \n Defaults to false."
-                            type: boolean
-                          disableHostsRewrite:
-                            description: DisableHostsRewrite disabled the hair pinning
-                              issue solution that adds the NLB's address as 127.0.0.1
-                              to the hosts file of each instance. This is by default,
-                              false.
-                            type: boolean
-                          healthCheckProtocol:
-                            description: HealthCheckProtocol sets the protocol type
-                              for ELB health check target default value is ELBProtocolSSL
-                            enum:
-                            - TCP
-                            - SSL
-                            - HTTP
-                            - HTTPS
-                            - TLS
-                            - UDP
-                            type: string
                           loadBalancerType:
                             default: classic
                             description: LoadBalancerType sets the type for a load

--- a/docs/book/src/topics/bring-your-own-aws-infrastructure.md
+++ b/docs/book/src/topics/bring-your-own-aws-infrastructure.md
@@ -163,11 +163,12 @@ It's also possible to specify custom ingress rules for the control plane load ba
 
 ```yaml
 spec:
-  additionalIngressRules:
-    - description: "example ingress rule"
-      protocol: "-1" # all
-      fromPort: 7777
-      toPort: 7777
+  controlPlaneLoadBalancer:
+    ingressRules:
+      - description: "example ingress rule"
+        protocol: "-1" # all
+        fromPort: 7777
+        toPort: 7777
 ```
 
 > **WARNING:** Using an existing Classic ELB is an advanced feature. **If you use an existing Classic ELB, you must correctly configure it, and attach subnets to it.**


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

We would like to customize the ingress rules that are included in the security group created for the control plane Load Balancer. Currently, capa always adds an ingress rule to allow traffic towards the k8s api from everywhere (`0.0.0.0/0`). But we would like to have more control over this. We would like to only allow traffic coming from our VPNs.

With the changes in this PR, when no additional ingress rules are defined, we add the ingress rule to allow traffic from everywhere. That way we are backwards compatible. But when additional rules are defined, these will be used instead.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow customization of ingress rules in control plane Load Balancer security group
```
