### PR TITLE
flatcar: Run kubeadm after containerd

### DIFF
--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -73,6 +73,8 @@ spec:
                   # kubeadm must run after coreos-metadata populated /run/metadata directory.
                   Requires=coreos-metadata.service
                   After=coreos-metadata.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
                   [Service]
                   # To make metadata environment variables available for pre-kubeadm commands.
                   EnvironmentFile=/run/metadata/*
@@ -155,6 +157,8 @@ spec:
                     # kubeadm must run after coreos-metadata populated /run/metadata directory.
                     Requires=coreos-metadata.service
                     After=coreos-metadata.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
                     [Service]
                     # To make metadata environment variables available for pre-kubeadm commands.
                     EnvironmentFile=/run/metadata/*

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ignition.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ignition.yaml
@@ -61,6 +61,8 @@ spec:
                   # kubeadm must run after coreos-metadata populated /run/metadata directory.
                   Requires=coreos-metadata.service
                   After=coreos-metadata.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
                   [Service]
                   # To make metadata environment variables available for pre-kubeadm commands.
                   EnvironmentFile=/run/metadata/*
@@ -154,6 +156,8 @@ spec:
                     # kubeadm must run after coreos-metadata populated /run/metadata directory.
                     Requires=coreos-metadata.service
                     After=coreos-metadata.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
                     [Service]
                     # To make metadata environment variables available for pre-kubeadm commands.
                     EnvironmentFile=/run/metadata/*

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/ignition/patches/control-plane-ignition.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/ignition/patches/control-plane-ignition.yaml
@@ -29,6 +29,8 @@ spec:
                   # kubeadm must run after coreos-metadata populated /run/metadata directory.
                   Requires=coreos-metadata.service
                   After=coreos-metadata.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
                   [Service]
                   # To make metadata environment variables available for pre-kubeadm commands.
                   EnvironmentFile=/run/metadata/*

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/ignition/patches/worker-ignition.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/ignition/patches/worker-ignition.yaml
@@ -25,6 +25,8 @@ spec:
                     # kubeadm must run after coreos-metadata populated /run/metadata directory.
                     Requires=coreos-metadata.service
                     After=coreos-metadata.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
                     [Service]
                     # To make metadata environment variables available for pre-kubeadm commands.
                     EnvironmentFile=/run/metadata/*


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

/kind bug

**What this PR does / why we need it**:

Ensure kubeadm runs after containerd to avoid a race condition between the two.

We intentionally add an `After=` directive and not a `Requires=` directive to avoid breaking things for distros which use Ignition and don't use containerd.

See https://github.com/kubernetes-sigs/image-builder/issues/939.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure kubeadm runs after containerd on Flatcar
```
