### PR TITLE
fix: kpromo failed during release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,6 @@ else
 	export GOPATH := $(shell go env GOPATH)
 endif
 
-USER_FORK ?= $(shell git config --get remote.origin.url | cut -d/ -f4) # only works on https://github.com/<username>/cluster-api.git style URLs
-ifeq ($(USER_FORK),)
-USER_FORK := $(shell git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1) # for git@github.com:<username>/cluster-api.git style URLs
-endif
-
 # Release variables
 
 STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api-aws
@@ -100,6 +95,10 @@ RELEASE_ALIAS_TAG ?= $(PULL_BASE_REF)
 RELEASE_DIR := out
 RELEASE_POLICIES := $(RELEASE_DIR)/AWSIAMManagedPolicyControllers.json $(RELEASE_DIR)/AWSIAMManagedPolicyControllersWithEKS.json $(RELEASE_DIR)/AWSIAMManagedPolicyCloudProviderControlPlane.json $(RELEASE_DIR)/AWSIAMManagedPolicyCloudProviderNodes.json $(RELEASE_DIR)/AWSIAMManagedPolicyControllersWithS3.json
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+USER_FORK ?= $(shell git config --get remote.origin.url | cut -d/ -f4) # only works on https://github.com/<username>/cluster-api-provider-aws.git style URLs
+ifeq ($(strip $(USER_FORK)),)
+USER_FORK := $(shell git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1) # for git@github.com:<username>/cluster-api-provider-aws.git style URLs
+endif
 
 # image name used to build the cmd/clusterawsadm
 TOOLCHAIN_IMAGE := toolchain
@@ -584,8 +583,7 @@ release-changelog: $(RELEASE_NOTES) check-release-tag check-previous-release-tag
 
 .PHONY: promote-images
 promote-images: $(KPROMO) $(YQ)
-	IMAGE_REVIEWERS="$(shell ./hack/get-project-maintainers.sh ${YQ})"
-	$(KPROMO) pr --project cluster-api-provider-aws --tag $(RELEASE_TAG) --reviewers "$(IMAGE_REVIEWERS)" --fork $(USER_FORK) --image cluster-api-aws-controller
+	$(KPROMO) pr --project cluster-api-aws --tag $(RELEASE_TAG) --reviewers "$(shell ./hack/get-project-maintainers.sh ${YQ})" --fork $(USER_FORK) --image cluster-api-aws-controller
 
 .PHONY: release-binaries
 release-binaries: ## Builds the binaries to publish with a release

--- a/docs/book/src/development/releasing.md
+++ b/docs/book/src/development/releasing.md
@@ -29,16 +29,22 @@ Promote the container images from the staging registry to the production registr
 3. Wait for an image to appear with the tagged release version.
 4. If you don't have a GitHub token, create one by going to your GitHub settings, in [Personal access tokens](https://github.com/settings/tokens). Make sure you give the token the `repo` scope.
 5. Create a PR to promote the images:
+
     ```bash
     export GITHUB_TOKEN=<your GH token>
     make promote-images
     ```
+
     **Notes**:
+     *`make promote-images` target tries to figure out your Github user handle in order to find the forked [k8s.io](https://github.com/kubernetes/k8s.io) repository.
+          If you have not forked the repo, please do it before running the Makefile target.
+     * if `make promote-images` fails with an error like `FATAL while checking fork of kubernetes/k8s.io` you may be able to solve it by manually setting the USER_FORK variable i.e.  `export USER_FORK=<personal GitHub handle>`
      * `kpromo` uses `git@github.com:...` as remote to push the branch for the PR. If you don't have `ssh` set up you can configure
        git to use `https` instead via `git config --global url."https://github.com/".insteadOf git@github.com:`.
      * This will automatically create a PR in [k8s.io](https://github.com/kubernetes/k8s.io) and assign the CAPA maintainers.
 6. Wait for the PR to be approved (typically by CAPA maintainers authorized to merge PRs into the k8s.io repository) and merged.
 7. Verify the images are available in the production registry:
+
     ```bash
     docker pull registry.k8s.io/cluster-api-aws/cluster-api-aws-controller:${VERSION}
     ```
@@ -69,6 +75,7 @@ Promote the container images from the staging registry to the production registr
 
 1. Publish release. Use the pre-release option for release candidate versions of Cluster API Provider AWS.
 1. Email `kubernetes-sig-cluster-lifecycle@googlegroups.com` to announce the release. You can use this template for the email:
+
     ```
     Subject: [ANNOUNCE] cluster-api-provider-aws v2.1.0 is released
     Body:
@@ -78,4 +85,5 @@ Promote the container images from the staging registry to the production registr
     If you have any questions about this release or CAPA, please join us on our Slack channel:
     https://kubernetes.slack.com/archives/CD6U2V71N
     ```
+
 1. Update the Title and Description of the Slack channel to point to the new version.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

During the v2.2.4 release `make promote` images failed for 2 reasons:

- incorrect project name
- blank fork

This change fixes both of these problems.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issues with kpromo to do with project name and fork
```
