### PR TITLE
:sparkles: Enable transit encryption to S3 bucket

### DIFF
--- a/pkg/cloud/services/s3/s3.go
+++ b/pkg/cloud/services/s3/s3.go
@@ -306,6 +306,20 @@ func (s *Service) bucketPolicy(bucketName string) (string, error) {
 			Action:   []string{"s3:GetObject"},
 			Resource: []string{fmt.Sprintf("arn:%s:s3:::%s/control-plane/*", partition, bucketName)},
 		},
+		{
+			Sid:    "ForceSSLOnlyAccess",
+			Effect: iam.EffectDeny,
+			Principal: map[iam.PrincipalType]iam.PrincipalID{
+				iam.PrincipalAWS: []string{"*"},
+			},
+			Action:   []string{"s3:*"},
+			Resource: []string{fmt.Sprintf("arn:%s:s3:::%s/*", partition, bucketName)},
+			Condition: iam.Conditions{
+				"Bool": map[string]interface{}{
+					"aws:SecureTransport": false,
+				},
+			},
+		},
 	}
 
 	for _, iamInstanceProfile := range bucket.NodesIAMInstanceProfiles {

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -201,6 +201,10 @@ func TestReconcileBucket(t *testing.T) {
 			if !strings.Contains(policy, "arn:aws:iam::foo:role/control-plane.cluster-api-provider-aws.sigs.k8s.io") {
 				t.Errorf("Expected arn to contain the right principal; got: %v", policy)
 			}
+
+			if !strings.Contains(policy, "SecureTransport") {
+				t.Errorf("Expected deny when not using SecureTransport; got: %v", policy)
+			}
 		}).Return(nil, nil).Times(1)
 
 		if err := svc.ReconcileBucket(); err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable transit encryption on S3 buckets
```
