### PR TITLE
Backport verify container images to release 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,10 @@ verify-gen: generate ## Verify generated files
 		echo "generated files are out of date, run make generate"; exit 1; \
 	fi
 
+.PHONY: verify-container-images
+verify-container-images: ## Verify container images
+	TRACE=$(TRACE) ./hack/verify-container-images.sh
+
 .PHONY: apidiff
 apidiff: APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 apidiff: $(GO_APIDIFF) ## Check for API differences

--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This refers https://github.com/kubernetes-sigs/cluster-api/blob/main/hack/verify-container-images.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+TRIVY_VERSION=0.35.0
+
+GO_OS="$(go env GOOS)"
+if [[ "${GO_OS}" == "linux" ]]; then
+  TRIVY_OS="Linux"
+elif [[ "${GO_OS}" == "darwin"* ]]; then
+  TRIVY_OS="macOS"
+fi
+
+GO_ARCH="$(go env GOARCH)"
+if [[ "${GO_ARCH}" == "amd" ]]; then
+  TRIVY_ARCH="32bit"
+elif [[ "${GO_ARCH}" == "amd64"* ]]; then
+  TRIVY_ARCH="64bit"
+elif [[ "${GO_ARCH}" == "arm" ]]; then
+  TRIVY_ARCH="ARM"
+elif [[ "${GO_ARCH}" == "arm64" ]]; then
+  TRIVY_ARCH="ARM64"
+fi
+
+TOOL_BIN=hack/tools/bin
+mkdir -p ${TOOL_BIN}
+
+# Downloads trivy scanner
+curl -L -o ${TOOL_BIN}/trivy.tar.gz \
+    https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz \
+
+tar xfO ${TOOL_BIN}/trivy.tar.gz trivy > ${TOOL_BIN}/trivy
+chmod +x ${TOOL_BIN}/trivy
+rm ${TOOL_BIN}/trivy.tar.gz
+
+## Builds the container images to be scanned
+make REGISTRY=gcr.io/k8s-staging-cluster-api-aws PULL_POLICY=IfNotPresent TAG=dev docker-build
+
+BRed='\033[1;31m'
+BGreen='\033[1;32m'
+NC='\033[0m' # No
+
+# Scan the images
+echo -e "\n${BGreen}List of dependencies that can bumped to fix the vulnerabilities:${NC}"
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller-${GO_ARCH}:dev && R1=$? || R1=$?
+echo -e "\n${BGreen}List of dependencies having fixes/no fixes for review only:${NC}"
+${TOOL_BIN}/trivy image -q  --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller-${GO_ARCH}:dev
+
+if [ "$R1" -ne "0" ]
+then
+  echo -e "\n${BRed}Container images check failed! There are vulnerability to be fixed${NC}"
+  exit 1
+fi
+
+echo -e "\n${BGreen}Container images check passed! No unfixed vulnerability found${NC}"
+


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

To support https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4394 in release-2.0 branch, backport make verify-container-image functionality.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4394 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support `make verify-container-image` to scan CVEs with trivy
```
