### PR TITLE
Fix launch template reconciliation if bootstrap data secret cannot be read

### DIFF
--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -167,7 +167,7 @@ func (m *MachinePoolScope) getBootstrapData() ([]byte, string, error) {
 	key := types.NamespacedName{Namespace: m.Namespace(), Name: *m.MachinePool.Spec.Template.Spec.Bootstrap.DataSecretName}
 
 	if err := m.Client.Get(context.TODO(), key, secret); err != nil {
-		return nil, "", errors.Wrapf(err, "failed to retrieve bootstrap data secret for AWSMachine %s/%s", m.Namespace(), m.Name())
+		return nil, "", errors.Wrapf(err, "failed to retrieve bootstrap data secret %s for AWSMachine %s/%s", key.Name, m.Namespace(), m.Name())
 	}
 
 	value, ok := secret.Data["value"]

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -59,6 +59,7 @@ func (s *Service) ReconcileLaunchTemplate(
 	bootstrapData, err := scope.GetRawBootstrapData()
 	if err != nil {
 		record.Eventf(scope.GetMachinePool(), corev1.EventTypeWarning, "FailedGetBootstrapData", err.Error())
+		return err
 	}
 	bootstrapDataHash := userdata.ComputeHash(bootstrapData)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When changing the machine pool's bootstrap config, e.g. `KubeadmConfig/{a => b}`, which is supported after CAPI's fix https://github.com/kubernetes-sigs/cluster-api/pull/8667, CAPA had a bug where it would continue even after the new bootstrap secret cannot be read, for instance because it doesn't exist yet as the bootstrap provider still needs a few seconds to make it ready. That could lead to a catastrophic misconfiguration where the launch template's user data is empty, typically leading to new instances not getting bootstrapped at all. Detailed problem description in [this comment](https://github.com/kubernetes-sigs/cluster-api/issues/8858#issuecomment-1737930898).

This provides the obvious fix. I couldn't find a great place to test this, since `ReconcileLaunchTemplate` is mocked away in tests.

I tested this successfully by changing the bootstrap config reference and observing how CAPI sets the new data secret name, CAPA intermittently failing to read the new secret until it's ready, and only then CAPA writing a new launch template version with the new bootstrap secret's data.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of https://github.com/kubernetes-sigs/cluster-api/issues/8858, but not a fix. Even with this patch, changing the bootstrap config object doesn't lead to an instance refresh (rolling out new nodes) because CAPA doesn't consider it a change. We need to discuss further how to solve the main issue.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix launch template reconciliation if bootstrap data secret cannot be read
```