### PR TITLE
:bug: e2e should delete the cluster before validating

### DIFF
--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -1069,7 +1069,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 			awsCluster, err := GetAWSClusterByName(ctx, namespace.Name, clusterName)
 			Expect(err).To(BeNil())
 
-			// Validate that s3 endpoints were created in the vpc.
+			ginkgo.By("Validating the s3 endpoint was created")
 			vpc, err := shared.GetVPCByName(e2eCtx, clusterName+"-vpc")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vpc).NotTo(BeNil())
@@ -1081,6 +1081,9 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 			Expect(*endpoints[0].ServiceName).To(Equal("com.amazonaws." + awsCluster.Spec.Region + ".s3"))
 			Expect(*endpoints[0].VpcId).To(Equal(*vpc.VpcId))
 
+			ginkgo.By("Deleting the cluster")
+			deleteCluster(ctx, cluster)
+
 			ginkgo.By("Waiting for AWSCluster to show the VPC endpoint as deleted in conditions")
 			Eventually(func() bool {
 				awsCluster, err := GetAWSClusterByName(ctx, namespace.Name, clusterName)
@@ -1088,9 +1091,6 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				return conditions.IsFalse(awsCluster, infrav1.VpcEndpointsReadyCondition) &&
 					conditions.GetReason(awsCluster, infrav1.VpcEndpointsReadyCondition) == clusterv1.DeletedReason
 			}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...).Should(BeTrue())
-
-			ginkgo.By("Deleting the cluster")
-			deleteCluster(ctx, cluster)
 		})
 	})
 })


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
