### PR TITLE
feat: allow for specifying subnet type for az

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -539,6 +539,7 @@ spec:
                 enum:
                 - public
                 - private
+                - all
                 type: string
               availabilityZones:
                 description: AvailabilityZones is an array of availability zones instances

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -533,6 +533,13 @@ spec:
                 description: AdditionalTags is an optional set of tags to add to an
                   instance, in addition to the ones added by default by the AWS provider.
                 type: object
+              availabilityZoneSubnetType:
+                description: AvailabilityZoneSubnetType specifies which type of subnets
+                  to use when an availability zone is specified.
+                enum:
+                - public
+                - private
+                type: string
               availabilityZones:
                 description: AvailabilityZones is an array of availability zones instances
                   can run in

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -525,6 +525,7 @@ spec:
                 enum:
                 - public
                 - private
+                - all
                 type: string
               availabilityZones:
                 description: AvailabilityZones is an array of availability zones instances

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -519,6 +519,13 @@ spec:
                   version will be used
                 minLength: 2
                 type: string
+              availabilityZoneSubnetType:
+                description: AvailabilityZoneSubnetType specifies which type of subnets
+                  to use when an availability zone is specified.
+                enum:
+                - public
+                - private
+                type: string
               availabilityZones:
                 description: AvailabilityZones is an array of availability zones instances
                   can run in

--- a/exp/api/v1beta1/conversion.go
+++ b/exp/api/v1beta1/conversion.go
@@ -96,12 +96,6 @@ func (src *AWSManagedMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 		}
 		dst.Spec.AWSLaunchTemplate.InstanceMetadataOptions = restored.Spec.AWSLaunchTemplate.InstanceMetadataOptions
 	}
-
-	// Manually restore data.
-	restored := &infrav1exp.AWSManagedMachinePool{}
-	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
-		return err
-	}
 	if restored.Spec.AvailabilityZoneSubnetType != nil {
 		dst.Spec.AvailabilityZoneSubnetType = restored.Spec.AvailabilityZoneSubnetType
 	}

--- a/exp/api/v1beta1/conversion.go
+++ b/exp/api/v1beta1/conversion.go
@@ -47,6 +47,9 @@ func (src *AWSMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 	if restored.Spec.AWSLaunchTemplate.InstanceMetadataOptions != nil {
 		dst.Spec.AWSLaunchTemplate.InstanceMetadataOptions = restored.Spec.AWSLaunchTemplate.InstanceMetadataOptions
 	}
+	if restored.Spec.AvailabilityZoneSubnetType != nil {
+		dst.Spec.AvailabilityZoneSubnetType = restored.Spec.AvailabilityZoneSubnetType
+	}
 
 	return nil
 }
@@ -92,6 +95,15 @@ func (src *AWSManagedMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.AWSLaunchTemplate = restored.Spec.AWSLaunchTemplate
 		}
 		dst.Spec.AWSLaunchTemplate.InstanceMetadataOptions = restored.Spec.AWSLaunchTemplate.InstanceMetadataOptions
+	}
+
+	// Manually restore data.
+	restored := &infrav1exp.AWSManagedMachinePool{}
+	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+		return err
+	}
+	if restored.Spec.AvailabilityZoneSubnetType != nil {
+		dst.Spec.AvailabilityZoneSubnetType = restored.Spec.AvailabilityZoneSubnetType
 	}
 
 	return nil

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -537,6 +537,7 @@ func autoConvert_v1beta2_AWSMachinePoolSpec_To_v1beta1_AWSMachinePoolSpec(in *v1
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.AvailabilityZones = *(*[]string)(unsafe.Pointer(&in.AvailabilityZones))
+	// WARNING: in.AvailabilityZoneSubnetType requires manual conversion: does not exist in peer-type
 	out.Subnets = *(*[]apiv1beta2.AWSResourceReference)(unsafe.Pointer(&in.Subnets))
 	out.AdditionalTags = *(*apiv1beta2.Tags)(unsafe.Pointer(&in.AdditionalTags))
 	if err := Convert_v1beta2_AWSLaunchTemplate_To_v1beta1_AWSLaunchTemplate(&in.AWSLaunchTemplate, &out.AWSLaunchTemplate, s); err != nil {
@@ -707,6 +708,7 @@ func Convert_v1beta1_AWSManagedMachinePoolSpec_To_v1beta2_AWSManagedMachinePoolS
 func autoConvert_v1beta2_AWSManagedMachinePoolSpec_To_v1beta1_AWSManagedMachinePoolSpec(in *v1beta2.AWSManagedMachinePoolSpec, out *AWSManagedMachinePoolSpec, s conversion.Scope) error {
 	out.EKSNodegroupName = in.EKSNodegroupName
 	out.AvailabilityZones = *(*[]string)(unsafe.Pointer(&in.AvailabilityZones))
+	// WARNING: in.AvailabilityZoneSubnetType requires manual conversion: does not exist in peer-type
 	out.SubnetIDs = *(*[]string)(unsafe.Pointer(&in.SubnetIDs))
 	out.AdditionalTags = *(*apiv1beta2.Tags)(unsafe.Pointer(&in.AdditionalTags))
 	out.RoleAdditionalPolicies = *(*[]string)(unsafe.Pointer(&in.RoleAdditionalPolicies))

--- a/exp/api/v1beta2/awsmachinepool_types.go
+++ b/exp/api/v1beta2/awsmachinepool_types.go
@@ -53,7 +53,7 @@ type AWSMachinePoolSpec struct {
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 
 	// AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.
-	// +kubebuilder:validation:Enum:=public;private
+	// +kubebuilder:validation:Enum:=public;private;all
 	// +optional
 	AvailabilityZoneSubnetType *AZSubnetType `json:"availabilityZoneSubnetType,omitempty"`
 

--- a/exp/api/v1beta2/awsmachinepool_types.go
+++ b/exp/api/v1beta2/awsmachinepool_types.go
@@ -52,6 +52,11 @@ type AWSMachinePoolSpec struct {
 	// AvailabilityZones is an array of availability zones instances can run in
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 
+	// AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.
+	// +kubebuilder:validation:Enum:=public;private
+	// +optional
+	AvailabilityZoneSubnetType *AZSubnetType `json:"availabilityZoneSubnetType,omitempty"`
+
 	// Subnets is an array of subnet configurations
 	// +optional
 	Subnets []infrav1.AWSResourceReference `json:"subnets,omitempty"`

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -68,6 +68,11 @@ type AWSManagedMachinePoolSpec struct {
 	// AvailabilityZones is an array of availability zones instances can run in
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 
+	// AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.
+	// +kubebuilder:validation:Enum:=public;private
+	// +optional
+	AvailabilityZoneSubnetType *AZSubnetType `json:"availabilityZoneSubnetType,omitempty"`
+
 	// SubnetIDs specifies which subnets are used for the
 	// auto scaling group of this nodegroup
 	// +optional

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -69,7 +69,7 @@ type AWSManagedMachinePoolSpec struct {
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 
 	// AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.
-	// +kubebuilder:validation:Enum:=public;private
+	// +kubebuilder:validation:Enum:=public;private;all
 	// +optional
 	AvailabilityZoneSubnetType *AZSubnetType `json:"availabilityZoneSubnetType,omitempty"`
 

--- a/exp/api/v1beta2/awsmanagedmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_webhook.go
@@ -243,6 +243,8 @@ func (r *AWSManagedMachinePool) validateImmutable(old *AWSManagedMachinePool) fi
 	appendErrorIfMutated(old.Spec.AMIType, r.Spec.AMIType, "amiType")
 	appendErrorIfMutated(old.Spec.RemoteAccess, r.Spec.RemoteAccess, "remoteAccess")
 	appendErrorIfSetAndMutated(old.Spec.CapacityType, r.Spec.CapacityType, "capacityType")
+	appendErrorIfMutated(old.Spec.AvailabilityZones, r.Spec.AvailabilityZones, "availabilityZones")
+	appendErrorIfMutated(old.Spec.AvailabilityZoneSubnetType, r.Spec.AvailabilityZoneSubnetType, "availabilityZoneSubnetType")
 	if (old.Spec.AWSLaunchTemplate != nil && r.Spec.AWSLaunchTemplate == nil) ||
 		(old.Spec.AWSLaunchTemplate == nil && r.Spec.AWSLaunchTemplate != nil) {
 		allErrs = append(

--- a/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
@@ -29,6 +29,17 @@ import (
 	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
+var (
+	oldDiskSize                   = int32(50)
+	newDiskSize                   = int32(100)
+	oldAmiType                    = Al2x86_64
+	newAmiType                    = Al2x86_64GPU
+	oldCapacityType               = ManagedMachinePoolCapacityTypeOnDemand
+	newCapacityType               = ManagedMachinePoolCapacityTypeSpot
+	oldAvailabilityZoneSubnetType = AZSubnetTypePublic
+	newAvailabilityZoneSubnetType = AZSubnetTypePrivate
+)
+
 func TestAWSManagedMachinePoolDefault(t *testing.T) {
 	fargate := &AWSManagedMachinePool{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 	t.Run("for AWSManagedMachinePool", utildefaulting.DefaultValidateTest(fargate))
@@ -249,6 +260,428 @@ func TestAWSManagedMachinePoolValidateUpdate(t *testing.T) {
 			new: &AWSManagedMachinePool{
 				Spec: AWSManagedMachinePoolSpec{
 					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "adding subnet id is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					SubnetIDs:        []string{"subnet-1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing subnet id is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					SubnetIDs:        []string{"subnet-1"},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing subnet id is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					SubnetIDs:        []string{"subnet-1"},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					SubnetIDs:        []string{"subnet-2"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing role name is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					RoleName:         "role-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing role name is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					RoleName:         "role-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					RoleName:         "role-2",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding disk size is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					DiskSize:         &newDiskSize,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing disk size is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					DiskSize:         &oldDiskSize,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing disk size is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					DiskSize:         &oldDiskSize,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					DiskSize:         &newDiskSize,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding ami type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AMIType:          &newAmiType,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing ami type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AMIType:          &oldAmiType,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing ami type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AMIType:          &oldAmiType,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AMIType:          &newAmiType,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding remote access is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					RemoteAccess: &ManagedRemoteAccess{
+						Public: false,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing remote access is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					RemoteAccess: &ManagedRemoteAccess{
+						Public: false,
+					},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing remote access is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					RemoteAccess: &ManagedRemoteAccess{
+						Public: false,
+					},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					RemoteAccess: &ManagedRemoteAccess{
+						Public: true,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing capacity type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					CapacityType:     &oldCapacityType,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing capacity type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					CapacityType:     &oldCapacityType,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					CapacityType:     &newCapacityType,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding availability zones is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:  "eks-node-group-1",
+					AvailabilityZones: []string{"us-east-1a"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing availability zones is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:  "eks-node-group-1",
+					AvailabilityZones: []string{"us-east-1a"},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing availability zones is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:  "eks-node-group-1",
+					AvailabilityZones: []string{"us-east-1a"},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:  "eks-node-group-1",
+					AvailabilityZones: []string{"us-east-1a", "us-east-1b"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding availability zone subnet type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:           "eks-node-group-1",
+					AvailabilityZoneSubnetType: &newAvailabilityZoneSubnetType,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing availability zone subnet type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:           "eks-node-group-1",
+					AvailabilityZoneSubnetType: &oldAvailabilityZoneSubnetType,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing availability zone subnet type is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:           "eks-node-group-1",
+					AvailabilityZoneSubnetType: &oldAvailabilityZoneSubnetType,
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName:           "eks-node-group-1",
+					AvailabilityZoneSubnetType: &newAvailabilityZoneSubnetType,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding launch template is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AWSLaunchTemplate: &AWSLaunchTemplate{
+						Name: "test",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing launch template is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AWSLaunchTemplate: &AWSLaunchTemplate{
+						Name: "test",
+					},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing launch template name is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AWSLaunchTemplate: &AWSLaunchTemplate{
+						Name: "test",
+					},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AWSLaunchTemplate: &AWSLaunchTemplate{
+						Name: "test2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing launch template fields other than name is accepted",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AWSLaunchTemplate: &AWSLaunchTemplate{
+						Name:              "test",
+						ImageLookupFormat: "test",
+					},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					AWSLaunchTemplate: &AWSLaunchTemplate{
+						Name:              "test",
+						ImageLookupFormat: "test2",
+					},
 				},
 			},
 			wantErr: false,

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -305,6 +305,8 @@ const (
 	AZSubnetTypePublic AZSubnetType = "public"
 	// AZSubnetTypePrivate is a private subnet.
 	AZSubnetTypePrivate AZSubnetType = "private"
+	// AZSubnetTypeAll is all subnets in an availability zone.
+	AZSubnetTypeAll AZSubnetType = "all"
 )
 
 // NewAZSubnetType returns a pointer to an AZSubnetType.

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -296,3 +296,18 @@ type UpdateConfig struct {
 	// +kubebuilder:validation:Minimum=1
 	MaxUnavailablePercentage *int `json:"maxUnavailablePercentage,omitempty"`
 }
+
+// AZSubnetType is the type of subnet to use when an availability zone is specified.
+type AZSubnetType string
+
+const (
+	// AZSubnetTypePublic is a public subnet.
+	AZSubnetTypePublic AZSubnetType = "public"
+	// AZSubnetTypePrivate is a private subnet.
+	AZSubnetTypePrivate AZSubnetType = "private"
+)
+
+// NewAZSubnetType returns a pointer to an AZSubnetType.
+func NewAZSubnetType(t AZSubnetType) *AZSubnetType {
+	return &t
+}

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -222,6 +222,11 @@ func (in *AWSMachinePoolSpec) DeepCopyInto(out *AWSMachinePoolSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AvailabilityZoneSubnetType != nil {
+		in, out := &in.AvailabilityZoneSubnetType, &out.AvailabilityZoneSubnetType
+		*out = new(AZSubnetType)
+		**out = **in
+	}
 	if in.Subnets != nil {
 		in, out := &in.Subnets, &out.Subnets
 		*out = make([]apiv1beta2.AWSResourceReference, len(*in))
@@ -385,6 +390,11 @@ func (in *AWSManagedMachinePoolSpec) DeepCopyInto(out *AWSManagedMachinePoolSpec
 		in, out := &in.AvailabilityZones, &out.AvailabilityZones
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.AvailabilityZoneSubnetType != nil {
+		in, out := &in.AvailabilityZoneSubnetType, &out.AvailabilityZoneSubnetType
+		*out = new(AZSubnetType)
+		**out = **in
 	}
 	if in.SubnetIDs != nil {
 		in, out := &in.SubnetIDs, &out.SubnetIDs

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -302,6 +302,7 @@ func (m *MachinePoolScope) SubnetIDs(subnetIDs []string) ([]string, error) {
 		SpecAvailabilityZones:   m.AWSMachinePool.Spec.AvailabilityZones,
 		ParentAvailabilityZones: m.MachinePool.Spec.FailureDomains,
 		ControlplaneSubnets:     m.InfraCluster.Subnets(),
+		SubnetPlacementType:     m.AWSMachinePool.Spec.AvailabilityZoneSubnetType,
 	})
 }
 

--- a/pkg/cloud/scope/managednodegroup.go
+++ b/pkg/cloud/scope/managednodegroup.go
@@ -216,6 +216,7 @@ func (s *ManagedMachinePoolScope) SubnetIDs() ([]string, error) {
 		SpecAvailabilityZones:   s.ManagedMachinePool.Spec.AvailabilityZones,
 		ParentAvailabilityZones: s.MachinePool.Spec.FailureDomains,
 		ControlplaneSubnets:     s.ControlPlaneSubnets(),
+		SubnetPlacementType:     s.ManagedMachinePool.Spec.AvailabilityZoneSubnetType,
 	})
 }
 

--- a/pkg/cloud/scope/shared.go
+++ b/pkg/cloud/scope/shared.go
@@ -111,6 +111,8 @@ func (p *defaultSubnetPlacementStrategy) getSubnetsForAZs(azs []string, controlP
 		subnets := controlPlaneSubnets.FilterByZone(zone)
 		if placementType != nil {
 			switch *placementType {
+			case expinfrav1.AZSubnetTypeAll:
+				// no-op
 			case expinfrav1.AZSubnetTypePublic:
 				subnets = subnets.FilterPublic()
 			case expinfrav1.AZSubnetTypePrivate:

--- a/pkg/cloud/scope/shared.go
+++ b/pkg/cloud/scope/shared.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 )
 
@@ -40,6 +41,7 @@ type placementInput struct {
 	SpecAvailabilityZones   []string
 	ParentAvailabilityZones []string
 	ControlplaneSubnets     infrav1.Subnets
+	SubnetPlacementType     *expinfrav1.AZSubnetType
 }
 
 type subnetsPlacementStratgey interface {
@@ -75,7 +77,7 @@ func (p *defaultSubnetPlacementStrategy) Place(input *placementInput) ([]string,
 
 	if len(input.SpecAvailabilityZones) > 0 {
 		p.logger.Debug("determining subnets to use from the spec availability zones")
-		subnetIDs, err := p.getSubnetsForAZs(input.SpecAvailabilityZones, input.ControlplaneSubnets)
+		subnetIDs, err := p.getSubnetsForAZs(input.SpecAvailabilityZones, input.ControlplaneSubnets, input.SubnetPlacementType)
 		if err != nil {
 			return nil, fmt.Errorf("getting subnets for spec azs: %w", err)
 		}
@@ -85,7 +87,7 @@ func (p *defaultSubnetPlacementStrategy) Place(input *placementInput) ([]string,
 
 	if len(input.ParentAvailabilityZones) > 0 {
 		p.logger.Debug("determining subnets to use from the parents availability zones")
-		subnetIDs, err := p.getSubnetsForAZs(input.ParentAvailabilityZones, input.ControlplaneSubnets)
+		subnetIDs, err := p.getSubnetsForAZs(input.ParentAvailabilityZones, input.ControlplaneSubnets, input.SubnetPlacementType)
 		if err != nil {
 			return nil, fmt.Errorf("getting subnets for parent azs: %w", err)
 		}
@@ -102,11 +104,19 @@ func (p *defaultSubnetPlacementStrategy) Place(input *placementInput) ([]string,
 	return nil, ErrNotPlaced
 }
 
-func (p *defaultSubnetPlacementStrategy) getSubnetsForAZs(azs []string, controlPlaneSubnets infrav1.Subnets) ([]string, error) {
+func (p *defaultSubnetPlacementStrategy) getSubnetsForAZs(azs []string, controlPlaneSubnets infrav1.Subnets, placementType *expinfrav1.AZSubnetType) ([]string, error) {
 	subnetIDs := []string{}
 
 	for _, zone := range azs {
 		subnets := controlPlaneSubnets.FilterByZone(zone)
+		if placementType != nil {
+			switch *placementType {
+			case expinfrav1.AZSubnetTypePublic:
+				subnets = subnets.FilterPublic()
+			case expinfrav1.AZSubnetTypePrivate:
+				subnets = subnets.FilterPrivate()
+			}
+		}
 		if len(subnets) == 0 {
 			return nil, fmt.Errorf("getting subnets for availability zone %s: %w", zone, ErrAZSubnetsNotFound)
 		}

--- a/pkg/cloud/scope/shared_test.go
+++ b/pkg/cloud/scope/shared_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 )
 
@@ -32,28 +33,43 @@ func TestSubnetPlacement(t *testing.T) {
 		specSubnetIDs       []string
 		specAZs             []string
 		parentAZs           []string
+		subnetPlacementType *expinfrav1.AZSubnetType
 		controlPlaneSubnets infrav1.Subnets
 		logger              *logger.Logger
 		expectedSubnetIDs   []string
 		expectError         bool
 	}{
 		{
-			name:          "spec subnets expected",
-			specSubnetIDs: []string{"az1"},
-			specAZs:       []string{"eu-west-1b"},
-			parentAZs:     []string{"eu-west-1c"},
+			name:                "spec subnets expected",
+			specSubnetIDs:       []string{"az1"},
+			specAZs:             []string{"eu-west-1b"},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: nil,
 			controlPlaneSubnets: infrav1.Subnets{
 				infrav1.SubnetSpec{
 					ID:               "az1",
 					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
 				},
 				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
 				},
 				infrav1.SubnetSpec{
 					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
 					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
 				},
 			},
 			logger:            logger.NewLogger(klog.Background()),
@@ -61,22 +77,147 @@ func TestSubnetPlacement(t *testing.T) {
 			expectError:       false,
 		},
 		{
-			name:          "spec azs expected",
-			specSubnetIDs: []string{},
-			specAZs:       []string{"eu-west-1b"},
-			parentAZs:     []string{"eu-west-1c"},
+			name:                "spec azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{"eu-west-1b"},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: nil,
 			controlPlaneSubnets: infrav1.Subnets{
 				infrav1.SubnetSpec{
 					ID:               "az1",
 					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
 				},
 				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
 				},
 				infrav1.SubnetSpec{
 					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
 					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
+			},
+			logger:            logger.NewLogger(klog.Background()),
+			expectedSubnetIDs: []string{"az2", "az3"},
+			expectError:       false,
+		},
+		{
+			name:                "parent azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: nil,
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
+			},
+			logger:            logger.NewLogger(klog.Background()),
+			expectedSubnetIDs: []string{"az4", "az5"},
+			expectError:       false,
+		},
+		{
+			name:                "spec private azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{"eu-west-1b"},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: expinfrav1.NewAZSubnetType(expinfrav1.AZSubnetTypePrivate),
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
+			},
+			logger:            logger.NewLogger(klog.Background()),
+			expectedSubnetIDs: []string{"az3"},
+			expectError:       false,
+		},
+		{
+			name:                "spec public azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{"eu-west-1b"},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: expinfrav1.NewAZSubnetType(expinfrav1.AZSubnetTypePublic),
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
 				},
 			},
 			logger:            logger.NewLogger(klog.Background()),
@@ -84,26 +225,114 @@ func TestSubnetPlacement(t *testing.T) {
 			expectError:       false,
 		},
 		{
-			name:          "parent azs expected",
-			specSubnetIDs: []string{},
-			specAZs:       []string{},
-			parentAZs:     []string{"eu-west-1c"},
+			name:                "spec public no azs found",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{"eu-west-1a"},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: expinfrav1.NewAZSubnetType(expinfrav1.AZSubnetTypePublic),
 			controlPlaneSubnets: infrav1.Subnets{
 				infrav1.SubnetSpec{
 					ID:               "az1",
 					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
 				},
 				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
 				},
 				infrav1.SubnetSpec{
 					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
 					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
 				},
 			},
 			logger:            logger.NewLogger(klog.Background()),
-			expectedSubnetIDs: []string{"az3"},
+			expectedSubnetIDs: []string{},
+			expectError:       true,
+		},
+		{
+			name:                "parent private azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: expinfrav1.NewAZSubnetType(expinfrav1.AZSubnetTypePrivate),
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
+			},
+			logger:            logger.NewLogger(klog.Background()),
+			expectedSubnetIDs: []string{"az5"},
+			expectError:       false,
+		},
+		{
+			name:                "parent public azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: expinfrav1.NewAZSubnetType(expinfrav1.AZSubnetTypePublic),
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
+			},
+			logger:            logger.NewLogger(klog.Background()),
+			expectedSubnetIDs: []string{"az4"},
 			expectError:       false,
 		},
 		{
@@ -120,16 +349,26 @@ func TestSubnetPlacement(t *testing.T) {
 				infrav1.SubnetSpec{
 					ID:               "az2",
 					AvailabilityZone: "eu-west-1b",
-					IsPublic:         false,
+					IsPublic:         true,
 				},
 				infrav1.SubnetSpec{
 					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
 					AvailabilityZone: "eu-west-1c",
 					IsPublic:         true,
 				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
 			},
 			logger:            logger.NewLogger(klog.Background()),
-			expectedSubnetIDs: []string{"az1", "az2"},
+			expectedSubnetIDs: []string{"az1", "az3", "az5"},
 			expectError:       false,
 		},
 		{
@@ -156,6 +395,7 @@ func TestSubnetPlacement(t *testing.T) {
 				SpecAvailabilityZones:   tc.specAZs,
 				ParentAvailabilityZones: tc.parentAZs,
 				ControlplaneSubnets:     tc.controlPlaneSubnets,
+				SubnetPlacementType:     tc.subnetPlacementType,
 			})
 
 			if tc.expectError {

--- a/pkg/cloud/scope/shared_test.go
+++ b/pkg/cloud/scope/shared_test.go
@@ -225,6 +225,43 @@ func TestSubnetPlacement(t *testing.T) {
 			expectError:       false,
 		},
 		{
+			name:                "spec all azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{"eu-west-1b"},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: expinfrav1.NewAZSubnetType(expinfrav1.AZSubnetTypeAll),
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
+			},
+			logger:            logger.NewLogger(klog.Background()),
+			expectedSubnetIDs: []string{"az2", "az3"},
+			expectError:       false,
+		},
+		{
 			name:                "spec public no azs found",
 			specSubnetIDs:       []string{},
 			specAZs:             []string{"eu-west-1a"},
@@ -333,6 +370,43 @@ func TestSubnetPlacement(t *testing.T) {
 			},
 			logger:            logger.NewLogger(klog.Background()),
 			expectedSubnetIDs: []string{"az4"},
+			expectError:       false,
+		},
+		{
+			name:                "parent all azs expected",
+			specSubnetIDs:       []string{},
+			specAZs:             []string{},
+			parentAZs:           []string{"eu-west-1c"},
+			subnetPlacementType: expinfrav1.NewAZSubnetType(expinfrav1.AZSubnetTypeAll),
+			controlPlaneSubnets: infrav1.Subnets{
+				infrav1.SubnetSpec{
+					ID:               "az1",
+					AvailabilityZone: "eu-west-1a",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az2",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az3",
+					AvailabilityZone: "eu-west-1b",
+					IsPublic:         false,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az4",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         true,
+				},
+				infrav1.SubnetSpec{
+					ID:               "az5",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+				},
+			},
+			logger:            logger.NewLogger(klog.Background()),
+			expectedSubnetIDs: []string{"az4", "az5"},
 			expectError:       false,
 		},
 		{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Currently when specifying the availability zone(s) for a (managed) machine pool, all the subnets in the zone(s) will be used. By default CAPI creates both a public and a private subnet in each availability zone. So when a machine pool specifies an availability zone, both the public and private subnets for the zone are used for the machine pool. It seems as though the private subnet is preferred in the ASG, however, I haven't been able to find any documentation regarding which subnet an instance gets launched in when an ASG contains both a private and public subnet. This means it's nondeterministic in which subnet an instance of the ASG will be launched in.

To solve for this, a new optional parameter `AvailabilityZoneSubnetType` is added to the `AWSManagedMachinePool` and `AWSMachinePool` specs allowing administrators to choose if the machine pool should use public or private subnets in the requested availability zones. If the parameter isn't specified the current behavior is kept where both public and private subnets in the availability zone(s) are used. This is also related to https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2191 where the preferred subnet type is `private` when no options are specified, but doing this currently isn't possible when specifying availability zone(s) for a machine pool.


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**:
Fixes #2991

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow for specifying if private or public subnets should be used when availability zones are defined in `AWSManagedMachinePool` and `AWSMachinePool` specs.
```
