### PR TITLE
Update CAPA supported AMI OS

### DIFF
--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -38,7 +38,7 @@ const (
 )
 
 func getSupportedOsList() []string {
-	return []string{"centos-7", "ubuntu-18.04", "ubuntu-20.04", "amazon-2", "flatcar-stable"}
+	return []string{"centos-7", "ubuntu-22.04", "ubuntu-18.04", "ubuntu-20.04", "amazon-2", "flatcar-stable"}
 }
 
 func getimageRegionList() []string {

--- a/docs/book/src/topics/images/built-amis.md
+++ b/docs/book/src/topics/images/built-amis.md
@@ -9,7 +9,7 @@ See [clusterawsadm ami list](https://cluster-api-aws.sigs.k8s.io/clusterawsadm/c
 
 ## Supported OS Distributions
 - Amazon Linux 2 (amazon-2)
-- Ubuntu (ubuntu-20.04, ubuntu-18.04)
+- Ubuntu (ubuntu-20.04, ubuntu-22.04)
 - Centos (centos-7)
 - Flatcar (flatcar-stable)
 
@@ -18,7 +18,7 @@ See [clusterawsadm ami list](https://cluster-api-aws.sigs.k8s.io/clusterawsadm/c
 - ap-northeast-2
 - ap-south-1
 - ap-southeast-1
-- ap-northeast-2
+- ap-southeast-2
 - ca-central-1
 - eu-central-1
 - eu-west-1


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Recent image-builder has removed support on ubuntu1804  in recent releases: [here](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/Makefile#L323).
CAPA in the meanwhile follows the same, starts to support ubuntu2204 ami and drop support on ubuntu1804 ami.  When listing amis with clusterawsadm, add ubuntu2204 filter to include ubuntu2204 to the list result.
In this PR, it also fixes a typo on a duplicate region `ap-northeast-2` on the doc 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

build clusterawsadm and test locally:

```
clusterawsadm ami list --kubernetes-version=v1.28.2 --region=ap-southeast-2
KUBERNETES VERSION   REGION           OS               NAME                                         AMI ID
v1.28.2              ap-southeast-2   centos-7         capa-ami-centos-7-v1.28.2-1698240556         ami-04d09efb987ba6e39
v1.28.2              ap-southeast-2   ubuntu-22.04     capa-ami-ubuntu-22.04-v1.28.2-1698245433     ami-037833b5c08755eba
v1.28.2              ap-southeast-2   ubuntu-20.04     capa-ami-ubuntu-20.04-v1.28.2-1698246116     ami-0869d5134668ef6de
v1.28.2              ap-southeast-2   amazon-2         capa-ami-amazon-2-v1.28.2-1698240568         ami-00a9c865ebfb45d52
v1.28.2              ap-southeast-2   flatcar-stable   capa-ami-flatcar-stable-v1.28.2-1698242503   ami-04532cb90a1ddaa8a
```

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update CAPA supported AMI OS: support on ubuntu2204 added, ubuntu1804 dropped
```
