### PR TITLE
Pass right SGs for IsExternallyManaged on creation

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -401,7 +401,14 @@ func (s *Service) getFilteredSubnets(criteria ...*ec2.Filter) ([]*ec2.Subnet, er
 // They are considered "core" to its proper functioning.
 func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, error) {
 	if scope.IsExternallyManaged() {
-		return nil, nil
+		ids := make([]string, 0)
+		for _, sg := range scope.AWSMachine.Spec.AdditionalSecurityGroups {
+			if sg.ID == nil {
+				continue
+			}
+			ids = append(ids, *sg.ID)
+		}
+		return ids, nil
 	}
 
 	// These are common across both controlplane and node machines


### PR DESCRIPTION
When IsExternallyManaged we want to make sure additionalSecurityGroups are passed on creation to satisfy user intent. This also prevents the default VPC SG from silently attached to the ec2 and so deviating even more from user intent.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4361

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
When IsExternallyManaged create instance request uses additionaSecurityGroups
```
