### PR TITLE
Use `AdditionalTags` for S3 buckets

### DIFF
--- a/pkg/cloud/services/s3/s3.go
+++ b/pkg/cloud/services/s3/s3.go
@@ -263,7 +263,7 @@ func (s *Service) tagBucket(bucketName string) error {
 		Lifecycle:   infrav1.ResourceLifecycleOwned,
 		Name:        nil,
 		Role:        aws.String("node"),
-		Additional:  nil,
+		Additional:  s.scope.AdditionalTags(),
 	})
 
 	for key, value := range tags {

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -81,6 +81,10 @@ func TestReconcileBucket(t *testing.T) {
 			Tagging: &s3svc.Tagging{
 				TagSet: []*s3svc.Tag{
 					{
+						Key:   aws.String("additional"),
+						Value: aws.String("from-aws-cluster"),
+					},
+					{
 						Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
 						Value: aws.String("owned"),
 					},
@@ -776,6 +780,9 @@ func testService(t *testing.T, bucket *infrav1.S3Bucket) (*s3.Service, *mock_s3i
 		AWSCluster: &infrav1.AWSCluster{
 			Spec: infrav1.AWSClusterSpec{
 				S3Bucket: bucket,
+				AdditionalTags: infrav1.Tags{
+					"additional": "from-aws-cluster",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
**What type of PR is this?**

Follow-up to #4518: also add `AWSCluster.spec.additionalTags` to S3 bucket.

/kind feature

**What this PR does / why we need it**:

All cloud resources should have the additional tags on them.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Use `AdditionalTags` for S3 buckets
```
