### PR TITLE
fix: eks e2e test failing as subnet name was used

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -278,7 +278,7 @@ func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.End
 	subnetIds := make([]*string, 0)
 	for i := range subnets {
 		subnet := subnets[i]
-		subnetIds = append(subnetIds, &subnet.ID)
+		subnetIds = append(subnetIds, &subnet.ResourceID)
 	}
 
 	cidrs := make([]*string, 0)

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -278,7 +278,8 @@ func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.End
 	subnetIds := make([]*string, 0)
 	for i := range subnets {
 		subnet := subnets[i]
-		subnetIds = append(subnetIds, &subnet.ResourceID)
+		subnetID := subnet.GetResourceID()
+		subnetIds = append(subnetIds, &subnetID)
 	}
 
 	cidrs := make([]*string, 0)

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -115,6 +115,7 @@ func (s *Service) reconcileRouteTables() error {
 			// Not recording "SuccessfulTagRouteTable" here as we don't know if this was a no-op or an actual change
 			continue
 		}
+		s.scope.Debug("Subnet isn't associated with route table", "subnet-id", sn.GetResourceID())
 
 		// For each subnet that doesn't have a routing table associated with it,
 		// create a new table with the appropriate default routes and associate it to the subnet.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug
/kind regression


**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4574 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue with EKE e2e tests due to a issue when specifying which subnets to use.
```
