### PR TITLE
Setup Trivy scanning for supported release branches

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,14 +10,20 @@ permissions: {}
 
 jobs:
   scan:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [ main, release-2.2, release-2.1, release-2.0 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v3.5.3
+        with:
+          ref: ${{ matrix.branch }}
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version-file: '${{ github.workspace }}/go.mod'
       - name: Run verify container script
         run: make verify-container-images


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR adds Trivy scanning job to all supported release branches. Same thing has been done for CAPI (https://github.com/kubernetes-sigs/cluster-api/pull/7874) and CAPV(https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1978)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4394 

**Special notes for your reviewer**:

try run in my folked repo: https://github.com/wyike/cluster-api-provider-aws/actions/runs/5699290555/job/15448043792

It depends on https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4401 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Setup Trivy scanning for supported release branches
```
