### PR TITLE
Customize golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM public.ecr.aws/docker/library/golang:1.20.6 as toolchain
+ARG builder_image
+FROM ${builder_image} as toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 # If you update this file, please follow
 # https://suva.sh/posts/well-documented-makefiles
 
+# Go
+GO_VERSION ?=1.20.6
+GO_CONTAINER_IMAGE ?= public.ecr.aws/docker/library/golang:$(GO_VERSION)
+
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts
 TOOLS_DIR := hack/tools
@@ -350,7 +354,7 @@ clusterawsadm: ## Build clusterawsadm binary
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	docker build --build-arg ARCH=$(ARCH) --build-arg LDFLAGS="$(LDFLAGS)" . -t $(CORE_CONTROLLER_IMG)-$(ARCH):$(TAG)
+	docker build --build-arg ARCH=$(ARCH) --build-arg builder_image=$(GO_CONTAINER_IMAGE) --build-arg LDFLAGS="$(LDFLAGS)" . -t $(CORE_CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-build-all ## Build all the architecture docker images
 docker-build-all: $(addprefix docker-build-,$(ALL_ARCH))
@@ -383,7 +387,7 @@ generate-test-flavors: $(KUSTOMIZE)  ## Generate test template flavors
 
 .PHONY: e2e-image
 e2e-image: docker-pull-prerequisites $(TOOLS_BIN_DIR)/start.sh $(TOOLS_BIN_DIR)/restart.sh ## Build an e2e test image
-	docker build -f Dockerfile --tag="gcr.io/k8s-staging-cluster-api/capa-manager:e2e" .
+	docker build --build-arg builder_image=$(GO_CONTAINER_IMAGE) -f Dockerfile --tag="gcr.io/k8s-staging-cluster-api/capa-manager:e2e" .
 
 .PHONY: install-setup-envtest
 install-setup-envtest: # Install setup-envtest so that setup-envtest's eval is executed after the tool has been installed.
@@ -462,7 +466,7 @@ $(RELEASE_DIR):
 
 .PHONY: build-toolchain
 build-toolchain: ## Build the toolchain
-	docker build --target toolchain -t $(TOOLCHAIN_IMAGE) .
+	docker build --build-arg builder_image=$(GO_CONTAINER_IMAGE) --target toolchain -t $(TOOLCHAIN_IMAGE) .
 
 .PHONY: check-github-token
 check-github-token: ## Check if the github token is set
@@ -690,3 +694,8 @@ clean-temporary: ## Remove all temporary files and folders
 	rm -rf test/e2e/capi-kubeadm-control-plane-controller-manager
 	rm -rf test/e2e/logs
 	rm -rf test/e2e/resources
+
+##@ helpers:
+
+go-version: ## Print the go version we use to compile our binaries and images
+	@echo $(GO_VERSION)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

We can customize golang version of golang image `public.ecr.aws/docker/library/golang` when building managers and binaries
We can even customize golang image as well.

The customization impacts:
`make docker-build`
`make e2e-image`
`make build-toolchain` (used by `make release-binaries`)

Usually we don't need to customize the golang version. Each release has it's default golang version.

CAPI (https://github.com/kubernetes-sigs/cluster-api/blob/main/Makefile#L26-L27) and CAPV(https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/Makefile#L25) have similar support. The benefit of the support:
1. sometimes I want to use different golang version to build manager or binaries in my testing.
2. I can read the golang version by the GO_VERSION variable to do other automation for example https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4394 .

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4401 

**Special notes for your reviewer**:

This support will backport to release 2.2, release 2.1, release 2.0.

testing: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4399#issuecomment-1637011702

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Customize golang version when compiling our binaries and images 
```
