### PR TITLE
:bug: compare string value of protocol in health check instead of pointer

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1438,7 +1438,7 @@ func (s *Service) getHealthCheckTarget() string {
 	protocol := &infrav1.ELBProtocolSSL
 	if controlPlaneELB != nil && controlPlaneELB.HealthCheckProtocol != nil {
 		protocol = controlPlaneELB.HealthCheckProtocol
-		if protocol == &infrav1.ELBProtocolHTTP || protocol == &infrav1.ELBProtocolHTTPS {
+		if protocol.String() == infrav1.ELBProtocolHTTP.String() || protocol.String() == infrav1.ELBProtocolHTTPS.String() {
 			return fmt.Sprintf("%v:%d/readyz", protocol, infrav1.DefaultAPIServerPort)
 		}
 	}

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -2317,6 +2317,10 @@ func TestChunkELBs(t *testing.T) {
 }
 
 func TestGetHealthCheckProtocol(t *testing.T) {
+	testHTTP := infrav1.ELBProtocol("HTTP")
+	testHTTPS := infrav1.ELBProtocol("HTTPS")
+	testTCP := infrav1.ELBProtocol("TCP")
+
 	tests := []struct {
 		testName                  string
 		lbSpec                    *infrav1.AWSLoadBalancerSpec
@@ -2330,21 +2334,21 @@ func TestGetHealthCheckProtocol(t *testing.T) {
 		{
 			"protocol http",
 			&infrav1.AWSLoadBalancerSpec{
-				HealthCheckProtocol: &infrav1.ELBProtocolHTTP,
+				HealthCheckProtocol: &testHTTP,
 			},
 			"HTTP:6443/readyz",
 		},
 		{
 			"protocol https",
 			&infrav1.AWSLoadBalancerSpec{
-				HealthCheckProtocol: &infrav1.ELBProtocolHTTPS,
+				HealthCheckProtocol: &testHTTPS,
 			},
 			"HTTPS:6443/readyz",
 		},
 		{
 			"protocol tcp",
 			&infrav1.AWSLoadBalancerSpec{
-				HealthCheckProtocol: &infrav1.ELBProtocolTCP,
+				HealthCheckProtocol: &testTCP,
 			},
 			"TCP:6443",
 		},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug 

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

when a user specified healthCheck to be HTTPS or HTTP they would see an error like this in the logs 

```
failed to configure health check for classic load balancer: &{<redacted object>}: ValidationError: HealthCheck HTTPS Target must specify a port followed by a path that begins with a slash. e.g. HTTP:80/ping/this/path 
```

This was because the comparison on line 1441 of this file was comparing the addresses of the ELBHealthCheck, rather than the object. That comparison always failed and so the value from line 1445 was always returned. 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes an error for HTTPS and HTTP health checks for classic ELBs 
```
