### PR TITLE
E2E tests for AlternativeGCStrategy

### DIFF
--- a/test/e2e/suites/gc_managed/gc_managed_test.go
+++ b/test/e2e/suites/gc_managed/gc_managed_test.go
@@ -159,6 +159,135 @@ var _ = ginkgo.Describe("[managed] [gc] EKS Cluster external resource GC tests",
 		Expect(err).NotTo(HaveOccurred())
 		Expect(arns).To(BeEmpty(), "there are %d service load balancers (elb) still", len(arns))
 	})
+
+	ginkgo.It("[managed] [gc] should cleanup a cluster that has ELB/NLB load balancers using AlternativeGCStrategy", func() {
+		ginkgo.By("should have a valid test configuration")
+		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
+		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
+
+		ctx = context.TODO()
+		shared.ReconfigureDeployment(ctx, shared.ReconfigureDeploymentInput{
+			Getter:       e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			ClientSet:    e2eCtx.Environment.BootstrapClusterProxy.GetClientSet(),
+			Name:         "capa-controller-manager",
+			Namespace:    "capa-system",
+			WaitInterval: e2eCtx.E2EConfig.GetIntervals("", "wait-deployment-ready"),
+		}, shared.EnableAlternativeGCStrategy, shared.ValidateAlternativeGCStrategyEnabled)
+
+		specName += "-alterstrategy"
+		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+
+		ginkgo.By("default iam role should exist")
+		ms.VerifyRoleExistsAndOwned(ekscontrolplanev1.DefaultEKSControlPlaneRole, clusterName, false, e2eCtx.BootstrapUserAWSSession)
+
+		ginkgo.By("should create an EKS control plane")
+		ms.ManagedClusterSpec(ctx, func() ms.ManagedClusterSpecInput {
+			return ms.ManagedClusterSpecInput{
+				E2EConfig:                e2eCtx.E2EConfig,
+				ConfigClusterFn:          defaultConfigCluster,
+				BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
+				AWSSession:               e2eCtx.BootstrapUserAWSSession,
+				Namespace:                namespace,
+				ClusterName:              clusterName,
+				Flavour:                  ms.EKSManagedPoolFlavor,
+				ControlPlaneMachineCount: 1, // NOTE: this cannot be zero as clusterctl returns an error
+				WorkerMachineCount:       1,
+			}
+		})
+
+		ginkgo.By(fmt.Sprintf("getting cluster with name %s", clusterName))
+		cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+			Getter:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Namespace: namespace.Name,
+			Name:      clusterName,
+		})
+		Expect(cluster).NotTo(BeNil(), "couldn't find cluster")
+
+		ginkgo.By("getting AWSManagedControlPlane")
+		cp := ms.GetControlPlaneByName(ctx, ms.GetControlPlaneByNameInput{
+			Getter:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Namespace: cluster.Spec.InfrastructureRef.Namespace,
+			Name:      cluster.Spec.ControlPlaneRef.Name,
+		})
+
+		ginkgo.By("Waiting for the machine pool to be running")
+		mp := framework.DiscoveryAndWaitForMachinePools(ctx, framework.DiscoveryAndWaitForMachinePoolsInput{
+			Lister:  e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Getter:  e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-worker-nodes")...)
+		Expect(len(mp)).To(Equal(1))
+
+		workloadClusterProxy := e2eCtx.Environment.BootstrapClusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name)
+		workloadYamlPath := e2eCtx.E2EConfig.GetVariable(shared.GcWorkloadPath)
+		ginkgo.By(fmt.Sprintf("Installing sample workload with load balancer services: %s", workloadYamlPath))
+		workloadYaml, err := os.ReadFile(workloadYamlPath) //nolint:gosec
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(workloadClusterProxy.Apply(ctx, workloadYaml)).ShouldNot(HaveOccurred())
+
+		ginkgo.By("Waiting for the Deployment to be available")
+		shared.WaitForDeploymentsAvailable(ctx, shared.WaitForDeploymentsAvailableInput{
+			Getter:    workloadClusterProxy.GetClient(),
+			Name:      "podinfo",
+			Namespace: "default",
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-deployment-ready")...)
+
+		ginkgo.By("Checking we have the load balancers in AWS")
+		shared.WaitForLoadBalancerToExistForService(shared.WaitForLoadBalancerToExistForServiceInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-nlb",
+			ServiceNamespace: "default",
+			ClusterName:      cp.Spec.EKSClusterName,
+			Type:             infrav1.LoadBalancerTypeNLB,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-loadbalancer-ready")...)
+		shared.WaitForLoadBalancerToExistForService(shared.WaitForLoadBalancerToExistForServiceInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-elb",
+			ServiceNamespace: "default",
+			ClusterName:      cp.Spec.EKSClusterName,
+			Type:             infrav1.LoadBalancerTypeELB,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-loadbalancer-ready")...)
+
+		ginkgo.By(fmt.Sprintf("Deleting workload/tenant cluster %s", clusterName))
+		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+			Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
+		})
+		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+			Getter:  e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
+
+		ginkgo.By("Getting counts of service load balancers")
+		arns, err := shared.GetLoadBalancerARNs(shared.GetLoadBalancerARNsInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-nlb",
+			ServiceNamespace: "default",
+			ClusterName:      cp.Spec.EKSClusterName,
+			Type:             infrav1.LoadBalancerTypeNLB,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arns).To(BeEmpty(), "there are %d service load balancers (nlb) still", len(arns))
+		arns, err = shared.GetLoadBalancerARNs(shared.GetLoadBalancerARNsInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-elb",
+			ServiceNamespace: "default",
+			ClusterName:      cp.Spec.EKSClusterName,
+			Type:             infrav1.LoadBalancerTypeELB,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arns).To(BeEmpty(), "there are %d service load balancers (elb) still", len(arns))
+
+		shared.ReconfigureDeployment(ctx, shared.ReconfigureDeploymentInput{
+			Getter:       e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			ClientSet:    e2eCtx.Environment.BootstrapClusterProxy.GetClientSet(),
+			Name:         "capa-controller-manager",
+			Namespace:    "capa-system",
+			WaitInterval: e2eCtx.E2EConfig.GetIntervals("", "wait-deployment-ready"),
+		}, shared.DisableAlternativeGCStrategy, shared.ValidateAlternativeGCStrategyDisabled)
+	})
 })
 
 // TODO (richardcase): remove this when we merge these tests with the main eks e2e tests.

--- a/test/e2e/suites/gc_unmanaged/gc_unmanaged_test.go
+++ b/test/e2e/suites/gc_unmanaged/gc_unmanaged_test.go
@@ -67,7 +67,6 @@ var _ = ginkgo.Context("[unmanaged] [gc]", func() {
 		clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 
 		configCluster := defaultConfigCluster(clusterName, namespace.Name)
-		configCluster.KubernetesVersion = e2eCtx.E2EConfig.GetVariable(shared.PreCSIKubernetesVer)
 		configCluster.WorkerMachineCount = pointer.Int64(1)
 		createCluster(ctx, configCluster, result)
 
@@ -138,6 +137,118 @@ var _ = ginkgo.Context("[unmanaged] [gc]", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(arns).To(BeEmpty(), "there are %d service load balancers (elb) still", len(arns))
+	})
+
+	ginkgo.It("[unmanaged] [gc] should cleanup a cluster that has ELB/NLB load balancers using AlternativeGCStrategy", func() {
+		ginkgo.By("should have a valid test configuration")
+		specName := "unmanaged-gc-alterstrategy-cluster"
+
+		ctx = context.TODO()
+		result = &clusterctl.ApplyClusterTemplateAndWaitResult{}
+
+		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
+		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
+
+		shared.ReconfigureDeployment(ctx, shared.ReconfigureDeploymentInput{
+			Getter:       e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			ClientSet:    e2eCtx.Environment.BootstrapClusterProxy.GetClientSet(),
+			Name:         "capa-controller-manager",
+			Namespace:    "capa-system",
+			WaitInterval: e2eCtx.E2EConfig.GetIntervals("", "wait-deployment-ready"),
+		}, shared.EnableAlternativeGCStrategy, shared.ValidateAlternativeGCStrategyEnabled)
+
+		requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1, EventBridgeRules: 50}
+		requiredResources.WriteRequestedResources(e2eCtx, specName)
+		Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		defer shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+		namespace := shared.SetupNamespace(ctx, specName, e2eCtx)
+		defer shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+		ginkgo.By("Creating cluster with single control plane")
+		clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+
+		configCluster := defaultConfigCluster(clusterName, namespace.Name)
+		configCluster.WorkerMachineCount = pointer.Int64(1)
+		c, md, cp := createCluster(ctx, configCluster, result)
+		Expect(c).NotTo(BeNil(), "Expecting cluster created")
+		Expect(len(md)).To(Equal(1), "Expecting one MachineDeployment")
+		Expect(cp).NotTo(BeNil(), "Expecting control plane created")
+
+		ginkgo.By(fmt.Sprintf("getting cluster with name %s", clusterName))
+		cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+			Getter:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Namespace: namespace.Name,
+			Name:      clusterName,
+		})
+		Expect(cluster).NotTo(BeNil(), "couldn't find cluster")
+
+		workloadClusterProxy := e2eCtx.Environment.BootstrapClusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name)
+		workloadYamlPath := e2eCtx.E2EConfig.GetVariable(shared.GcWorkloadPath)
+		ginkgo.By(fmt.Sprintf("Installing sample workload with load balancer services: %s", workloadYamlPath))
+		workloadYaml, err := os.ReadFile(workloadYamlPath) //nolint:gosec
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(workloadClusterProxy.Apply(ctx, workloadYaml)).ShouldNot(HaveOccurred())
+
+		ginkgo.By("Waiting for the Deployment to be available")
+		shared.WaitForDeploymentsAvailable(ctx, shared.WaitForDeploymentsAvailableInput{
+			Getter:    workloadClusterProxy.GetClient(),
+			Name:      "podinfo",
+			Namespace: "default",
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-deployment-ready")...)
+
+		ginkgo.By("Checking we have the load balancers in AWS")
+		shared.WaitForLoadBalancerToExistForService(shared.WaitForLoadBalancerToExistForServiceInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-nlb",
+			ServiceNamespace: "default",
+			ClusterName:      clusterName,
+			Type:             infrav1.LoadBalancerTypeNLB,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-loadbalancer-ready")...)
+		shared.WaitForLoadBalancerToExistForService(shared.WaitForLoadBalancerToExistForServiceInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-elb",
+			ServiceNamespace: "default",
+			ClusterName:      clusterName,
+			Type:             infrav1.LoadBalancerTypeELB,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-loadbalancer-ready")...)
+
+		ginkgo.By(fmt.Sprintf("Deleting workload/tenant cluster %s", clusterName))
+		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+			Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
+		})
+		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+			Getter:  e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
+
+		ginkgo.By("Getting counts of service load balancers")
+		arns, err := shared.GetLoadBalancerARNs(shared.GetLoadBalancerARNsInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-nlb",
+			ServiceNamespace: "default",
+			ClusterName:      clusterName,
+			Type:             infrav1.LoadBalancerTypeNLB,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arns).To(BeEmpty(), "there are %d service load balancers (nlb) still", len(arns))
+		arns, err = shared.GetLoadBalancerARNs(shared.GetLoadBalancerARNsInput{
+			AWSSession:       e2eCtx.BootstrapUserAWSSession,
+			ServiceName:      "podinfo-elb",
+			ServiceNamespace: "default",
+			ClusterName:      clusterName,
+			Type:             infrav1.LoadBalancerTypeELB,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arns).To(BeEmpty(), "there are %d service load balancers (elb) still", len(arns))
+
+		shared.ReconfigureDeployment(ctx, shared.ReconfigureDeploymentInput{
+			Getter:       e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			ClientSet:    e2eCtx.Environment.BootstrapClusterProxy.GetClientSet(),
+			Name:         "capa-controller-manager",
+			Namespace:    "capa-system",
+			WaitInterval: e2eCtx.E2EConfig.GetIntervals("", "wait-deployment-ready"),
+		}, shared.DisableAlternativeGCStrategy, shared.ValidateAlternativeGCStrategyDisabled)
 	})
 })
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Add two e2e for AlternativeGCStrategy feature

- [managed] [gc] should cleanup a cluster that has ELB/NLB load balancers using AlternativeGCStrategy
- [unmanaged] [gc] should cleanup a cluster that has ELB/NLB load balancers using AlternativeGCStrategy

They have exact same test steps with ` [managed] [gc] should cleanup a cluster that has ELB/NLB load balancers` and `[unmanaged] [gc] should cleanup a cluster that has ELB/NLB load balancers`, except that before creating workload cluster, `shared.ReconfigureDeployment` is executed to reconfigure capa deployment with AlternativeGCStrategy feature flag set to true and will recover capa after test is done

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4161

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add E2E tests for AlternativeGCStrategy
```
