### PR TITLE
Replace all AWS SDK calls with their WithContext analogs

### DIFF
--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -425,7 +425,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 }
 
 func mockedDeleteSGCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.DescribeSecurityGroupsPages(gomock.Any(), gomock.Any()).Return(nil)
+	m.DescribeSecurityGroupsPagesWithContext(context.TODO(), gomock.Any(), gomock.Any()).Return(nil)
 }
 
 func createControllerIdentity(g *WithT) *infrav1.AWSClusterControllerIdentity {
@@ -447,7 +447,7 @@ func createControllerIdentity(g *WithT) *infrav1.AWSClusterControllerIdentity {
 }
 
 func mockedDescribeInstanceCall(m *mocks.MockEC2APIMockRecorder) {
-	m.DescribeInstances(gomock.Eq(&ec2.DescribeInstancesInput{
+	m.DescribeInstancesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag:sigs.k8s.io/cluster-api-provider-aws/role"),
@@ -498,12 +498,12 @@ func mockedDescribeInstanceCall(m *mocks.MockEC2APIMockRecorder) {
 }
 
 func mockedDeleteInstanceAndAwaitTerminationCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.TerminateInstances(
+	m.TerminateInstancesWithContext(context.TODO(),
 		gomock.Eq(&ec2.TerminateInstancesInput{
 			InstanceIds: aws.StringSlice([]string{"id-1"}),
 		}),
 	).Return(nil, nil)
-	m.WaitUntilInstanceTerminated(
+	m.WaitUntilInstanceTerminatedWithContext(context.TODO(),
 		gomock.Eq(&ec2.DescribeInstancesInput{
 			InstanceIds: aws.StringSlice([]string{"id-1"}),
 		}),
@@ -511,7 +511,7 @@ func mockedDeleteInstanceAndAwaitTerminationCalls(m *mocks.MockEC2APIMockRecorde
 }
 
 func mockedDeleteInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.TerminateInstances(
+	m.TerminateInstancesWithContext(context.TODO(),
 		gomock.Eq(&ec2.TerminateInstancesInput{
 			InstanceIds: aws.StringSlice([]string{"id-1"}),
 		}),
@@ -519,7 +519,7 @@ func mockedDeleteInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 }
 
 func mockedCreateVPCCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+	m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 		Resources: aws.StringSlice([]string{"subnet-1"}),
 		Tags: []*ec2.Tag{
 			{
@@ -532,7 +532,7 @@ func mockedCreateVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	})).Return(&ec2.CreateTagsOutput{}, nil)
-	m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+	m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 		Resources: aws.StringSlice([]string{"subnet-2"}),
 		Tags: []*ec2.Tag{
 			{
@@ -545,7 +545,7 @@ func mockedCreateVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	})).Return(&ec2.CreateTagsOutput{}, nil)
-	m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+	m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("state"),
@@ -591,7 +591,7 @@ func mockedCreateVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil)
-	m.DescribeRouteTables(gomock.Eq(&ec2.DescribeRouteTablesInput{
+	m.DescribeRouteTablesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
@@ -608,7 +608,7 @@ func mockedCreateVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil)
-	m.DescribeNatGatewaysPages(gomock.Eq(&ec2.DescribeNatGatewaysInput{
+	m.DescribeNatGatewaysPagesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
 		Filter: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
@@ -619,7 +619,7 @@ func mockedCreateVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 				Values: aws.StringSlice([]string{ec2.VpcStatePending, ec2.VpcStateAvailable}),
 			},
 		}}), gomock.Any()).Return(nil)
-	m.DescribeVpcs(gomock.Eq(&ec2.DescribeVpcsInput{
+	m.DescribeVpcsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeVpcsInput{
 		VpcIds: []*string{
 			aws.String("vpc-exists"),
 		},
@@ -652,11 +652,11 @@ func mockedCreateVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 }
 
 func mockedCreateMaximumVPCCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.CreateVpc(gomock.AssignableToTypeOf(&ec2.CreateVpcInput{})).Return(nil, errors.New("The maximum number of VPCs has been reached"))
+	m.CreateVpcWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateVpcInput{})).Return(nil, errors.New("The maximum number of VPCs has been reached"))
 }
 
 func mockedDeleteVPCCallsForNonExistentVPC(m *mocks.MockEC2APIMockRecorder) {
-	m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+	m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("state"),
@@ -669,7 +669,7 @@ func mockedDeleteVPCCallsForNonExistentVPC(m *mocks.MockEC2APIMockRecorder) {
 		}})).Return(&ec2.DescribeSubnetsOutput{
 		Subnets: []*ec2.Subnet{},
 	}, nil).AnyTimes()
-	m.DescribeRouteTables(gomock.Eq(&ec2.DescribeRouteTablesInput{
+	m.DescribeRouteTablesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{{
 			Name:   aws.String("vpc-id"),
 			Values: aws.StringSlice([]string{""}),
@@ -680,7 +680,7 @@ func mockedDeleteVPCCallsForNonExistentVPC(m *mocks.MockEC2APIMockRecorder) {
 			},
 		}})).Return(&ec2.DescribeRouteTablesOutput{
 		RouteTables: []*ec2.RouteTable{}}, nil).AnyTimes()
-	m.DescribeInternetGateways(gomock.Eq(&ec2.DescribeInternetGatewaysInput{
+	m.DescribeInternetGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInternetGatewaysInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("attachment.vpc-id"),
@@ -690,7 +690,7 @@ func mockedDeleteVPCCallsForNonExistentVPC(m *mocks.MockEC2APIMockRecorder) {
 	})).Return(&ec2.DescribeInternetGatewaysOutput{
 		InternetGateways: []*ec2.InternetGateway{},
 	}, nil)
-	m.DescribeNatGatewaysPages(gomock.Eq(&ec2.DescribeNatGatewaysInput{
+	m.DescribeNatGatewaysPagesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
 		Filter: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
@@ -698,19 +698,19 @@ func mockedDeleteVPCCallsForNonExistentVPC(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}), gomock.Any()).Return(nil).AnyTimes()
-	m.DescribeAddresses(gomock.Eq(&ec2.DescribeAddressesInput{
+	m.DescribeAddressesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeAddressesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag-key"),
 				Values: aws.StringSlice([]string{"sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"}),
 			}},
 	})).Return(nil, nil)
-	m.DeleteVpc(gomock.AssignableToTypeOf(&ec2.DeleteVpcInput{
+	m.DeleteVpcWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DeleteVpcInput{
 		VpcId: aws.String("vpc-exists")})).Return(nil, nil)
 }
 
 func mockedDeleteVPCCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+	m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("state"),
@@ -731,7 +731,7 @@ func mockedDeleteVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil).AnyTimes()
-	m.DescribeRouteTables(gomock.Eq(&ec2.DescribeRouteTablesInput{
+	m.DescribeRouteTablesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
@@ -753,10 +753,10 @@ func mockedDeleteVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil).AnyTimes()
-	m.DeleteRouteTable(gomock.Eq(&ec2.DeleteRouteTableInput{
+	m.DeleteRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.DeleteRouteTableInput{
 		RouteTableId: aws.String("rt-12345"),
 	}))
-	m.DescribeInternetGateways(gomock.Eq(&ec2.DescribeInternetGatewaysInput{
+	m.DescribeInternetGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInternetGatewaysInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("attachment.vpc-id"),
@@ -771,14 +771,14 @@ func mockedDeleteVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil)
-	m.DetachInternetGateway(gomock.Eq(&ec2.DetachInternetGatewayInput{
+	m.DetachInternetGatewayWithContext(context.TODO(), gomock.Eq(&ec2.DetachInternetGatewayInput{
 		VpcId:             aws.String("vpc-exists"),
 		InternetGatewayId: aws.String("ig-12345"),
 	}))
-	m.DeleteInternetGateway(gomock.Eq(&ec2.DeleteInternetGatewayInput{
+	m.DeleteInternetGatewayWithContext(context.TODO(), gomock.Eq(&ec2.DeleteInternetGatewayInput{
 		InternetGatewayId: aws.String("ig-12345"),
 	}))
-	m.DescribeNatGatewaysPages(gomock.Eq(&ec2.DescribeNatGatewaysInput{
+	m.DescribeNatGatewaysPagesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
 		Filter: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
@@ -789,7 +789,7 @@ func mockedDeleteVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 				Values: aws.StringSlice([]string{ec2.VpcStatePending, ec2.VpcStateAvailable}),
 			},
 		}}), gomock.Any()).Return(nil).AnyTimes()
-	m.DescribeAddresses(gomock.Eq(&ec2.DescribeAddressesInput{
+	m.DescribeAddressesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeAddressesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag-key"),
@@ -804,13 +804,13 @@ func mockedDeleteVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil)
-	m.DisassociateAddress(&ec2.DisassociateAddressInput{
+	m.DisassociateAddressWithContext(context.TODO(), &ec2.DisassociateAddressInput{
 		AssociationId: aws.String("1234"),
 	})
-	m.ReleaseAddress(&ec2.ReleaseAddressInput{
+	m.ReleaseAddressWithContext(context.TODO(), &ec2.ReleaseAddressInput{
 		AllocationId: aws.String("1234"),
 	})
-	m.DescribeVpcs(gomock.Eq(&ec2.DescribeVpcsInput{
+	m.DescribeVpcsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeVpcsInput{
 		VpcIds: []*string{
 			aws.String("vpc-exists"),
 		},
@@ -844,16 +844,16 @@ func mockedDeleteVPCCalls(m *mocks.MockEC2APIMockRecorder) {
 				},
 			},
 		}, nil)
-	m.DeleteSubnet(gomock.Eq(&ec2.DeleteSubnetInput{
+	m.DeleteSubnetWithContext(context.TODO(), gomock.Eq(&ec2.DeleteSubnetInput{
 		SubnetId: aws.String("subnet-1"),
 	}))
-	m.DeleteVpc(gomock.Eq(&ec2.DeleteVpcInput{
+	m.DeleteVpcWithContext(context.TODO(), gomock.Eq(&ec2.DeleteVpcInput{
 		VpcId: aws.String("vpc-exists"),
 	}))
 }
 
 func mockedCreateSGCalls(recordLBV2 bool, m *mocks.MockEC2APIMockRecorder) {
-	m.DescribeSecurityGroups(gomock.Eq(&ec2.DescribeSecurityGroupsInput{
+	m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
@@ -873,7 +873,7 @@ func mockedCreateSGCalls(recordLBV2 bool, m *mocks.MockEC2APIMockRecorder) {
 				},
 			},
 		}, nil)
-	m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+	m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 		VpcId:       aws.String("vpc-exists"),
 		GroupName:   aws.String("test-cluster-bastion"),
 		Description: aws.String("Kubernetes cluster test-cluster: bastion"),
@@ -898,7 +898,7 @@ func mockedCreateSGCalls(recordLBV2 bool, m *mocks.MockEC2APIMockRecorder) {
 		},
 	})).
 		Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-bastion")}, nil)
-	m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+	m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 		VpcId:       aws.String("vpc-exists"),
 		GroupName:   aws.String("test-cluster-apiserver-lb"),
 		Description: aws.String("Kubernetes cluster test-cluster: apiserver-lb"),
@@ -923,7 +923,7 @@ func mockedCreateSGCalls(recordLBV2 bool, m *mocks.MockEC2APIMockRecorder) {
 		},
 	})).
 		Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-apiserver-lb")}, nil)
-	m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+	m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 		VpcId:       aws.String("vpc-exists"),
 		GroupName:   aws.String("test-cluster-lb"),
 		Description: aws.String("Kubernetes cluster test-cluster: lb"),
@@ -952,7 +952,7 @@ func mockedCreateSGCalls(recordLBV2 bool, m *mocks.MockEC2APIMockRecorder) {
 		},
 	})).
 		Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-lb")}, nil)
-	securityGroupControl := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+	securityGroupControl := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 		VpcId:       aws.String("vpc-exists"),
 		GroupName:   aws.String("test-cluster-controlplane"),
 		Description: aws.String("Kubernetes cluster test-cluster: controlplane"),
@@ -977,7 +977,7 @@ func mockedCreateSGCalls(recordLBV2 bool, m *mocks.MockEC2APIMockRecorder) {
 		},
 	})).
 		Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-controlplane")}, nil)
-	securityGroupNode := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+	securityGroupNode := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 		VpcId:       aws.String("vpc-exists"),
 		GroupName:   aws.String("test-cluster-node"),
 		Description: aws.String("Kubernetes cluster test-cluster: node"),
@@ -1002,18 +1002,18 @@ func mockedCreateSGCalls(recordLBV2 bool, m *mocks.MockEC2APIMockRecorder) {
 		},
 	})).
 		Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-node")}, nil)
-	m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+	m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String("sg-controlplane"),
 	})).
 		Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 		After(securityGroupControl).Times(2)
-	m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+	m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String("sg-node"),
 	})).
 		Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 		After(securityGroupNode).Times(2)
 	if recordLBV2 {
-		m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+		m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 			GroupId: aws.String("sg-lb"),
 		})).
 			Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -336,7 +337,7 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 		expect := func(m *mocks.MockEC2APIMockRecorder, ev2 *mocks.MockELBV2APIMockRecorder, e *mocks.MockELBAPIMockRecorder) {
 			mockedDescribeInstanceCalls(m)
 			mockedDeleteLBCalls(false, ev2, e)
-			m.TerminateInstances(
+			m.TerminateInstancesWithContext(context.TODO(),
 				gomock.Eq(&ec2.TerminateInstancesInput{
 					InstanceIds: aws.StringSlice([]string{"id-1"}),
 				}),
@@ -527,7 +528,7 @@ func mockedCreateSecretCall(s *mock_services.MockSecretInterfaceMockRecorder) {
 }
 
 func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.DescribeInstances(gomock.Eq(&ec2.DescribeInstancesInput{
+	m.DescribeInstancesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
@@ -547,7 +548,7 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	})).Return(&ec2.DescribeInstancesOutput{}, nil)
-	m.DescribeInstanceTypes(gomock.Any()).
+	m.DescribeInstanceTypesWithContext(context.TODO(), gomock.Any()).
 		Return(&ec2.DescribeInstanceTypesOutput{
 			InstanceTypes: []*ec2.InstanceTypeInfo{
 				{
@@ -559,7 +560,7 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 				},
 			},
 		}, nil)
-	m.DescribeImages(gomock.Eq(&ec2.DescribeImagesInput{
+	m.DescribeImagesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("owner-id"),
@@ -587,7 +588,7 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 			CreationDate: aws.String("2019-02-08T17:02:31.000Z"),
 		},
 	}}, nil)
-	m.RunInstances(gomock.Any()).Return(&ec2.Reservation{
+	m.RunInstancesWithContext(context.TODO(), gomock.Any()).Return(&ec2.Reservation{
 		Instances: []*ec2.Instance{
 			{
 				State: &ec2.InstanceState{
@@ -615,7 +616,7 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 			},
 		},
 	}, nil)
-	m.DescribeNetworkInterfaces(gomock.Eq(&ec2.DescribeNetworkInterfacesInput{Filters: []*ec2.Filter{
+	m.DescribeNetworkInterfacesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNetworkInterfacesInput{Filters: []*ec2.Filter{
 		{
 			Name:   aws.String("attachment.instance-id"),
 			Values: aws.StringSlice([]string{"two"}),
@@ -631,12 +632,12 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 				},
 			},
 		}}, nil).MaxTimes(3)
-	m.DescribeNetworkInterfaceAttribute(gomock.Eq(&ec2.DescribeNetworkInterfaceAttributeInput{
+	m.DescribeNetworkInterfaceAttributeWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String("eni-1"),
 		Attribute:          aws.String("groupSet"),
 	})).Return(&ec2.DescribeNetworkInterfaceAttributeOutput{Groups: []*ec2.GroupIdentifier{{GroupId: aws.String("3")}}}, nil).MaxTimes(1)
-	m.ModifyNetworkInterfaceAttribute(gomock.Any()).AnyTimes()
-	m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{Filters: []*ec2.Filter{
+	m.ModifyNetworkInterfaceAttributeWithContext(context.TODO(), gomock.Any()).AnyTimes()
+	m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{Filters: []*ec2.Filter{
 		{
 			Name:   aws.String("state"),
 			Values: aws.StringSlice([]string{"pending", "available"}),
@@ -657,7 +658,7 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 }
 
 func mockedDescribeInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
-	m.DescribeInstances(gomock.Eq(&ec2.DescribeInstancesInput{
+	m.DescribeInstancesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice([]string{"myMachine"}),
 	})).Return(&ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{{Instances: []*ec2.Instance{{Placement: &ec2.Placement{AvailabilityZone: aws.String("us-east-1a")}, InstanceId: aws.String("id-1"), State: &ec2.InstanceState{Name: aws.String("id-1"), Code: aws.Int64(16)}}}}},

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -2560,7 +2560,7 @@ func TestAWSMachineReconcilerReconcileDefaultsToLoadBalancerTypeClassic(t *testi
 		return secretMock
 	}
 
-	ec2Mock.EXPECT().DescribeInstances(gomock.Eq(&ec2.DescribeInstancesInput{
+	ec2Mock.EXPECT().DescribeInstancesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice([]string{"two"}),
 	})).Return(&ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
@@ -2592,7 +2592,7 @@ func TestAWSMachineReconcilerReconcileDefaultsToLoadBalancerTypeClassic(t *testi
 	// Must attach to a classic LB, not another type. Only these mock calls are therefore expected.
 	mockedCreateLBCalls(t, elbMock.EXPECT())
 
-	ec2Mock.EXPECT().DescribeNetworkInterfaces(gomock.Eq(&ec2.DescribeNetworkInterfacesInput{Filters: []*ec2.Filter{
+	ec2Mock.EXPECT().DescribeNetworkInterfacesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNetworkInterfacesInput{Filters: []*ec2.Filter{
 		{
 			Name:   aws.String("attachment.instance-id"),
 			Values: aws.StringSlice([]string{"two"}),
@@ -2608,11 +2608,11 @@ func TestAWSMachineReconcilerReconcileDefaultsToLoadBalancerTypeClassic(t *testi
 				},
 			},
 		}}, nil).MaxTimes(3)
-	ec2Mock.EXPECT().DescribeNetworkInterfaceAttribute(gomock.Eq(&ec2.DescribeNetworkInterfaceAttributeInput{
+	ec2Mock.EXPECT().DescribeNetworkInterfaceAttributeWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String("eni-1"),
 		Attribute:          aws.String("groupSet"),
 	})).Return(&ec2.DescribeNetworkInterfaceAttributeOutput{Groups: []*ec2.GroupIdentifier{{GroupId: aws.String("3")}}}, nil).MaxTimes(1)
-	ec2Mock.EXPECT().ModifyNetworkInterfaceAttribute(gomock.Any()).AnyTimes()
+	ec2Mock.EXPECT().ModifyNetworkInterfaceAttributeWithContext(context.TODO(), gomock.Any()).AnyTimes()
 
 	_, err = reconciler.Reconcile(ctx, ctrl.Request{
 		NamespacedName: client.ObjectKey{

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package asg
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -132,7 +133,7 @@ func (s *Service) ASGIfExists(name *string) (*expinfrav1.AutoScalingGroup, error
 		AutoScalingGroupNames: []*string{name},
 	}
 
-	out, err := s.ASGClient.DescribeAutoScalingGroups(input)
+	out, err := s.ASGClient.DescribeAutoScalingGroupsWithContext(context.TODO(), input)
 	switch {
 	case awserrors.IsNotFound(err):
 		return nil, nil
@@ -239,7 +240,7 @@ func (s *Service) runPool(i *expinfrav1.AutoScalingGroup, launchTemplateID strin
 		input.Tags = BuildTagsFromMap(i.Name, i.Tags)
 	}
 
-	if _, err := s.ASGClient.CreateAutoScalingGroup(input); err != nil {
+	if _, err := s.ASGClient.CreateAutoScalingGroupWithContext(context.TODO(), input); err != nil {
 		return errors.Wrap(err, "failed to create autoscaling group")
 	}
 
@@ -258,7 +259,7 @@ func (s *Service) DeleteASGAndWait(name string) error {
 		AutoScalingGroupNames: aws.StringSlice([]string{name}),
 	}
 
-	if err := s.ASGClient.WaitUntilGroupNotExists(input); err != nil {
+	if err := s.ASGClient.WaitUntilGroupNotExistsWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to wait for ASG %q deletion", name)
 	}
 
@@ -274,7 +275,7 @@ func (s *Service) DeleteASG(name string) error {
 		ForceDelete:          aws.Bool(true),
 	}
 
-	if _, err := s.ASGClient.DeleteAutoScalingGroup(input); err != nil {
+	if _, err := s.ASGClient.DeleteAutoScalingGroupWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to delete ASG %q", name)
 	}
 
@@ -310,7 +311,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 		}
 	}
 
-	if _, err := s.ASGClient.UpdateAutoScalingGroup(input); err != nil {
+	if _, err := s.ASGClient.UpdateAutoScalingGroupWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to update ASG %q", scope.Name())
 	}
 
@@ -320,7 +321,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 // CanStartASGInstanceRefresh will start an ASG instance with refresh.
 func (s *Service) CanStartASGInstanceRefresh(scope *scope.MachinePoolScope) (bool, error) {
 	describeInput := &autoscaling.DescribeInstanceRefreshesInput{AutoScalingGroupName: aws.String(scope.Name())}
-	refreshes, err := s.ASGClient.DescribeInstanceRefreshes(describeInput)
+	refreshes, err := s.ASGClient.DescribeInstanceRefreshesWithContext(context.TODO(), describeInput)
 	if err != nil {
 		return false, err
 	}
@@ -365,7 +366,7 @@ func (s *Service) StartASGInstanceRefresh(scope *scope.MachinePoolScope) error {
 		},
 	}
 
-	if _, err := s.ASGClient.StartInstanceRefresh(input); err != nil {
+	if _, err := s.ASGClient.StartInstanceRefreshWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to start ASG instance refresh %q", scope.Name())
 	}
 
@@ -437,7 +438,7 @@ func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[stri
 
 		createOrUpdateTagsInput.Tags = mapToTags(create, resourceID)
 
-		if _, err := s.ASGClient.CreateOrUpdateTags(createOrUpdateTagsInput); err != nil {
+		if _, err := s.ASGClient.CreateOrUpdateTagsWithContext(context.TODO(), createOrUpdateTagsInput); err != nil {
 			return errors.Wrapf(err, "failed to update tags on AutoScalingGroup %q", *resourceID)
 		}
 	}
@@ -455,7 +456,7 @@ func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[stri
 		}
 
 		// Delete tags in AWS.
-		if _, err := s.ASGClient.DeleteTags(input); err != nil {
+		if _, err := s.ASGClient.DeleteTagsWithContext(context.TODO(), input); err != nil {
 			return errors.Wrapf(err, "failed to delete tags on AutoScalingGroup %q: %v", *resourceID, remove)
 		}
 	}
@@ -468,7 +469,7 @@ func (s *Service) SuspendProcesses(name string, processes []string) error {
 		AutoScalingGroupName: aws.String(name),
 		ScalingProcesses:     aws.StringSlice(processes),
 	}
-	if _, err := s.ASGClient.SuspendProcesses(&input); err != nil {
+	if _, err := s.ASGClient.SuspendProcessesWithContext(context.TODO(), &input); err != nil {
 		return errors.Wrapf(err, "failed to suspend processes for AutoScalingGroup: %q", name)
 	}
 	return nil
@@ -479,7 +480,7 @@ func (s *Service) ResumeProcesses(name string, processes []string) error {
 		AutoScalingGroupName: aws.String(name),
 		ScalingProcesses:     aws.StringSlice(processes),
 	}
-	if _, err := s.ASGClient.ResumeProcesses(&input); err != nil {
+	if _, err := s.ASGClient.ResumeProcessesWithContext(context.TODO(), &input); err != nil {
 		return errors.Wrapf(err, "failed to resume processes for AutoScalingGroup: %q", name)
 	}
 	return nil
@@ -519,7 +520,7 @@ func (s *Service) SubnetIDs(scope *scope.MachinePoolScope) ([]string, error) {
 	}
 
 	if len(inputFilters) > 0 {
-		out, err := s.EC2Client.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		out, err := s.EC2Client.DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 			Filters: inputFilters,
 		})
 		if err != nil {

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package asg
 
 import (
+	"context"
 	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
@@ -57,7 +59,7 @@ func TestServiceGetASGByName(t *testing.T) {
 			wantErr:         false,
 			wantASG:         false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.DescribeAutoScalingGroupsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: []*string{
 						aws.String("test-asg-is-not-present"),
 					},
@@ -71,7 +73,7 @@ func TestServiceGetASGByName(t *testing.T) {
 			wantErr:         true,
 			wantASG:         false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.DescribeAutoScalingGroupsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: []*string{
 						aws.String("dependency-failure-occurred"),
 					},
@@ -85,7 +87,7 @@ func TestServiceGetASGByName(t *testing.T) {
 			wantErr:         false,
 			wantASG:         true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.DescribeAutoScalingGroupsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: []*string{
 						aws.String("test-group-is-present"),
 					},
@@ -398,7 +400,7 @@ func TestServiceASGIfExists(t *testing.T) {
 			wantErr: false,
 			wantASG: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.DescribeAutoScalingGroupsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: []*string{
 						aws.String("asgName"),
 					},
@@ -412,7 +414,7 @@ func TestServiceASGIfExists(t *testing.T) {
 			wantErr: true,
 			wantASG: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.DescribeAutoScalingGroupsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: []*string{
 						aws.String("asgName"),
 					},
@@ -426,7 +428,7 @@ func TestServiceASGIfExists(t *testing.T) {
 			wantErr: false,
 			wantASG: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeAutoScalingGroups(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.DescribeAutoScalingGroupsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: []*string{
 						aws.String("asgName"),
 					},
@@ -543,8 +545,8 @@ func TestServiceCreateASG(t *testing.T) {
 					VPCZoneIdentifier: aws.String("subnet1"),
 				}
 
-				m.CreateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
-					func(actual *autoscaling.CreateAutoScalingGroupInput) (*autoscaling.CreateAutoScalingGroupOutput, error) {
+				m.CreateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
+					func(ctx context.Context, actual *autoscaling.CreateAutoScalingGroupInput, requestOptions ...request.Option) (*autoscaling.CreateAutoScalingGroupOutput, error) {
 						sortTagsByKey := func(tags []*autoscaling.Tag) {
 							sort.Slice(tags, func(i, j int) bool {
 								return *(tags[i].Key) < *(tags[j].Key)
@@ -573,8 +575,8 @@ func TestServiceCreateASG(t *testing.T) {
 			},
 			wantErr: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.CreateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
-					func(actual *autoscaling.CreateAutoScalingGroupInput) (*autoscaling.CreateAutoScalingGroupOutput, error) {
+				m.CreateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
+					func(ctx context.Context, actual *autoscaling.CreateAutoScalingGroupInput, requestOptions ...request.Option) (*autoscaling.CreateAutoScalingGroupOutput, error) {
 						if actual.DesiredCapacity != nil {
 							t.Fatalf("Actual DesiredCapacity did not match expected, Actual: %d, Expected: <nil>", *actual.DesiredCapacity)
 						}
@@ -595,8 +597,8 @@ func TestServiceCreateASG(t *testing.T) {
 			},
 			wantErr: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.CreateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
-					func(actual *autoscaling.CreateAutoScalingGroupInput) (*autoscaling.CreateAutoScalingGroupOutput, error) {
+				m.CreateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Do(
+					func(ctx context.Context, actual *autoscaling.CreateAutoScalingGroupInput, requestOptions ...request.Option) (*autoscaling.CreateAutoScalingGroupOutput, error) {
 						if actual.DesiredCapacity != nil {
 							t.Fatalf("Actual DesiredCapacity did not match expected, Actual: %d, Expected: <nil>", *actual.DesiredCapacity)
 						}
@@ -646,7 +648,7 @@ func TestServiceCreateASG(t *testing.T) {
 			wantErr: true,
 			wantASG: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.CreateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
+				m.CreateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.CreateAutoScalingGroupInput{})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
 			},
 		},
 		{
@@ -707,7 +709,7 @@ func TestServiceUpdateASG(t *testing.T) {
 				mps.AWSMachinePool.Spec.Subnets = nil
 			},
 			expect: func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.UpdateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(&autoscaling.UpdateAutoScalingGroupOutput{}, nil)
+				m.UpdateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(&autoscaling.UpdateAutoScalingGroupOutput{}, nil)
 			},
 		},
 		{
@@ -718,7 +720,7 @@ func TestServiceUpdateASG(t *testing.T) {
 				mps.AWSMachinePool.Spec.MixedInstancesPolicy = nil
 			},
 			expect: func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.UpdateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
+				m.UpdateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
 			},
 		},
 	}
@@ -766,10 +768,10 @@ func TestServiceUpdateASGWithSubnetFilters(t *testing.T) {
 				},
 			},
 			expect: func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				e.DescribeSubnets(gomock.AssignableToTypeOf(&ec2.DescribeSubnetsInput{})).Return(&ec2.DescribeSubnetsOutput{
+				e.DescribeSubnetsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSubnetsInput{})).Return(&ec2.DescribeSubnetsOutput{
 					Subnets: []*ec2.Subnet{{SubnetId: aws.String("subnet-02")}},
 				}, nil)
-				m.UpdateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(&autoscaling.UpdateAutoScalingGroupOutput{}, nil)
+				m.UpdateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(&autoscaling.UpdateAutoScalingGroupOutput{}, nil)
 			},
 		},
 		{
@@ -787,7 +789,7 @@ func TestServiceUpdateASGWithSubnetFilters(t *testing.T) {
 				},
 			},
 			expect: func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				e.DescribeSubnets(gomock.AssignableToTypeOf(&ec2.DescribeSubnetsInput{})).Return(&ec2.DescribeSubnetsOutput{
+				e.DescribeSubnetsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSubnetsInput{})).Return(&ec2.DescribeSubnetsOutput{
 					Subnets: []*ec2.Subnet{},
 				}, nil)
 			},
@@ -802,7 +804,7 @@ func TestServiceUpdateASGWithSubnetFilters(t *testing.T) {
 				},
 			},
 			expect: func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.UpdateAutoScalingGroup(gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
+				m.UpdateAutoScalingGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&autoscaling.UpdateAutoScalingGroupInput{})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
 			},
 		},
 	}
@@ -868,7 +870,7 @@ func TestServiceUpdateResourceTags(t *testing.T) {
 			},
 			wantErr: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.CreateOrUpdateTags(gomock.Eq(&autoscaling.CreateOrUpdateTagsInput{
+				m.CreateOrUpdateTagsWithContext(context.TODO(), gomock.Eq(&autoscaling.CreateOrUpdateTagsInput{
 					Tags: mapToTags(map[string]string{
 						"key1": "value1",
 					}, aws.String("mock-resource-id")),
@@ -886,7 +888,7 @@ func TestServiceUpdateResourceTags(t *testing.T) {
 			},
 			wantErr: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.CreateOrUpdateTags(gomock.Eq(&autoscaling.CreateOrUpdateTagsInput{
+				m.CreateOrUpdateTagsWithContext(context.TODO(), gomock.Eq(&autoscaling.CreateOrUpdateTagsInput{
 					Tags: mapToTags(map[string]string{
 						"key1": "value1",
 					}, aws.String("mock-resource-id")),
@@ -904,7 +906,7 @@ func TestServiceUpdateResourceTags(t *testing.T) {
 			},
 			wantErr: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DeleteTags(gomock.Eq(&autoscaling.DeleteTagsInput{
+				m.DeleteTagsWithContext(context.TODO(), gomock.Eq(&autoscaling.DeleteTagsInput{
 					Tags: mapToTags(map[string]string{
 						"key1": "value1",
 					}, aws.String("mock-resource-id")),
@@ -922,7 +924,7 @@ func TestServiceUpdateResourceTags(t *testing.T) {
 			},
 			wantErr: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DeleteTags(gomock.Eq(&autoscaling.DeleteTagsInput{
+				m.DeleteTagsWithContext(context.TODO(), gomock.Eq(&autoscaling.DeleteTagsInput{
 					Tags: mapToTags(map[string]string{
 						"key1": "value1",
 					}, aws.String("mock-resource-id")),
@@ -963,7 +965,7 @@ func TestServiceDeleteASG(t *testing.T) {
 			name:    "Delete ASG successful",
 			wantErr: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DeleteAutoScalingGroup(gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
+				m.DeleteAutoScalingGroupWithContext(context.TODO(), gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
 					AutoScalingGroupName: aws.String("asgName"),
 					ForceDelete:          aws.Bool(true),
 				})).
@@ -974,7 +976,7 @@ func TestServiceDeleteASG(t *testing.T) {
 			name:    "Delete ASG should fail when ASG is not found",
 			wantErr: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DeleteAutoScalingGroup(gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
+				m.DeleteAutoScalingGroupWithContext(context.TODO(), gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
 					AutoScalingGroupName: aws.String("asgName"),
 					ForceDelete:          aws.Bool(true),
 				})).
@@ -1014,12 +1016,12 @@ func TestServiceDeleteASGAndWait(t *testing.T) {
 			name:    "Delete ASG with wait passed",
 			wantErr: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DeleteAutoScalingGroup(gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
+				m.DeleteAutoScalingGroupWithContext(context.TODO(), gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
 					AutoScalingGroupName: aws.String("asgName"),
 					ForceDelete:          aws.Bool(true),
 				})).
 					Return(nil, nil)
-				m.WaitUntilGroupNotExists(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.WaitUntilGroupNotExistsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: aws.StringSlice([]string{"asgName"}),
 				})).
 					Return(nil)
@@ -1029,12 +1031,12 @@ func TestServiceDeleteASGAndWait(t *testing.T) {
 			name:    "should return error if delete ASG failed while waiting",
 			wantErr: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DeleteAutoScalingGroup(gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
+				m.DeleteAutoScalingGroupWithContext(context.TODO(), gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
 					AutoScalingGroupName: aws.String("asgName"),
 					ForceDelete:          aws.Bool(true),
 				})).
 					Return(nil, nil)
-				m.WaitUntilGroupNotExists(gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
+				m.WaitUntilGroupNotExistsWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeAutoScalingGroupsInput{
 					AutoScalingGroupNames: aws.StringSlice([]string{"asgName"}),
 				})).
 					Return(awserrors.NewFailedDependency("dependency error"))
@@ -1044,7 +1046,7 @@ func TestServiceDeleteASGAndWait(t *testing.T) {
 			name:    "should return error if delete ASG failed during ASG deletion",
 			wantErr: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DeleteAutoScalingGroup(gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
+				m.DeleteAutoScalingGroupWithContext(context.TODO(), gomock.Eq(&autoscaling.DeleteAutoScalingGroupInput{
 					AutoScalingGroupName: aws.String("asgName"),
 					ForceDelete:          aws.Bool(true),
 				})).
@@ -1086,7 +1088,7 @@ func TestServiceCanStartASGInstanceRefresh(t *testing.T) {
 			wantErr:  true,
 			canStart: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeInstanceRefreshes(gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
+				m.DescribeInstanceRefreshesWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
 					AutoScalingGroupName: aws.String("machinePoolName"),
 				})).
 					Return(nil, awserrors.NewNotFound("not found"))
@@ -1097,7 +1099,7 @@ func TestServiceCanStartASGInstanceRefresh(t *testing.T) {
 			wantErr:  false,
 			canStart: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeInstanceRefreshes(gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
+				m.DescribeInstanceRefreshesWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
 					AutoScalingGroupName: aws.String("machinePoolName"),
 				})).
 					Return(&autoscaling.DescribeInstanceRefreshesOutput{}, nil)
@@ -1108,7 +1110,7 @@ func TestServiceCanStartASGInstanceRefresh(t *testing.T) {
 			wantErr:  false,
 			canStart: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.DescribeInstanceRefreshes(gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
+				m.DescribeInstanceRefreshesWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
 					AutoScalingGroupName: aws.String("machinePoolName"),
 				})).
 					Return(&autoscaling.DescribeInstanceRefreshesOutput{
@@ -1162,7 +1164,7 @@ func TestServiceStartASGInstanceRefresh(t *testing.T) {
 			name:    "should return error if start instance refresh failed",
 			wantErr: true,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.StartInstanceRefresh(gomock.Eq(&autoscaling.StartInstanceRefreshInput{
+				m.StartInstanceRefreshWithContext(context.TODO(), gomock.Eq(&autoscaling.StartInstanceRefreshInput{
 					AutoScalingGroupName: aws.String("mpn"),
 					Strategy:             aws.String("Rolling"),
 					Preferences: &autoscaling.RefreshPreferences{
@@ -1177,7 +1179,7 @@ func TestServiceStartASGInstanceRefresh(t *testing.T) {
 			name:    "should return nil if start instance refresh is success",
 			wantErr: false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
-				m.StartInstanceRefresh(gomock.Eq(&autoscaling.StartInstanceRefreshInput{
+				m.StartInstanceRefreshWithContext(context.TODO(), gomock.Eq(&autoscaling.StartInstanceRefreshInput{
 					AutoScalingGroupName: aws.String("mpn"),
 					Strategy:             aws.String("Rolling"),
 					Preferences: &autoscaling.RefreshPreferences{

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -18,6 +18,7 @@ package ec2
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -116,7 +117,7 @@ func (s *Service) pickArchitectureForInstanceType(instanceType string) (string, 
 	descInstanceTypeInput := &ec2.DescribeInstanceTypesInput{
 		InstanceTypes: []*string{&instanceType},
 	}
-	describeInstanceTypeResult, err := s.EC2Client.DescribeInstanceTypes(descInstanceTypeInput)
+	describeInstanceTypeResult, err := s.EC2Client.DescribeInstanceTypesWithContext(context.TODO(), descInstanceTypeInput)
 	if err != nil {
 		// if call to DescribeInstanceTypes fails due to permissions error, log a warning and return the default architecture.
 		if awserrors.IsPermissionsError(err) {
@@ -200,7 +201,7 @@ func DefaultAMILookup(ec2Client ec2iface.EC2API, ownerID, baseOS, kubernetesVers
 		},
 	}
 
-	out, err := ec2Client.DescribeImages(describeImageInput)
+	out, err := ec2Client.DescribeImagesWithContext(context.TODO(), describeImageInput)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find ami: %q", amiName)
 	}
@@ -294,7 +295,7 @@ func (s *Service) defaultBastionAMILookup() (string, error) {
 	}
 	describeImageInput.Filters = append(describeImageInput.Filters, filter)
 
-	out, err := s.EC2Client.DescribeImages(describeImageInput)
+	out, err := s.EC2Client.DescribeImagesWithContext(context.TODO(), describeImageInput)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to describe images within region: %q", s.scope.Region())
 	}

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ec2
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,7 +61,7 @@ func TestDefaultAMILookup(t *testing.T) {
 				amiNameFormat:     "ami-name",
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{
 						Images: []*ec2.Image{
 							{
@@ -86,7 +87,7 @@ func TestDefaultAMILookup(t *testing.T) {
 		{
 			name: "Should return with error if AWS DescribeImages call failed with some error",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(nil, awserrors.NewFailedDependency("dependency failure"))
 			},
 			check: func(g *WithT, img *ec2.Image, err error) {
@@ -97,7 +98,7 @@ func TestDefaultAMILookup(t *testing.T) {
 		{
 			name: "Should return with error if empty list of images returned from AWS ",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{}, nil)
 			},
 			check: func(g *WithT, img *ec2.Image, err error) {
@@ -148,7 +149,7 @@ func TestDefaultAMILookupArm64(t *testing.T) {
 				amiNameFormat:     "ami-name",
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{
 						Images: []*ec2.Image{
 							{
@@ -174,7 +175,7 @@ func TestDefaultAMILookupArm64(t *testing.T) {
 		{
 			name: "Should return with error if AWS DescribeImages call failed with some error",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(nil, awserrors.NewFailedDependency("dependency failure"))
 			},
 			check: func(g *WithT, img *ec2.Image, err error) {
@@ -185,7 +186,7 @@ func TestDefaultAMILookupArm64(t *testing.T) {
 		{
 			name: "Should return with error if empty list of images returned from AWS ",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{}, nil)
 			},
 			check: func(g *WithT, img *ec2.Image, err error) {
@@ -219,7 +220,7 @@ func TestAMIs(t *testing.T) {
 		{
 			name: "Should return latest AMI in case of valid inputs",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{
 						Images: []*ec2.Image{
 							{
@@ -245,7 +246,7 @@ func TestAMIs(t *testing.T) {
 		{
 			name: "Should return error if invalid creation date passed",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{
 						Images: []*ec2.Image{
 							{

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ec2
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -147,7 +148,7 @@ func (s *Service) describeBastionInstance() (*infrav1.Instance, error) {
 		},
 	}
 
-	out, err := s.EC2Client.DescribeInstances(input)
+	out, err := s.EC2Client.DescribeInstancesWithContext(context.TODO(), input)
 	if err != nil {
 		record.Eventf(s.scope.InfraCluster(), "FailedDescribeBastionHost", "Failed to describe bastion host: %v", err)
 		return nil, errors.Wrap(err, "failed to describe bastion host")

--- a/pkg/cloud/services/ec2/bastion_test.go
+++ b/pkg/cloud/services/ec2/bastion_test.go
@@ -80,7 +80,7 @@ func TestServiceDeleteBastion(t *testing.T) {
 			name: "instance not found",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(&ec2.DescribeInstancesOutput{}, nil)
 			},
 			expectError: false,
@@ -89,7 +89,7 @@ func TestServiceDeleteBastion(t *testing.T) {
 			name: "describe error",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(nil, errors.New("some error"))
 			},
 			expectError: true,
@@ -98,10 +98,10 @@ func TestServiceDeleteBastion(t *testing.T) {
 			name: "terminate fails",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(foundOutput, nil)
 				m.
-					TerminateInstances(
+					TerminateInstancesWithContext(context.TODO(),
 						gomock.Eq(&ec2.TerminateInstancesInput{
 							InstanceIds: aws.StringSlice([]string{"id123"}),
 						}),
@@ -114,17 +114,17 @@ func TestServiceDeleteBastion(t *testing.T) {
 			name: "wait after terminate fails",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(foundOutput, nil)
 				m.
-					TerminateInstances(
+					TerminateInstancesWithContext(context.TODO(),
 						gomock.Eq(&ec2.TerminateInstancesInput{
 							InstanceIds: aws.StringSlice([]string{"id123"}),
 						}),
 					).
 					Return(nil, nil)
 				m.
-					WaitUntilInstanceTerminated(
+					WaitUntilInstanceTerminatedWithContext(context.TODO(),
 						gomock.Eq(&ec2.DescribeInstancesInput{
 							InstanceIds: aws.StringSlice([]string{"id123"}),
 						}),
@@ -137,17 +137,17 @@ func TestServiceDeleteBastion(t *testing.T) {
 			name: "success",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(foundOutput, nil)
 				m.
-					TerminateInstances(
+					TerminateInstancesWithContext(context.TODO(),
 						gomock.Eq(&ec2.TerminateInstancesInput{
 							InstanceIds: aws.StringSlice([]string{"id123"}),
 						}),
 					).
 					Return(nil, nil)
 				m.
-					WaitUntilInstanceTerminated(
+					WaitUntilInstanceTerminatedWithContext(context.TODO(),
 						gomock.Eq(&ec2.DescribeInstancesInput{
 							InstanceIds: aws.StringSlice([]string{"id123"}),
 						}),
@@ -271,7 +271,7 @@ func TestServiceReconcileBastion(t *testing.T) {
 			name: "Should ignore reconciliation if instance not found",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(&ec2.DescribeInstancesOutput{}, nil)
 			},
 			expectError: false,
@@ -280,7 +280,7 @@ func TestServiceReconcileBastion(t *testing.T) {
 			name: "Should fail reconcile if describe instance fails",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(nil, errors.New("some error"))
 			},
 			expectError: true,
@@ -289,10 +289,10 @@ func TestServiceReconcileBastion(t *testing.T) {
 			name: "Should fail reconcile if terminate instance fails",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(foundOutput, nil).MinTimes(1)
 				m.
-					TerminateInstances(
+					TerminateInstancesWithContext(context.TODO(),
 						gomock.Eq(&ec2.TerminateInstancesInput{
 							InstanceIds: aws.StringSlice([]string{"id123"}),
 						}),
@@ -304,9 +304,9 @@ func TestServiceReconcileBastion(t *testing.T) {
 		{
 			name: "Should create bastion successfully",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeInstances(gomock.Eq(describeInput)).
+				m.DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(&ec2.DescribeInstancesOutput{}, nil).MinTimes(1)
-				m.DescribeImages(gomock.Eq(&ec2.DescribeImagesInput{Filters: []*ec2.Filter{
+				m.DescribeImagesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeImagesInput{Filters: []*ec2.Filter{
 					{
 						Name:   aws.String("architecture"),
 						Values: aws.StringSlice([]string{"x86_64"}),
@@ -337,7 +337,7 @@ func TestServiceReconcileBastion(t *testing.T) {
 						CreationDate: aws.String("2014-02-08T17:02:31.000Z"),
 					},
 				}}, nil)
-				m.RunInstances(gomock.Any()).
+				m.RunInstancesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.Reservation{
 						Instances: []*ec2.Instance{
 							{
@@ -505,7 +505,7 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 			name: "Should ignore reconciliation if instance not found",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(&ec2.DescribeInstancesOutput{}, nil)
 			},
 			expectError: false,
@@ -514,7 +514,7 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 			name: "Should fail reconcile if describe instance fails",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(nil, errors.New("some error"))
 			},
 			expectError: true,
@@ -523,10 +523,10 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 			name: "Should fail reconcile if terminate instance fails",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				m.
-					DescribeInstances(gomock.Eq(describeInput)).
+					DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(foundOutput, nil).MinTimes(1)
 				m.
-					TerminateInstances(
+					TerminateInstancesWithContext(context.TODO(),
 						gomock.Eq(&ec2.TerminateInstancesInput{
 							InstanceIds: aws.StringSlice([]string{"id123"}),
 						}),
@@ -538,9 +538,9 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 		{
 			name: "Should create bastion successfully",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeInstances(gomock.Eq(describeInput)).
+				m.DescribeInstancesWithContext(context.TODO(), gomock.Eq(describeInput)).
 					Return(&ec2.DescribeInstancesOutput{}, nil).MinTimes(1)
-				m.DescribeImages(gomock.Eq(&ec2.DescribeImagesInput{Filters: []*ec2.Filter{
+				m.DescribeImagesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeImagesInput{Filters: []*ec2.Filter{
 					{
 						Name:   aws.String("architecture"),
 						Values: aws.StringSlice([]string{"x86_64"}),
@@ -571,7 +571,7 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 						CreationDate: aws.String("2014-02-08T17:02:31.000Z"),
 					},
 				}}, nil)
-				m.RunInstances(gomock.Any()).
+				m.RunInstancesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.Reservation{
 						Instances: []*ec2.Instance{
 							{

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ec2
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"sort"
@@ -51,7 +52,7 @@ func (s *Service) GetRunningInstanceByTags(scope *scope.MachineScope) (*infrav1.
 		},
 	}
 
-	out, err := s.EC2Client.DescribeInstances(input)
+	out, err := s.EC2Client.DescribeInstancesWithContext(context.TODO(), input)
 	switch {
 	case awserrors.IsNotFound(err):
 		return nil, nil
@@ -86,7 +87,7 @@ func (s *Service) InstanceIfExists(id *string) (*infrav1.Instance, error) {
 		InstanceIds: []*string{id},
 	}
 
-	out, err := s.EC2Client.DescribeInstances(input)
+	out, err := s.EC2Client.DescribeInstancesWithContext(context.TODO(), input)
 	switch {
 	case awserrors.IsNotFound(err):
 		record.Eventf(s.scope.InfraCluster(), "FailedFindInstances", "failed to find instance by providerId %q: %v", *id, err)
@@ -390,7 +391,7 @@ func (s *Service) findSubnet(scope *scope.MachineScope) (string, error) {
 
 // getFilteredSubnets fetches subnets filtered based on the criteria passed.
 func (s *Service) getFilteredSubnets(criteria ...*ec2.Filter) ([]*ec2.Subnet, error) {
-	out, err := s.EC2Client.DescribeSubnets(&ec2.DescribeSubnetsInput{Filters: criteria})
+	out, err := s.EC2Client.DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{Filters: criteria})
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +477,7 @@ func (s *Service) TerminateInstance(instanceID string) error {
 		InstanceIds: aws.StringSlice([]string{instanceID}),
 	}
 
-	if _, err := s.EC2Client.TerminateInstances(input); err != nil {
+	if _, err := s.EC2Client.TerminateInstancesWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to terminate instance with id %q", instanceID)
 	}
 
@@ -497,7 +498,7 @@ func (s *Service) TerminateInstanceAndWait(instanceID string) error {
 		InstanceIds: aws.StringSlice([]string{instanceID}),
 	}
 
-	if err := s.EC2Client.WaitUntilInstanceTerminated(input); err != nil {
+	if err := s.EC2Client.WaitUntilInstanceTerminatedWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to wait for instance %q termination", instanceID)
 	}
 
@@ -604,7 +605,7 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 		input.Placement.GroupName = &i.PlacementGroupName
 	}
 
-	out, err := s.EC2Client.RunInstances(input)
+	out, err := s.EC2Client.RunInstancesWithContext(context.TODO(), input)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to run instance")
 	}
@@ -707,7 +708,7 @@ func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[stri
 		}
 
 		// Create/Update tags in AWS.
-		if _, err := s.EC2Client.CreateTags(input); err != nil {
+		if _, err := s.EC2Client.CreateTagsWithContext(context.TODO(), input); err != nil {
 			return errors.Wrapf(err, "failed to create tags for resource %q: %+v", *resourceID, create)
 		}
 	}
@@ -726,7 +727,7 @@ func (s *Service) UpdateResourceTags(resourceID *string, create, remove map[stri
 		}
 
 		// Delete tags in AWS.
-		if _, err := s.EC2Client.DeleteTags(input); err != nil {
+		if _, err := s.EC2Client.DeleteTagsWithContext(context.TODO(), input); err != nil {
 			return errors.Wrapf(err, "failed to delete tags for resource %q: %v", *resourceID, remove)
 		}
 	}
@@ -744,7 +745,7 @@ func (s *Service) getInstanceENIs(instanceID string) ([]*ec2.NetworkInterface, e
 		},
 	}
 
-	output, err := s.EC2Client.DescribeNetworkInterfaces(input)
+	output, err := s.EC2Client.DescribeNetworkInterfacesWithContext(context.TODO(), input)
 	if err != nil {
 		return nil, err
 	}
@@ -757,7 +758,7 @@ func (s *Service) getImageRootDevice(imageID string) (*string, error) {
 		ImageIds: []*string{aws.String(imageID)},
 	}
 
-	output, err := s.EC2Client.DescribeImages(input)
+	output, err := s.EC2Client.DescribeImagesWithContext(context.TODO(), input)
 	if err != nil {
 		return nil, err
 	}
@@ -774,7 +775,7 @@ func (s *Service) getImageSnapshotSize(imageID string) (*int64, error) {
 		ImageIds: []*string{aws.String(imageID)},
 	}
 
-	output, err := s.EC2Client.DescribeImages(input)
+	output, err := s.EC2Client.DescribeImagesWithContext(context.TODO(), input)
 	if err != nil {
 		return nil, err
 	}
@@ -898,7 +899,7 @@ func (s *Service) getNetworkInterfaceSecurityGroups(interfaceID string) ([]strin
 		NetworkInterfaceId: aws.String(interfaceID),
 	}
 
-	output, err := s.EC2Client.DescribeNetworkInterfaceAttribute(input)
+	output, err := s.EC2Client.DescribeNetworkInterfaceAttributeWithContext(context.TODO(), input)
 	if err != nil {
 		return nil, err
 	}
@@ -919,7 +920,7 @@ func (s *Service) attachSecurityGroupsToNetworkInterface(groups []string, interf
 		Groups:             aws.StringSlice(groups),
 	}
 
-	if _, err := s.EC2Client.ModifyNetworkInterfaceAttribute(input); err != nil {
+	if _, err := s.EC2Client.ModifyNetworkInterfaceAttributeWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to modify interface %q to have security groups %v", interfaceID, groups)
 	}
 	return nil
@@ -943,7 +944,7 @@ func (s *Service) DetachSecurityGroupsFromNetworkInterface(groups []string, inte
 		Groups:             aws.StringSlice(remainingGroups),
 	}
 
-	if _, err := s.EC2Client.ModifyNetworkInterfaceAttribute(input); err != nil {
+	if _, err := s.EC2Client.ModifyNetworkInterfaceAttributeWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to modify interface %q", interfaceID)
 	}
 	return nil
@@ -980,7 +981,7 @@ func (s *Service) ModifyInstanceMetadataOptions(instanceID string, options *infr
 	}
 
 	s.scope.Info("Updating instance metadata options", "instance id", instanceID, "options", input)
-	if _, err := s.EC2Client.ModifyInstanceMetadataOptions(input); err != nil {
+	if _, err := s.EC2Client.ModifyInstanceMetadataOptionsWithContext(context.TODO(), input); err != nil {
 		return err
 	}
 

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ec2
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"sort"
@@ -333,7 +334,7 @@ func (s *Service) GetLaunchTemplate(launchTemplateName string) (*expinfrav1.AWSL
 		Versions:           aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
 	}
 
-	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
+	out, err := s.EC2Client.DescribeLaunchTemplateVersionsWithContext(context.TODO(), input)
 	switch {
 	case awserrors.IsNotFound(err):
 		return nil, "", nil
@@ -359,7 +360,7 @@ func (s *Service) GetLaunchTemplateID(launchTemplateName string) (string, error)
 		Versions:           aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
 	}
 
-	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
+	out, err := s.EC2Client.DescribeLaunchTemplateVersionsWithContext(context.TODO(), input)
 	switch {
 	case awserrors.IsNotFound(err):
 		return "", nil
@@ -412,7 +413,7 @@ func (s *Service) CreateLaunchTemplate(scope scope.LaunchTemplateScope, imageID 
 		input.TagSpecifications = append(input.TagSpecifications, spec)
 	}
 
-	result, err := s.EC2Client.CreateLaunchTemplate(input)
+	result, err := s.EC2Client.CreateLaunchTemplateWithContext(context.TODO(), input)
 	if err != nil {
 		return "", err
 	}
@@ -433,7 +434,7 @@ func (s *Service) CreateLaunchTemplateVersion(id string, scope scope.LaunchTempl
 		LaunchTemplateId:   &id,
 	}
 
-	_, err = s.EC2Client.CreateLaunchTemplateVersion(input)
+	_, err = s.EC2Client.CreateLaunchTemplateVersionWithContext(context.TODO(), input)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create launch template version")
 	}
@@ -555,7 +556,7 @@ func (s *Service) DeleteLaunchTemplate(id string) error {
 		LaunchTemplateId: aws.String(id),
 	}
 
-	if _, err := s.EC2Client.DeleteLaunchTemplate(input); err != nil {
+	if _, err := s.EC2Client.DeleteLaunchTemplateWithContext(context.TODO(), input); err != nil {
 		return errors.Wrapf(err, "failed to delete launch template %q", id)
 	}
 
@@ -580,7 +581,7 @@ func (s *Service) PruneLaunchTemplateVersions(id string) error {
 		MaxResults:       aws.Int64(minCountToAllowPrune),
 	}
 
-	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
+	out, err := s.EC2Client.DescribeLaunchTemplateVersionsWithContext(context.TODO(), input)
 	if err != nil {
 		s.scope.Info("", "aerr", err.Error())
 		return err
@@ -604,7 +605,7 @@ func (s *Service) GetLaunchTemplateLatestVersion(id string) (string, error) {
 		Versions:         aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
 	}
 
-	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
+	out, err := s.EC2Client.DescribeLaunchTemplateVersionsWithContext(context.TODO(), input)
 	if err != nil {
 		s.scope.Info("", "aerr", err.Error())
 		return "", err
@@ -630,7 +631,7 @@ func (s *Service) deleteLaunchTemplateVersion(id string, version *int64) error {
 		Versions:         aws.StringSlice(versions),
 	}
 
-	_, err := s.EC2Client.DeleteLaunchTemplateVersions(input)
+	_, err := s.EC2Client.DeleteLaunchTemplateVersionsWithContext(context.TODO(), input)
 	if err != nil {
 		return err
 	}
@@ -878,7 +879,7 @@ func (s *Service) getFilteredSecurityGroupIDs(securityGroup infrav1.AWSResourceR
 		filters = append(filters, &ec2.Filter{Name: aws.String(f.Name), Values: aws.StringSlice(f.Values)})
 	}
 
-	sgs, err := s.EC2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: filters})
+	sgs, err := s.EC2Client.DescribeSecurityGroupsWithContext(context.TODO(), &ec2.DescribeSecurityGroupsInput{Filters: filters})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package ec2
 
 import (
+	"context"
 	"encoding/base64"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/golang/mock/gomock"
@@ -99,7 +101,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 			name:               "Should not return error if no launch template exist with given name",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).
@@ -119,7 +121,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 			name:               "Should return error if AWS failed during launch template fetching",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
@@ -134,7 +136,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 			name:               "Should not return with error if no launch template versions received from AWS",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(nil, nil)
@@ -149,7 +151,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 			name:               "Should successfully return launch template if exist with given name",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(&ec2.DescribeLaunchTemplateVersionsOutput{
@@ -208,7 +210,7 @@ func TestGetLaunchTemplate(t *testing.T) {
 			name:               "Should return computed userData if AWS returns empty userData",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(&ec2.DescribeLaunchTemplateVersionsOutput{
@@ -452,9 +454,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroups(gomock.Eq(&ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{{Name: aws.String("sg-1"), Values: aws.StringSlice([]string{"test-1"})}}})).
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{{Name: aws.String("sg-1"), Values: aws.StringSlice([]string{"test-1"})}}})).
 					Return(&ec2.DescribeSecurityGroupsOutput{SecurityGroups: []*ec2.SecurityGroup{{GroupId: aws.String("sg-1")}}}, nil)
-				m.DescribeSecurityGroups(gomock.Eq(&ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{{Name: aws.String("sg-2"), Values: aws.StringSlice([]string{"test-2"})}}})).
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{{Name: aws.String("sg-2"), Values: aws.StringSlice([]string{"test-2"})}}})).
 					Return(&ec2.DescribeSecurityGroupsOutput{SecurityGroups: []*ec2.SecurityGroup{{GroupId: aws.String("sg-2")}}}, nil)
 			},
 			want:    true,
@@ -553,7 +555,7 @@ func TestGetLaunchTemplateID(t *testing.T) {
 			name:               "Should not return error if launch template does not exist",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(nil, awserr.New(
@@ -571,7 +573,7 @@ func TestGetLaunchTemplateID(t *testing.T) {
 			name:               "Should return with error if AWS failed to fetch launch template",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(nil, awserrors.NewFailedDependency("Dependency issue from AWS"))
@@ -585,7 +587,7 @@ func TestGetLaunchTemplateID(t *testing.T) {
 			name:               "Should not return error if AWS returns no launch template versions info in output",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(nil, nil)
@@ -599,7 +601,7 @@ func TestGetLaunchTemplateID(t *testing.T) {
 			name:               "Should successfully return launch template ID for given name if exists",
 			launchTemplateName: "foo",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
+				m.DescribeLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).Return(&ec2.DescribeLaunchTemplateVersionsOutput{
@@ -681,7 +683,7 @@ func TestDeleteLaunchTemplate(t *testing.T) {
 			name:      "Should not return error if successfully deletes given launch template ID",
 			versionID: "1",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DeleteLaunchTemplate(gomock.Eq(&ec2.DeleteLaunchTemplateInput{
+				m.DeleteLaunchTemplateWithContext(context.TODO(), gomock.Eq(&ec2.DeleteLaunchTemplateInput{
 					LaunchTemplateId: aws.String("1"),
 				})).Return(&ec2.DeleteLaunchTemplateOutput{}, nil)
 			},
@@ -690,7 +692,7 @@ func TestDeleteLaunchTemplate(t *testing.T) {
 			name:      "Should return error if failed to delete given launch template ID",
 			versionID: "1",
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DeleteLaunchTemplate(gomock.Eq(&ec2.DeleteLaunchTemplateInput{
+				m.DeleteLaunchTemplateWithContext(context.TODO(), gomock.Eq(&ec2.DeleteLaunchTemplateInput{
 					LaunchTemplateId: aws.String("1"),
 				})).Return(nil, awserrors.NewFailedDependency("dependency failure"))
 			},
@@ -785,11 +787,11 @@ func TestCreateLaunchTemplate(t *testing.T) {
 						},
 					},
 				}
-				m.CreateLaunchTemplate(gomock.AssignableToTypeOf(expectedInput)).Return(&ec2.CreateLaunchTemplateOutput{
+				m.CreateLaunchTemplateWithContext(context.TODO(), gomock.AssignableToTypeOf(expectedInput)).Return(&ec2.CreateLaunchTemplateOutput{
 					LaunchTemplate: &ec2.LaunchTemplate{
 						LaunchTemplateId: aws.String("launch-template-id"),
 					},
-				}, nil).Do(func(arg *ec2.CreateLaunchTemplateInput) {
+				}, nil).Do(func(ctx context.Context, arg *ec2.CreateLaunchTemplateInput, requestOptions ...request.Option) {
 					// formatting added to match arrays during cmp.Equal
 					formatTagsInput(arg)
 					if !cmp.Equal(expectedInput, arg) {
@@ -845,18 +847,18 @@ func TestCreateLaunchTemplate(t *testing.T) {
 						},
 					},
 				}
-				m.CreateLaunchTemplate(gomock.AssignableToTypeOf(expectedInput)).Return(&ec2.CreateLaunchTemplateOutput{
+				m.CreateLaunchTemplateWithContext(context.TODO(), gomock.AssignableToTypeOf(expectedInput)).Return(&ec2.CreateLaunchTemplateOutput{
 					LaunchTemplate: &ec2.LaunchTemplate{
 						LaunchTemplateId: aws.String("launch-template-id"),
 					},
-				}, nil).Do(func(arg *ec2.CreateLaunchTemplateInput) {
+				}, nil).Do(func(ctx context.Context, arg *ec2.CreateLaunchTemplateInput, requestOptions ...request.Option) {
 					// formatting added to match arrays during reflect.DeepEqual
 					formatTagsInput(arg)
 					if !cmp.Equal(expectedInput, arg) {
 						t.Fatalf("mismatch in input expected: %+v, got: %+v", expectedInput, arg)
 					}
 				})
-				m.DescribeSecurityGroups(gomock.Eq(&ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{{Name: aws.String("sg-1"), Values: aws.StringSlice([]string{"test"})}}})).
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{{Name: aws.String("sg-1"), Values: aws.StringSlice([]string{"test"})}}})).
 					Return(&ec2.DescribeSecurityGroupsOutput{SecurityGroups: []*ec2.SecurityGroup{{GroupId: aws.String("sg-1")}}}, nil)
 			},
 			check: func(g *WithT, id string, err error) {
@@ -907,8 +909,8 @@ func TestCreateLaunchTemplate(t *testing.T) {
 						},
 					},
 				}
-				m.CreateLaunchTemplate(gomock.AssignableToTypeOf(expectedInput)).Return(nil,
-					awserrors.NewFailedDependency("dependency failure")).Do(func(arg *ec2.CreateLaunchTemplateInput) {
+				m.CreateLaunchTemplateWithContext(context.TODO(), gomock.AssignableToTypeOf(expectedInput)).Return(nil,
+					awserrors.NewFailedDependency("dependency failure")).Do(func(ctx context.Context, arg *ec2.CreateLaunchTemplateInput, requestOptions ...request.Option) {
 					// formatting added to match arrays during cmp.Equal
 					formatTagsInput(arg)
 					if !cmp.Equal(expectedInput, arg) {
@@ -1030,12 +1032,12 @@ func TestCreateLaunchTemplateVersion(t *testing.T) {
 					},
 					LaunchTemplateId: aws.String("launch-template-id"),
 				}
-				m.CreateLaunchTemplateVersion(gomock.AssignableToTypeOf(expectedInput)).Return(&ec2.CreateLaunchTemplateVersionOutput{
+				m.CreateLaunchTemplateVersionWithContext(context.TODO(), gomock.AssignableToTypeOf(expectedInput)).Return(&ec2.CreateLaunchTemplateVersionOutput{
 					LaunchTemplateVersion: &ec2.LaunchTemplateVersion{
 						LaunchTemplateId: aws.String("launch-template-id"),
 					},
 				}, nil).Do(
-					func(arg *ec2.CreateLaunchTemplateVersionInput) {
+					func(ctx context.Context, arg *ec2.CreateLaunchTemplateVersionInput, requestOptions ...request.Option) {
 						// formatting added to match tags slice during cmp.Equal()
 						formatTagsInput(arg)
 						if !cmp.Equal(expectedInput, arg) {
@@ -1081,9 +1083,9 @@ func TestCreateLaunchTemplateVersion(t *testing.T) {
 					},
 					LaunchTemplateId: aws.String("launch-template-id"),
 				}
-				m.CreateLaunchTemplateVersion(gomock.AssignableToTypeOf(expectedInput)).Return(nil,
+				m.CreateLaunchTemplateVersionWithContext(context.TODO(), gomock.AssignableToTypeOf(expectedInput)).Return(nil,
 					awserrors.NewFailedDependency("dependency failure")).Do(
-					func(arg *ec2.CreateLaunchTemplateVersionInput) {
+					func(ctx context.Context, arg *ec2.CreateLaunchTemplateVersionInput, requestOptions ...request.Option) {
 						// formatting added to match tags slice during cmp.Equal()
 						formatTagsInput(arg)
 						if !cmp.Equal(expectedInput, arg) {
@@ -1201,7 +1203,7 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{
 						Images: []*ec2.Image{
 							{
@@ -1218,7 +1220,7 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.DescribeInstanceTypes(gomock.Eq(&ec2.DescribeInstanceTypesInput{
+				m.DescribeInstanceTypesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstanceTypesInput{
 					InstanceTypes: []*string{
 						aws.String("m5.large"),
 					},
@@ -1252,7 +1254,7 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{
 						Images: []*ec2.Image{
 							{
@@ -1269,7 +1271,7 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.DescribeInstanceTypes(gomock.Eq(&ec2.DescribeInstanceTypesInput{
+				m.DescribeInstanceTypesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstanceTypesInput{
 					InstanceTypes: []*string{
 						aws.String("m5.large"),
 					},
@@ -1303,7 +1305,7 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(&ec2.DescribeImagesOutput{
 						Images: []*ec2.Image{
 							{
@@ -1320,7 +1322,7 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.DescribeInstanceTypes(gomock.Eq(&ec2.DescribeInstanceTypesInput{
+				m.DescribeInstanceTypesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstanceTypesInput{
 					InstanceTypes: []*string{
 						aws.String("t4g.large"),
 					},
@@ -1375,9 +1377,9 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeImages(gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
+				m.DescribeImagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeImagesInput{})).
 					Return(nil, awserrors.NewFailedDependency("dependency-failure"))
-				m.DescribeInstanceTypes(gomock.Eq(&ec2.DescribeInstanceTypesInput{
+				m.DescribeInstanceTypesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstanceTypesInput{
 					InstanceTypes: []*string{
 						aws.String("m5.large"),
 					},
@@ -1447,7 +1449,7 @@ func TestDiscoverLaunchTemplateAMIForEKS(t *testing.T) {
 		{
 			name: "Should return AMI and use EKS infra cluster image details, if not passed in aws launch template",
 			expectEC2: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeInstanceTypes(gomock.Any()).
+				m.DescribeInstanceTypesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeInstanceTypesOutput{
 						InstanceTypes: []*ec2.InstanceTypeInfo{
 							{
@@ -1534,7 +1536,7 @@ func TestDeleteLaunchTemplateVersion(t *testing.T) {
 				version: aws.Int64(12),
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DeleteLaunchTemplateVersions(gomock.Eq(
+				m.DeleteLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(
 					&ec2.DeleteLaunchTemplateVersionsInput{
 						LaunchTemplateId: aws.String("id"),
 						Versions:         aws.StringSlice([]string{"12"}),
@@ -1550,7 +1552,7 @@ func TestDeleteLaunchTemplateVersion(t *testing.T) {
 				version: aws.Int64(12),
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DeleteLaunchTemplateVersions(gomock.Eq(
+				m.DeleteLaunchTemplateVersionsWithContext(context.TODO(), gomock.Eq(
 					&ec2.DeleteLaunchTemplateVersionsInput{
 						LaunchTemplateId: aws.String("id"),
 						Versions:         aws.StringSlice([]string{"12"}),

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -81,7 +81,7 @@ func (s *NodegroupService) describeASGs(ng *eks.Nodegroup) (*autoscaling.Group, 
 		},
 	}
 
-	out, err := s.AutoscalingClient.DescribeAutoScalingGroups(input)
+	out, err := s.AutoscalingClient.DescribeAutoScalingGroupsWithContext(context.TODO(), input)
 	switch {
 	case awserrors.IsNotFound(err):
 		return nil, nil
@@ -596,7 +596,7 @@ func (s *NodegroupService) setStatus(ng *eks.Nodegroup) error {
 		for _, asg := range ng.Resources.AutoScalingGroups {
 			req.AutoScalingGroupNames = append(req.AutoScalingGroupNames, asg.Name)
 		}
-		groups, err := s.AutoscalingClient.DescribeAutoScalingGroups(&req)
+		groups, err := s.AutoscalingClient.DescribeAutoScalingGroupsWithContext(context.TODO(), &req)
 		if err != nil {
 			return errors.Wrap(err, "failed to describe AutoScalingGroup for nodegroup")
 		}

--- a/pkg/cloud/services/eks/securitygroup.go
+++ b/pkg/cloud/services/eks/securitygroup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -45,7 +46,7 @@ func (s *Service) reconcileSecurityGroups(cluster *eks.Cluster) error {
 		},
 	}
 
-	output, err := s.EC2Client.DescribeSecurityGroups(input)
+	output, err := s.EC2Client.DescribeSecurityGroupsWithContext(context.TODO(), input)
 	if err != nil {
 		return fmt.Errorf("describing security groups: %w", err)
 	}
@@ -67,7 +68,7 @@ func (s *Service) reconcileSecurityGroups(cluster *eks.Cluster) error {
 		},
 	}
 
-	output, err = s.EC2Client.DescribeSecurityGroups(input)
+	output, err = s.EC2Client.DescribeSecurityGroupsWithContext(context.TODO(), input)
 	if err != nil || len(output.SecurityGroups) == 0 {
 		return fmt.Errorf("describing EKS cluster security group: %w", err)
 	}

--- a/pkg/cloud/services/eks/tags.go
+++ b/pkg/cloud/services/eks/tags.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -147,7 +148,7 @@ func (s *NodegroupService) reconcileASGTags(ng *eks.Nodegroup) error {
 				Value:             &vCopy,
 			})
 		}
-		_, err = s.AutoscalingClient.CreateOrUpdateTags(input)
+		_, err = s.AutoscalingClient.CreateOrUpdateTagsWithContext(context.TODO(), input)
 		if err != nil {
 			return errors.Wrap(err, "failed to add tags to nodegroup's AutoScalingGroup")
 		}
@@ -165,7 +166,7 @@ func (s *NodegroupService) reconcileASGTags(ng *eks.Nodegroup) error {
 				ResourceType: pointer.String("auto-scaling-group"),
 			})
 		}
-		_, err = s.AutoscalingClient.DeleteTags(input)
+		_, err = s.AutoscalingClient.DeleteTagsWithContext(context.TODO(), input)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete tags to nodegroup's AutoScalingGroup")
 		}

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package elb
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -196,7 +197,7 @@ func (s *Service) getAPIServerLBSpec(elbName string) (*infrav1.LoadBalancer, err
 		input := &ec2.DescribeSubnetsInput{
 			SubnetIds: aws.StringSlice(s.scope.ControlPlaneLoadBalancer().Subnets),
 		}
-		out, err := s.EC2Client.DescribeSubnets(input)
+		out, err := s.EC2Client.DescribeSubnetsWithContext(context.TODO(), input)
 		if err != nil {
 			return nil, err
 		}
@@ -784,7 +785,7 @@ func (s *Service) getControlPlaneLoadBalancerSubnets() (infrav1.Subnets, error) 
 	input := &ec2.DescribeSubnetsInput{
 		SubnetIds: aws.StringSlice(s.scope.ControlPlaneLoadBalancer().Subnets),
 	}
-	res, err := s.EC2Client.DescribeSubnets(input)
+	res, err := s.EC2Client.DescribeSubnetsWithContext(context.TODO(), input)
 	if err != nil {
 		return nil, err
 	}
@@ -971,7 +972,7 @@ func (s *Service) getAPIServerClassicELBSpec(elbName string) (*infrav1.LoadBalan
 		input := &ec2.DescribeSubnetsInput{
 			SubnetIds: aws.StringSlice(s.scope.ControlPlaneLoadBalancer().Subnets),
 		}
-		out, err := s.EC2Client.DescribeSubnets(input)
+		out, err := s.EC2Client.DescribeSubnetsWithContext(context.TODO(), input)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -187,7 +187,7 @@ func TestGetAPIServerClassicELBSpecControlPlaneLoadBalancer(t *testing.T) {
 				Subnets: []string{"subnet-1", "subnet-2"},
 			},
 			mocks: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					SubnetIds: []*string{
 						aws.String("subnet-1"),
 						aws.String("subnet-2"),
@@ -336,7 +336,7 @@ func TestGetAPIServerV2ELBSpecControlPlaneLoadBalancer(t *testing.T) {
 				Subnets: []string{"subnet-1", "subnet-2"},
 			},
 			mocks: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					SubnetIds: []*string{
 						aws.String("subnet-1"),
 						aws.String("subnet-2"),
@@ -603,7 +603,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 					}, nil)
 			},
 			ec2Mocks: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					SubnetIds: []*string{
 						aws.String(elbSubnetID),
 					},
@@ -678,7 +678,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 					}, nil)
 			},
 			ec2Mocks: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					SubnetIds: []*string{
 						aws.String(elbSubnetID),
 					},

--- a/pkg/cloud/services/gc/ec2.go
+++ b/pkg/cloud/services/gc/ec2.go
@@ -80,7 +80,7 @@ func (s *Service) getProviderOwnedSecurityGroups(ctx context.Context) ([]*AWSRes
 	}
 
 	var resources []*AWSResource
-	err := s.ec2Client.DescribeSecurityGroupsPages(input, func(out *ec2.DescribeSecurityGroupsOutput, last bool) bool {
+	err := s.ec2Client.DescribeSecurityGroupsPagesWithContext(context.TODO(), input, func(out *ec2.DescribeSecurityGroupsOutput, last bool) bool {
 		for _, group := range out.SecurityGroups {
 			arn := composeFakeArn(sgService, sgResourcePrefix+*group.GroupId)
 			resource, err := composeAWSResource(arn, converters.TagsToMap(group.Tags))

--- a/pkg/cloud/services/network/account.go
+++ b/pkg/cloud/services/network/account.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"sort"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -27,7 +28,7 @@ import (
 )
 
 func (s *Service) getAvailableZones() ([]string, error) {
-	out, err := s.EC2Client.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{
+	out, err := s.EC2Client.DescribeAvailabilityZonesWithContext(context.TODO(), &ec2.DescribeAvailabilityZonesInput{
 		Filters: []*ec2.Filter{
 			filter.EC2.Available(),
 			filter.EC2.IgnoreLocalZones(),

--- a/pkg/cloud/services/network/egress_only_gateways.go
+++ b/pkg/cloud/services/network/egress_only_gateways.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -104,7 +105,7 @@ func (s *Service) deleteEgressOnlyInternetGateways() error {
 			EgressOnlyInternetGatewayId: ig.EgressOnlyInternetGatewayId,
 		}
 
-		if _, err = s.EC2Client.DeleteEgressOnlyInternetGateway(deleteReq); err != nil {
+		if _, err = s.EC2Client.DeleteEgressOnlyInternetGatewayWithContext(context.TODO(), deleteReq); err != nil {
 			record.Warnf(s.scope.InfraCluster(), "FailedDeleteEgressOnlyInternetGateway", "Failed to delete Egress Only Internet Gateway %q previously attached to VPC %q: %v", *ig.EgressOnlyInternetGatewayId, s.scope.VPC().ID, err)
 			return errors.Wrapf(err, "failed to delete egress only internet gateway %q", *ig.EgressOnlyInternetGatewayId)
 		}
@@ -117,7 +118,7 @@ func (s *Service) deleteEgressOnlyInternetGateways() error {
 }
 
 func (s *Service) createEgressOnlyInternetGateway() (*ec2.EgressOnlyInternetGateway, error) {
-	ig, err := s.EC2Client.CreateEgressOnlyInternetGateway(&ec2.CreateEgressOnlyInternetGatewayInput{
+	ig, err := s.EC2Client.CreateEgressOnlyInternetGatewayWithContext(context.TODO(), &ec2.CreateEgressOnlyInternetGatewayInput{
 		TagSpecifications: []*ec2.TagSpecification{
 			tags.BuildParamsToTagSpecification(ec2.ResourceTypeEgressOnlyInternetGateway, s.getEgressOnlyGatewayTagParams(services.TemporaryResourceID)),
 		},
@@ -134,7 +135,7 @@ func (s *Service) createEgressOnlyInternetGateway() (*ec2.EgressOnlyInternetGate
 }
 
 func (s *Service) describeEgressOnlyVpcInternetGateways() ([]*ec2.EgressOnlyInternetGateway, error) {
-	out, err := s.EC2Client.DescribeEgressOnlyInternetGateways(&ec2.DescribeEgressOnlyInternetGatewaysInput{
+	out, err := s.EC2Client.DescribeEgressOnlyInternetGatewaysWithContext(context.TODO(), &ec2.DescribeEgressOnlyInternetGatewaysInput{
 		Filters: []*ec2.Filter{
 			filter.EC2.VPCAttachment(s.scope.VPC().ID),
 		},

--- a/pkg/cloud/services/network/egress_only_gateways_test.go
+++ b/pkg/cloud/services/network/egress_only_gateways_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -54,7 +55,7 @@ func TestReconcileEgressOnlyInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeEgressOnlyInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeEgressOnlyInternetGatewaysInput{})).
+				m.DescribeEgressOnlyInternetGatewaysWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeEgressOnlyInternetGatewaysInput{})).
 					Return(&ec2.DescribeEgressOnlyInternetGatewaysOutput{
 						EgressOnlyInternetGateways: []*ec2.EgressOnlyInternetGateway{
 							{
@@ -69,7 +70,7 @@ func TestReconcileEgressOnlyInternetGateways(t *testing.T) {
 						},
 					}, nil)
 
-				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+				m.CreateTagsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(nil, nil)
 			},
 		},
@@ -85,10 +86,10 @@ func TestReconcileEgressOnlyInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeEgressOnlyInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeEgressOnlyInternetGatewaysInput{})).
+				m.DescribeEgressOnlyInternetGatewaysWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeEgressOnlyInternetGatewaysInput{})).
 					Return(&ec2.DescribeEgressOnlyInternetGatewaysOutput{}, nil)
 
-				m.CreateEgressOnlyInternetGateway(gomock.AssignableToTypeOf(&ec2.CreateEgressOnlyInternetGatewayInput{})).
+				m.CreateEgressOnlyInternetGatewayWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateEgressOnlyInternetGatewayInput{})).
 					Return(&ec2.CreateEgressOnlyInternetGatewayOutput{
 						EgressOnlyInternetGateway: &ec2.EgressOnlyInternetGateway{
 							EgressOnlyInternetGatewayId: aws.String("igw-1"),
@@ -194,7 +195,7 @@ func TestDeleteEgressOnlyInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeEgressOnlyInternetGateways(gomock.Eq(&ec2.DescribeEgressOnlyInternetGatewaysInput{
+				m.DescribeEgressOnlyInternetGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeEgressOnlyInternetGatewaysInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("attachment.vpc-id"),
@@ -216,7 +217,7 @@ func TestDeleteEgressOnlyInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeEgressOnlyInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeEgressOnlyInternetGatewaysInput{})).
+				m.DescribeEgressOnlyInternetGatewaysWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeEgressOnlyInternetGatewaysInput{})).
 					Return(&ec2.DescribeEgressOnlyInternetGatewaysOutput{
 						EgressOnlyInternetGateways: []*ec2.EgressOnlyInternetGateway{
 							{
@@ -230,7 +231,7 @@ func TestDeleteEgressOnlyInternetGateways(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.DeleteEgressOnlyInternetGateway(&ec2.DeleteEgressOnlyInternetGatewayInput{
+				m.DeleteEgressOnlyInternetGatewayWithContext(context.TODO(), &ec2.DeleteEgressOnlyInternetGatewayInput{
 					EgressOnlyInternetGatewayId: aws.String("eigw-0"),
 				}).Return(&ec2.DeleteEgressOnlyInternetGatewayOutput{}, nil)
 			},

--- a/pkg/cloud/services/network/gateways_test.go
+++ b/pkg/cloud/services/network/gateways_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -53,7 +54,7 @@ func TestReconcileInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+				m.DescribeInternetGatewaysWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
 					Return(&ec2.DescribeInternetGatewaysOutput{
 						InternetGateways: []*ec2.InternetGateway{
 							{
@@ -68,7 +69,7 @@ func TestReconcileInternetGateways(t *testing.T) {
 						},
 					}, nil)
 
-				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+				m.CreateTagsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(nil, nil)
 			},
 		},
@@ -83,10 +84,10 @@ func TestReconcileInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+				m.DescribeInternetGatewaysWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
 					Return(&ec2.DescribeInternetGatewaysOutput{}, nil)
 
-				m.CreateInternetGateway(gomock.AssignableToTypeOf(&ec2.CreateInternetGatewayInput{})).
+				m.CreateInternetGatewayWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateInternetGatewayInput{})).
 					Return(&ec2.CreateInternetGatewayOutput{
 						InternetGateway: &ec2.InternetGateway{
 							InternetGatewayId: aws.String("igw-1"),
@@ -107,7 +108,7 @@ func TestReconcileInternetGateways(t *testing.T) {
 						},
 					}, nil)
 
-				m.AttachInternetGateway(gomock.Eq(&ec2.AttachInternetGatewayInput{
+				m.AttachInternetGatewayWithContext(context.TODO(), gomock.Eq(&ec2.AttachInternetGatewayInput{
 					InternetGatewayId: aws.String("igw-1"),
 					VpcId:             aws.String("vpc-gateways"),
 				})).
@@ -181,7 +182,7 @@ func TestDeleteInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeInternetGateways(gomock.Eq(&ec2.DescribeInternetGatewaysInput{
+				m.DescribeInternetGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInternetGatewaysInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("attachment.vpc-id"),
@@ -202,7 +203,7 @@ func TestDeleteInternetGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeInternetGateways(gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
+				m.DescribeInternetGatewaysWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeInternetGatewaysInput{})).
 					Return(&ec2.DescribeInternetGatewaysOutput{
 						InternetGateways: []*ec2.InternetGateway{
 							{
@@ -216,11 +217,11 @@ func TestDeleteInternetGateways(t *testing.T) {
 							},
 						},
 					}, nil)
-				m.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
+				m.DetachInternetGatewayWithContext(context.TODO(), &ec2.DetachInternetGatewayInput{
 					InternetGatewayId: aws.String("igw-0"),
 					VpcId:             aws.String("vpc-gateways"),
 				}).Return(&ec2.DetachInternetGatewayOutput{}, nil)
-				m.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+				m.DeleteInternetGatewayWithContext(context.TODO(), &ec2.DeleteInternetGatewayInput{
 					InternetGatewayId: aws.String("igw-0"),
 				}).Return(&ec2.DeleteInternetGatewayOutput{}, nil)
 			},

--- a/pkg/cloud/services/network/natgateways_test.go
+++ b/pkg/cloud/services/network/natgateways_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -59,7 +60,7 @@ func TestReconcileNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.CreateNatGateway(gomock.Any()).Times(0)
+				m.CreateNatGatewayWithContext(context.TODO(), gomock.Any()).Times(0)
 			},
 		},
 		{
@@ -73,8 +74,8 @@ func TestReconcileNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(gomock.Any(), gomock.Any()).Times(0)
-				m.CreateNatGateway(gomock.Any()).Times(0)
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(), gomock.Any(), gomock.Any()).Times(0)
+				m.CreateNatGatewayWithContext(context.TODO(), gomock.Any()).Times(0)
 			},
 		},
 		{
@@ -94,7 +95,7 @@ func TestReconcileNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -109,10 +110,10 @@ func TestReconcileNatGateways(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.DescribeAddresses(gomock.Any()).
+				m.DescribeAddressesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeAddressesOutput{}, nil)
 
-				m.AllocateAddress(&ec2.AllocateAddressInput{
+				m.AllocateAddressWithContext(context.TODO(), &ec2.AllocateAddressInput{
 					Domain: aws.String("vpc"),
 					TagSpecifications: []*ec2.TagSpecification{
 						{
@@ -137,7 +138,7 @@ func TestReconcileNatGateways(t *testing.T) {
 					AllocationId: aws.String(ElasticIPAllocationID),
 				}, nil)
 
-				m.CreateNatGateway(&ec2.CreateNatGatewayInput{
+				m.CreateNatGatewayWithContext(context.TODO(), &ec2.CreateNatGatewayInput{
 					AllocationId: aws.String(ElasticIPAllocationID),
 					SubnetId:     aws.String("subnet-1"),
 					TagSpecifications: []*ec2.TagSpecification{
@@ -167,7 +168,7 @@ func TestReconcileNatGateways(t *testing.T) {
 					},
 				}, nil)
 
-				m.WaitUntilNatGatewayAvailable(&ec2.DescribeNatGatewaysInput{
+				m.WaitUntilNatGatewayAvailableWithContext(context.TODO(), &ec2.DescribeNatGatewaysInput{
 					NatGatewayIds: []*string{aws.String("natgateway")},
 				}).Return(nil)
 			},
@@ -195,7 +196,7 @@ func TestReconcileNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -208,7 +209,7 @@ func TestReconcileNatGateways(t *testing.T) {
 							},
 						},
 					}),
-					gomock.Any()).Do(func(_, y interface{}) {
+					gomock.Any()).Do(func(ctx context.Context, _, y interface{}, requestOptions ...request.Option) {
 					funct := y.(func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool)
 					funct(&ec2.DescribeNatGatewaysOutput{NatGateways: []*ec2.NatGateway{{
 						NatGatewayId: aws.String("gateway"),
@@ -216,10 +217,10 @@ func TestReconcileNatGateways(t *testing.T) {
 					}}}, true)
 				}).Return(nil)
 
-				m.DescribeAddresses(gomock.Any()).
+				m.DescribeAddressesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeAddressesOutput{}, nil)
 
-				m.AllocateAddress(&ec2.AllocateAddressInput{
+				m.AllocateAddressWithContext(context.TODO(), &ec2.AllocateAddressInput{
 					Domain: aws.String("vpc"),
 					TagSpecifications: []*ec2.TagSpecification{
 						{
@@ -244,7 +245,7 @@ func TestReconcileNatGateways(t *testing.T) {
 					AllocationId: aws.String(ElasticIPAllocationID),
 				}, nil)
 
-				m.CreateNatGateway(&ec2.CreateNatGatewayInput{
+				m.CreateNatGatewayWithContext(context.TODO(), &ec2.CreateNatGatewayInput{
 					AllocationId: aws.String(ElasticIPAllocationID),
 					SubnetId:     aws.String("subnet-3"),
 					TagSpecifications: []*ec2.TagSpecification{
@@ -273,11 +274,11 @@ func TestReconcileNatGateways(t *testing.T) {
 					},
 				}, nil)
 
-				m.WaitUntilNatGatewayAvailable(&ec2.DescribeNatGatewaysInput{
+				m.WaitUntilNatGatewayAvailableWithContext(context.TODO(), &ec2.DescribeNatGatewaysInput{
 					NatGatewayIds: []*string{aws.String("natgateway")},
 				}).Return(nil)
 
-				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+				m.CreateTagsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(nil, nil).Times(1)
 			},
 		},
@@ -298,7 +299,7 @@ func TestReconcileNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -311,7 +312,7 @@ func TestReconcileNatGateways(t *testing.T) {
 							},
 						},
 					}),
-					gomock.Any()).Do(func(_, y interface{}) {
+					gomock.Any()).Do(func(ctx context.Context, _, y interface{}, requestOptions ...request.Option) {
 					funct := y.(func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool)
 					funct(&ec2.DescribeNatGatewaysOutput{NatGateways: []*ec2.NatGateway{{
 						NatGatewayId: aws.String("gateway"),
@@ -333,9 +334,9 @@ func TestReconcileNatGateways(t *testing.T) {
 					}}}, true)
 				}).Return(nil)
 
-				m.DescribeAddresses(gomock.Any()).Times(0)
-				m.AllocateAddress(gomock.Any()).Times(0)
-				m.CreateNatGateway(gomock.Any()).Times(0)
+				m.DescribeAddressesWithContext(context.TODO(), gomock.Any()).Times(0)
+				m.AllocateAddressWithContext(context.TODO(), gomock.Any()).Times(0)
+				m.CreateNatGatewayWithContext(context.TODO(), gomock.Any()).Times(0)
 			},
 		},
 		{
@@ -355,7 +356,7 @@ func TestReconcileNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(gomock.Any(), gomock.Any()).
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(), gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(1)
 			},
@@ -461,7 +462,7 @@ func TestDeleteNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -494,15 +495,15 @@ func TestDeleteNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{}),
 					gomock.Any()).Do(mockDescribeNatGatewaysOutput).Return(nil)
 
-				m.DeleteNatGateway(gomock.Eq(&ec2.DeleteNatGatewayInput{
+				m.DeleteNatGatewayWithContext(context.TODO(), gomock.Eq(&ec2.DeleteNatGatewayInput{
 					NatGatewayId: aws.String("natgateway"),
 				})).Return(&ec2.DeleteNatGatewayOutput{}, nil)
 
-				m.DescribeNatGateways(gomock.Eq(&ec2.DescribeNatGatewaysInput{
+				m.DescribeNatGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
 					NatGatewayIds: []*string{aws.String("natgateway")},
 				})).Return(&ec2.DescribeNatGatewaysOutput{
 					NatGateways: []*ec2.NatGateway{
@@ -511,7 +512,7 @@ func TestDeleteNatGateways(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.DescribeNatGateways(gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{})).Return(&ec2.DescribeNatGatewaysOutput{
+				m.DescribeNatGatewaysWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{})).Return(&ec2.DescribeNatGatewaysOutput{
 					NatGateways: []*ec2.NatGateway{
 						{
 							State: aws.String("deleted"),
@@ -543,14 +544,14 @@ func TestDeleteNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{}), gomock.Any()).Do(mockDescribeNatGatewaysOutput).Return(nil)
 
-				m.DeleteNatGateway(gomock.Eq(&ec2.DeleteNatGatewayInput{
+				m.DeleteNatGatewayWithContext(context.TODO(), gomock.Eq(&ec2.DeleteNatGatewayInput{
 					NatGatewayId: aws.String("natgateway"),
 				})).Return(&ec2.DeleteNatGatewayOutput{}, nil)
 
-				m.DescribeNatGateways(gomock.Eq(&ec2.DescribeNatGatewaysInput{
+				m.DescribeNatGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
 					NatGatewayIds: []*string{aws.String("natgateway")},
 				})).Return(&ec2.DescribeNatGatewaysOutput{
 					NatGateways: []*ec2.NatGateway{
@@ -579,14 +580,14 @@ func TestDeleteNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{}), gomock.Any()).Do(mockDescribeNatGatewaysOutput).Return(nil)
 
-				m.DeleteNatGateway(gomock.Eq(&ec2.DeleteNatGatewayInput{
+				m.DeleteNatGatewayWithContext(context.TODO(), gomock.Eq(&ec2.DeleteNatGatewayInput{
 					NatGatewayId: aws.String("natgateway"),
 				})).Return(&ec2.DeleteNatGatewayOutput{}, nil)
 
-				m.DescribeNatGateways(gomock.Eq(&ec2.DescribeNatGatewaysInput{
+				m.DescribeNatGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
 					NatGatewayIds: []*string{aws.String("natgateway")},
 				})).Return(nil, nil)
 			},
@@ -609,7 +610,7 @@ func TestDeleteNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{}), gomock.Any()).Return(awserrors.NewFailedDependency("failed dependency"))
 			},
 			wantErr: true,
@@ -631,10 +632,10 @@ func TestDeleteNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{}), gomock.Any()).Do(mockDescribeNatGatewaysOutput).Return(nil)
 
-				m.DeleteNatGateway(gomock.Eq(&ec2.DeleteNatGatewayInput{
+				m.DeleteNatGatewayWithContext(context.TODO(), gomock.Eq(&ec2.DeleteNatGatewayInput{
 					NatGatewayId: aws.String("natgateway"),
 				})).Return(nil, awserrors.NewFailedDependency("failed dependency"))
 			},
@@ -657,14 +658,14 @@ func TestDeleteNatGateways(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.AssignableToTypeOf(&ec2.DescribeNatGatewaysInput{}), gomock.Any()).Do(mockDescribeNatGatewaysOutput).Return(nil)
 
-				m.DeleteNatGateway(gomock.Eq(&ec2.DeleteNatGatewayInput{
+				m.DeleteNatGatewayWithContext(context.TODO(), gomock.Eq(&ec2.DeleteNatGatewayInput{
 					NatGatewayId: aws.String("natgateway"),
 				})).Return(&ec2.DeleteNatGatewayOutput{}, nil)
 
-				m.DescribeNatGateways(gomock.Eq(&ec2.DescribeNatGatewaysInput{
+				m.DescribeNatGatewaysWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
 					NatGatewayIds: []*string{aws.String("natgateway")},
 				})).Return(nil, awserrors.NewNotFound("not found"))
 			},
@@ -721,7 +722,7 @@ func TestDeleteNatGateways(t *testing.T) {
 	}
 }
 
-var mockDescribeNatGatewaysOutput = func(_, y interface{}) {
+var mockDescribeNatGatewaysOutput = func(ctx context.Context, _, y interface{}, requestOptions ...request.Option) {
 	funct := y.(func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool)
 	funct(&ec2.DescribeNatGatewaysOutput{NatGateways: []*ec2.NatGateway{{
 		NatGatewayId: aws.String("natgateway"),

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -171,7 +172,7 @@ func (s *Service) fixMismatchedRouting(specRoute *ec2.Route, currentRoute *ec2.R
 	}
 	if input != nil {
 		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
-			if _, err := s.EC2Client.ReplaceRoute(input); err != nil {
+			if _, err := s.EC2Client.ReplaceRouteWithContext(context.TODO(), input); err != nil {
 				return false, err
 			}
 			return true, nil
@@ -225,7 +226,7 @@ func (s *Service) deleteRouteTables() error {
 				continue
 			}
 
-			if _, err := s.EC2Client.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{AssociationId: as.RouteTableAssociationId}); err != nil {
+			if _, err := s.EC2Client.DisassociateRouteTableWithContext(context.TODO(), &ec2.DisassociateRouteTableInput{AssociationId: as.RouteTableAssociationId}); err != nil {
 				record.Warnf(s.scope.InfraCluster(), "FailedDisassociateRouteTable", "Failed to disassociate managed RouteTable %q from Subnet %q: %v", *rt.RouteTableId, *as.SubnetId, err)
 				return errors.Wrapf(err, "failed to disassociate route table %q from subnet %q", *rt.RouteTableId, *as.SubnetId)
 			}
@@ -234,7 +235,7 @@ func (s *Service) deleteRouteTables() error {
 			s.scope.Debug("Deleted association between route table and subnet", "route-table-id", *rt.RouteTableId, "subnet-id", *as.SubnetId)
 		}
 
-		if _, err := s.EC2Client.DeleteRouteTable(&ec2.DeleteRouteTableInput{RouteTableId: rt.RouteTableId}); err != nil {
+		if _, err := s.EC2Client.DeleteRouteTableWithContext(context.TODO(), &ec2.DeleteRouteTableInput{RouteTableId: rt.RouteTableId}); err != nil {
 			record.Warnf(s.scope.InfraCluster(), "FailedDeleteRouteTable", "Failed to delete managed RouteTable %q: %v", *rt.RouteTableId, err)
 			return errors.Wrapf(err, "failed to delete route table %q", *rt.RouteTableId)
 		}
@@ -254,7 +255,7 @@ func (s *Service) describeVpcRouteTables() ([]*ec2.RouteTable, error) {
 		filters = append(filters, filter.EC2.Cluster(s.scope.Name()))
 	}
 
-	out, err := s.EC2Client.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+	out, err := s.EC2Client.DescribeRouteTablesWithContext(context.TODO(), &ec2.DescribeRouteTablesInput{
 		Filters: filters,
 	})
 	if err != nil {
@@ -266,7 +267,7 @@ func (s *Service) describeVpcRouteTables() ([]*ec2.RouteTable, error) {
 }
 
 func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool, zone string) (*infrav1.RouteTable, error) {
-	out, err := s.EC2Client.CreateRouteTable(&ec2.CreateRouteTableInput{
+	out, err := s.EC2Client.CreateRouteTableWithContext(context.TODO(), &ec2.CreateRouteTableInput{
 		VpcId: aws.String(s.scope.VPC().ID),
 		TagSpecifications: []*ec2.TagSpecification{
 			tags.BuildParamsToTagSpecification(ec2.ResourceTypeRouteTable, s.getRouteTableTagParams(services.TemporaryResourceID, isPublic, zone))},
@@ -281,7 +282,7 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool,
 	for i := range routes {
 		route := routes[i]
 		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
-			if _, err := s.EC2Client.CreateRoute(&ec2.CreateRouteInput{
+			if _, err := s.EC2Client.CreateRouteWithContext(context.TODO(), &ec2.CreateRouteInput{
 				RouteTableId:                out.RouteTable.RouteTableId,
 				DestinationCidrBlock:        route.DestinationCidrBlock,
 				DestinationIpv6CidrBlock:    route.DestinationIpv6CidrBlock,
@@ -309,7 +310,7 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.Route, isPublic bool,
 }
 
 func (s *Service) associateRouteTable(rt *infrav1.RouteTable, subnetID string) error {
-	_, err := s.EC2Client.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+	_, err := s.EC2Client.AssociateRouteTableWithContext(context.TODO(), &ec2.AssociateRouteTableInput{
 		RouteTableId: aws.String(rt.ID),
 		SubnetId:     aws.String(subnetID),
 	})

--- a/pkg/cloud/services/network/routetables_test.go
+++ b/pkg/cloud/services/network/routetables_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -72,37 +73,37 @@ func TestReconcileRouteTables(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				privateRouteTable := m.CreateRouteTable(matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
+				privateRouteTable := m.CreateRouteTableWithContext(context.TODO(), matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
 					Return(&ec2.CreateRouteTableOutput{RouteTable: &ec2.RouteTable{RouteTableId: aws.String("rt-1")}}, nil)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					NatGatewayId:         aws.String("nat-01"),
 					DestinationCidrBlock: aws.String("0.0.0.0/0"),
 					RouteTableId:         aws.String("rt-1"),
 				})).
 					After(privateRouteTable)
 
-				m.AssociateRouteTable(gomock.Eq(&ec2.AssociateRouteTableInput{
+				m.AssociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.AssociateRouteTableInput{
 					RouteTableId: aws.String("rt-1"),
 					SubnetId:     aws.String("subnet-routetables-private"),
 				})).
 					Return(&ec2.AssociateRouteTableOutput{}, nil).
 					After(privateRouteTable)
 
-				publicRouteTable := m.CreateRouteTable(matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
+				publicRouteTable := m.CreateRouteTableWithContext(context.TODO(), matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
 					Return(&ec2.CreateRouteTableOutput{RouteTable: &ec2.RouteTable{RouteTableId: aws.String("rt-2")}}, nil)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					GatewayId:            aws.String("igw-01"),
 					DestinationCidrBlock: aws.String("0.0.0.0/0"),
 					RouteTableId:         aws.String("rt-2"),
 				})).
 					After(publicRouteTable)
 
-				m.AssociateRouteTable(gomock.Eq(&ec2.AssociateRouteTableInput{
+				m.AssociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.AssociateRouteTableInput{
 					RouteTableId: aws.String("rt-2"),
 					SubnetId:     aws.String("subnet-routetables-public"),
 				})).
@@ -144,51 +145,51 @@ func TestReconcileRouteTables(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				privateRouteTable := m.CreateRouteTable(matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
+				privateRouteTable := m.CreateRouteTableWithContext(context.TODO(), matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
 					Return(&ec2.CreateRouteTableOutput{RouteTable: &ec2.RouteTable{RouteTableId: aws.String("rt-1")}}, nil)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					NatGatewayId:         aws.String("nat-01"),
 					DestinationCidrBlock: aws.String("0.0.0.0/0"),
 					RouteTableId:         aws.String("rt-1"),
 				})).
 					After(privateRouteTable)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					DestinationIpv6CidrBlock:    aws.String("::/0"),
 					EgressOnlyInternetGatewayId: aws.String("eigw-01"),
 					RouteTableId:                aws.String("rt-1"),
 				})).
 					After(privateRouteTable)
 
-				m.AssociateRouteTable(gomock.Eq(&ec2.AssociateRouteTableInput{
+				m.AssociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.AssociateRouteTableInput{
 					RouteTableId: aws.String("rt-1"),
 					SubnetId:     aws.String("subnet-routetables-private"),
 				})).
 					Return(&ec2.AssociateRouteTableOutput{}, nil).
 					After(privateRouteTable)
 
-				publicRouteTable := m.CreateRouteTable(matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
+				publicRouteTable := m.CreateRouteTableWithContext(context.TODO(), matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
 					Return(&ec2.CreateRouteTableOutput{RouteTable: &ec2.RouteTable{RouteTableId: aws.String("rt-2")}}, nil)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					GatewayId:            aws.String("igw-01"),
 					DestinationCidrBlock: aws.String("0.0.0.0/0"),
 					RouteTableId:         aws.String("rt-2"),
 				})).
 					After(publicRouteTable)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					DestinationIpv6CidrBlock: aws.String("::/0"),
 					GatewayId:                aws.String("igw-01"),
 					RouteTableId:             aws.String("rt-2"),
 				})).
 					After(publicRouteTable)
 
-				m.AssociateRouteTable(gomock.Eq(&ec2.AssociateRouteTableInput{
+				m.AssociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.AssociateRouteTableInput{
 					RouteTableId: aws.String("rt-2"),
 					SubnetId:     aws.String("subnet-routetables-public"),
 				})).
@@ -230,51 +231,51 @@ func TestReconcileRouteTables(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				privateRouteTable := m.CreateRouteTable(matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
+				privateRouteTable := m.CreateRouteTableWithContext(context.TODO(), matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
 					Return(&ec2.CreateRouteTableOutput{RouteTable: &ec2.RouteTable{RouteTableId: aws.String("rt-1")}}, nil)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					NatGatewayId:         aws.String("nat-01"),
 					DestinationCidrBlock: aws.String("0.0.0.0/0"),
 					RouteTableId:         aws.String("rt-1"),
 				})).
 					After(privateRouteTable)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					DestinationIpv6CidrBlock:    aws.String("::/0"),
 					EgressOnlyInternetGatewayId: aws.String("eigw-01"),
 					RouteTableId:                aws.String("rt-1"),
 				})).
 					After(privateRouteTable)
 
-				m.AssociateRouteTable(gomock.Eq(&ec2.AssociateRouteTableInput{
+				m.AssociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.AssociateRouteTableInput{
 					RouteTableId: aws.String("rt-1"),
 					SubnetId:     aws.String("subnet-routetables-private"),
 				})).
 					Return(&ec2.AssociateRouteTableOutput{}, nil).
 					After(privateRouteTable)
 
-				publicRouteTable := m.CreateRouteTable(matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
+				publicRouteTable := m.CreateRouteTableWithContext(context.TODO(), matchRouteTableInput(&ec2.CreateRouteTableInput{VpcId: aws.String("vpc-routetables")})).
 					Return(&ec2.CreateRouteTableOutput{RouteTable: &ec2.RouteTable{RouteTableId: aws.String("rt-2")}}, nil)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					GatewayId:            aws.String("igw-01"),
 					DestinationCidrBlock: aws.String("0.0.0.0/0"),
 					RouteTableId:         aws.String("rt-2"),
 				})).
 					After(publicRouteTable)
 
-				m.CreateRoute(gomock.Eq(&ec2.CreateRouteInput{
+				m.CreateRouteWithContext(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
 					DestinationIpv6CidrBlock: aws.String("::/0"),
 					GatewayId:                aws.String("igw-01"),
 					RouteTableId:             aws.String("rt-2"),
 				})).
 					After(publicRouteTable)
 
-				m.AssociateRouteTable(gomock.Eq(&ec2.AssociateRouteTableInput{
+				m.AssociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.AssociateRouteTableInput{
 					RouteTableId: aws.String("rt-2"),
 					SubnetId:     aws.String("subnet-routetables-public"),
 				})).
@@ -307,7 +308,7 @@ func TestReconcileRouteTables(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 			},
 			err: errors.New(`no nat gateways available in "us-east-1a"`),
@@ -338,7 +339,7 @@ func TestReconcileRouteTables(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{
 						RouteTables: []*ec2.RouteTable{
 							{
@@ -408,7 +409,7 @@ func TestReconcileRouteTables(t *testing.T) {
 						},
 					}, nil)
 
-				m.ReplaceRoute(gomock.Eq(
+				m.ReplaceRouteWithContext(context.TODO(), gomock.Eq(
 					&ec2.ReplaceRouteInput{
 						DestinationCidrBlock: aws.String("0.0.0.0/0"),
 						RouteTableId:         aws.String("route-table-private"),
@@ -443,7 +444,7 @@ func TestReconcileRouteTables(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{
 						RouteTables: []*ec2.RouteTable{
 							{
@@ -634,18 +635,18 @@ func TestDeleteRouteTables(t *testing.T) {
 			name:  "Should delete route table successfully",
 			input: &infrav1.NetworkSpec{},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(describeRouteTableOutput, nil)
 
-				m.DeleteRouteTable(gomock.Eq(&ec2.DeleteRouteTableInput{
+				m.DeleteRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.DeleteRouteTableInput{
 					RouteTableId: aws.String("route-table-private"),
 				})).Return(&ec2.DeleteRouteTableOutput{}, nil)
 
-				m.DisassociateRouteTable(gomock.Eq(&ec2.DisassociateRouteTableInput{
+				m.DisassociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.DisassociateRouteTableInput{
 					AssociationId: aws.String("route-table-public"),
 				})).Return(&ec2.DisassociateRouteTableOutput{}, nil)
 
-				m.DeleteRouteTable(gomock.Eq(&ec2.DeleteRouteTableInput{
+				m.DeleteRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.DeleteRouteTableInput{
 					RouteTableId: aws.String("route-table-public"),
 				})).Return(&ec2.DeleteRouteTableOutput{}, nil)
 			},
@@ -654,7 +655,7 @@ func TestDeleteRouteTables(t *testing.T) {
 			name:  "Should return error if describe route table fails",
 			input: &infrav1.NetworkSpec{},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(nil, awserrors.NewFailedDependency("failed dependency"))
 			},
 			wantErr: true,
@@ -663,10 +664,10 @@ func TestDeleteRouteTables(t *testing.T) {
 			name:  "Should return error if delete route table fails",
 			input: &infrav1.NetworkSpec{},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(describeRouteTableOutput, nil)
 
-				m.DeleteRouteTable(gomock.Eq(&ec2.DeleteRouteTableInput{
+				m.DeleteRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.DeleteRouteTableInput{
 					RouteTableId: aws.String("route-table-private"),
 				})).Return(nil, awserrors.NewNotFound("not found"))
 			},
@@ -676,14 +677,14 @@ func TestDeleteRouteTables(t *testing.T) {
 			name:  "Should return error if disassociate route table fails",
 			input: &infrav1.NetworkSpec{},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(describeRouteTableOutput, nil)
 
-				m.DeleteRouteTable(gomock.Eq(&ec2.DeleteRouteTableInput{
+				m.DeleteRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.DeleteRouteTableInput{
 					RouteTableId: aws.String("route-table-private"),
 				})).Return(&ec2.DeleteRouteTableOutput{}, nil)
 
-				m.DisassociateRouteTable(gomock.Eq(&ec2.DisassociateRouteTableInput{
+				m.DisassociateRouteTableWithContext(context.TODO(), gomock.Eq(&ec2.DisassociateRouteTableInput{
 					AssociationId: aws.String("route-table-public"),
 				})).Return(nil, awserrors.NewNotFound("not found"))
 			},

--- a/pkg/cloud/services/network/secondarycidr.go
+++ b/pkg/cloud/services/network/secondarycidr.go
@@ -17,6 +17,8 @@ limitations under the License.
 package network
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -33,7 +35,7 @@ func (s *Service) associateSecondaryCidr() error {
 		return nil
 	}
 
-	vpcs, err := s.EC2Client.DescribeVpcs(&ec2.DescribeVpcsInput{
+	vpcs, err := s.EC2Client.DescribeVpcsWithContext(context.TODO(), &ec2.DescribeVpcsInput{
 		VpcIds: []*string{&s.scope.VPC().ID},
 	})
 	if err != nil {
@@ -51,7 +53,7 @@ func (s *Service) associateSecondaryCidr() error {
 		}
 	}
 
-	out, err := s.EC2Client.AssociateVpcCidrBlock(&ec2.AssociateVpcCidrBlockInput{
+	out, err := s.EC2Client.AssociateVpcCidrBlockWithContext(context.TODO(), &ec2.AssociateVpcCidrBlockInput{
 		VpcId:     &s.scope.VPC().ID,
 		CidrBlock: s.scope.SecondaryCidrBlock(),
 	})
@@ -71,7 +73,7 @@ func (s *Service) disassociateSecondaryCidr() error {
 		return nil
 	}
 
-	vpcs, err := s.EC2Client.DescribeVpcs(&ec2.DescribeVpcsInput{
+	vpcs, err := s.EC2Client.DescribeVpcsWithContext(context.TODO(), &ec2.DescribeVpcsInput{
 		VpcIds: []*string{&s.scope.VPC().ID},
 	})
 	if err != nil {
@@ -85,7 +87,7 @@ func (s *Service) disassociateSecondaryCidr() error {
 	existingAssociations := vpcs.Vpcs[0].CidrBlockAssociationSet
 	for _, existing := range existingAssociations {
 		if cmp.Equal(existing.CidrBlock, s.scope.SecondaryCidrBlock()) {
-			if _, err := s.EC2Client.DisassociateVpcCidrBlock(&ec2.DisassociateVpcCidrBlockInput{
+			if _, err := s.EC2Client.DisassociateVpcCidrBlockWithContext(context.TODO(), &ec2.DisassociateVpcCidrBlockInput{
 				AssociationId: existing.AssociationId,
 			}); err != nil {
 				record.Warnf(s.scope.InfraCluster(), "FailedDisassociateSecondaryCidr", "Failed disassociating secondary CIDR with VPC %v", err)

--- a/pkg/cloud/services/network/secondarycidr_test.go
+++ b/pkg/cloud/services/network/secondarycidr_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -76,7 +77,7 @@ func TestServiceAssociateSecondaryCidr(t *testing.T) {
 			name:              "Should return error if unable to describe VPC",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
 			},
 			wantErr: true,
 		},
@@ -84,7 +85,7 @@ func TestServiceAssociateSecondaryCidr(t *testing.T) {
 			name:              "Should not associate secondary cidr block if already exist in VPC",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
 					Vpcs: []*ec2.Vpc{
 						{
 							CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
@@ -98,7 +99,7 @@ func TestServiceAssociateSecondaryCidr(t *testing.T) {
 			name:              "Should return error if no VPC found",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, nil)
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, nil)
 			},
 			wantErr: true,
 		},
@@ -106,7 +107,7 @@ func TestServiceAssociateSecondaryCidr(t *testing.T) {
 			name:              "Should return error if failed during associating secondary cidr block",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
 					Vpcs: []*ec2.Vpc{
 						{
 							CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
@@ -114,7 +115,7 @@ func TestServiceAssociateSecondaryCidr(t *testing.T) {
 							},
 						},
 					}}, nil)
-				m.AssociateVpcCidrBlock(gomock.AssignableToTypeOf(&ec2.AssociateVpcCidrBlockInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
+				m.AssociateVpcCidrBlockWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AssociateVpcCidrBlockInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
 			},
 			wantErr: true,
 		},
@@ -170,7 +171,7 @@ func TestServiceDiassociateSecondaryCidr(t *testing.T) {
 			name:              "Should return error if unable to describe VPC",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
 			},
 			wantErr: true,
 		},
@@ -178,7 +179,7 @@ func TestServiceDiassociateSecondaryCidr(t *testing.T) {
 			name:              "Should return error if no VPC found",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, nil)
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(nil, nil)
 			},
 			wantErr: true,
 		},
@@ -186,7 +187,7 @@ func TestServiceDiassociateSecondaryCidr(t *testing.T) {
 			name:              "Should diassociate secondary cidr block if already exist in VPC",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
 					Vpcs: []*ec2.Vpc{
 						{
 							CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
@@ -194,14 +195,14 @@ func TestServiceDiassociateSecondaryCidr(t *testing.T) {
 							},
 						},
 					}}, nil)
-				m.DisassociateVpcCidrBlock(gomock.AssignableToTypeOf(&ec2.DisassociateVpcCidrBlockInput{})).Return(nil, nil)
+				m.DisassociateVpcCidrBlockWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DisassociateVpcCidrBlockInput{})).Return(nil, nil)
 			},
 		},
 		{
 			name:              "Should return error if failed to diassociate secondary cidr block",
 			haveSecondaryCIDR: true,
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeVpcs(gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
+				m.DescribeVpcsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeVpcsInput{})).Return(&ec2.DescribeVpcsOutput{
 					Vpcs: []*ec2.Vpc{
 						{
 							CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
@@ -209,7 +210,7 @@ func TestServiceDiassociateSecondaryCidr(t *testing.T) {
 							},
 						},
 					}}, nil)
-				m.DisassociateVpcCidrBlock(gomock.AssignableToTypeOf(&ec2.DisassociateVpcCidrBlockInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
+				m.DisassociateVpcCidrBlockWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DisassociateVpcCidrBlockInput{})).Return(nil, awserrors.NewFailedDependency("dependency-failure"))
 			},
 			wantErr: true,
 		},

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -64,7 +65,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}).WithTagUnmanagedNetworkResources(false),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -95,7 +96,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{
 						RouteTables: []*ec2.RouteTable{
 							{
@@ -115,7 +116,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -148,7 +149,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}).WithTagUnmanagedNetworkResources(true),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -179,7 +180,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{
 						RouteTables: []*ec2.RouteTable{
 							{
@@ -199,7 +200,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -214,7 +215,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-1"}),
 					Tags: []*ec2.Tag{
 						{
@@ -229,7 +230,7 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.CreateTagsOutput{}, nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-2"}),
 					Tags: []*ec2.Tag{
 						{
@@ -266,7 +267,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}).WithTagUnmanagedNetworkResources(true),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -317,7 +318,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{
 						RouteTables: []*ec2.RouteTable{
 							{
@@ -337,7 +338,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -352,7 +353,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-1"}),
 					Tags: []*ec2.Tag{
 						{
@@ -367,7 +368,7 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.CreateTagsOutput{}, nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-2"}),
 					Tags: []*ec2.Tag{
 						{
@@ -401,7 +402,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}).WithTagUnmanagedNetworkResources(true),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -432,10 +433,10 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -450,7 +451,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-1"}),
 					Tags: []*ec2.Tag{
 						{
@@ -465,7 +466,7 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.CreateTagsOutput{}, nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-2"}),
 					Tags: []*ec2.Tag{
 						{
@@ -499,7 +500,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}).WithTagUnmanagedNetworkResources(true),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -530,7 +531,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{
 						RouteTables: []*ec2.RouteTable{
 							{
@@ -550,7 +551,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -565,7 +566,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-1"}),
 					Tags: []*ec2.Tag{
 						{
@@ -591,7 +592,7 @@ func TestReconcileSubnets(t *testing.T) {
 				Subnets: []infrav1.SubnetSpec{},
 			}).WithTagUnmanagedNetworkResources(true),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -622,10 +623,10 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -663,7 +664,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}).WithTagUnmanagedNetworkResources(true),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -677,10 +678,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -718,7 +719,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}).WithTagUnmanagedNetworkResources(true),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -749,10 +750,10 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -767,7 +768,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-1"}),
 					Tags: []*ec2.Tag{
 						{
@@ -782,7 +783,7 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.CreateTagsOutput{}, nil)
 
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{"subnet-2"}),
 					Tags: []*ec2.Tag{
 						{
@@ -823,7 +824,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				describeCall := m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				describeCall := m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -837,10 +838,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -855,7 +856,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				firstSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				firstSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.1.0.0/16"),
 					AvailabilityZone: aws.String("us-east-1a"),
@@ -898,10 +899,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(describeCall)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(firstSubnet)
 
-				secondSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				secondSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.2.0.0/16"),
 					AvailabilityZone: aws.String("us-east-1b"),
@@ -944,10 +945,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(firstSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(secondSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -975,7 +976,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -989,10 +990,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -1022,7 +1023,7 @@ func TestReconcileSubnets(t *testing.T) {
 				Subnets: []infrav1.SubnetSpec{},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeAvailabilityZones(gomock.Any()).
+				m.DescribeAvailabilityZonesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeAvailabilityZonesOutput{
 						AvailabilityZones: []*ec2.AvailabilityZone{
 							{
@@ -1031,7 +1032,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				describeCall := m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				describeCall := m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -1045,10 +1046,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -1063,7 +1064,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				firstSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				firstSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.0.0/17"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -1106,10 +1107,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(describeCall)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(firstSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -1118,7 +1119,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(firstSubnet)
 
-				secondSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				secondSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.128.0/17"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -1161,7 +1162,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(firstSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(secondSubnet)
 			},
 		},
@@ -1182,7 +1183,7 @@ func TestReconcileSubnets(t *testing.T) {
 				Subnets: []infrav1.SubnetSpec{},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeAvailabilityZones(gomock.Any()).
+				m.DescribeAvailabilityZonesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeAvailabilityZonesOutput{
 						AvailabilityZones: []*ec2.AvailabilityZone{
 							{
@@ -1191,7 +1192,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				describeCall := m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				describeCall := m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -1205,10 +1206,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -1223,7 +1224,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				firstSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				firstSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.0.0/17"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -1277,10 +1278,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(describeCall)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(firstSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					AssignIpv6AddressOnCreation: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -1289,7 +1290,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(firstSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					AssignIpv6AddressOnCreation: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -1298,7 +1299,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(firstSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -1307,7 +1308,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(firstSubnet)
 
-				secondSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				secondSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.128.0/17"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -1361,7 +1362,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(firstSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(secondSubnet)
 			},
 		},
@@ -1378,7 +1379,7 @@ func TestReconcileSubnets(t *testing.T) {
 				Subnets: []infrav1.SubnetSpec{},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeAvailabilityZones(gomock.Any()).
+				m.DescribeAvailabilityZonesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeAvailabilityZonesOutput{
 						AvailabilityZones: []*ec2.AvailabilityZone{
 							{
@@ -1390,7 +1391,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				describeCall := m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				describeCall := m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -1404,10 +1405,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -1422,7 +1423,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				zone1PublicSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone1PublicSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.0.0/19"),
 					AvailabilityZone: aws.String("us-east-1b"),
@@ -1465,10 +1466,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(describeCall)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone1PublicSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -1477,7 +1478,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(zone1PublicSubnet)
 
-				zone1PrivateSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone1PrivateSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.64.0/18"),
 					AvailabilityZone: aws.String("us-east-1b"),
@@ -1520,12 +1521,12 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(zone1PublicSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone1PrivateSubnet)
 
 				// zone 2
 
-				zone2PublicSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone2PublicSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.32.0/19"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -1568,10 +1569,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(zone1PrivateSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone2PublicSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -1580,7 +1581,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(zone2PublicSubnet)
 
-				zone2PrivateSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone2PrivateSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.128.0/18"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -1623,7 +1624,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(zone2PublicSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone2PrivateSubnet)
 			},
 		},
@@ -1642,7 +1643,7 @@ func TestReconcileSubnets(t *testing.T) {
 				Subnets: []infrav1.SubnetSpec{},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeAvailabilityZones(gomock.Any()).
+				m.DescribeAvailabilityZonesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeAvailabilityZonesOutput{
 						AvailabilityZones: []*ec2.AvailabilityZone{
 							{
@@ -1654,7 +1655,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				describeCall := m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				describeCall := m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -1668,10 +1669,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -1686,7 +1687,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				zone1PublicSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone1PublicSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.0.0/17"),
 					AvailabilityZone: aws.String("us-east-1b"),
@@ -1729,10 +1730,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(describeCall)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone1PublicSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -1741,7 +1742,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(zone1PublicSubnet)
 
-				zone1PrivateSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone1PrivateSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.128.0/17"),
 					AvailabilityZone: aws.String("us-east-1b"),
@@ -1784,7 +1785,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(zone1PublicSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone1PrivateSubnet)
 			},
 		},
@@ -1812,7 +1813,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -1853,10 +1854,10 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -1871,7 +1872,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.128.0/17"),
 					AvailabilityZone: aws.String("us-east-1a"),
@@ -1912,10 +1913,10 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.WaitUntilSubnetAvailable(gomock.Any())
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any())
 
 				// Public subnet
-				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+				m.CreateTagsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(nil, nil)
 			},
 		},
@@ -1944,7 +1945,7 @@ func TestReconcileSubnets(t *testing.T) {
 				},
 			}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -1985,10 +1986,10 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -2003,7 +2004,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.128.0/17"),
 					AvailabilityZone: aws.String("us-east-1a"),
@@ -2044,10 +2045,10 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.WaitUntilSubnetAvailable(gomock.Any())
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any())
 
 				// Public subnet
-				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+				m.CreateTagsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(nil, nil)
 			},
 		},
@@ -2066,7 +2067,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Subnets: []infrav1.SubnetSpec{},
 				}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeAvailabilityZones(gomock.Any()).
+				m.DescribeAvailabilityZonesWithContext(context.TODO(), gomock.Any()).
 					Return(&ec2.DescribeAvailabilityZonesOutput{
 						AvailabilityZones: []*ec2.AvailabilityZone{
 							{
@@ -2078,7 +2079,7 @@ func TestReconcileSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				describeCall := m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				describeCall := m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -2092,10 +2093,10 @@ func TestReconcileSubnets(t *testing.T) {
 				})).
 					Return(&ec2.DescribeSubnetsOutput{}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -2110,7 +2111,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				zone1PublicSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone1PublicSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.0.0/19"),
 					AvailabilityZone: aws.String("us-east-1b"),
@@ -2153,10 +2154,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(describeCall)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone1PublicSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -2165,7 +2166,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(zone1PublicSubnet)
 
-				zone1PrivateSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone1PrivateSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.64.0/18"),
 					AvailabilityZone: aws.String("us-east-1b"),
@@ -2208,12 +2209,12 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(zone1PublicSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone1PrivateSubnet)
 
 				// zone 2
 
-				zone2PublicSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone2PublicSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.32.0/19"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -2256,10 +2257,10 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(zone1PrivateSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone2PublicSubnet)
 
-				m.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
 					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
@@ -2268,7 +2269,7 @@ func TestReconcileSubnets(t *testing.T) {
 					Return(&ec2.ModifySubnetAttributeOutput{}, nil).
 					After(zone2PublicSubnet)
 
-				zone2PrivateSubnet := m.CreateSubnet(gomock.Eq(&ec2.CreateSubnetInput{
+				zone2PrivateSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
 					VpcId:            aws.String(subnetsVPCID),
 					CidrBlock:        aws.String("10.0.128.0/18"),
 					AvailabilityZone: aws.String("us-east-1c"),
@@ -2311,7 +2312,7 @@ func TestReconcileSubnets(t *testing.T) {
 					}, nil).
 					After(zone2PublicSubnet)
 
-				m.WaitUntilSubnetAvailable(gomock.Any()).
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
 					After(zone2PrivateSubnet)
 			},
 		},
@@ -2373,7 +2374,7 @@ func TestDiscoverSubnets(t *testing.T) {
 				},
 			},
 			mocks: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -2414,7 +2415,7 @@ func TestDiscoverSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeRouteTables(gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
 					Return(&ec2.DescribeRouteTablesOutput{
 						RouteTables: []*ec2.RouteTable{
 							{
@@ -2452,7 +2453,7 @@ func TestDiscoverSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DescribeNatGatewaysPages(
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
 					gomock.Eq(&ec2.DescribeNatGatewaysInput{
 						Filter: []*ec2.Filter{
 							{
@@ -2467,7 +2468,7 @@ func TestDiscoverSubnets(t *testing.T) {
 					}),
 					gomock.Any()).Return(nil)
 
-				m.CreateTags(gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
+				m.CreateTagsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.CreateTagsInput{})).
 					Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()
 			},
 			expect: []infrav1.SubnetSpec{
@@ -2586,7 +2587,7 @@ func TestDeleteSubnets(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSubnets(gomock.Eq(&ec2.DescribeSubnetsInput{
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("state"),
@@ -2617,12 +2618,12 @@ func TestDeleteSubnets(t *testing.T) {
 						},
 					}, nil)
 
-				m.DeleteSubnet(&ec2.DeleteSubnetInput{
+				m.DeleteSubnetWithContext(context.TODO(), &ec2.DeleteSubnetInput{
 					SubnetId: aws.String("subnet-1"),
 				}).
 					Return(nil, nil)
 
-				m.DeleteSubnet(&ec2.DeleteSubnetInput{
+				m.DeleteSubnetWithContext(context.TODO(), &ec2.DeleteSubnetInput{
 					SubnetId: aws.String("subnet-2"),
 				}).
 					Return(nil, nil)

--- a/pkg/cloud/services/securitygroup/securitygroups_test.go
+++ b/pkg/cloud/services/securitygroup/securitygroups_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package securitygroup
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -88,10 +90,10 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
 					Return(&ec2.DescribeSecurityGroupsOutput{}, nil)
 
-				securityGroupBastion := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupBastion := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-bastion"),
 					Description: aws.String("Kubernetes cluster test-cluster: bastion"),
@@ -117,13 +119,13 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-bastion")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-bastion"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 					After(securityGroupBastion)
 
-				securityGroupAPIServerLb := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupAPIServerLb := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-apiserver-lb"),
 					Description: aws.String("Kubernetes cluster test-cluster: apiserver-lb"),
@@ -149,13 +151,13 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-apiserver-lb")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-apiserver-lb"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 					After(securityGroupAPIServerLb)
 
-				m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-lb"),
 					Description: aws.String("Kubernetes cluster test-cluster: lb"),
@@ -185,7 +187,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-lb")}, nil)
 
-				securityGroupControl := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupControl := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-controlplane"),
 					Description: aws.String("Kubernetes cluster test-cluster: controlplane"),
@@ -211,13 +213,13 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-control")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-control"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 					After(securityGroupControl)
 
-				securityGroupNode := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupNode := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-node"),
 					Description: aws.String("Kubernetes cluster test-cluster: node"),
@@ -243,7 +245,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-node")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-node"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
@@ -282,10 +284,10 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
 					Return(&ec2.DescribeSecurityGroupsOutput{}, nil)
 
-				securityGroupBastion := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupBastion := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-bastion"),
 					Description: aws.String("Kubernetes cluster test-cluster: bastion"),
@@ -311,13 +313,13 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-bastion")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-bastion"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 					After(securityGroupBastion)
 
-				securityGroupAPIServerLb := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupAPIServerLb := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-apiserver-lb"),
 					Description: aws.String("Kubernetes cluster test-cluster: apiserver-lb"),
@@ -343,13 +345,13 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-apiserver-lb")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-apiserver-lb"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 					After(securityGroupAPIServerLb)
 
-				lbSecurityGroup := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				lbSecurityGroup := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-lb"),
 					Description: aws.String("Kubernetes cluster test-cluster: lb"),
@@ -378,13 +380,13 @@ func TestReconcileSecurityGroups(t *testing.T) {
 					},
 				})).Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-lb")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-lb"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 					After(lbSecurityGroup)
 
-				securityGroupControl := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupControl := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-controlplane"),
 					Description: aws.String("Kubernetes cluster test-cluster: controlplane"),
@@ -410,13 +412,13 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-control")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-control"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
 					After(securityGroupControl)
 
-				securityGroupNode := m.CreateSecurityGroup(gomock.Eq(&ec2.CreateSecurityGroupInput{
+				securityGroupNode := m.CreateSecurityGroupWithContext(context.TODO(), gomock.Eq(&ec2.CreateSecurityGroupInput{
 					VpcId:       aws.String("vpc-securitygroups"),
 					GroupName:   aws.String("test-cluster-node"),
 					Description: aws.String("Kubernetes cluster test-cluster: node"),
@@ -442,7 +444,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				})).
 					Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-node")}, nil)
 
-				m.AuthorizeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
+				m.AuthorizeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId: aws.String("sg-node"),
 				})).
 					Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).
@@ -481,7 +483,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
 					Return(&ec2.DescribeSecurityGroupsOutput{
 						SecurityGroups: []*ec2.SecurityGroup{
 							{GroupId: aws.String("sg-bastion"), GroupName: aws.String("Bastion Security Group")},
@@ -528,7 +530,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).
 					Return(&ec2.DescribeSecurityGroupsOutput{
 						SecurityGroups: []*ec2.SecurityGroup{
 							{GroupId: aws.String("sg-bastion"), GroupName: aws.String("Bastion Security Group")},
@@ -1096,7 +1098,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroupsPages(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).Return(nil)
+				m.DescribeSecurityGroupsPagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).Return(nil)
 			},
 		},
 		{
@@ -1111,7 +1113,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				VPC: infrav1.VPCSpec{ID: "vpc-id"},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroupsPages(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).Return(awserrors.NewFailedDependency("dependency-failure"))
+				m.DescribeSecurityGroupsPagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).Return(awserrors.NewFailedDependency("dependency-failure"))
 			},
 			wantErr: true,
 		},
@@ -1121,9 +1123,9 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				VPC: infrav1.VPCSpec{ID: "vpc-id"},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroupsPages(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
+				m.DescribeSecurityGroupsPagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
 					Do(processSecurityGroupsPage).Return(nil)
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(nil, awserr.New("dependency-failure", "dependency-failure", errors.Errorf("dependency-failure")))
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(nil, awserr.New("dependency-failure", "dependency-failure", errors.Errorf("dependency-failure")))
 			},
 			wantErr: true,
 		},
@@ -1133,9 +1135,9 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				VPC: infrav1.VPCSpec{ID: "vpc-id"},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroupsPages(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
+				m.DescribeSecurityGroupsPagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
 					Do(processSecurityGroupsPage).Return(nil)
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(&ec2.DescribeSecurityGroupsOutput{
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(&ec2.DescribeSecurityGroupsOutput{
 					SecurityGroups: []*ec2.SecurityGroup{
 						{
 							GroupId:   aws.String("group-id"),
@@ -1143,7 +1145,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.DeleteSecurityGroup(gomock.AssignableToTypeOf(&ec2.DeleteSecurityGroupInput{})).Return(nil, nil)
+				m.DeleteSecurityGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DeleteSecurityGroupInput{})).Return(nil, nil)
 			},
 		},
 		{
@@ -1152,9 +1154,9 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				VPC: infrav1.VPCSpec{ID: "vpc-id"},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroupsPages(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
+				m.DescribeSecurityGroupsPagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
 					Do(processSecurityGroupsPage).Return(nil)
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(&ec2.DescribeSecurityGroupsOutput{
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(&ec2.DescribeSecurityGroupsOutput{
 					SecurityGroups: []*ec2.SecurityGroup{
 						{
 							GroupId:   aws.String("group-id"),
@@ -1167,7 +1169,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.RevokeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.RevokeSecurityGroupIngressInput{})).Return(nil, awserr.New("failure", "failure", errors.Errorf("failure")))
+				m.RevokeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.RevokeSecurityGroupIngressInput{})).Return(nil, awserr.New("failure", "failure", errors.Errorf("failure")))
 			},
 			wantErr: true,
 		},
@@ -1177,9 +1179,9 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				VPC: infrav1.VPCSpec{ID: "vpc-id"},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeSecurityGroupsPages(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
+				m.DescribeSecurityGroupsPagesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{}), gomock.Any()).
 					Do(processSecurityGroupsPage).Return(nil)
-				m.DescribeSecurityGroups(gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(&ec2.DescribeSecurityGroupsOutput{
+				m.DescribeSecurityGroupsWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeSecurityGroupsInput{})).Return(&ec2.DescribeSecurityGroupsOutput{
 					SecurityGroups: []*ec2.SecurityGroup{
 						{
 							GroupId:   aws.String("group-id"),
@@ -1192,8 +1194,8 @@ func TestDeleteSecurityGroups(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.RevokeSecurityGroupIngress(gomock.AssignableToTypeOf(&ec2.RevokeSecurityGroupIngressInput{})).Return(nil, nil)
-				m.DeleteSecurityGroup(gomock.AssignableToTypeOf(&ec2.DeleteSecurityGroupInput{})).Return(nil, nil)
+				m.RevokeSecurityGroupIngressWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.RevokeSecurityGroupIngressInput{})).Return(nil, nil)
+				m.DeleteSecurityGroupWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DeleteSecurityGroupInput{})).Return(nil, nil)
 			},
 		},
 	}
@@ -1328,7 +1330,7 @@ func TestIngressRulesFromSDKType(t *testing.T) {
 	}
 }
 
-var processSecurityGroupsPage = func(_, y interface{}) {
+var processSecurityGroupsPage = func(ctx context.Context, _, y interface{}, requestOptions ...request.Option) {
 	funcType := y.(func(out *ec2.DescribeSecurityGroupsOutput, last bool) bool)
 	funcType(&ec2.DescribeSecurityGroupsOutput{
 		SecurityGroups: []*ec2.SecurityGroup{

--- a/pkg/cloud/tags/tags.go
+++ b/pkg/cloud/tags/tags.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tags
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -114,7 +115,7 @@ func WithEC2(ec2client ec2iface.EC2API) BuilderOption {
 				Tags:      awsTags,
 			}
 
-			_, err := ec2client.CreateTags(createTagsInput)
+			_, err := ec2client.CreateTagsWithContext(context.TODO(), createTagsInput)
 			return errors.Wrapf(err, "failed to tag resource %q in cluster %q", params.ResourceID, params.ClusterName)
 		}
 	}

--- a/pkg/cloud/tags/tags_test.go
+++ b/pkg/cloud/tags/tags_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tags
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -142,7 +143,7 @@ func TestTagsEnsureWithEC2(t *testing.T) {
 			name:    "Should return error when create tag fails",
 			builder: Builder{params: &bp},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{""}),
 					Tags:      tags,
 				})).Return(nil, errors.New("failed to create tag"))
@@ -160,7 +161,7 @@ func TestTagsEnsureWithEC2(t *testing.T) {
 			name:    "Should ensure tags successfully",
 			builder: Builder{params: &bp},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.CreateTags(gomock.Eq(&ec2.CreateTagsInput{
+				m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 					Resources: aws.StringSlice([]string{""}),
 					Tags:      tags,
 				})).Return(nil, nil)

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -869,7 +869,7 @@ func conformanceImageID(e2eCtx *E2EContext) string {
 
 func GetAvailabilityZones(sess client.ConfigProvider) []*ec2.AvailabilityZone {
 	ec2Client := ec2.New(sess)
-	azs, err := ec2Client.DescribeAvailabilityZones(nil)
+	azs, err := ec2Client.DescribeAvailabilityZonesWithContext(context.TODO(), nil)
 	Expect(err).NotTo(HaveOccurred())
 	return azs.AvailabilityZones
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This is the first PR in a series.

Now we don't pass context from `Reconcile` functions to AWS SDK calls, which limits our ability to trace requests using OpenTelemetry. To improve this we want to start passing context from top to bottom.

In this PR we just replace AWS SDK calls with their `WithContext` analogs, so that they can accept a context parameter. In the following PRs we are going to start passing context from `Reconcile` to the SDK calls.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially-Fixes #4504

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
