### PR TITLE
Fix error loop for ignition

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -775,7 +775,12 @@ func (r *AWSMachineReconciler) ignitionUserData(scope *scope.MachineScope, objec
 }
 
 func (r *AWSMachineReconciler) deleteBootstrapData(machineScope *scope.MachineScope, clusterScope cloud.ClusterScoper, objectStoreScope scope.S3Scope) error {
-	if !machineScope.AWSMachine.Spec.CloudInit.InsecureSkipSecretsManager {
+	_, userDataFormat, err := machineScope.GetRawBootstrapDataWithFormat()
+	if err != nil {
+		return errors.Wrap(err, "failed to get raw userdata")
+	}
+
+	if machineScope.UseSecretsManager(userDataFormat) {
 		if err := r.deleteEncryptedBootstrapDataSecret(machineScope, clusterScope); err != nil {
 			return err
 		}

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -177,6 +177,17 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 		ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("integ-test-%s", util.RandomString(5)))
 		g.Expect(err).To(BeNil())
 
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrap-data",
+				Namespace: ns.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("shell-script"),
+			},
+		}
+		g.Expect(testEnv.Create(ctx, secret)).To(Succeed())
+
 		setup(t, g)
 		awsMachine := getAWSMachine()
 		awsMachine.Namespace = ns.Name
@@ -336,6 +347,17 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 
 		ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("integ-test-%s", util.RandomString(5)))
 		g.Expect(err).To(BeNil())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrap-data",
+				Namespace: ns.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("shell-script"),
+			},
+		}
+		g.Expect(testEnv.Create(ctx, secret)).To(Succeed())
 
 		setup(t, g)
 		awsMachine := getAWSMachine()


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
At the moment, if the user uses Ignition as a bootstrap configuration, the user face a breaking error loop that prevents them from using this option.
The change makes sure that after the machine is successfully created, the data secret content in the S3 bucket gets removed correctly.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4489 

**Special notes for your reviewer**:
With the change made, we needed to make sure to not break the unit tests that are already in place - we needed to add the secrets to the clients that didn't have it previously.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
