### PR TITLE
Set availability zones in status.networkStatus.apiServerElb when using BYO NLB

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1467,8 +1467,10 @@ func fromSDKTypeToClassicELB(v *elb.LoadBalancerDescription, attrs *elb.LoadBala
 
 func fromSDKTypeToLB(v *elbv2.LoadBalancer, attrs []*elbv2.LoadBalancerAttribute, tags []*elbv2.Tag) *infrav1.LoadBalancer {
 	subnetIds := make([]*string, len(v.AvailabilityZones))
+	availabilityZones := make([]*string, len(v.AvailabilityZones))
 	for i, az := range v.AvailabilityZones {
 		subnetIds[i] = az.SubnetId
+		availabilityZones[i] = az.ZoneName
 	}
 	res := &infrav1.LoadBalancer{
 		ARN:       aws.StringValue(v.LoadBalancerArn),
@@ -1476,8 +1478,9 @@ func fromSDKTypeToLB(v *elbv2.LoadBalancer, attrs []*elbv2.LoadBalancerAttribute
 		Scheme:    infrav1.ELBScheme(aws.StringValue(v.Scheme)),
 		SubnetIDs: aws.StringValueSlice(subnetIds),
 		// SecurityGroupIDs: aws.StringValueSlice(v.SecurityGroups),
-		DNSName: aws.StringValue(v.DNSName),
-		Tags:    converters.V2TagsToMap(tags),
+		AvailabilityZones: aws.StringValueSlice(availabilityZones),
+		DNSName:           aws.StringValue(v.DNSName),
+		Tags:              converters.V2TagsToMap(tags),
 	}
 
 	infraAttrs := make(map[string]*string, len(attrs))


### PR DESCRIPTION
This ensures that failure domains are correctly set when using an externally managed (BYO) NLB

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

When using a BYO NLB, control plane nodes are only created in a single AZ regardless of the subnet AZs specified. This is due to the availability zones not being set in the lb status field, which causes the failure domains to not be detected in the AWSCluster reconciliation.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4448

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Availability zone status is correctly set when using BYO NLBs, fixing an issue where control plane nodes were only created in a single AZ
```
