### PR TITLE
Improve AWSMachinePool diff to default to existing values when comparing launch templates

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -404,9 +404,16 @@ func (r *AWSMachinePoolReconciler) updatePool(machinePoolScope *scope.MachinePoo
 		"subnets of machinePoolScope", subnetIDs,
 		"subnets of existing asg", existingASG.Subnets)
 	less := func(a, b string) bool { return a < b }
-	subnetChanges := cmp.Diff(subnetIDs, existingASG.Subnets, cmpopts.SortSlices(less)) != ""
+	subnetDiff := cmp.Diff(subnetIDs, existingASG.Subnets, cmpopts.SortSlices(less))
+	if subnetDiff != "" {
+		machinePoolScope.Debug("asg subnet diff detected", "diff", subnetDiff)
+	}
 
-	if asgNeedsUpdates(machinePoolScope, existingASG) || subnetChanges {
+	asgDiff := diffASG(machinePoolScope, existingASG)
+	if asgDiff != "" {
+		machinePoolScope.Debug("asg diff detected", "diff", subnetDiff)
+	}
+	if asgDiff != "" || subnetDiff != "" {
 		machinePoolScope.Info("updating AutoScalingGroup")
 
 		if err := asgSvc.UpdateASG(machinePoolScope); err != nil {
@@ -493,36 +500,37 @@ func (r *AWSMachinePoolReconciler) findASG(machinePoolScope *scope.MachinePoolSc
 	return asg, nil
 }
 
-// asgNeedsUpdates compares incoming AWSMachinePool and compares against existing ASG.
-func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *expinfrav1.AutoScalingGroup) bool {
+// diffASG compares incoming AWSMachinePool and compares against existing ASG.
+func diffASG(machinePoolScope *scope.MachinePoolScope, existingASG *expinfrav1.AutoScalingGroup) string {
+	detectedMachinePoolSpec := machinePoolScope.MachinePool.Spec.DeepCopy()
+
 	if !scope.ReplicasExternallyManaged(machinePoolScope.MachinePool) {
-		if machinePoolScope.MachinePool.Spec.Replicas != nil {
-			if existingASG.DesiredCapacity == nil || *machinePoolScope.MachinePool.Spec.Replicas != *existingASG.DesiredCapacity {
-				return true
-			}
-		} else if existingASG.DesiredCapacity != nil {
-			return true
+		detectedMachinePoolSpec.Replicas = existingASG.DesiredCapacity
+	}
+	if diff := cmp.Diff(machinePoolScope.MachinePool.Spec, *detectedMachinePoolSpec); diff != "" {
+		return diff
+	}
+
+	detectedAWSMachinePoolSpec := machinePoolScope.AWSMachinePool.Spec.DeepCopy()
+	detectedAWSMachinePoolSpec.MaxSize = existingASG.MaxSize
+	detectedAWSMachinePoolSpec.MinSize = existingASG.MinSize
+	detectedAWSMachinePoolSpec.CapacityRebalance = existingASG.CapacityRebalance
+	{
+		mixedInstancesPolicy := machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy
+		// InstancesDistribution is optional, and the default values come from AWS, so
+		// they are not set by the AWSMachinePool defaulting webhook. If InstancesDistribution is
+		// not set, we use the AWS values for the purpose of comparison.
+		if mixedInstancesPolicy != nil && mixedInstancesPolicy.InstancesDistribution == nil {
+			mixedInstancesPolicy = machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy.DeepCopy()
+			mixedInstancesPolicy.InstancesDistribution = existingASG.MixedInstancesPolicy.InstancesDistribution
+		}
+
+		if !cmp.Equal(mixedInstancesPolicy, existingASG.MixedInstancesPolicy) {
+			detectedAWSMachinePoolSpec.MixedInstancesPolicy = existingASG.MixedInstancesPolicy
 		}
 	}
 
-	if machinePoolScope.AWSMachinePool.Spec.MaxSize != existingASG.MaxSize {
-		return true
-	}
-
-	if machinePoolScope.AWSMachinePool.Spec.MinSize != existingASG.MinSize {
-		return true
-	}
-
-	if machinePoolScope.AWSMachinePool.Spec.CapacityRebalance != existingASG.CapacityRebalance {
-		return true
-	}
-
-	if !cmp.Equal(machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy, existingASG.MixedInstancesPolicy) {
-		machinePoolScope.Info("got a mixed diff here", "incoming", machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy, "existing", existingASG.MixedInstancesPolicy)
-		return true
-	}
-
-	return false
+	return cmp.Diff(machinePoolScope.AWSMachinePool.Spec, *detectedAWSMachinePoolSpec)
 }
 
 // getOwnerMachinePool returns the MachinePool object owning the current resource.

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -531,7 +532,7 @@ func setupCluster(clusterName string) (*scope.ClusterScope, error) {
 	})
 }
 
-func TestASGNeedsUpdates(t *testing.T) {
+func TestDiffASG(t *testing.T) {
 	type args struct {
 		machinePoolScope *scope.MachinePoolScope
 		existingASG      *expinfrav1.AutoScalingGroup
@@ -696,6 +697,106 @@ func TestASGNeedsUpdates(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "MixedInstancesPolicy.InstancesDistribution != asg.MixedInstancesPolicy.InstancesDistribution",
+			args: args{
+				machinePoolScope: &scope.MachinePoolScope{
+					MachinePool: &expclusterv1.MachinePool{
+						Spec: expclusterv1.MachinePoolSpec{
+							Replicas: pointer.Int32(1),
+						},
+					},
+					AWSMachinePool: &expinfrav1.AWSMachinePool{
+						Spec: expinfrav1.AWSMachinePoolSpec{
+							MaxSize:           2,
+							MinSize:           0,
+							CapacityRebalance: true,
+							MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
+								InstancesDistribution: &expinfrav1.InstancesDistribution{
+									OnDemandAllocationStrategy:          expinfrav1.OnDemandAllocationStrategyPrioritized,
+									SpotAllocationStrategy:              expinfrav1.SpotAllocationStrategyCapacityOptimized,
+									OnDemandBaseCapacity:                aws.Int64(0),
+									OnDemandPercentageAboveBaseCapacity: aws.Int64(100),
+								},
+								Overrides: []expinfrav1.Overrides{
+									{
+										InstanceType: "m6a.32xlarge",
+									},
+								},
+							},
+						},
+					},
+					Logger: *logger.NewLogger(logr.Discard()),
+				},
+				existingASG: &expinfrav1.AutoScalingGroup{
+					DesiredCapacity:   pointer.Int32(1),
+					MaxSize:           2,
+					MinSize:           0,
+					CapacityRebalance: true,
+					MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
+						InstancesDistribution: &expinfrav1.InstancesDistribution{
+							OnDemandAllocationStrategy:          expinfrav1.OnDemandAllocationStrategyPrioritized,
+							SpotAllocationStrategy:              expinfrav1.SpotAllocationStrategyLowestPrice,
+							OnDemandBaseCapacity:                aws.Int64(0),
+							OnDemandPercentageAboveBaseCapacity: aws.Int64(100),
+						},
+						Overrides: []expinfrav1.Overrides{
+							{
+								InstanceType: "m6a.32xlarge",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "MixedInstancesPolicy.InstancesDistribution unset",
+			args: args{
+				machinePoolScope: &scope.MachinePoolScope{
+					MachinePool: &expclusterv1.MachinePool{
+						Spec: expclusterv1.MachinePoolSpec{
+							Replicas: pointer.Int32(1),
+						},
+					},
+					AWSMachinePool: &expinfrav1.AWSMachinePool{
+						Spec: expinfrav1.AWSMachinePoolSpec{
+							MaxSize:           2,
+							MinSize:           0,
+							CapacityRebalance: true,
+							MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
+								Overrides: []expinfrav1.Overrides{
+									{
+										InstanceType: "m6a.32xlarge",
+									},
+								},
+							},
+						},
+					},
+					Logger: *logger.NewLogger(logr.Discard()),
+				},
+				existingASG: &expinfrav1.AutoScalingGroup{
+					DesiredCapacity:   pointer.Int32(1),
+					MaxSize:           2,
+					MinSize:           0,
+					CapacityRebalance: true,
+					MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
+						InstancesDistribution: &expinfrav1.InstancesDistribution{
+							OnDemandAllocationStrategy:          expinfrav1.OnDemandAllocationStrategyPrioritized,
+							SpotAllocationStrategy:              expinfrav1.SpotAllocationStrategyLowestPrice,
+							OnDemandBaseCapacity:                aws.Int64(0),
+							OnDemandPercentageAboveBaseCapacity: aws.Int64(100),
+						},
+						Overrides: []expinfrav1.Overrides{
+							{
+								InstanceType: "m6a.32xlarge",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "SuspendProcesses != asg.SuspendProcesses",
 			args: args{
 				machinePoolScope: &scope.MachinePoolScope{
@@ -821,7 +922,7 @@ func TestASGNeedsUpdates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(asgNeedsUpdates(tt.args.machinePoolScope, tt.args.existingASG)).To(Equal(tt.want))
+			g.Expect(diffASG(tt.args.machinePoolScope, tt.args.existingASG) != "").To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Changes how the AWSMachinePool and ASG retrieved from AWS is compared, so that we copy the existing AWSMachinePool values, and compare only fields we manage. This fixes bugs around partially set fields (e.g , `MixedInstancesPolicy` is set with an instance distribution, but no mixed instance policy) where the AWS defaults do not match the zero-values of fields.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4070

**Special notes for your reviewer**:
Split off from #4194

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve AWSMachinePool diff to default to existing values when comparing launch templates.
```
