### PR TITLE
Multiple instance types for managed machine pools

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -703,8 +703,18 @@ spec:
                   and name of the managed machine pool.
                 type: string
               instanceType:
-                description: InstanceType specifies the AWS instance type
+                description: InstanceType specifies the AWS instance type. This field
+                  is deprecated. Use InstanceTypes instead.
                 type: string
+              instanceTypes:
+                description: InstanceTypes specifies the AWS instance types which
+                  could be part of the machine pool. The order of instance types specified
+                  determines priority of picking that instance type. This is also
+                  influenced by the CapacityType. See AWS documentation https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
+                  for more information.
+                items:
+                  type: string
+                type: array
               labels:
                 additionalProperties:
                   type: string

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -716,6 +716,7 @@ func autoConvert_v1beta2_AWSManagedMachinePoolSpec_To_v1beta1_AWSManagedMachineP
 	out.Taints = *(*Taints)(unsafe.Pointer(&in.Taints))
 	out.DiskSize = (*int32)(unsafe.Pointer(in.DiskSize))
 	out.InstanceType = (*string)(unsafe.Pointer(in.InstanceType))
+	// WARNING: in.InstanceTypes requires manual conversion: does not exist in peer-type
 	out.Scaling = (*ManagedMachinePoolScaling)(unsafe.Pointer(in.Scaling))
 	out.RemoteAccess = (*ManagedRemoteAccess)(unsafe.Pointer(in.RemoteAccess))
 	out.ProviderIDList = *(*[]string)(unsafe.Pointer(&in.ProviderIDList))

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -116,9 +116,17 @@ type AWSManagedMachinePoolSpec struct {
 	// +optional
 	DiskSize *int32 `json:"diskSize,omitempty"`
 
-	// InstanceType specifies the AWS instance type
+	// InstanceType specifies the AWS instance type.
+	// This field is deprecated. Use InstanceTypes instead.
 	// +optional
 	InstanceType *string `json:"instanceType,omitempty"`
+
+	// InstanceTypes specifies the AWS instance types which could be part of the machine pool. The order of instance
+	// types specified determines priority of picking that instance type. This is also influenced by the CapacityType.
+	// See AWS documentation https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
+	// for more information.
+	// +optional
+	InstanceTypes []string `json:"instanceTypes,omitempty"`
 
 	// Scaling specifies scaling for the ASG behind this pool
 	// +optional

--- a/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
@@ -139,6 +139,17 @@ func TestAWSManagedMachinePoolValidateCreate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "both instanceType and instanceTypes are specified",
+			pool: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-3",
+					InstanceTypes:    []string{"m5.xlarge", "m5.2xlarge"},
+					InstanceType:     pointer.String("m5.xlarge"),
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -252,6 +263,23 @@ func TestAWSManagedMachinePoolValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "adding both instanceType and instanceTypes is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceType:     pointer.String("m5.xlarge"),
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceType:     pointer.String("m5.xlarge"),
+					InstanceTypes:    []string{"m5.xlarge", "m6.xlarge"},
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -430,6 +430,11 @@ func (in *AWSManagedMachinePoolSpec) DeepCopyInto(out *AWSManagedMachinePoolSpec
 		*out = new(string)
 		**out = **in
 	}
+	if in.InstanceTypes != nil {
+		in, out := &in.InstanceTypes, &out.InstanceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Scaling != nil {
 		in, out := &in.Scaling, &out.Scaling
 		*out = new(ManagedMachinePoolScaling)

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -227,6 +227,10 @@ func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 	if managedPool.InstanceType != nil {
 		input.InstanceTypes = []*string{managedPool.InstanceType}
 	}
+	for _, instanceType := range managedPool.InstanceTypes {
+		input.InstanceTypes = append(input.InstanceTypes, aws.String(instanceType))
+	}
+
 	if len(managedPool.Taints) > 0 {
 		s.Info("adding taints to nodegroup", "nodegroup", nodegroupName)
 		taints, err := converters.TaintsToSDK(managedPool.Taints)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

EKS node groups support [multiple instance types](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateNodegroup.html#API_CreateNodegroup_RequestSyntax). The order of the instance types and capacity type together determine which instances are created by AWS when the node group is scaled up. Also added validation so that both fields `instanceType` and `instanceTypes` cannot be specified together. . Added this as a new field to the `AWSManagedMachinePool` in in version `v1beta2`. 

Fixes #3585 

**Special notes for your reviewer**:
This new field does not exist in the older `v1beta1` type of `AWSManagedMachinePool`. I'm not sure if it is even needed because the older single instance type field is still present. However code-gen complains that this field is not properly converted. Note that `v1beta2` is the stored version so there's no chance for a loss of data.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
NONE
```
