### PR TITLE
Pass logger to machine pool scope to get verbosity right, fix copying logger in `With...` methods

### DIFF
--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -131,6 +131,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Create the machine pool scope
 	machinePoolScope, err := scope.NewMachinePoolScope(scope.MachinePoolScopeParams{
 		Client:         r.Client,
+		Logger:         log,
 		Cluster:        cluster,
 		MachinePool:    machinePool,
 		InfraCluster:   infraCluster,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -99,11 +99,15 @@ func (c *Logger) GetLogger() logr.Logger {
 }
 
 func (c *Logger) WithValues(keysAndValues ...any) *Logger {
-	c.logger = c.logger.WithValues(keysAndValues...)
-	return c
+	return &Logger{
+		callStackHelper: c.callStackHelper,
+		logger:          c.logger.WithValues(keysAndValues...),
+	}
 }
 
 func (c *Logger) WithName(name string) *Logger {
-	c.logger = c.logger.WithName(name)
-	return c
+	return &Logger{
+		callStackHelper: c.callStackHelper,
+		logger:          c.logger.WithName(name),
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I found that not all of these logs were printed in production:

```
func (s *Service) ReconcileLaunchTemplate(
	scope scope.LaunchTemplateScope,
	ec2svc services.EC2Interface,
	canUpdateLaunchTemplate func() (bool, error),
	runPostLaunchTemplateUpdateOperation func() error,
) error {
	// [...]

	// <=== NOT PRINTED ===>
	scope.Info("checking for existing launch template")
	
	// [...]

	if needsUpdate || tagsChanged || amiChanged || userDataHashChanged || userDataSecretKeyChanged || launchTemplateNeedsUserDataSecretKeyTag {
		// <=== PRINTED ===>
		scope.Info("creating new version for launch template", "existing", launchTemplate, "incoming", scope.GetLaunchTemplate(), "needsUpdate", needsUpdate, "tagsChanged", tagsChanged, "amiChanged", amiChanged, "userDataHashChanged", userDataHashChanged, "userDataSecretKeyChanged", userDataSecretKeyChanged)
		
		// [...]
	}
	
	// [...]
}
```

That puzzled me a lot, given how both have the same verbosity. It turned out that the parent logger wasn't passed correctly to the `MachinePoolScope`. Also, `WithName` and other logger context functions mistakenly changed the object itself when using the `Logger` interface, as opposed to go-logr's behavior and interface documentation. With that, the deployed CAPA controller pod logged all desired lines in a reasonable format.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

n/a

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix logging verbosity for machine pool reconciliation
```
