### PR TITLE
Filter out reconciling events on externally managed AWSManagedClusters

### DIFF
--- a/controllers/awsmanagedcluster_controller.go
+++ b/controllers/awsmanagedcluster_controller.go
@@ -125,6 +125,7 @@ func (r *AWSManagedClusterReconciler) SetupWithManager(ctx context.Context, mgr 
 		WithOptions(options).
 		For(awsManagedCluster).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceIsNotExternallyManaged(log.GetLogger())).
 		Build(r)
 
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Users may specify that some AWS resources should not be managed by CAPA controllers, because they may be managed by a different mechanism. We expose the `cluster.x-k8s.io/managed-by: "<name-of-system>"` annotation, so that users can specify which resources should not be reconciled by capa controllers. [We use it for our `AWSCluster` controller](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/controllers/awscluster_controller.go#L385), but we don't use it for our `AWSManagedCluster` controller. I believe it should also use it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Filter out reconciling events on externally managed AWSManagedClusters
```
