### PR TITLE
chore: Bump golangci-lint to v1.53.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
     - bidichk
     - contextcheck
     - cyclop
+    - depguard
     - dupl
     - durationcheck
     - errname
@@ -87,8 +88,6 @@ linters-settings:
         alias: apiextensionsv1
       - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
         alias: metav1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
       - pkg: k8s.io/apimachinery/pkg/util/errors
         alias: kerrors
       - pkg: sigs.k8s.io/controller-runtime/pkg/conversion

--- a/api/v1beta2/awscluster_webhook_test.go
+++ b/api/v1beta2/awscluster_webhook_test.go
@@ -364,7 +364,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			g.Eventually(func() bool {
 				err := testEnv.Get(ctx, key, c)
 				return err == nil
-			}, 10*time.Second).Should(Equal(true))
+			}, 10*time.Second).Should(BeTrue())
 
 			if tt.expect != nil {
 				tt.expect(g, c.Spec.ControlPlaneLoadBalancer)

--- a/api/v1beta2/bastion.go
+++ b/api/v1beta2/bastion.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 )
 
 var (
@@ -51,12 +52,13 @@ func (b *Bastion) Validate() []*field.Error {
 
 func validateSSHKeyName(sshKeyName *string) field.ErrorList {
 	var allErrs field.ErrorList
+	sshKey := pointer.StringDeref(sshKeyName, "")
 	switch {
 	case sshKeyName == nil:
 	// nil is accepted
 	case sshKeyName != nil && *sshKeyName == "":
 	// empty string is accepted
-	case sshKeyName != nil && !sshKeyValidNameRegex.Match([]byte(*sshKeyName)):
+	case sshKeyName != nil && !sshKeyValidNameRegex.MatchString(sshKey):
 		allErrs = append(allErrs, field.Invalid(field.NewPath("sshKeyName"), sshKeyName, "Name is invalid. Must be specified in ASCII and must not start or end in whitespace"))
 	}
 	return allErrs

--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -218,7 +218,7 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 	if !conditions.IsTrue(cluster, clusterv1.ControlPlaneInitializedCondition) {
 		log.Info("Control Plane has not yet been initialized")
 		conditions.MarkFalse(config, eksbootstrapv1.DataSecretAvailableCondition, eksbootstrapv1.WaitingForControlPlaneInitializationReason, clusterv1.ConditionSeverityInfo, "")
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	controlPlane := &ekscontrolplanev1.AWSManagedControlPlane{}

--- a/bootstrap/eks/controllers/eksconfig_controller_test.go
+++ b/bootstrap/eks/controllers/eksconfig_controller_test.go
@@ -67,7 +67,7 @@ func TestEKSConfigReconcilerReturnEarlyIfClusterControlPlaneNotInitialized(t *te
 
 	g.Eventually(func(gomega Gomega) {
 		result, err := reconciler.joinWorker(context.Background(), cluster, config, configOwner("Machine"))
-		gomega.Expect(result).To(Equal(reconcile.Result{}))
+		gomega.Expect(result).To(Equal(reconcile.Result{RequeueAfter: 0, Requeue: true}))
 		gomega.Expect(err).NotTo(HaveOccurred())
 	}).Should(Succeed())
 }

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -191,14 +191,14 @@ func (r *AWSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Handle deleted clusters
 	if !awsCluster.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, clusterScope)
+		return reconcile.Result{}, r.reconcileDelete(ctx, clusterScope)
 	}
 
 	// Handle non-deleted clusters
 	return r.reconcileNormal(clusterScope)
 }
 
-func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
+func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *scope.ClusterScope) error {
 	clusterScope.Info("Reconciling AWSCluster delete")
 
 	ec2svc := r.getEC2Service(clusterScope)
@@ -217,39 +217,39 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 
 	if err := elbsvc.DeleteLoadbalancers(); err != nil {
 		clusterScope.Error(err, "error deleting load balancer")
-		return reconcile.Result{}, err
+		return err
 	}
 
 	if err := ec2svc.DeleteBastion(); err != nil {
 		clusterScope.Error(err, "error deleting bastion")
-		return reconcile.Result{}, err
+		return err
 	}
 
 	if err := sgService.DeleteSecurityGroups(); err != nil {
 		clusterScope.Error(err, "error deleting security groups")
-		return reconcile.Result{}, err
+		return err
 	}
 
 	if r.ExternalResourceGC {
 		gcSvc := gc.NewService(clusterScope, gc.WithGCStrategy(r.AlternativeGCStrategy))
 		if gcErr := gcSvc.ReconcileDelete(ctx); gcErr != nil {
-			return reconcile.Result{}, fmt.Errorf("failed delete reconcile for gc service: %w", gcErr)
+			return fmt.Errorf("failed delete reconcile for gc service: %w", gcErr)
 		}
 	}
 
 	if err := networkSvc.DeleteNetwork(); err != nil {
 		clusterScope.Error(err, "error deleting network")
-		return reconcile.Result{}, err
+		return err
 	}
 
 	if err := s3Service.DeleteBucket(); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "error deleting S3 Bucket")
+		return errors.Wrapf(err, "error deleting S3 Bucket")
 	}
 
 	// Cluster is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(clusterScope.AWSCluster, infrav1.ClusterFinalizer)
 
-	return reconcile.Result{}, nil
+	return nil
 }
 
 func (r *AWSClusterReconciler) reconcileNormal(clusterScope *scope.ClusterScope) (reconcile.Result, error) {

--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -98,7 +98,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			}
 			err := testEnv.Get(ctx, key, cluster)
 			return err == nil
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 
 		defer teardown()
 		defer t.Cleanup(func() {
@@ -197,7 +197,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			}
 			err := testEnv.Get(ctx, key, cluster)
 			return err == nil
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 
 		defer teardown()
 		defer t.Cleanup(func() {
@@ -303,7 +303,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			}
 			err := testEnv.Get(ctx, key, cluster)
 			return err == nil
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 		defer t.Cleanup(func() {
 			g.Expect(testEnv.Cleanup(ctx, &awsCluster, controllerIdentity, ns)).To(Succeed())
 		})
@@ -333,7 +333,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 		_, err = reconciler.reconcileNormal(cs)
 		g.Expect(err.Error()).To(ContainSubstring("The maximum number of VPCs has been reached"))
 
-		_, err = reconciler.reconcileDelete(ctx, cs)
+		err = reconciler.reconcileDelete(ctx, cs)
 		g.Expect(err).To(BeNil())
 	})
 	t.Run("Should successfully delete AWSCluster with managed VPC", func(t *testing.T) {
@@ -368,7 +368,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			}
 			err := testEnv.Get(ctx, key, cluster)
 			return err == nil
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 
 		defer t.Cleanup(func() {
 			g.Expect(testEnv.Cleanup(ctx, &awsCluster, controllerIdentity, ns)).To(Succeed())
@@ -410,7 +410,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			return sgSvc
 		}
 
-		_, err = reconciler.reconcileDelete(ctx, cs)
+		err = reconciler.reconcileDelete(ctx, cs)
 		g.Expect(err).To(BeNil())
 		expectAWSClusterConditions(g, cs.AWSCluster, []conditionAssertion{{infrav1.LoadBalancerReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletedReason},
 			{infrav1.BastionHostReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletedReason},

--- a/controllers/awscluster_controller_unit_test.go
+++ b/controllers/awscluster_controller_unit_test.go
@@ -412,7 +412,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					},
 				)
 				g.Expect(err).To(BeNil())
-				_, err = reconciler.reconcileDelete(ctx, cs)
+				err = reconciler.reconcileDelete(ctx, cs)
 				g.Expect(err).To(BeNil())
 				g.Expect(awsCluster.GetFinalizers()).ToNot(ContainElement(infrav1.ClusterFinalizer))
 			})
@@ -438,7 +438,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					},
 				)
 				g.Expect(err).To(BeNil())
-				_, err = reconciler.reconcileDelete(ctx, cs)
+				err = reconciler.reconcileDelete(ctx, cs)
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(awsCluster.GetFinalizers()).To(ContainElement(infrav1.ClusterFinalizer))
 			})
@@ -461,7 +461,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					},
 				)
 				g.Expect(err).To(BeNil())
-				_, err = reconciler.reconcileDelete(ctx, cs)
+				err = reconciler.reconcileDelete(ctx, cs)
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(awsCluster.GetFinalizers()).To(ContainElement(infrav1.ClusterFinalizer))
 			})
@@ -485,7 +485,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					},
 				)
 				g.Expect(err).To(BeNil())
-				_, err = reconciler.reconcileDelete(ctx, cs)
+				err = reconciler.reconcileDelete(ctx, cs)
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(awsCluster.GetFinalizers()).To(ContainElement(infrav1.ClusterFinalizer))
 			})
@@ -510,7 +510,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					},
 				)
 				g.Expect(err).To(BeNil())
-				_, err = reconciler.reconcileDelete(ctx, cs)
+				err = reconciler.reconcileDelete(ctx, cs)
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(awsCluster.GetFinalizers()).To(ContainElement(infrav1.ClusterFinalizer))
 			})
@@ -621,7 +621,7 @@ func createCluster(g *WithT, awsCluster *infrav1.AWSCluster, namespace string) {
 			}
 			err := testEnv.Get(ctx, key, cluster)
 			return err == nil
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 	}
 }
 

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -419,7 +419,7 @@ func createAWSMachine(g *WithT, awsMachine *infrav1.AWSMachine) {
 			Namespace: awsMachine.Namespace,
 		}
 		return testEnv.Get(ctx, key, machine) == nil
-	}, 10*time.Second).Should(Equal(true))
+	}, 10*time.Second).Should(BeTrue())
 }
 
 func getAWSMachine() *infrav1.AWSMachine {

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -52,7 +52,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
 )
@@ -287,9 +286,6 @@ func TestAWSMachineReconciler(t *testing.T) {
 			id := providerID
 			providerID := func(t *testing.T, g *WithT) {
 				t.Helper()
-				_, err := noderefutil.NewProviderID(id)
-				g.Expect(err).To(BeNil())
-
 				ms.AWSMachine.Spec.ProviderID = &id
 			}
 
@@ -2342,7 +2338,7 @@ func TestAWSMachineReconcilerReconcile(t *testing.T) {
 					}
 					err = testEnv.Get(ctx, key, machine)
 					return err == nil
-				}, 10*time.Second).Should(Equal(true))
+				}, 10*time.Second).Should(BeTrue())
 
 				result, err := reconciler.Reconcile(ctx, ctrl.Request{
 					NamespacedName: client.ObjectKey{

--- a/exp/controlleridentitycreator/awscontrolleridentity_controller_test.go
+++ b/exp/controlleridentitycreator/awscontrolleridentity_controller_test.go
@@ -54,6 +54,6 @@ func TestAWSControllerIdentityController(t *testing.T) {
 				return true
 			}
 			return false
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 	})
 }

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -454,7 +454,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 			expectedErr := errors.New("no connection available ")
 			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 
-			_, err := reconciler.reconcileDelete(ms, cs, cs)
+			err := reconciler.reconcileDelete(ms, cs, cs)
 			g.Expect(errors.Cause(err)).To(MatchError(expectedErr))
 		})
 		t.Run("should log and remove finalizer when no machinepool exists", func(t *testing.T) {
@@ -469,7 +469,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			_, err := reconciler.reconcileDelete(ms, cs, cs)
+			err := reconciler.reconcileDelete(ms, cs, cs)
 			g.Expect(err).To(BeNil())
 			g.Expect(buf.String()).To(ContainSubstring("Unable to locate ASG"))
 			g.Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
@@ -490,7 +490,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
-			_, err := reconciler.reconcileDelete(ms, cs, cs)
+			err := reconciler.reconcileDelete(ms, cs, cs)
 			g.Expect(err).To(BeNil())
 			g.Expect(ms.AWSMachinePool.Status.Ready).To(BeFalse())
 			g.Eventually(recorder.Events).Should(Receive(ContainSubstring("DeletionInProgress")))

--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -187,22 +187,21 @@ func (r *AWSManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctr
 	}()
 
 	if !awsPool.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, machinePoolScope, managedControlPlaneScope)
+		return ctrl.Result{}, r.reconcileDelete(ctx, machinePoolScope, managedControlPlaneScope)
 	}
 
-	return r.reconcileNormal(ctx, machinePoolScope, managedControlPlaneScope)
+	return ctrl.Result{}, r.reconcileNormal(ctx, machinePoolScope, managedControlPlaneScope)
 }
 
 func (r *AWSManagedMachinePoolReconciler) reconcileNormal(
 	ctx context.Context,
 	machinePoolScope *scope.ManagedMachinePoolScope,
-	ec2Scope scope.EC2Scope,
-) (ctrl.Result, error) {
+	ec2Scope scope.EC2Scope) error {
 	machinePoolScope.Info("Reconciling AWSManagedMachinePool")
 
 	if controllerutil.AddFinalizer(machinePoolScope.ManagedMachinePool, expinfrav1.ManagedMachinePoolFinalizer) {
 		if err := machinePoolScope.PatchObject(); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -220,7 +219,7 @@ func (r *AWSManagedMachinePoolReconciler) reconcileNormal(
 			r.Recorder.Eventf(machinePoolScope.ManagedMachinePool, corev1.EventTypeWarning, "FailedLaunchTemplateReconcile", "Failed to reconcile launch template: %v", err)
 			machinePoolScope.Error(err, "failed to reconcile launch template")
 			conditions.MarkFalse(machinePoolScope.ManagedMachinePool, expinfrav1.LaunchTemplateReadyCondition, expinfrav1.LaunchTemplateReconcileFailedReason, clusterv1.ConditionSeverityError, "")
-			return ctrl.Result{}, err
+			return err
 		}
 
 		launchTemplateID := machinePoolScope.GetLaunchTemplateIDStatus()
@@ -229,7 +228,7 @@ func (r *AWSManagedMachinePoolReconciler) reconcileNormal(
 			ResourceService: ec2svc,
 		}}
 		if err := ec2svc.ReconcileTags(machinePoolScope, resourceServiceToUpdate); err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "error updating tags")
+			return errors.Wrap(err, "error updating tags")
 		}
 
 		// set the LaunchTemplateReady condition
@@ -237,44 +236,43 @@ func (r *AWSManagedMachinePoolReconciler) reconcileNormal(
 	}
 
 	if err := ekssvc.ReconcilePool(ctx); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile machine pool for AWSManagedMachinePool %s/%s", machinePoolScope.ManagedMachinePool.Namespace, machinePoolScope.ManagedMachinePool.Name)
+		return errors.Wrapf(err, "failed to reconcile machine pool for AWSManagedMachinePool %s/%s", machinePoolScope.ManagedMachinePool.Namespace, machinePoolScope.ManagedMachinePool.Name)
 	}
 
-	return ctrl.Result{}, nil
+	return nil
 }
 
 func (r *AWSManagedMachinePoolReconciler) reconcileDelete(
 	_ context.Context,
 	machinePoolScope *scope.ManagedMachinePoolScope,
-	ec2Scope scope.EC2Scope,
-) (ctrl.Result, error) {
+	ec2Scope scope.EC2Scope) error {
 	machinePoolScope.Info("Reconciling deletion of AWSManagedMachinePool")
 
 	ekssvc := eks.NewNodegroupService(machinePoolScope)
 	ec2Svc := ec2.NewService(ec2Scope)
 
 	if err := ekssvc.ReconcilePoolDelete(); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile machine pool deletion for AWSManagedMachinePool %s/%s", machinePoolScope.ManagedMachinePool.Namespace, machinePoolScope.ManagedMachinePool.Name)
+		return errors.Wrapf(err, "failed to reconcile machine pool deletion for AWSManagedMachinePool %s/%s", machinePoolScope.ManagedMachinePool.Namespace, machinePoolScope.ManagedMachinePool.Name)
 	}
 
 	if machinePoolScope.ManagedMachinePool.Spec.AWSLaunchTemplate != nil {
 		launchTemplateID := machinePoolScope.ManagedMachinePool.Status.LaunchTemplateID
 		launchTemplate, _, err := ec2Svc.GetLaunchTemplate(machinePoolScope.LaunchTemplateName())
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 
 		if launchTemplate == nil {
 			machinePoolScope.Debug("Unable to find matching launch template")
 			r.Recorder.Eventf(machinePoolScope.ManagedMachinePool, corev1.EventTypeNormal, "NoLaunchTemplateFound", "Unable to find matching launch template")
 			controllerutil.RemoveFinalizer(machinePoolScope.ManagedMachinePool, expinfrav1.ManagedMachinePoolFinalizer)
-			return ctrl.Result{}, nil
+			return nil
 		}
 
 		machinePoolScope.Info("deleting launch template", "name", launchTemplate.Name)
 		if err := ec2Svc.DeleteLaunchTemplate(*launchTemplateID); err != nil {
 			r.Recorder.Eventf(machinePoolScope.ManagedMachinePool, corev1.EventTypeWarning, "FailedDelete", "Failed to delete launch template %q: %v", launchTemplate.Name, err)
-			return ctrl.Result{}, errors.Wrap(err, "failed to delete launch template")
+			return errors.Wrap(err, "failed to delete launch template")
 		}
 
 		machinePoolScope.Info("successfully deleted launch template")
@@ -282,7 +280,7 @@ func (r *AWSManagedMachinePoolReconciler) reconcileDelete(
 
 	controllerutil.RemoveFinalizer(machinePoolScope.ManagedMachinePool, expinfrav1.ManagedMachinePoolFinalizer)
 
-	return reconcile.Result{}, nil
+	return nil
 }
 
 // GetOwnerClusterKey returns only the Cluster name and namespace.

--- a/exp/instancestate/awsinstancestate_controller_test.go
+++ b/exp/instancestate/awsinstancestate_controller_test.go
@@ -135,7 +135,7 @@ func TestAWSInstanceStateController(t *testing.T) {
 				exist = exist && ok
 			}
 			return exist
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 
 		deleteAWSCluster(g, "aws-cluster-2")
 		t.Log("Ensuring we stop tracking deleted queue")
@@ -153,7 +153,7 @@ func TestAWSInstanceStateController(t *testing.T) {
 				exist = exist && ok
 			}
 			return exist
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 
 		t.Log("Ensuring machine is labelled with correct instance state")
 		g.Eventually(func() bool {
@@ -166,7 +166,7 @@ func TestAWSInstanceStateController(t *testing.T) {
 			labels := m.GetLabels()
 			val := labels[Ec2InstanceStateLabelKey]
 			return val == "shutting-down"
-		}, 10*time.Second).Should(Equal(true))
+		}, 10*time.Second).Should(BeTrue())
 	})
 }
 

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -45,7 +45,7 @@ ifeq ($(OS), windows)
 	MDBOOK_EXTRACT_COMMAND := unzip -d /tmp
 endif
 
-GOLANGCI_LINT_VERSION := v1.52.2
+GOLANGCI_LINT_VERSION := v1.53.2
 ## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -238,7 +238,7 @@ func TestGetAPIServerClassicELBSpecControlPlaneLoadBalancer(t *testing.T) {
 			expect: func(t *testing.T, g *WithT, res *infrav1.LoadBalancer) {
 				t.Helper()
 				expectedTarget := fmt.Sprintf("%v:%d", infrav1.ELBProtocolTCP, infrav1.DefaultAPIServerPort)
-				g.Expect(expectedTarget, res.HealthCheck.Target)
+				g.Expect(expectedTarget).To(Equal(res.HealthCheck.Target))
 			},
 		},
 		{
@@ -247,8 +247,8 @@ func TestGetAPIServerClassicELBSpecControlPlaneLoadBalancer(t *testing.T) {
 			mocks: func(m *mocks.MockEC2APIMockRecorder) {},
 			expect: func(t *testing.T, g *WithT, res *infrav1.LoadBalancer) {
 				t.Helper()
-				expectedTarget := fmt.Sprintf("%v:%d", infrav1.ELBProtocolTCP, infrav1.DefaultAPIServerPort)
-				g.Expect(expectedTarget, res.HealthCheck.Target)
+				expectedTarget := fmt.Sprintf("%v:%d", infrav1.ELBProtocolSSL, infrav1.DefaultAPIServerPort)
+				g.Expect(expectedTarget).To(Equal(res.HealthCheck.Target))
 			},
 		},
 	}

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -646,7 +646,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 					machineList := getAWSMachinesForDeployment(ns2.Name, *md2[0])
 					labels := machineList.Items[0].GetLabels()
 					return labels[instancestate.Ec2InstanceStateLabelKey] == string(infrav1.InstanceStateTerminated)
-				}, e2eCtx.E2EConfig.GetIntervals("", "wait-machine-status")...).Should(Equal(true))
+				}, e2eCtx.E2EConfig.GetIntervals("", "wait-machine-status")...).Should(BeTrue())
 
 				ginkgo.By("Waiting for machine to reach Failed state")
 				statusChecks := []framework.MachineStatusCheck{framework.MachinePhaseCheck(string(clusterv1.MachinePhaseFailed))}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support


**What this PR does / why we need it**:
bump golangci-lint to v1.53.2 and fix errors related to that.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Comments _Originally posted by @richardcase in https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4321#pullrequestreview-1471233824_ addressed. For one of the comments: _Originally posted by @Ankitasw in https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4321#issuecomment-1584001902_

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump golangci-lint to v1.53.2
```
