### PR TITLE
:bug: Don't error if ASG is missing when deciding to refresh instances

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -323,6 +323,9 @@ func (s *Service) CanStartASGInstanceRefresh(scope *scope.MachinePoolScope) (boo
 	describeInput := &autoscaling.DescribeInstanceRefreshesInput{AutoScalingGroupName: aws.String(scope.Name())}
 	refreshes, err := s.ASGClient.DescribeInstanceRefreshesWithContext(context.TODO(), describeInput)
 	if err != nil {
+		if awserrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	hasUnfinishedRefresh := false

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -1091,6 +1091,17 @@ func TestServiceCanStartASGInstanceRefresh(t *testing.T) {
 				m.DescribeInstanceRefreshesWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
 					AutoScalingGroupName: aws.String("machinePoolName"),
 				})).
+					Return(nil, awserrors.NewConflict("some error"))
+			},
+		},
+		{
+			name:     "should NOT return error if describe instance failed due to 'not found'",
+			wantErr:  false,
+			canStart: false,
+			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
+				m.DescribeInstanceRefreshesWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
+					AutoScalingGroupName: aws.String("machinePoolName"),
+				})).
 					Return(nil, awserrors.NewNotFound("not found"))
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Avoid erroring when ASG does not exist when deciding to refresh instances.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4655

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
