### PR TITLE
:bug: Update awsmachine providerID and instanceID immediately after ec2:RunInstances is called

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -250,6 +250,10 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, use
 		return nil, err
 	}
 
+	// Set the providerID and instanceID as soon as we create an instance so that we keep it in case of errors afterward
+	scope.SetProviderID(out.ID, out.AvailabilityZone)
+	scope.SetInstanceID(out.ID)
+
 	if len(input.NetworkInterfaces) > 0 {
 		for _, id := range input.NetworkInterfaces {
 			s.scope.Debug("Attaching security groups to provided network interface", "groups", input.SecurityGroupIDs, "interface", id)
@@ -261,7 +265,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, use
 
 	s.scope.Debug("Adding tags on each network interface from resource", "resource-id", out.ID)
 
-	// Fetching the network interfaces attached to the specific instanace
+	// Fetching the network interfaces attached to the specific instance
 	networkInterfaces, err := s.getInstanceENIs(out.ID)
 	if err != nil {
 		return nil, err
@@ -269,7 +273,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, use
 
 	s.scope.Debug("Fetched the network interfaces")
 
-	// Once all the network interfaces attached to the specific instanace are found, the similar tags of instance are created for network interfaces too
+	// Once all the network interfaces attached to the specific instance are found, the similar tags of instance are created for network interfaces too
 	if len(networkInterfaces) > 0 {
 		s.scope.Debug("Attempting to create tags from resource", "resource-id", out.ID)
 		for _, networkInterface := range networkInterfaces {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This mitigates issues caused by falling back to tag-based searching for EC2 instances in case future AWS calls fail within `CreateInstance()`, such as attaching ENIs to security groups or tagging ENIs.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/c9b9276eb1491e75d5073a1c7965722b1fec090e/controllers/awsmachine_controller.go#L421-L448

**Which issue(s) this PR fixes**:
Related to #4629 

**Special notes for your reviewer**:

This PR focuses on mitigating the impact when the controller fails to tag ENIs after creating EC2 instances. Another PR to make the fallback tag-based searching more robust is in the works in #4630 

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Update AWSMachine providerID and instanceID earlier to minimize scenarios where tag-based searching is needed
```
