### PR TITLE
[E2E] update the client so it can handle using local AWS credentials

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -813,7 +813,12 @@ func newUserAccessKey(prov client.ConfigProvider, userName string) *iam.AccessKe
 }
 
 func DumpCloudTrailEvents(e2eCtx *E2EContext) {
-	client := cloudtrail.New(e2eCtx.BootstrapUserAWSSession)
+	var client *cloudtrail.CloudTrail
+	if e2eCtx.BootstrapUserAWSSession == nil {
+		client = cloudtrail.New(e2eCtx.AWSSession)
+	} else {
+		client = cloudtrail.New(e2eCtx.BootstrapUserAWSSession)
+	}
 	events := []*cloudtrail.Event{}
 	err := client.LookupEventsPages(
 		&cloudtrail.LookupEventsInput{


### PR DESCRIPTION
update the client so it can handle using local AWS credentials and not need the bootstrap credentials

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When using VScode for developing, my launch template was attempting to use my local AWS credentials (AWS_PROFILE).  However, this wasnt working as the code is reliant upon the b64 encoded credentials. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No Issue filed

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[E2E] Allows use of local AWS credentials instead of being reliant upon the bootstrap credentials
```
