### PR TITLE
✨ Supporting externally managed Control Plane

### DIFF
--- a/api/v1beta2/awscluster_types.go
+++ b/api/v1beta2/awscluster_types.go
@@ -167,10 +167,11 @@ type Bastion struct {
 type LoadBalancerType string
 
 var (
-	LoadBalancerTypeClassic = LoadBalancerType("classic")
-	LoadBalancerTypeELB     = LoadBalancerType("elb")
-	LoadBalancerTypeALB     = LoadBalancerType("alb")
-	LoadBalancerTypeNLB     = LoadBalancerType("nlb")
+	LoadBalancerTypeClassic  = LoadBalancerType("classic")
+	LoadBalancerTypeELB      = LoadBalancerType("elb")
+	LoadBalancerTypeALB      = LoadBalancerType("alb")
+	LoadBalancerTypeNLB      = LoadBalancerType("nlb")
+	LoadBalancerTypeDisabled = LoadBalancerType("disabled")
 )
 
 // AWSLoadBalancerSpec defines the desired state of an AWS load balancer.
@@ -229,7 +230,7 @@ type AWSLoadBalancerSpec struct {
 
 	// LoadBalancerType sets the type for a load balancer. The default type is classic.
 	// +kubebuilder:default=classic
-	// +kubebuilder:validation:Enum:=classic;elb;alb;nlb
+	// +kubebuilder:validation:Enum:=classic;elb;alb;nlb;disabled
 	LoadBalancerType LoadBalancerType `json:"loadBalancerType,omitempty"`
 
 	// DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts

--- a/api/v1beta2/awscluster_webhook.go
+++ b/api/v1beta2/awscluster_webhook.go
@@ -298,5 +298,49 @@ func (r *AWSCluster) validateControlPlaneLBs() field.ErrorList {
 		}
 	}
 
+	if r.Spec.ControlPlaneLoadBalancer.LoadBalancerType == LoadBalancerTypeDisabled {
+		if r.Spec.ControlPlaneLoadBalancer.Name != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "name"), r.Spec.ControlPlaneLoadBalancer.Name, "cannot configure a name if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if r.Spec.ControlPlaneLoadBalancer.CrossZoneLoadBalancing {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "crossZoneLoadBalancing"), r.Spec.ControlPlaneLoadBalancer.CrossZoneLoadBalancing, "cross-zone load balancing cannot be set if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if len(r.Spec.ControlPlaneLoadBalancer.Subnets) > 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "subnets"), r.Spec.ControlPlaneLoadBalancer.Subnets, "subnets cannot be set if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if r.Spec.ControlPlaneLoadBalancer.HealthCheckProtocol != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "healthCheckProtocol"), r.Spec.ControlPlaneLoadBalancer.HealthCheckProtocol, "healthcheck protocol cannot be set if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if len(r.Spec.ControlPlaneLoadBalancer.AdditionalSecurityGroups) > 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "additionalSecurityGroups"), r.Spec.ControlPlaneLoadBalancer.AdditionalSecurityGroups, "additional Security Groups cannot be set if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if len(r.Spec.ControlPlaneLoadBalancer.AdditionalListeners) > 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "additionalListeners"), r.Spec.ControlPlaneLoadBalancer.AdditionalListeners, "cannot set additional listeners if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if len(r.Spec.ControlPlaneLoadBalancer.IngressRules) > 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "ingressRules"), r.Spec.ControlPlaneLoadBalancer.IngressRules, "ingress rules cannot be set if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if r.Spec.ControlPlaneLoadBalancer.PreserveClientIP {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "preserveClientIP"), r.Spec.ControlPlaneLoadBalancer.PreserveClientIP, "cannot preserve client IP if the LoadBalancer reconciliation is disabled"))
+		}
+
+		if r.Spec.ControlPlaneLoadBalancer.DisableHostsRewrite {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "disableHostsRewrite"), r.Spec.ControlPlaneLoadBalancer.DisableHostsRewrite, "cannot disable hosts rewrite if the LoadBalancer reconciliation is disabled"))
+		}
+	}
+
+	for _, rule := range r.Spec.ControlPlaneLoadBalancer.IngressRules {
+		if (rule.CidrBlocks != nil || rule.IPv6CidrBlocks != nil) && (rule.SourceSecurityGroupIDs != nil || rule.SourceSecurityGroupRoles != nil) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "ingressRules"), r.Spec.ControlPlaneLoadBalancer.IngressRules, "CIDR blocks and security group IDs or security group roles cannot be used together"))
+		}
+	}
+
 	return allErrs
 }

--- a/api/v1beta2/awscluster_webhook_test.go
+++ b/api/v1beta2/awscluster_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-aws/v2/feature"
@@ -50,6 +51,126 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 		wantErr bool
 		expect  func(g *WithT, res *AWSLoadBalancerSpec)
 	}{
+		{
+			name: "No options are allowed when LoadBalancer is disabled (name)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						LoadBalancerType: LoadBalancerTypeDisabled,
+						Name:             ptr.To("name"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (crossZoneLoadBalancing)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						CrossZoneLoadBalancing: true,
+						LoadBalancerType:       LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (subnets)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						Subnets:          []string{"foo", "bar"},
+						LoadBalancerType: LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (healthCheckProtocol)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						HealthCheckProtocol: &ELBProtocolTCP,
+						LoadBalancerType:    LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (additionalSecurityGroups)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						AdditionalSecurityGroups: []string{"foo", "bar"},
+						LoadBalancerType:         LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (additionalListeners)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						AdditionalListeners: []AdditionalListenerSpec{
+							{
+								Port:     6443,
+								Protocol: ELBProtocolTCP,
+							},
+						},
+						LoadBalancerType: LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (ingressRules)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						IngressRules: []IngressRule{
+							{
+								Description: "ingress rule",
+								Protocol:    SecurityGroupProtocolTCP,
+								FromPort:    6443,
+								ToPort:      6443,
+							},
+						},
+						LoadBalancerType: LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (disableHostsRewrite)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						DisableHostsRewrite: true,
+						LoadBalancerType:    LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No options are allowed when LoadBalancer is disabled (preserveClientIP)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						PreserveClientIP: true,
+						LoadBalancerType: LoadBalancerTypeDisabled,
+					},
+				},
+			},
+			wantErr: true,
+		},
 		// The SSHKeyName tests were moved to sshkeyname_test.go
 		{
 			name: "Supported schemes are 'internet-facing, Internet-facing, internal, or nil', rest will be rejected",

--- a/api/v1beta2/conditions_consts.go
+++ b/api/v1beta2/conditions_consts.go
@@ -125,6 +125,9 @@ const (
 	LoadBalancerReadyCondition clusterv1.ConditionType = "LoadBalancerReady"
 	// WaitForDNSNameReason used while waiting for a DNS name for the API server to be populated.
 	WaitForDNSNameReason = "WaitForDNSName"
+	// WaitForExternalControlPlaneEndpointReason is available when the AWS Cluster is waiting for an externally managed
+	// Load Balancer, such as an external Control Plane provider.
+	WaitForExternalControlPlaneEndpointReason = "WaitForExternalControlPlaneEndpoint"
 	// WaitForDNSNameResolveReason used while waiting for DNS name to resolve.
 	WaitForDNSNameResolveReason = "WaitForDNSNameResolve"
 	// LoadBalancerFailedReason used when an error occurs during load balancer reconciliation.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1109,6 +1109,7 @@ spec:
                     - elb
                     - alb
                     - nlb
+                    - disabled
                     type: string
                   name:
                     description: Name sets the name of the classic ELB load balancer.
@@ -1689,6 +1690,7 @@ spec:
                     - elb
                     - alb
                     - nlb
+                    - disabled
                     type: string
                   name:
                     description: Name sets the name of the classic ELB load balancer.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -707,6 +707,7 @@ spec:
                             - elb
                             - alb
                             - nlb
+                            - disabled
                             type: string
                           name:
                             description: Name sets the name of the classic ELB load
@@ -1316,6 +1317,7 @@ spec:
                             - elb
                             - alb
                             - nlb
+                            - disabled
                             type: string
                           name:
                             description: Name sets the name of the classic ELB load

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -122,6 +122,14 @@ rules:
 - apiGroups:
   - controlplane.cluster.x-k8s.io
   resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
   - awsmanagedcontrolplanes
   verbs:
   - delete

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -266,6 +266,45 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 	return nil
 }
 
+func (r *AWSClusterReconciler) reconcileLoadBalancer(clusterScope *scope.ClusterScope, awsCluster *infrav1.AWSCluster) (*time.Duration, error) {
+	retryAfterDuration := 15 * time.Second
+	if clusterScope.AWSCluster.Spec.ControlPlaneLoadBalancer.LoadBalancerType == infrav1.LoadBalancerTypeDisabled {
+		clusterScope.Debug("load balancer reconciliation shifted to external provider, checking external endpoint")
+
+		return r.checkForExternalControlPlaneLoadBalancer(clusterScope, awsCluster), nil
+	}
+
+	elbService := r.getELBService(clusterScope)
+
+	if err := elbService.ReconcileLoadbalancers(); err != nil {
+		clusterScope.Error(err, "failed to reconcile load balancer")
+		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.LoadBalancerFailedReason, infrautilconditions.ErrorConditionAfterInit(clusterScope.ClusterObj()), err.Error())
+		return nil, err
+	}
+
+	if awsCluster.Status.Network.APIServerELB.DNSName == "" {
+		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForDNSNameReason, clusterv1.ConditionSeverityInfo, "")
+		clusterScope.Info("Waiting on API server ELB DNS name")
+		return &retryAfterDuration, nil
+	}
+
+	clusterScope.Debug("looking up IP address for DNS", "dns", awsCluster.Status.Network.APIServerELB.DNSName)
+	if _, err := net.LookupIP(awsCluster.Status.Network.APIServerELB.DNSName); err != nil {
+		clusterScope.Error(err, "failed to get IP address for dns name", "dns", awsCluster.Status.Network.APIServerELB.DNSName)
+		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForDNSNameResolveReason, clusterv1.ConditionSeverityInfo, "")
+		clusterScope.Info("Waiting on API server ELB DNS name to resolve")
+		return &retryAfterDuration, nil
+	}
+	conditions.MarkTrue(awsCluster, infrav1.LoadBalancerReadyCondition)
+
+	awsCluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+		Host: awsCluster.Status.Network.APIServerELB.DNSName,
+		Port: clusterScope.APIServerPort(),
+	}
+
+	return nil, nil
+}
+
 func (r *AWSClusterReconciler) reconcileNormal(clusterScope *scope.ClusterScope) (reconcile.Result, error) {
 	clusterScope.Info("Reconciling AWSCluster")
 
@@ -280,7 +319,6 @@ func (r *AWSClusterReconciler) reconcileNormal(clusterScope *scope.ClusterScope)
 	}
 
 	ec2Service := r.getEC2Service(clusterScope)
-	elbService := r.getELBService(clusterScope)
 	networkSvc := r.getNetworkService(*clusterScope)
 	sgService := r.getSecurityGroupService(*clusterScope)
 	s3Service := s3.NewService(clusterScope)
@@ -310,35 +348,15 @@ func (r *AWSClusterReconciler) reconcileNormal(clusterScope *scope.ClusterScope)
 		}
 	}
 
-	if err := elbService.ReconcileLoadbalancers(); err != nil {
-		clusterScope.Error(err, "failed to reconcile load balancer")
-		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.LoadBalancerFailedReason, infrautilconditions.ErrorConditionAfterInit(clusterScope.ClusterObj()), err.Error())
+	if requeueAfter, err := r.reconcileLoadBalancer(clusterScope, awsCluster); err != nil {
 		return reconcile.Result{}, err
+	} else if requeueAfter != nil {
+		return reconcile.Result{RequeueAfter: *requeueAfter}, err
 	}
 
 	if err := s3Service.ReconcileBucket(); err != nil {
 		conditions.MarkFalse(awsCluster, infrav1.S3BucketReadyCondition, infrav1.S3BucketFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile S3 Bucket for AWSCluster %s/%s", awsCluster.Namespace, awsCluster.Name)
-	}
-
-	if awsCluster.Status.Network.APIServerELB.DNSName == "" {
-		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForDNSNameReason, clusterv1.ConditionSeverityInfo, "")
-		clusterScope.Info("Waiting on API server ELB DNS name")
-		return reconcile.Result{RequeueAfter: 15 * time.Second}, nil
-	}
-
-	clusterScope.Debug("looking up IP address for DNS", "dns", awsCluster.Status.Network.APIServerELB.DNSName)
-	if _, err := net.LookupIP(awsCluster.Status.Network.APIServerELB.DNSName); err != nil {
-		clusterScope.Error(err, "failed to get IP address for dns name", "dns", awsCluster.Status.Network.APIServerELB.DNSName)
-		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForDNSNameResolveReason, clusterv1.ConditionSeverityInfo, "")
-		clusterScope.Info("Waiting on API server ELB DNS name to resolve")
-		return reconcile.Result{RequeueAfter: 15 * time.Second}, nil
-	}
-	conditions.MarkTrue(awsCluster, infrav1.LoadBalancerReadyCondition)
-
-	awsCluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
-		Host: awsCluster.Status.Network.APIServerELB.DNSName,
-		Port: clusterScope.APIServerPort(),
 	}
 
 	for _, subnet := range clusterScope.Subnets().FilterPrivate() {
@@ -445,5 +463,31 @@ func (r *AWSClusterReconciler) requeueAWSClusterForUnpausedCluster(_ context.Con
 				NamespacedName: client.ObjectKey{Namespace: c.Namespace, Name: c.Spec.InfrastructureRef.Name},
 			},
 		}
+	}
+}
+
+func (r *AWSClusterReconciler) checkForExternalControlPlaneLoadBalancer(clusterScope *scope.ClusterScope, awsCluster *infrav1.AWSCluster) *time.Duration {
+	requeueAfterPeriod := 15 * time.Second
+
+	switch {
+	case len(awsCluster.Spec.ControlPlaneEndpoint.Host) == 0 && awsCluster.Spec.ControlPlaneEndpoint.Port == 0:
+		clusterScope.Info("AWSCluster control plane endpoint is still non-populated")
+		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForExternalControlPlaneEndpointReason, clusterv1.ConditionSeverityInfo, "")
+
+		return &requeueAfterPeriod
+	case len(awsCluster.Spec.ControlPlaneEndpoint.Host) == 0:
+		clusterScope.Info("AWSCluster control plane endpoint host is still non-populated")
+		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForExternalControlPlaneEndpointReason, clusterv1.ConditionSeverityInfo, "")
+
+		return &requeueAfterPeriod
+	case awsCluster.Spec.ControlPlaneEndpoint.Port == 0:
+		clusterScope.Info("AWSCluster control plane endpoint port is still non-populated")
+		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForExternalControlPlaneEndpointReason, clusterv1.ConditionSeverityInfo, "")
+
+		return &requeueAfterPeriod
+	default:
+		conditions.MarkTrue(awsCluster, infrav1.LoadBalancerReadyCondition)
+
+		return nil
 	}
 }

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -288,7 +288,7 @@ func (r *AWSClusterReconciler) reconcileLoadBalancer(clusterScope *scope.Cluster
 		return &retryAfterDuration, nil
 	}
 
-	clusterScope.Debug("looking up IP address for DNS", "dns", awsCluster.Status.Network.APIServerELB.DNSName)
+	clusterScope.Debug("Looking up IP address for DNS", "dns", awsCluster.Status.Network.APIServerELB.DNSName)
 	if _, err := net.LookupIP(awsCluster.Status.Network.APIServerELB.DNSName); err != nil {
 		clusterScope.Error(err, "failed to get IP address for dns name", "dns", awsCluster.Status.Network.APIServerELB.DNSName)
 		conditions.MarkFalse(awsCluster, infrav1.LoadBalancerReadyCondition, infrav1.WaitForDNSNameResolveReason, clusterv1.ConditionSeverityInfo, "")

--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -65,7 +66,118 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 	teardown := func() {
 		mockCtrl.Finish()
 	}
+	t.Run("Should wait for external Control Plane endpoint when LoadBalancer is disabled, and eventually succeed when patched", func(t *testing.T) {
+		g := NewWithT(t)
+		mockCtrl = gomock.NewController(t)
+		ec2Mock := mocks.NewMockEC2API(mockCtrl)
+		expect := func(m *mocks.MockEC2APIMockRecorder) {
+			// First iteration, when the AWS Cluster is missing a valid Control Plane Endpoint
+			mockedCreateVPCCalls(m)
+			mockedCreateSGCalls(false, m)
+			mockedDescribeInstanceCall(m)
+			// Second iteration: the AWS Cluster object has been patched,
+			// thus a valid Control Plane Endpoint has been provided
+			mockedCreateVPCCalls(m)
+			mockedCreateSGCalls(false, m)
+			mockedDescribeInstanceCall(m)
+		}
+		expect(ec2Mock.EXPECT())
 
+		setup(t)
+		controllerIdentity := createControllerIdentity(g)
+		ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("integ-test-%s", util.RandomString(5)))
+		g.Expect(err).To(BeNil())
+		// Creating the AWS cluster with a disabled Load Balancer:
+		// no ALB, ELB, or NLB specified, the AWS cluster must consistently be reported
+		// waiting for the control Plane endpoint.
+		awsCluster := getAWSCluster("test", ns.Name)
+		awsCluster.Spec.ControlPlaneLoadBalancer = &infrav1.AWSLoadBalancerSpec{
+			LoadBalancerType: infrav1.LoadBalancerTypeDisabled,
+		}
+
+		g.Expect(testEnv.Create(ctx, &awsCluster)).To(Succeed())
+
+		defer teardown()
+		defer t.Cleanup(func() {
+			g.Expect(testEnv.Cleanup(ctx, &awsCluster, controllerIdentity, ns)).To(Succeed())
+		})
+
+		cs, err := getClusterScope(awsCluster)
+		g.Expect(err).To(BeNil())
+		networkSvc := network.NewService(cs)
+		networkSvc.EC2Client = ec2Mock
+		reconciler.networkServiceFactory = func(clusterScope scope.ClusterScope) services.NetworkInterface {
+			return networkSvc
+		}
+
+		ec2Svc := ec2Service.NewService(cs)
+		ec2Svc.EC2Client = ec2Mock
+		reconciler.ec2ServiceFactory = func(scope scope.EC2Scope) services.EC2Interface {
+			return ec2Svc
+		}
+		testSecurityGroupRoles := []infrav1.SecurityGroupRole{
+			infrav1.SecurityGroupBastion,
+			infrav1.SecurityGroupAPIServerLB,
+			infrav1.SecurityGroupLB,
+			infrav1.SecurityGroupControlPlane,
+			infrav1.SecurityGroupNode,
+		}
+		sgSvc := securitygroup.NewService(cs, testSecurityGroupRoles)
+		sgSvc.EC2Client = ec2Mock
+
+		reconciler.securityGroupFactory = func(clusterScope scope.ClusterScope) services.SecurityGroupInterface {
+			return sgSvc
+		}
+		cs.SetSubnets([]infrav1.SubnetSpec{
+			{
+				ID:               "subnet-2",
+				AvailabilityZone: "us-east-1c",
+				IsPublic:         true,
+				CidrBlock:        "10.0.11.0/24",
+			},
+			{
+				ID:               "subnet-1",
+				AvailabilityZone: "us-east-1a",
+				CidrBlock:        "10.0.10.0/24",
+				IsPublic:         false,
+			},
+		})
+
+		_, err = reconciler.reconcileNormal(cs)
+		g.Expect(err).To(BeNil())
+
+		cluster := &infrav1.AWSCluster{}
+		g.Expect(testEnv.Get(ctx, client.ObjectKey{Name: cs.AWSCluster.Name, Namespace: cs.AWSCluster.Namespace}, cluster)).ToNot(HaveOccurred())
+		g.Expect(cluster.Spec.ControlPlaneEndpoint.Host).To(BeEmpty())
+		g.Expect(cluster.Spec.ControlPlaneEndpoint.Port).To(BeZero())
+		expectAWSClusterConditions(g, cs.AWSCluster, []conditionAssertion{
+			{conditionType: infrav1.LoadBalancerReadyCondition, status: corev1.ConditionFalse, severity: clusterv1.ConditionSeverityInfo, reason: infrav1.WaitForExternalControlPlaneEndpointReason},
+		})
+		// Mimicking an external operator patching the cluster with an already provisioned Load Balancer:
+		// this could be done by a human who provisioned a LB, or by a Control Plane provider.
+		g.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err = testEnv.Get(ctx, client.ObjectKey{Name: cs.AWSCluster.Name, Namespace: cs.AWSCluster.Namespace}, cs.AWSCluster); err != nil {
+				return err
+			}
+
+			cs.AWSCluster.Spec.ControlPlaneEndpoint.Host = "10.0.10.1"
+			cs.AWSCluster.Spec.ControlPlaneEndpoint.Port = 6443
+
+			return testEnv.Update(ctx, cs.AWSCluster)
+		})).To(Succeed())
+		// Executing back a second reconciliation:
+		// the AWS Cluster should be ready with no LoadBalancer false condition.
+		_, err = reconciler.reconcileNormal(cs)
+		g.Expect(err).To(BeNil())
+		g.Expect(cs.VPC().ID).To(Equal("vpc-exists"))
+		expectAWSClusterConditions(g, cs.AWSCluster, []conditionAssertion{
+			{conditionType: infrav1.ClusterSecurityGroupsReadyCondition, status: corev1.ConditionTrue, severity: "", reason: ""},
+			{conditionType: infrav1.BastionHostReadyCondition, status: corev1.ConditionTrue, severity: "", reason: ""},
+			{conditionType: infrav1.VpcReadyCondition, status: corev1.ConditionTrue, severity: "", reason: ""},
+			{conditionType: infrav1.SubnetsReadyCondition, status: corev1.ConditionTrue, severity: "", reason: ""},
+			{conditionType: infrav1.LoadBalancerReadyCondition, status: corev1.ConditionTrue, severity: "", reason: ""},
+		})
+	})
 	t.Run("Should successfully reconcile AWSCluster creation with unmanaged VPC", func(t *testing.T) {
 		g := NewWithT(t)
 		mockCtrl = gomock.NewController(t)

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -417,6 +418,7 @@ func getMachineScope(cs *scope.ClusterScope, awsMachine *infrav1.AWSMachine) (*s
 					InfrastructureReady: true,
 				},
 			},
+			ControlPlane: &unstructured.Unstructured{},
 			Machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,6 +29,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/helpers"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 )
 
 var (
@@ -45,6 +46,7 @@ func TestMain(m *testing.M) {
 func setup() {
 	utilruntime.Must(infrav1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(kubeadmv1beta1.AddToScheme(scheme.Scheme))
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
 		path.Join("config", "crd", "bases"),
 	},

--- a/pkg/cloud/scope/machine_test.go
+++ b/pkg/cloud/scope/machine_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -132,7 +133,8 @@ func setupMachineScope() (*MachineScope, error) {
 			InfraCluster: &ClusterScope{
 				AWSCluster: awsCluster,
 			},
-			AWSMachine: awsMachine,
+			ControlPlane: &unstructured.Unstructured{},
+			AWSMachine:   awsMachine,
 		},
 	)
 }
@@ -223,9 +225,10 @@ func TestGetRawBootstrapDataWithFormat(t *testing.T) {
 
 		machineScope, err := NewMachineScope(
 			MachineScopeParams{
-				Client:  client,
-				Machine: machine,
-				Cluster: cluster,
+				Client:       client,
+				Machine:      machine,
+				Cluster:      cluster,
+				ControlPlane: &unstructured.Unstructured{},
 				InfraCluster: &ClusterScope{
 					AWSCluster: awsCluster,
 				},

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -181,7 +181,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, use
 	}
 	input.SubnetID = subnetID
 
-	if !scope.IsExternallyManaged() && !scope.IsEKSManaged() && s.scope.Network().APIServerELB.DNSName == "" {
+	if !scope.IsControlPlaneExternallyManaged() && !scope.IsExternallyManaged() && !scope.IsEKSManaged() && s.scope.Network().APIServerELB.DNSName == "" {
 		record.Eventf(s.scope.InfraCluster(), "FailedCreateInstance", "Failed to run controlplane, APIServer ELB not available")
 
 		return nil, awserrors.NewFailedDependency("failed to run controlplane, APIServer ELB not available")

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -4035,6 +4036,7 @@ func TestCreateInstance(t *testing.T) {
 			machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
 				Client:       client,
 				Cluster:      cluster,
+				ControlPlane: &unstructured.Unstructured{},
 				Machine:      machine,
 				AWSMachine:   awsMachine,
 				InfraCluster: clusterScope,

--- a/pkg/cloud/services/secretsmanager/secret_test.go
+++ b/pkg/cloud/services/secretsmanager/secret_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -280,6 +281,7 @@ func getClusterScope(client client.Client) (*scope.ClusterScope, error) {
 func getMachineScope(client client.Client, clusterScope *scope.ClusterScope) (*scope.MachineScope, error) {
 	return scope.NewMachineScope(scope.MachineScopeParams{
 		Client:       client,
+		ControlPlane: &unstructured.Unstructured{},
 		Cluster:      clusterScope.Cluster,
 		Machine:      &clusterv1.Machine{},
 		InfraCluster: clusterScope,

--- a/pkg/cloud/services/ssm/secret_test.go
+++ b/pkg/cloud/services/ssm/secret_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -273,6 +274,7 @@ func getClusterScope(client client.Client) (*scope.ClusterScope, error) {
 func getMachineScope(client client.Client, clusterScope *scope.ClusterScope) (*scope.MachineScope, error) {
 	return scope.NewMachineScope(scope.MachineScopeParams{
 		Client:       client,
+		ControlPlane: &unstructured.Unstructured{},
 		Cluster:      clusterScope.Cluster,
 		Machine:      &clusterv1.Machine{},
 		InfraCluster: clusterScope,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Cluster API allows defining externally managed control plane for the given cluster, the current code-base doesn't consider this since it nevertheless performs the following actions:

- reconciliation of a Load Balancer, although already provisioned by the ControlPlane provider
- blocking the EC2 creation since it requires an ELB DNS name

**Which issue(s) this PR fixes**:
Fixes #4437

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:

```release-note
A new enum value, `disabled`, is added for the `AWSCluster.spec.controlPlaneLoadBalancer.loadBalancerType` field, which skips the reconciliation of the load balancer for the given cluster, useful for clusters which are consuming an externally managed Control Plane.
```
