### PR TITLE
Use default arch x86_64 for AMI lookup if `ec2:DescribeInstanceTypes` permission is missing

### DIFF
--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -50,6 +50,7 @@ const (
 	RouteTableNotFound                      = "InvalidRouteTableID.NotFound"
 	SubnetNotFound                          = "InvalidSubnetID.NotFound"
 	UnrecognizedClientException             = "UnrecognizedClientException"
+	UnauthorizedOperation                   = "UnauthorizedOperation"
 	VPCNotFound                             = "InvalidVpcID.NotFound"
 	VPCMissingParameter                     = "MissingParameter"
 	ErrCodeRepositoryAlreadyExistsException = "RepositoryAlreadyExistsException"
@@ -169,6 +170,15 @@ func IsInvalidNotFoundError(err error) bool {
 		case LaunchTemplateNameNotFound:
 			return true
 		}
+	}
+
+	return false
+}
+
+// IsPermissionsError tests for common aws permission errors.
+func IsPermissionsError(err error) bool {
+	if code, ok := Code(err); ok {
+		return code == AuthFailure || code == UnauthorizedOperation
 	}
 
 	return false


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

when upgrading to v2.1.2 we encountered the following error:
```
- lastTransitionTime: "2023-06-14T11:25:42Z"
    message: "failed to create AWSMachine instance: UnauthorizedOperation: You are
      not authorized to perform this operation.\n\tstatus code: 403, request id: 8b50824a-16ab-40cf-b737-47cb80ad34e4"
    reason: InstanceProvisionFailed
    severity: Error
    status: "False"
    type: InstanceReady
 ```
the message doesn't really provide any hints on the cause. After some investigation we found the issue to be a missing `ec2:DescribeInstanceTypes` permission which was introduced here https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4054. However, new permissions should not be required by a new version of the controller.

This PR warns the user about permissions error (i.e. missing `ec2:DescribeInstanceTypes`) and returns the default arch `x86_64` instead of failing. Also provide a better error message for other types of errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4342

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use default arch x86_64 for AMI lookup if `ec2:DescribeInstanceTypes` permission is missing
```
