### PR TITLE
flatcar: Set cloud-provider kubelet flag to "external"

### DIFF
--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -45,19 +45,19 @@ spec:
       nodeRegistration:
         name: $${COREOS_EC2_HOSTNAME}
         kubeletExtraArgs:
-          cloud-provider: aws
+          cloud-provider: external
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: aws
+          cloud-provider: external
       controllerManager:
         extraArgs:
-          cloud-provider: aws
+          cloud-provider: external
     joinConfiguration:
       nodeRegistration:
         name: $${COREOS_EC2_HOSTNAME}
         kubeletExtraArgs:
-          cloud-provider: aws
+          cloud-provider: external
     format: ignition
     ignition:
       containerLinuxConfig:
@@ -138,7 +138,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: aws
+            cloud-provider: external
           name: $${COREOS_EC2_HOSTNAME}
       format: ignition
       ignition:


### PR DESCRIPTION
In-tree cloud provider support was removed in k8s v1.27.

See the following:

- https://github.com/kubernetes/kubernetes/pull/118899
- https://github.com/kubernetes/kubernetes/pull/115838
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4301

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

/kind bug

**What this PR does / why we need it**:

Support for in-tree cloud providers was removed, which is currently causing errors when using `templates/cluster-template-flatcar.yaml`. Set `cloud-provider` to `external` to fix this.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

* I'm not sure why in some places it's OK to use `cloud-provider: aws` and in others it's breaking things. See https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4301#issuecomment-1569863946.
* I'm not sure if I need to update the e2e tests.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
