### PR TITLE
:bug: cleanup: eliminate log spam when using S3 secrets

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -284,6 +284,7 @@ func (t Template) ControllersPolicy() *iamv1.PolicyDocument {
 			Action: iamv1.Actions{
 				"s3:CreateBucket",
 				"s3:DeleteBucket",
+				"s3:GetObject",
 				"s3:PutObject",
 				"s3:DeleteObject",
 				"s3:PutBucketPolicy",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -289,6 +289,7 @@ Resources:
         - Action:
           - s3:CreateBucket
           - s3:DeleteBucket
+          - s3:GetObject
           - s3:PutObject
           - s3:DeleteObject
           - s3:PutBucketPolicy

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -850,8 +850,6 @@ func (r *AWSMachineReconciler) deleteIgnitionBootstrapDataFromS3(machineScope *s
 		return nil
 	}
 
-	machineScope.Info("Deleting unneeded entry from AWS S3", "secretPrefix", machineScope.GetSecretPrefix())
-
 	if err := objectStoreSvc.Delete(machineScope); err != nil {
 		return errors.Wrap(err, "deleting bootstrap data object")
 	}

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -1136,7 +1136,6 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				_, err := reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 				g.Expect(err).To(BeNil())
-				g.Expect(buf.String()).To(ContainSubstring("Deleting unneeded entry from AWS S3"))
 			})
 		})
 

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -631,6 +631,8 @@ func TestDeleteObject(t *testing.T) {
 			},
 		}
 
+		s3Mock.EXPECT().HeadObject(gomock.Any())
+
 		s3Mock.EXPECT().DeleteObject(gomock.Any()).Do(func(deleteObjectInput *s3svc.DeleteObjectInput) {
 			t.Run("use_configured_bucket_name_on_cluster_level", func(t *testing.T) {
 				t.Parallel()
@@ -672,7 +674,7 @@ func TestDeleteObject(t *testing.T) {
 			},
 		}
 
-		s3Mock.EXPECT().DeleteObject(gomock.Any()).Return(nil, awserr.New(s3svc.ErrCodeNoSuchBucket, "", nil)).Times(1)
+		s3Mock.EXPECT().HeadObject(gomock.Any()).Return(nil, awserr.New(s3svc.ErrCodeNoSuchBucket, "", nil))
 
 		if err := svc.Delete(machineScope); err != nil {
 			t.Fatalf("Unexpected error, got: %v", err)
@@ -696,6 +698,7 @@ func TestDeleteObject(t *testing.T) {
 				},
 			}
 
+			s3Mock.EXPECT().HeadObject(gomock.Any())
 			s3Mock.EXPECT().DeleteObject(gomock.Any()).Return(nil, errors.New("foo")).Times(1)
 
 			if err := svc.Delete(machineScope); err == nil {
@@ -747,6 +750,7 @@ func TestDeleteObject(t *testing.T) {
 			},
 		}
 
+		s3Mock.EXPECT().HeadObject(gomock.Any()).Times(2)
 		s3Mock.EXPECT().DeleteObject(gomock.Any()).Return(nil, nil).Times(2)
 
 		if err := svc.Delete(machineScope); err != nil {


### PR DESCRIPTION
/kind cleanup

Currently, the S3 object store generates a large amount of log spam during reconciliation. Objects are stated to be deleting regardless of objects already being deleted.

Example:
```
I1129 02:23:28.008345       1 logger.go:67] "Deleting unneeded entry from AWS S3" secretPrefix=""
I1129 02:23:28.008394       1 logger.go:67] "Deleting object" controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="clusters-system/us-west-2-production-worker-us-west-2d-infra-vln7r-xzcsk" namespace="clusters-system" name="us-west-2-production-worker-us-west-2d-infra-vln7r-xzcsk" reconcileID="c10cc649-57ce-40f4-99bb-17d06590c2cf" machine="clusters-system/us-west-2-production-worker-us-west-2d-5lgbh-6cbb9999d5xlnxtcvd" cluster="clusters-system/us-west-2-production" bucket_name="cluster-api-provider-aws-gremlin-us-west-2-production" key="node/us-west-2-production-worker-us-west-2d-infra-vln7r-xzcsk"
I1129 02:24:05.691604       1 awsmanagedcluster_controller.go:114] "Successfully reconciled AWSManagedCluster" controller="awsmanagedcluster" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSManagedCluster" AWSManagedCluster="clusters-system/us-east-1-production-testing" namespace="clusters-system" name="us-east-1-production-testing" reconcileID="8cbaa551-85ef-4feb-9fac-533577193662" cluster="us-east-1-production-testing" controlPlane="us-east-1-production-testing-control-plane"
```

- [x] squashed commits
- [x] includes documentation (N/A)
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests (N/A
- [x] adds or updates e2e tests

**Release note**:
```release-note
If you're using S3 buckets for bootstrap data, the following permissions are required on the controller to automatically detect whether an object is still needing to be deleted: `s3:GetObject`. The following permissions are optional: `s3:ListBucket`.
```
