### PR TITLE
[PROPOSAL] Reviewer and maintainer changes

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -37,8 +37,6 @@ aliases:
     - dlipovetsky
     - vincepri
   cluster-api-aws-reviewers:
-    - dthorsen
-    - pydctw
     - AverageMarcus
     - luthermonson
     - cnmcavoy

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,24 +1,33 @@
-# See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+# See the OWNERS docs: <https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md>
 
 aliases:
-  # Correct as of 2022/10/13
+
+# Correct as of 2023/10/04
+
   sig-cluster-lifecycle-leads:
     - fabriziopandini
     - justinsb
     - neolit123
-    - timothysc
-  # Correct as of 2022/10/13
+    - vincepri
+
+# Correct as of 2023/10/04
+
   cluster-api-admins:
     - CecileRobertMichon
     - vincepri
-  # Correct as of 2022/10/13
+
+# Correct as of 2023/10/04
+
   cluster-api-maintainers:
     - CecileRobertMichon
     - enxebre
     - fabriziopandini
+    - killianmuldoon
     - sbueringer
     - vincepri
-  # Correct as of 2023/01/04
+
+# Correct as of 2023/01/04
+
   cluster-api-aws-admins:
     - richardcase
   cluster-api-aws-maintainers:
@@ -26,9 +35,12 @@ aliases:
     - Skarlso
     - Ankitasw
     - dlipovetsky
+    - vincepri
   cluster-api-aws-reviewers:
     - dthorsen
     - pydctw
-    - shivi28
     - AverageMarcus
     - luthermonson
+    - cnmcavoy
+    - nrb
+    - faiq

--- a/README.md
+++ b/README.md
@@ -185,12 +185,10 @@ Thank you to all contributors and a special thanks to our current maintainers & 
 | Maintainers                                                      | Reviewers                                                            |
 |------------------------------------------------------------------| -------------------------------------------------------------------- |
 | [@richardcase](https://github.com/richardcase) (from 2020-12-04) | [@cnmcavoy](https://github.com/cnmcavoy) (from 2023-10-16)           |
-| [@Skarlso](https://github.com/Skarlso) (from 2022-10-19)         | [@dthorsen](https://github.com/dthorsen) (from 2020-12-04)           |
-| [@Ankitasw](https://github.com/Ankitasw) (from 2022-10-19)       | [@pydctw](https://github.com/pydctw) (from 2021-12-09)               |
-| [@dlipovetsky](https://github.com/dlipovetsky) (from 2021-10-31) | [@AverageMarcus](https://github.com/AverageMarcus) (from 2022-10-19) |
-| [@vincepri](https://github.com/vincepri) (og & from 2023-10-16)  | [@luthermonson](https://github.com/luthermonson ) (from 2023-03-08)  |
-|                                                                  | [@nrb](https://github.com/nrb) (from 2023-10-16)                     |
-|                                                                  | [@faiq](https://github.com/faiq) (from 2023-10-16)                   |
+| [@Skarlso](https://github.com/Skarlso) (from 2022-10-19)         | [@AverageMarcus](https://github.com/AverageMarcus) (from 2022-10-19) |
+| [@Ankitasw](https://github.com/Ankitasw) (from 2022-10-19)       | [@luthermonson](https://github.com/luthermonson ) (from 2023-03-08)  |
+| [@dlipovetsky](https://github.com/dlipovetsky) (from 2021-10-31) | [@nrb](https://github.com/nrb) (from 2023-10-16)                     |
+| [@vincepri](https://github.com/vincepri) (og & from 2023-10-16)  | [@faiq](https://github.com/faiq) (from 2023-10-16)                   |
 
 and the previous/emeritus maintainers & reviewers:
 
@@ -203,6 +201,8 @@ and the previous/emeritus maintainers & reviewers:
 | [@rudoi](https://github.com/rudoi)                   | [@michaelbeaumont](https://github.com/michaelbeaumont) |
 | [@sedefsavas](https://github.com/sedefsavas)         | [@sethp-nr](https://github.com/sethp-nr)               |
 |                                                      | [@shivi28](https://github.com/shivi28)                 |
+|                                                      | [@dthorsen](https://github.com/dthorsen)               |
+|                                                      | [@pydctw](https://github.com/pydctw)                   |
 
 All the CAPA contributors:
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ See [amis] for the list of most recently published AMIs.
 
 `clusterawsadm` could also be installed via Homebrew on macOS and linux OS.
 Install the latest release using homebrew:
+
 ```shell
 brew install clusterawsadm
 ```
 
 Test to ensure the version you installed is up-to-date:
+
 ```shell
 clusterawsadm version
 ```
@@ -182,11 +184,13 @@ Thank you to all contributors and a special thanks to our current maintainers & 
 
 | Maintainers                                                      | Reviewers                                                            |
 |------------------------------------------------------------------| -------------------------------------------------------------------- |
-| [@richardcase](https://github.com/richardcase) (from 2020-12-04) | [@shivi28](https://github.com/shivi28) (from 2021-08-27)             |
+| [@richardcase](https://github.com/richardcase) (from 2020-12-04) | [@cnmcavoy](https://github.com/cnmcavoy) (from 2023-10-16)           |
 | [@Skarlso](https://github.com/Skarlso) (from 2022-10-19)         | [@dthorsen](https://github.com/dthorsen) (from 2020-12-04)           |
 | [@Ankitasw](https://github.com/Ankitasw) (from 2022-10-19)       | [@pydctw](https://github.com/pydctw) (from 2021-12-09)               |
 | [@dlipovetsky](https://github.com/dlipovetsky) (from 2021-10-31) | [@AverageMarcus](https://github.com/AverageMarcus) (from 2022-10-19) |
-|                                                                  | [@luthermonson](https://github.com/luthermonson ) (from 2023-03-08)  |
+| [@vincepri](https://github.com/vincepri) (og & from 2023-10-16)  | [@luthermonson](https://github.com/luthermonson ) (from 2023-03-08)  |
+|                                                                  | [@nrb](https://github.com/nrb) (from 2023-10-16)                     |
+|                                                                  | [@faiq](https://github.com/faiq) (from 2023-10-16)                   |
 
 and the previous/emeritus maintainers & reviewers:
 
@@ -198,7 +202,7 @@ and the previous/emeritus maintainers & reviewers:
 | [@randomvariable](https://github.com/randomvariable) | [@ingvagabund](https://github.com/ingvagabund)         |
 | [@rudoi](https://github.com/rudoi)                   | [@michaelbeaumont](https://github.com/michaelbeaumont) |
 | [@sedefsavas](https://github.com/sedefsavas)         | [@sethp-nr](https://github.com/sethp-nr)               |
-| [@vincepri](https://github.com/vincepri)             |                                                        | 
+|                                                      | [@shivi28](https://github.com/shivi28)                 |
 
 All the CAPA contributors:
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This PR makes the following changes:

- @cnmcavoy moves to reviewer
- @nrb moves to reviewer
- @faiq moves to reviewer
- @vincepri moves from emeritus to maintainer
- @shivi28 moves to emeritus reviewer
- @dthorsen moves to emeritus reviewer
- @pydctw moves to emeritus reviewer
- Updates the owner alias with changes in CAPI / SIG cluster lifecycle leads

> For anyone moving to emeritus, if you feel you want to move back to reviewer in th efuture feel free to reach out to any of the maintainers to discuss.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Maintainer and reviewer changes.
```
