### PR TITLE
✨ Add AWSMachine fields to control vpc placement for the instance

### DIFF
--- a/api/v1beta1/awsmachine_conversion.go
+++ b/api/v1beta1/awsmachine_conversion.go
@@ -39,6 +39,8 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.InstanceMetadataOptions = restored.Spec.InstanceMetadataOptions
 	dst.Spec.PlacementGroupName = restored.Spec.PlacementGroupName
 	dst.Spec.PrivateDNSName = restored.Spec.PrivateDNSName
+	dst.Spec.VPC = restored.Spec.VPC
+	dst.Spec.SecurityGroupOverrides = restored.Spec.SecurityGroupOverrides
 
 	return nil
 }
@@ -87,6 +89,8 @@ func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Template.Spec.InstanceMetadataOptions = restored.Spec.Template.Spec.InstanceMetadataOptions
 	dst.Spec.Template.Spec.PlacementGroupName = restored.Spec.Template.Spec.PlacementGroupName
 	dst.Spec.Template.Spec.PrivateDNSName = restored.Spec.Template.Spec.PrivateDNSName
+	dst.Spec.Template.Spec.VPC = restored.Spec.Template.Spec.VPC
+	dst.Spec.Template.Spec.SecurityGroupOverrides = restored.Spec.Template.Spec.SecurityGroupOverrides
 
 	return nil
 }

--- a/api/v1beta1/awsmachine_conversion.go
+++ b/api/v1beta1/awsmachine_conversion.go
@@ -39,7 +39,6 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.InstanceMetadataOptions = restored.Spec.InstanceMetadataOptions
 	dst.Spec.PlacementGroupName = restored.Spec.PlacementGroupName
 	dst.Spec.PrivateDNSName = restored.Spec.PrivateDNSName
-	dst.Spec.VPC = restored.Spec.VPC
 	dst.Spec.SecurityGroupOverrides = restored.Spec.SecurityGroupOverrides
 
 	return nil
@@ -89,7 +88,6 @@ func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Template.Spec.InstanceMetadataOptions = restored.Spec.Template.Spec.InstanceMetadataOptions
 	dst.Spec.Template.Spec.PlacementGroupName = restored.Spec.Template.Spec.PlacementGroupName
 	dst.Spec.Template.Spec.PrivateDNSName = restored.Spec.Template.Spec.PrivateDNSName
-	dst.Spec.Template.Spec.VPC = restored.Spec.Template.Spec.VPC
 	dst.Spec.Template.Spec.SecurityGroupOverrides = restored.Spec.Template.Spec.SecurityGroupOverrides
 
 	return nil

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1390,6 +1390,7 @@ func autoConvert_v1beta2_AWSMachineSpec_To_v1beta1_AWSMachineSpec(in *v1beta2.AW
 	} else {
 		out.AdditionalSecurityGroups = nil
 	}
+	// WARNING: in.VPC requires manual conversion: does not exist in peer-type
 	if in.Subnet != nil {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)
@@ -1399,6 +1400,7 @@ func autoConvert_v1beta2_AWSMachineSpec_To_v1beta1_AWSMachineSpec(in *v1beta2.AW
 	} else {
 		out.Subnet = nil
 	}
+	// WARNING: in.SecurityGroupOverrides requires manual conversion: does not exist in peer-type
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))
 	out.RootVolume = (*Volume)(unsafe.Pointer(in.RootVolume))
 	out.NonRootVolumes = *(*[]Volume)(unsafe.Pointer(&in.NonRootVolumes))

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1390,7 +1390,6 @@ func autoConvert_v1beta2_AWSMachineSpec_To_v1beta1_AWSMachineSpec(in *v1beta2.AW
 	} else {
 		out.AdditionalSecurityGroups = nil
 	}
-	// WARNING: in.VPC requires manual conversion: does not exist in peer-type
 	if in.Subnet != nil {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)

--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -109,10 +109,20 @@ type AWSMachineSpec struct {
 	// +optional
 	AdditionalSecurityGroups []AWSResourceReference `json:"additionalSecurityGroups,omitempty"`
 
+	// VPC is a reference to the VPC to use when picking a subnet to use for this
+	// instance. Only valid if the subnet (id or filters) is also specified.
+	// +optional
+	VPC *AWSResourceReference `json:"vpc,omitempty"`
+
 	// Subnet is a reference to the subnet to use for this instance. If not specified,
 	// the cluster subnet will be used.
 	// +optional
 	Subnet *AWSResourceReference `json:"subnet,omitempty"`
+
+	// SecurityGroupOverrides is an optional set of security groups to use for the node.
+	// This is optional - if not provided security groups from the cluster will be used.
+	// +optional
+	SecurityGroupOverrides map[SecurityGroupRole]string `json:"securityGroupOverrides,omitempty"`
 
 	// SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
 	// +optional

--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -109,11 +109,6 @@ type AWSMachineSpec struct {
 	// +optional
 	AdditionalSecurityGroups []AWSResourceReference `json:"additionalSecurityGroups,omitempty"`
 
-	// VPC is a reference to the VPC to use when picking a subnet to use for this
-	// instance. Only valid if the subnet (id or filters) is also specified.
-	// +optional
-	VPC *AWSResourceReference `json:"vpc,omitempty"`
-
 	// Subnet is a reference to the subnet to use for this instance. If not specified,
 	// the cluster subnet will be used.
 	// +optional

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -695,11 +695,6 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.VPC != nil {
-		in, out := &in.VPC, &out.VPC
-		*out = new(AWSResourceReference)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Subnet != nil {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -695,10 +695,22 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VPC != nil {
+		in, out := &in.VPC, &out.VPC
+		*out = new(AWSResourceReference)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Subnet != nil {
 		in, out := &in.Subnet, &out.Subnet
 		*out = new(AWSResourceReference)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SecurityGroupOverrides != nil {
+		in, out := &in.SecurityGroupOverrides, &out.SecurityGroupOverrides
+		*out = make(map[SecurityGroupRole]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.SSHKeyName != nil {
 		in, out := &in.SSHKeyName, &out.SSHKeyName

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -912,36 +912,6 @@ spec:
                   built-in support for gzip-compressed user data user data stored
                   in aws secret manager is always gzip-compressed.
                 type: boolean
-              vpc:
-                description: VPC is a reference to the VPC to use when picking a subnet
-                  to use for this instance. Only valid if the subnet (id or filters)
-                  is also specified.
-                properties:
-                  filters:
-                    description: 'Filters is a set of key/value pairs used to identify
-                      a resource They are applied according to the rules defined by
-                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
-                    items:
-                      description: Filter is a filter used to identify an AWS resource.
-                      properties:
-                        name:
-                          description: Name of the filter. Filter names are case-sensitive.
-                          type: string
-                        values:
-                          description: Values includes one or more filter values.
-                            Filter values are case-sensitive.
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - name
-                      - values
-                      type: object
-                    type: array
-                  id:
-                    description: ID of resource
-                    type: string
-                type: object
             required:
             - instanceType
             type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -848,6 +848,13 @@ spec:
                 required:
                 - size
                 type: object
+              securityGroupOverrides:
+                additionalProperties:
+                  type: string
+                description: SecurityGroupOverrides is an optional set of security
+                  groups to use for the node. This is optional - if not provided security
+                  groups from the cluster will be used.
+                type: object
               spotMarketOptions:
                 description: SpotMarketOptions allows users to configure instances
                   to be run using AWS Spot instances.
@@ -905,6 +912,36 @@ spec:
                   built-in support for gzip-compressed user data user data stored
                   in aws secret manager is always gzip-compressed.
                 type: boolean
+              vpc:
+                description: VPC is a reference to the VPC to use when picking a subnet
+                  to use for this instance. Only valid if the subnet (id or filters)
+                  is also specified.
+                properties:
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource.
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
             required:
             - instanceType
             type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -876,38 +876,6 @@ spec:
                           cloud-init has built-in support for gzip-compressed user
                           data user data stored in aws secret manager is always gzip-compressed.
                         type: boolean
-                      vpc:
-                        description: VPC is a reference to the VPC to use when picking
-                          a subnet to use for this instance. Only valid if the subnet
-                          (id or filters) is also specified.
-                        properties:
-                          filters:
-                            description: 'Filters is a set of key/value pairs used
-                              to identify a resource They are applied according to
-                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
-                            items:
-                              description: Filter is a filter used to identify an
-                                AWS resource.
-                              properties:
-                                name:
-                                  description: Name of the filter. Filter names are
-                                    case-sensitive.
-                                  type: string
-                                values:
-                                  description: Values includes one or more filter
-                                    values. Filter values are case-sensitive.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - name
-                              - values
-                              type: object
-                            type: array
-                          id:
-                            description: ID of resource
-                            type: string
-                        type: object
                     required:
                     - instanceType
                     type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -807,6 +807,14 @@ spec:
                         required:
                         - size
                         type: object
+                      securityGroupOverrides:
+                        additionalProperties:
+                          type: string
+                        description: SecurityGroupOverrides is an optional set of
+                          security groups to use for the node. This is optional -
+                          if not provided security groups from the cluster will be
+                          used.
+                        type: object
                       spotMarketOptions:
                         description: SpotMarketOptions allows users to configure instances
                           to be run using AWS Spot instances.
@@ -868,6 +876,38 @@ spec:
                           cloud-init has built-in support for gzip-compressed user
                           data user data stored in aws secret manager is always gzip-compressed.
                         type: boolean
+                      vpc:
+                        description: VPC is a reference to the VPC to use when picking
+                          a subnet to use for this instance. Only valid if the subnet
+                          (id or filters) is also specified.
+                        properties:
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource.
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
                     required:
                     - instanceType
                     type: object

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -531,10 +531,6 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 	m.DescribeInstancesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("vpc-id"),
-				Values: aws.StringSlice([]string{""}),
-			},
-			{
 				Name:   aws.String("tag:sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
 				Values: aws.StringSlice([]string{"owned"}),
 			},
@@ -641,10 +637,6 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 		{
 			Name:   aws.String("state"),
 			Values: aws.StringSlice([]string{"pending", "available"}),
-		},
-		{
-			Name:   aws.String("vpc-id"),
-			Values: aws.StringSlice([]string{""}),
 		},
 		{
 			Name:   aws.String("subnet-id"),

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -549,6 +549,221 @@ func TestCreateInstance(t *testing.T) {
 			},
 		},
 		{
+			name: "with vpc and sg roles",
+			machine: clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"set": "node"},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: pointer.String("bootstrap-data"),
+					},
+					FailureDomain: aws.String("us-east-1c"),
+				},
+			},
+			machineConfig: &infrav1.AWSMachineSpec{
+				AMI: infrav1.AMIReference{
+					ID: aws.String("abc"),
+				},
+				InstanceType: "m5.2xlarge",
+				VPC: &infrav1.AWSResourceReference{
+					ID: aws.String("vpc-bar"),
+				},
+				Subnet: &infrav1.AWSResourceReference{
+					Filters: []infrav1.Filter{
+						{
+							Name:   "availability-zone",
+							Values: []string{"us-east-1c"},
+						},
+					},
+				},
+				SecurityGroupOverrides: map[infrav1.SecurityGroupRole]string{
+					infrav1.SecurityGroupNode: "4",
+				},
+				UncompressedUserData: &isUncompressedFalse,
+			},
+			awsCluster: &infrav1.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: infrav1.AWSClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						VPC: infrav1.VPCSpec{
+							ID: "vpc-foo",
+						},
+						Subnets: infrav1.Subnets{
+							infrav1.SubnetSpec{
+								ID:               "subnet-1",
+								AvailabilityZone: "us-east-1a",
+								IsPublic:         false,
+							},
+							infrav1.SubnetSpec{
+								ID:               "subnet-2",
+								AvailabilityZone: "us-east-1b",
+								IsPublic:         false,
+							},
+							infrav1.SubnetSpec{
+								ID:               "subnet-3",
+								AvailabilityZone: "us-east-1c",
+								IsPublic:         false,
+							},
+							infrav1.SubnetSpec{
+								ID:               "subnet-3-public",
+								AvailabilityZone: "us-east-1c",
+								IsPublic:         true,
+							},
+						},
+					},
+				},
+				Status: infrav1.AWSClusterStatus{
+					Network: infrav1.NetworkStatus{
+						SecurityGroups: map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+							infrav1.SecurityGroupControlPlane: {
+								ID: "1",
+							},
+							infrav1.SecurityGroupNode: {
+								ID: "2",
+							},
+							infrav1.SecurityGroupLB: {
+								ID: "3",
+							},
+						},
+						APIServerELB: infrav1.LoadBalancer{
+							DNSName: "test-apiserver.us-east-1.aws",
+						},
+					},
+				},
+			},
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.
+					DescribeInstanceTypesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstanceTypesInput{
+						InstanceTypes: []*string{
+							aws.String("m5.2xlarge"),
+						},
+					})).
+					Return(&ec2.DescribeInstanceTypesOutput{
+						InstanceTypes: []*ec2.InstanceTypeInfo{
+							{
+								ProcessorInfo: &ec2.ProcessorInfo{
+									SupportedArchitectures: []*string{
+										aws.String("x86_64"),
+									},
+								},
+							},
+						},
+					}, nil)
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name:   aws.String("state"),
+							Values: aws.StringSlice([]string{ec2.VpcStatePending, ec2.VpcStateAvailable}),
+						},
+						{
+							Name:   aws.String("vpc-id"),
+							Values: aws.StringSlice([]string{"vpc-bar"}),
+						},
+						{
+							Name:   aws.String("availability-zone"),
+							Values: aws.StringSlice([]string{"us-east-1c"}),
+						},
+					}})).Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						{
+							VpcId:               aws.String("vpc-bar"),
+							SubnetId:            aws.String("subnet-4"),
+							AvailabilityZone:    aws.String("us-east-1a"),
+							CidrBlock:           aws.String("10.0.10.0/24"),
+							MapPublicIpOnLaunch: aws.Bool(false),
+						},
+						{
+							VpcId:            aws.String("vpc-bar"),
+							SubnetId:         aws.String("subnet-5"),
+							AvailabilityZone: aws.String("us-east-1c"),
+							CidrBlock:        aws.String("10.0.11.0/24"),
+						},
+					},
+				}, nil)
+				m.
+					RunInstancesWithContext(context.TODO(), &ec2.RunInstancesInput{
+						ImageId:          aws.String("abc"),
+						InstanceType:     aws.String("m5.2xlarge"),
+						KeyName:          aws.String("default"),
+						SecurityGroupIds: aws.StringSlice([]string{"4", "3"}),
+						SubnetId:         aws.String("subnet-5"),
+						TagSpecifications: []*ec2.TagSpecification{
+							{
+								ResourceType: aws.String("instance"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("/"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+						},
+						UserData: aws.String(base64.StdEncoding.EncodeToString(userDataCompressed)),
+						MaxCount: aws.Int64(1),
+						MinCount: aws.Int64(1),
+					}).Return(&ec2.Reservation{
+					Instances: []*ec2.Instance{
+						{
+							State: &ec2.InstanceState{
+								Name: aws.String(ec2.InstanceStateNamePending),
+							},
+							IamInstanceProfile: &ec2.IamInstanceProfile{
+								Arn: aws.String("arn:aws:iam::123456789012:instance-profile/foo"),
+							},
+							InstanceId:     aws.String("two"),
+							InstanceType:   aws.String("m5.large"),
+							SubnetId:       aws.String("subnet-5"),
+							ImageId:        aws.String("ami-1"),
+							RootDeviceName: aws.String("device-1"),
+							BlockDeviceMappings: []*ec2.InstanceBlockDeviceMapping{
+								{
+									DeviceName: aws.String("device-1"),
+									Ebs: &ec2.EbsInstanceBlockDevice{
+										VolumeId: aws.String("volume-1"),
+									},
+								},
+							},
+							Placement: &ec2.Placement{
+								AvailabilityZone: &az,
+							},
+						},
+					},
+				}, nil)
+				m.
+					DescribeNetworkInterfacesWithContext(context.TODO(), gomock.Any()).
+					Return(&ec2.DescribeNetworkInterfacesOutput{
+						NetworkInterfaces: []*ec2.NetworkInterface{},
+						NextToken:         nil,
+					}, nil)
+			},
+			check: func(instance *infrav1.Instance, err error) {
+				if err != nil {
+					t.Fatalf("did not expect error: %v", err)
+				}
+
+				if instance.SubnetID != "subnet-5" {
+					t.Fatalf("expected subnet-5 from availability zone us-east-1c, got %q", instance.SubnetID)
+				}
+			},
+		},
+		{
 			name: "with ImageLookupOrg specified at the machine level",
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -549,14 +549,14 @@ func TestCreateInstance(t *testing.T) {
 			},
 		},
 		{
-			name: "with vpc and sg roles",
-			machine: clusterv1.Machine{
+			name: "when multiple subnets match filters, subnets in the cluster vpc are preferred",
+			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"set": "node"},
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						DataSecretName: pointer.String("bootstrap-data"),
+						DataSecretName: aws.String("bootstrap-data"),
 					},
 					FailureDomain: aws.String("us-east-1c"),
 				},
@@ -566,9 +566,6 @@ func TestCreateInstance(t *testing.T) {
 					ID: aws.String("abc"),
 				},
 				InstanceType: "m5.2xlarge",
-				VPC: &infrav1.AWSResourceReference{
-					ID: aws.String("vpc-bar"),
-				},
 				Subnet: &infrav1.AWSResourceReference{
 					Filters: []infrav1.Filter{
 						{
@@ -576,9 +573,6 @@ func TestCreateInstance(t *testing.T) {
 							Values: []string{"us-east-1c"},
 						},
 					},
-				},
-				SecurityGroupOverrides: map[infrav1.SecurityGroupRole]string{
-					infrav1.SecurityGroupNode: "4",
 				},
 				UncompressedUserData: &isUncompressedFalse,
 			},
@@ -604,11 +598,6 @@ func TestCreateInstance(t *testing.T) {
 								ID:               "subnet-3",
 								AvailabilityZone: "us-east-1c",
 								IsPublic:         false,
-							},
-							infrav1.SubnetSpec{
-								ID:               "subnet-3-public",
-								AvailabilityZone: "us-east-1c",
-								IsPublic:         true,
 							},
 						},
 					},
@@ -652,14 +641,7 @@ func TestCreateInstance(t *testing.T) {
 					}, nil)
 				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
-						{
-							Name:   aws.String("state"),
-							Values: aws.StringSlice([]string{ec2.VpcStatePending, ec2.VpcStateAvailable}),
-						},
-						{
-							Name:   aws.String("vpc-id"),
-							Values: aws.StringSlice([]string{"vpc-bar"}),
-						},
+						filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
 						{
 							Name:   aws.String("availability-zone"),
 							Values: aws.StringSlice([]string{"us-east-1c"}),
@@ -669,10 +651,208 @@ func TestCreateInstance(t *testing.T) {
 						{
 							VpcId:               aws.String("vpc-bar"),
 							SubnetId:            aws.String("subnet-4"),
-							AvailabilityZone:    aws.String("us-east-1a"),
+							AvailabilityZone:    aws.String("us-east-1c"),
 							CidrBlock:           aws.String("10.0.10.0/24"),
 							MapPublicIpOnLaunch: aws.Bool(false),
 						},
+						{
+							VpcId:            aws.String("vpc-foo"),
+							SubnetId:         aws.String("subnet-3"),
+							AvailabilityZone: aws.String("us-east-1c"),
+							CidrBlock:        aws.String("10.0.11.0/24"),
+						},
+					},
+				}, nil)
+				m.
+					RunInstancesWithContext(context.TODO(), &ec2.RunInstancesInput{
+						ImageId:          aws.String("abc"),
+						InstanceType:     aws.String("m5.2xlarge"),
+						KeyName:          aws.String("default"),
+						SecurityGroupIds: aws.StringSlice([]string{"2", "3"}),
+						SubnetId:         aws.String("subnet-3"),
+						TagSpecifications: []*ec2.TagSpecification{
+							{
+								ResourceType: aws.String("instance"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("/"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+						},
+						UserData: aws.String(base64.StdEncoding.EncodeToString(userDataCompressed)),
+						MaxCount: aws.Int64(1),
+						MinCount: aws.Int64(1),
+					}).Return(&ec2.Reservation{
+					Instances: []*ec2.Instance{
+						{
+							State: &ec2.InstanceState{
+								Name: aws.String(ec2.InstanceStateNamePending),
+							},
+							IamInstanceProfile: &ec2.IamInstanceProfile{
+								Arn: aws.String("arn:aws:iam::123456789012:instance-profile/foo"),
+							},
+							InstanceId:     aws.String("two"),
+							InstanceType:   aws.String("m5.large"),
+							SubnetId:       aws.String("subnet-3"),
+							ImageId:        aws.String("ami-1"),
+							RootDeviceName: aws.String("device-1"),
+							BlockDeviceMappings: []*ec2.InstanceBlockDeviceMapping{
+								{
+									DeviceName: aws.String("device-1"),
+									Ebs: &ec2.EbsInstanceBlockDevice{
+										VolumeId: aws.String("volume-1"),
+									},
+								},
+							},
+							Placement: &ec2.Placement{
+								AvailabilityZone: &az,
+							},
+						},
+					},
+				}, nil)
+				m.
+					DescribeNetworkInterfacesWithContext(context.TODO(), gomock.Any()).
+					Return(&ec2.DescribeNetworkInterfacesOutput{
+						NetworkInterfaces: []*ec2.NetworkInterface{},
+						NextToken:         nil,
+					}, nil)
+			},
+			check: func(instance *infrav1.Instance, err error) {
+				if err != nil {
+					t.Fatalf("did not expect error: %v", err)
+				}
+
+				if instance.SubnetID != "subnet-3" {
+					t.Fatalf("expected subnet-3 from availability zone us-east-1c, got %q", instance.SubnetID)
+				}
+			},
+		},
+		{
+			name: "with a subnet outside the cluster vpc",
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"set": "node"},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: aws.String("bootstrap-data"),
+					},
+					FailureDomain: aws.String("us-east-1c"),
+				},
+			},
+			machineConfig: &infrav1.AWSMachineSpec{
+				AMI: infrav1.AMIReference{
+					ID: aws.String("abc"),
+				},
+				InstanceType: "m5.2xlarge",
+				Subnet: &infrav1.AWSResourceReference{
+					Filters: []infrav1.Filter{
+						{
+							Name:   "vpc-id",
+							Values: []string{"vpc-bar"},
+						},
+						{
+							Name:   "availability-zone",
+							Values: []string{"us-east-1c"},
+						},
+					},
+				},
+				SecurityGroupOverrides: map[infrav1.SecurityGroupRole]string{
+					infrav1.SecurityGroupNode: "4",
+				},
+				UncompressedUserData: &isUncompressedFalse,
+			},
+			awsCluster: &infrav1.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: infrav1.AWSClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						VPC: infrav1.VPCSpec{
+							ID: "vpc-foo",
+						},
+						Subnets: infrav1.Subnets{
+							infrav1.SubnetSpec{
+								ID:               "subnet-1",
+								AvailabilityZone: "us-east-1a",
+								IsPublic:         false,
+							},
+							infrav1.SubnetSpec{
+								ID:               "subnet-2",
+								AvailabilityZone: "us-east-1b",
+								IsPublic:         false,
+							},
+							infrav1.SubnetSpec{
+								ID:               "subnet-3",
+								AvailabilityZone: "us-east-1c",
+								IsPublic:         false,
+							},
+						},
+					},
+				},
+				Status: infrav1.AWSClusterStatus{
+					Network: infrav1.NetworkStatus{
+						SecurityGroups: map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+							infrav1.SecurityGroupControlPlane: {
+								ID: "1",
+							},
+							infrav1.SecurityGroupNode: {
+								ID: "2",
+							},
+							infrav1.SecurityGroupLB: {
+								ID: "3",
+							},
+						},
+						APIServerELB: infrav1.LoadBalancer{
+							DNSName: "test-apiserver.us-east-1.aws",
+						},
+					},
+				},
+			},
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.
+					DescribeInstanceTypesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeInstanceTypesInput{
+						InstanceTypes: []*string{
+							aws.String("m5.2xlarge"),
+						},
+					})).
+					Return(&ec2.DescribeInstanceTypesOutput{
+						InstanceTypes: []*ec2.InstanceTypeInfo{
+							{
+								ProcessorInfo: &ec2.ProcessorInfo{
+									SupportedArchitectures: []*string{
+										aws.String("x86_64"),
+									},
+								},
+							},
+						},
+					}, nil)
+				m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
+					Filters: []*ec2.Filter{
+						filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
+						filter.EC2.VPC("vpc-bar"),
+						{
+							Name:   aws.String("availability-zone"),
+							Values: aws.StringSlice([]string{"us-east-1c"}),
+						},
+					}})).Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
 						{
 							VpcId:            aws.String("vpc-bar"),
 							SubnetId:         aws.String("subnet-5"),
@@ -1289,7 +1469,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("tag:some-tag"), Values: aws.StringSlice([]string{"some-value"})},
 						},
 					}).
@@ -1399,7 +1578,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("subnet-id"), Values: aws.StringSlice([]string{"matching-subnet"})},
 						},
 					}).
@@ -1543,7 +1721,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("subnet-id"), Values: aws.StringSlice([]string{"non-matching-subnet"})},
 						},
 					}).
@@ -1666,7 +1843,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("subnet-id"), Values: aws.StringSlice([]string{"matching-subnet"})},
 						},
 					}).
@@ -1747,7 +1923,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("subnet-id"), Values: aws.StringSlice([]string{"subnet-1"})},
 						},
 					}).
@@ -1928,7 +2103,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("subnet-id"), Values: aws.StringSlice([]string{"public-subnet-1"})},
 						},
 					}).
@@ -2058,7 +2232,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("subnet-id"), Values: aws.StringSlice([]string{"private-subnet-1"})},
 						},
 					}).
@@ -2183,7 +2356,6 @@ func TestCreateInstance(t *testing.T) {
 					DescribeSubnetsWithContext(context.TODO(), &ec2.DescribeSubnetsInput{
 						Filters: []*ec2.Filter{
 							filter.EC2.SubnetStates(ec2.SubnetStatePending, ec2.SubnetStateAvailable),
-							filter.EC2.VPC("vpc-id"),
 							{Name: aws.String("tag:some-tag"), Values: aws.StringSlice([]string{"some-value"})},
 						},
 					}).


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Adds fields to the AWSMachine and AWSMachineTemplate resources to allow VPC selection, as well as overriding the security groups chosen for various infrastructure roles.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4540

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Added AWSMachine and AWSMachineTemplate fields to control vpc placement for individual instances
```
