### PR TITLE
fix: don't generate nodegroup role name starting with hyphen

### DIFF
--- a/pkg/cloud/services/eks/roles.go
+++ b/pkg/cloud/services/eks/roles.go
@@ -182,8 +182,8 @@ func (s *NodegroupService) reconcileNodegroupIAMRole() error {
 		} else {
 			s.scope.Info("no EKS nodegroup role specified, using role based on nodegroup name")
 			roleName, err = eks.GenerateEKSName(
+				"nodegroup-iam-service-role",
 				fmt.Sprintf("%s-%s", s.scope.KubernetesClusterName(), s.scope.NodegroupName()),
-				"-nodegroup-iam-service-role",
 				maxIAMRoleNameLength,
 			)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Currently if `EnableIAM` is set to true and no role is specified for a node group the controller auto generates a role. However, the name formatting seems to be backwards from what it is intended to be, causing the role name to start with a `-`. What's surprising to me is that this doesn't seem to cause problems, other than that it looks weird. The name for the role that is currently generated looks like: `-nodegroup-iam-service-role_<cluster-name>-<nodegroup-name>`. This PR swaps the generated role name so it will be: `<cluster-name>-<nodegroup-name>_nodegroup-iam-service-role`. This is follows the same format as the name generated for Fargate.

<!-- Enter a description of the change and why this change is needed -->

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change generated nodegroup IAM role name from `-nodegroup-iam-service-role_<cluster-name>-<nodegroup-name>` to `<cluster-name>-<nodegroup-name>_nodegroup-iam-service-role`
```
