### PR TITLE
[E2E] Bump k8s version to v1.26.6 to fix conformance tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -143,8 +143,8 @@ variables:
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
   KUBERNETES_VERSION_MANAGEMENT: "v1.27.3"
-  KUBERNETES_VERSION: "v1.26.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.26.0"
+  KUBERNETES_VERSION: "v1.26.6"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.26.6"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.25.3"
   # Pre and post 1.23 Kubernetes versions are being used for CSI upgrade tests
   PRE_1_23_KUBERNETES_VERSION: "v1.22.17"
@@ -156,7 +156,7 @@ variables:
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_MACHINE_TYPE_VCPU_USAGE: 2
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.26.0"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.26.6"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "3"
   ETCD_VERSION_UPGRADE_TO: "3.5.6-0"


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind support


**What this PR does / why we need it**:
This PR bumps k8s version to v1.26.6, AMIs of which uses containerd v1.6.14, this would fix failing conformance tests
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/119446

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump k8s version to v1.26.6 to fix conformance tests
```
