### PR TITLE
🌱 Tag S3 bucket as owned by cluster

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -283,6 +283,7 @@ func (t Template) ControllersPolicy() *iamv1.PolicyDocument {
 				"s3:PutObject",
 				"s3:DeleteObject",
 				"s3:PutBucketPolicy",
+				"s3:PutBucketTagging",
 			},
 		})
 	}

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -288,6 +288,7 @@ Resources:
           - s3:PutObject
           - s3:DeleteObject
           - s3:PutBucketPolicy
+          - s3:PutBucketTagging
           Effect: Allow
           Resource:
           - arn:*:s3:::cluster-api-provider-aws-*

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -75,6 +75,25 @@ func TestReconcileBucket(t *testing.T) {
 		}
 
 		s3Mock.EXPECT().CreateBucket(gomock.Eq(input)).Return(nil, nil).Times(1)
+
+		taggingInput := &s3svc.PutBucketTaggingInput{
+			Bucket: aws.String(expectedBucketName),
+			Tagging: &s3svc.Tagging{
+				TagSet: []*s3svc.Tag{
+					{
+						Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+						Value: aws.String("owned"),
+					},
+					{
+						Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+						Value: aws.String("node"),
+					},
+				},
+			},
+		}
+
+		s3Mock.EXPECT().PutBucketTagging(gomock.Eq(taggingInput)).Return(nil, nil).Times(1)
+
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -129,6 +148,7 @@ func TestReconcileBucket(t *testing.T) {
 			}
 		}).Return(nil, nil).Times(1)
 
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -150,6 +170,7 @@ func TestReconcileBucket(t *testing.T) {
 		})
 
 		s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(1)
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Do(func(input *s3svc.PutBucketPolicyInput) {
 			if input.Policy == nil {
 				t.Fatalf("Policy must be defined")
@@ -189,6 +210,7 @@ func TestReconcileBucket(t *testing.T) {
 		svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
 		s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(2)
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(2)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(2)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -208,6 +230,7 @@ func TestReconcileBucket(t *testing.T) {
 		err := awserr.New(s3svc.ErrCodeBucketAlreadyOwnedByYou, "err", errors.New("err"))
 
 		s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, err).Times(1)
+		s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 		s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {
@@ -248,6 +271,7 @@ func TestReconcileBucket(t *testing.T) {
 			svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
 			s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(1)
+			s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 
 			mockCtrl := gomock.NewController(t)
 			stsMock := mock_stsiface.NewMockSTSAPI(mockCtrl)
@@ -265,6 +289,7 @@ func TestReconcileBucket(t *testing.T) {
 			svc, s3Mock := testService(t, &infrav1.S3Bucket{})
 
 			s3Mock.EXPECT().CreateBucket(gomock.Any()).Return(nil, nil).Times(1)
+			s3Mock.EXPECT().PutBucketTagging(gomock.Any()).Return(nil, nil).Times(1)
 			s3Mock.EXPECT().PutBucketPolicy(gomock.Any()).Return(nil, errors.New("error")).Times(1)
 
 			if err := svc.ReconcileBucket(); err == nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

I noticed that the S3 bucket isn't tagged. Some companies use AWS tags for grouping resources, calculating costs, or to clean up accidental remainders of clusters that CAPI/CAPA couldn't delete after a misconfiguration. With this change, the bucket is tagged as belonging to the cluster.

I'm not entirely sure if there's a use case where people provide a shared S3 bucket. In the S3 service code, there's such a hint in a `TODO`. For that case, we would need to introduce `AWSCluster.spec.s3Bucket.additionalTags` where users can set `sigs.k8s.io/cluster-api-provider-aws/cluster/...=shared`. And the implementation should be changed to only upsert tags instead of overwriting them, given that multiple `AWSCluster` objects could reconcile the same bucket. Let me know if that's a supported use case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

n/a

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Tag S3 bucket as owned by the cluster
```
