### PR TITLE
fix: update kpromo versions

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -154,7 +154,7 @@ $(PLANTUML): plantuml.Dockerfile ../../versions.mk
 KPROMO_BIN := kpromo
 KPROMO :=  $(BIN_DIR)/$(KPROMO_BIN)
 $(KPROMO):
-	CGO_ENABLED=0 go build -o $@ sigs.k8s.io/promo-tools/v3/cmd/kpromo
+	CGO_ENABLED=0 go build -o $@ sigs.k8s.io/promo-tools/v4/cmd/kpromo
 
 YQ_BIN := yq
 YQ :=  $(BIN_DIR)/$(YQ_BIN)

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -19,7 +19,7 @@ require (
 	sigs.k8s.io/controller-tools v0.12.1
 	sigs.k8s.io/kind v0.20.0
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.7
-	sigs.k8s.io/promo-tools/v3 v4.0.4
+	sigs.k8s.io/promo-tools/v4 v4.0.4
 	sigs.k8s.io/testing_frameworks v0.1.2
 )
 

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -1635,8 +1635,8 @@ sigs.k8s.io/kustomize/kustomize/v4 v4.5.7 h1:cDW6AVMl6t/SLuQaezMET8hgnadZGIAr8tU
 sigs.k8s.io/kustomize/kustomize/v4 v4.5.7/go.mod h1:VSNKEH9D9d9bLiWEGbS6Xbg/Ih0tgQalmPvntzRxZ/Q=
 sigs.k8s.io/kustomize/kyaml v0.13.9 h1:Qz53EAaFFANyNgyOEJbT/yoIHygK40/ZcvU3rgry2Tk=
 sigs.k8s.io/kustomize/kyaml v0.13.9/go.mod h1:QsRbD0/KcU+wdk0/L0fIp2KLnohkVzs6fQ85/nOXac4=
-sigs.k8s.io/promo-tools/v3 v3.6.0 h1:C2L08ezrWm1aZI8Emd3iZPZQserLPRgzuqQVxvI0PUI=
-sigs.k8s.io/promo-tools/v3 v3.6.0/go.mod h1:XJ3jy0hJYs+hWKt8XsLHFzGQV8PUtvllvbxjN/E5RXI=
+sigs.k8s.io/promo-tools/v4 v4.0.4 h1:84Z2G5oKHXl+XgYJwsb8KfyLUruGC4YzrAP4oaiuRUk=
+sigs.k8s.io/promo-tools/v4 v4.0.4/go.mod h1:k7sVi4j+Ywy3swTn+lZW3IdC+VeLiDIzE1BdNNdqeWg=
 sigs.k8s.io/release-sdk v0.10.2 h1:FXY2x8Isld5xDj/pQ6xNiMvlguVOzA1aQYGdrIfnURg=
 sigs.k8s.io/release-sdk v0.10.2/go.mod h1:pafL29n+JFFOikvBpBSIHu0spAr5o0LLaPCkuvJV+jo=
 sigs.k8s.io/release-utils v0.7.4 h1:17LmJrydpUloTCtaoWj95uKlcrUp4h2A9Sa+ZL+lV9w=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -39,6 +39,6 @@ import (
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kind"
 	_ "sigs.k8s.io/kustomize/kustomize/v4"
-	_ "sigs.k8s.io/promo-tools/v3/cmd/kpromo"
+	_ "sigs.k8s.io/promo-tools/v4/cmd/kpromo"
 	_ "sigs.k8s.io/testing_frameworks/integration"
 )


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Ensure the versions of kpromo are consistent across the branch. There was this issue previously:

```
go: errors parsing go.mod:
go.mod:22:2: require sigs.k8s.io/promo-tools/v3: version "v4.0.4" invalid: should be v3, not v4
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure kpromo versions are consistent
```
