### PR TITLE
fix: building release-binaries fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,7 @@ release-binary: $(RELEASE_DIR) versions.mk build-toolchain ## Release binary
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		$(TOOLCHAIN_IMAGE) \
+		git config --global --add safe.directory /workspace; \
 		go build -ldflags '$(LDFLAGS) -extldflags "-static"' \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH)$(EXT) $(RELEASE_BINARY)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind support


**What this PR does / why we need it**:

When doing the v2.1.3 there was an error when building the release binaries. Specifically the `release-binary` task was failing with the following error:

```
error obtaining vcs status exit status 128
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Thanks to @killianmuldoon  for the change in CAPI that we are using here.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits

**Release note**:

```release-note
Fix issue with building release binaries.
```
