### PR TITLE
:sparkles: Prevent users setting values that are invalid configuration on AWS

### DIFF
--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -108,6 +108,13 @@ func (r *AWSMachinePool) validateAdditionalSecurityGroups() field.ErrorList {
 	}
 	return allErrs
 }
+func (r *AWSMachinePool) validateSpotInstances() field.ErrorList {
+	var allErrs field.ErrorList
+	if r.Spec.AWSLaunchTemplate.SpotMarketOptions != nil && r.Spec.MixedInstancesPolicy != nil {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.awsLaunchTemplate.AdditionalSecurityGroups"), "either spec.awsLaunchTemplate.SpotMarketOptions or spec.MixedInstancesPolicy should be used"))
+	}
+	return allErrs
+}
 
 // ValidateCreate will do any extra validation when creating a AWSMachinePool.
 func (r *AWSMachinePool) ValidateCreate() (admission.Warnings, error) {
@@ -120,6 +127,7 @@ func (r *AWSMachinePool) ValidateCreate() (admission.Warnings, error) {
 	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 	allErrs = append(allErrs, r.validateSubnets()...)
 	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
+	allErrs = append(allErrs, r.validateSpotInstances()...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
@@ -140,6 +148,7 @@ func (r *AWSMachinePool) ValidateUpdate(old runtime.Object) (admission.Warnings,
 	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 	allErrs = append(allErrs, r.validateSubnets()...)
 	allErrs = append(allErrs, r.validateAdditionalSecurityGroups()...)
+	allErrs = append(allErrs, r.validateSpotInstances()...)
 
 	if len(allErrs) == 0 {
 		return nil, nil

--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -111,7 +111,7 @@ func (r *AWSMachinePool) validateAdditionalSecurityGroups() field.ErrorList {
 func (r *AWSMachinePool) validateSpotInstances() field.ErrorList {
 	var allErrs field.ErrorList
 	if r.Spec.AWSLaunchTemplate.SpotMarketOptions != nil && r.Spec.MixedInstancesPolicy != nil {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.awsLaunchTemplate.AdditionalSecurityGroups"), "either spec.awsLaunchTemplate.SpotMarketOptions or spec.MixedInstancesPolicy should be used"))
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.awsLaunchTemplate.spotMarketOptions"), "either spec.awsLaunchTemplate.spotMarketOptions or spec.mixedInstancesPolicy should be used"))
 	}
 	return allErrs
 }

--- a/exp/api/v1beta2/awsmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook_test.go
@@ -139,6 +139,20 @@ func TestAWSMachinePoolValidateCreate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Should fail if both spot market options or mixed instances policy are set",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					MixedInstancesPolicy: &MixedInstancesPolicy{
+						Overrides: []Overrides{{InstanceType: "t3.medium"}},
+					},
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						SpotMarketOptions: &infrav1.SpotMarketOptions{MaxPrice: aws.String("0.1")},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -251,6 +265,27 @@ func TestAWSMachinePoolValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "Should fail update if both spec.awsLaunchTemplate.SpotMarketOptions and spec.MixedInstancesPolicy are passed in AWSMachinePool spec",
+			old: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					MixedInstancesPolicy: &MixedInstancesPolicy{
+						Overrides: []Overrides{{InstanceType: "t3.medium"}},
+					},
+				},
+			},
+			new: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					MixedInstancesPolicy: &MixedInstancesPolicy{
+						Overrides: []Overrides{{InstanceType: "t3.medium"}},
+					},
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						SpotMarketOptions: &infrav1.SpotMarketOptions{MaxPrice: pointer.String("0.1")},
+					},
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Users can currently set both `SpotMarketOptions` and `MixedInstancesPolicy`, but this is not a valid configuration on AWS, resulting on this error
```
InvalidQueryParameter: Incompatible launch template: You cannot use a launch template that is set to request Spot Instances (InstanceMarketOptions) when you configure an Auto Scaling group with a mixed instances policy. Add a different launch template to the group and try again.
```

It's better to prevent this configuration early, so users get quick feedback on what's wrong with their clusters.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent users setting SpotMarketOptions and MixedInstancesPolicy at the same time
```
