### PR TITLE
✨ Add separate eks kubeconfig secret keys for the cluster-autoscaler

### DIFF
--- a/docs/book/src/topics/eks/creating-a-cluster.md
+++ b/docs/book/src/topics/eks/creating-a-cluster.md
@@ -34,4 +34,12 @@ kubectl --namespace=default get secret managed-test-user-kubeconfig \
 
 This kubeconfig is used internally by CAPI and shouldn't be used outside of the management server. It is used by CAPI to perform operations, such as draining a node. The name of the secret that contains the kubeconfig will be `[cluster-name]-kubeconfig` where you need to replace **[cluster-name]** with the name of your cluster. Note that there is NO `-user` in the name.
 
-The kubeconfig is regenerated every `sync-period` as the token that is embedded in the kubeconfig is only valid for a short period of time. When EKS support is enabled the maximum sync period is 10 minutes. If you try to set `--sync-period` to greater than 10 minutes then an error will be raised.
+There are three keys in the CAPI kubeconfig for eks clusters:
+
+| keys        | purpose                                                                                                                                                                            |
+|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| value       | contains a complete kubeconfig with the cluster admin user and token embedded                                                                                                      |
+| relative    | contains a kubeconfig with the cluster admin user, referencing the token file in a relative path - assumes you are mounting all the secret keys in the same dir                    |
+| single-file | contains the same token embedded in the complete kubeconfig, it is separated into a single file so that existing APIMachinery can reload the token file when the secret is updated |
+
+The secret contents are regenerated every `sync-period` as the token that is embedded in the kubeconfig and token file is only valid for a short period of time. When EKS support is enabled the maximum sync period is 10 minutes. If you try to set `--sync-period` to greater than 10 minutes then an error will be raised.

--- a/pkg/cloud/services/eks/config_test.go
+++ b/pkg/cloud/services/eks/config_test.go
@@ -1,0 +1,268 @@
+package eks
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts/mock_stsiface"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/secret"
+)
+
+func Test_createCAPIKubeconfigSecret(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       *eks.Cluster
+		serviceFunc func() *Service
+		wantErr     bool
+	}{
+		{
+			name: "create kubeconfig secret",
+			input: &eks.Cluster{
+				CertificateAuthority: &eks.Certificate{Data: aws.String("")},
+				Endpoint:             aws.String("https://F00BA4.gr4.us-east-2.eks.amazonaws.com"),
+			},
+			serviceFunc: func() *Service {
+				mockCtrl := gomock.NewController(t)
+				stsMock := mock_stsiface.NewMockSTSAPI(mockCtrl)
+				op := request.Request{
+					Operation: &request.Operation{Name: "GetCallerIdentity",
+						HTTPMethod: "POST",
+						HTTPPath:   "/",
+					},
+					HTTPRequest: &http.Request{
+						Header: make(http.Header),
+						URL: &url.URL{
+							Scheme: "https",
+							Host:   "F00BA4.gr4.us-east-2.eks.amazonaws.com",
+						},
+					},
+				}
+				stsMock.EXPECT().GetCallerIdentityRequest(gomock.Any()).Return(&op, &sts.GetCallerIdentityOutput{})
+
+				scheme := runtime.NewScheme()
+				_ = infrav1.AddToScheme(scheme)
+				_ = ekscontrolplanev1.AddToScheme(scheme)
+				_ = corev1.AddToScheme(scheme)
+
+				client := fake.NewClientBuilder().WithScheme(scheme).Build()
+				managedScope, _ := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
+					Client: client,
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns",
+							Name:      "capi-cluster-foo",
+						},
+					},
+					ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns",
+							Name:      "capi-cluster-foo",
+							UID:       types.UID("1"),
+						},
+						Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+							EKSClusterName: "cluster-foo",
+						},
+					},
+				})
+
+				service := NewService(managedScope)
+				service.STSClient = stsMock
+				return service
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			service := tc.serviceFunc()
+			clusterRef := types.NamespacedName{
+				Namespace: service.scope.Namespace(),
+				Name:      service.scope.Name(),
+			}
+			err := service.createCAPIKubeconfigSecret(context.TODO(), tc.input, &clusterRef)
+			if tc.wantErr {
+				g.Expect(err).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+				var kubeconfigSecret corev1.Secret
+				g.Expect(service.scope.Client.Get(context.TODO(), types.NamespacedName{Namespace: "ns", Name: "capi-cluster-foo-kubeconfig"}, &kubeconfigSecret)).To(BeNil())
+				g.Expect(kubeconfigSecret.Data).ToNot(BeNil())
+				g.Expect(len(kubeconfigSecret.Data)).To(BeIdenticalTo(3))
+				g.Expect(kubeconfigSecret.Data[secret.KubeconfigDataName]).ToNot(BeEmpty())
+				g.Expect(kubeconfigSecret.Data[relativeKubeconfigKey]).ToNot(BeEmpty())
+				g.Expect(kubeconfigSecret.Data[relativeTokenFileKey]).ToNot(BeEmpty())
+			}
+		})
+	}
+}
+
+func Test_updateCAPIKubeconfigSecret(t *testing.T) {
+	type testCase struct {
+		name        string
+		input       *eks.Cluster
+		secret      *corev1.Secret
+		serviceFunc func(tc testCase) *Service
+		wantErr     bool
+	}
+	testCases := []testCase{
+		{
+			name: "update kubeconfig secret",
+			input: &eks.Cluster{
+				Name:                 aws.String("cluster-foo"),
+				CertificateAuthority: &eks.Certificate{Data: aws.String("")},
+				Endpoint:             aws.String("https://F00BA4.gr4.us-east-2.eks.amazonaws.com"),
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "capi-cluster-foo-kubeconfig",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta2",
+							Kind:       "AWSManagedControlPlane",
+							Name:       "capi-cluster-foo",
+							UID:        "1",
+							Controller: aws.Bool(true),
+						},
+					},
+				},
+				Data: make(map[string][]byte),
+			},
+			serviceFunc: func(tc testCase) *Service {
+				mockCtrl := gomock.NewController(t)
+				stsMock := mock_stsiface.NewMockSTSAPI(mockCtrl)
+				op := request.Request{
+					Operation: &request.Operation{Name: "GetCallerIdentity",
+						HTTPMethod: "POST",
+						HTTPPath:   "/",
+					},
+					HTTPRequest: &http.Request{
+						Header: make(http.Header),
+						URL: &url.URL{
+							Scheme: "https",
+							Host:   "F00BA4.gr4.us-east-2.eks.amazonaws.com",
+						},
+					},
+				}
+				stsMock.EXPECT().GetCallerIdentityRequest(gomock.Any()).Return(&op, &sts.GetCallerIdentityOutput{})
+
+				scheme := runtime.NewScheme()
+				_ = infrav1.AddToScheme(scheme)
+				_ = ekscontrolplanev1.AddToScheme(scheme)
+				_ = corev1.AddToScheme(scheme)
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.secret).Build()
+				managedScope, _ := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
+					Client: client,
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns",
+							Name:      "capi-cluster-foo",
+						},
+					},
+					ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns",
+							Name:      "capi-cluster-foo",
+							UID:       "1",
+						},
+						Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+							EKSClusterName: "cluster-foo",
+						},
+					},
+				})
+
+				service := NewService(managedScope)
+				service.STSClient = stsMock
+				return service
+			},
+		},
+		{
+			name: "detect incorrect ownership on the kubeconfig secret",
+			input: &eks.Cluster{
+				Name:                 aws.String("cluster-foo"),
+				CertificateAuthority: &eks.Certificate{Data: aws.String("")},
+				Endpoint:             aws.String("https://F00BA4.gr4.us-east-2.eks.amazonaws.com"),
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "capi-cluster-foo-kubeconfig",
+				},
+				Data: make(map[string][]byte),
+			},
+			serviceFunc: func(tc testCase) *Service {
+				scheme := runtime.NewScheme()
+				_ = infrav1.AddToScheme(scheme)
+				_ = ekscontrolplanev1.AddToScheme(scheme)
+				_ = corev1.AddToScheme(scheme)
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.secret).Build()
+				managedScope, _ := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
+					Client: client,
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns",
+							Name:      "capi-cluster-foo",
+						},
+					},
+					ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns",
+							Name:      "capi-cluster-foo",
+							UID:       "1",
+						},
+						Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+							EKSClusterName: "cluster-foo",
+						},
+					},
+				})
+
+				service := NewService(managedScope)
+				return service
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			service := tc.serviceFunc(tc)
+			err := service.updateCAPIKubeconfigSecret(context.TODO(), tc.secret, tc.input)
+			if tc.wantErr {
+				g.Expect(err).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+				var kubeconfigSecret corev1.Secret
+				g.Expect(service.scope.Client.Get(context.TODO(), types.NamespacedName{Namespace: "ns", Name: "capi-cluster-foo-kubeconfig"}, &kubeconfigSecret)).To(BeNil())
+				g.Expect(kubeconfigSecret.Data).ToNot(BeNil())
+				g.Expect(len(kubeconfigSecret.Data)).To(BeIdenticalTo(3))
+				g.Expect(kubeconfigSecret.Data[secret.KubeconfigDataName]).ToNot(BeEmpty())
+				g.Expect(kubeconfigSecret.Data[relativeKubeconfigKey]).ToNot(BeEmpty())
+				g.Expect(kubeconfigSecret.Data[relativeTokenFileKey]).ToNot(BeEmpty())
+			}
+		})
+	}
+}

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -140,6 +140,7 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 			By(fmt.Sprintf("Trying to create CloudFormation stack... attempt %d", count))
 			success := true
 			if err := createCloudFormationStack(e2eCtx.AWSSession, bootstrapTemplate, bootstrapTags); err != nil {
+				By(fmt.Sprintf("Failed to create CloudFormation stack in attempt %d: %s", count, err.Error()))
 				deleteCloudFormationStack(e2eCtx.AWSSession, bootstrapTemplate)
 				success = false
 			}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**: Cluster Autoscaler can not mount and consume the [Cluster API Kubeconfig](https://cluster-api-aws.sigs.k8s.io/topics/eks/creating-a-cluster.html?highlight=kubeconfig#cluster-api-capi-kubeconfig) because the secret contents are refreshed every ten minutes, and no API Machinery exists to reload a kubeconfig safely.

Initially, I attempted solve this in the Cluster Autoscaler: https://github.com/kubernetes/autoscaler/issues/4784 - [However meeting with SIG APIMachinery on Nov 1 2023](https://youtu.be/JVs79gb7qJE), the SIG cautioned against this approach and advised splitting the token out from the kubeconfig, [as there is existing machinery to reload a token file auth](https://github.com/kubernetes/kubernetes/pull/67359). By switching to this approach, no change in the Cluster Autoscaler is needed, users only need to update their Cluster Autoscaler configuration to use the correct secret file from their secret volume mount.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4607

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add separate eks kubeconfig secret keys for the cluster-autoscaler to support refreshing the token automatically, see eks kubeconfig for more info.
```
