### PR TITLE
Allow garbage collector to delete ec2 instances

### DIFF
--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -83,6 +83,9 @@ const (
 type GCTask string
 
 var (
+	// GCTaskEC2Instance defines a task to cleaning up resources for AWS EC2 instances.
+	GCTaskEC2Instance = GCTask("instance")
+
 	// GCTaskLoadBalancer defines a task to cleaning up resources for AWS load balancers.
 	GCTaskLoadBalancer = GCTask("load-balancer")
 

--- a/pkg/cloud/services/gc/cleanup.go
+++ b/pkg/cloud/services/gc/cleanup.go
@@ -72,6 +72,7 @@ func (s *Service) deleteResources(ctx context.Context) error {
 
 	if val, found := annotations.Get(s.scope.InfraCluster(), infrav1.ExternalResourceGCTasksAnnotation); found {
 		var gcTaskToFunc = map[infrav1.GCTask]ResourceCleanupFunc{
+			infrav1.GCTaskEC2Instance:   s.deleteEC2Instances,
 			infrav1.GCTaskLoadBalancer:  s.deleteLoadBalancers,
 			infrav1.GCTaskTargetGroup:   s.deleteTargetGroups,
 			infrav1.GCTaskSecurityGroup: s.deleteSecurityGroups,

--- a/pkg/cloud/services/gc/service.go
+++ b/pkg/cloud/services/gc/service.go
@@ -62,6 +62,7 @@ func NewService(clusterScope cloud.ClusterScoper, opts ...ServiceOption) *Servic
 
 func addDefaultCleanupFuncs(s *Service) {
 	s.cleanupFuncs = []ResourceCleanupFunc{
+		s.deleteEC2Instances,
 		s.deleteLoadBalancers,
 		s.deleteTargetGroups,
 		s.deleteSecurityGroups,


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

/kind feature

Addition to the experimental gc by @richardcase, we should also see if we can scan the CAPA owned tags, to make sure we don't have any leftover. Thoughts?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
