### PR TITLE
:bug: Return on wrong type in event filters

### DIFF
--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -369,6 +369,7 @@ func (r *EKSConfigReconciler) MachineToBootstrapMapFunc(_ context.Context, o cli
 	m, ok := o.(*clusterv1.Machine)
 	if !ok {
 		klog.Errorf("Expected a Machine but got a %T", o)
+		return nil
 	}
 	if m.Spec.Bootstrap.ConfigRef != nil && m.Spec.Bootstrap.ConfigRef.GroupVersionKind() == eksbootstrapv1.GroupVersion.WithKind("EKSConfig") {
 		name := client.ObjectKey{Namespace: m.Namespace, Name: m.Spec.Bootstrap.ConfigRef.Name}
@@ -385,6 +386,7 @@ func (r *EKSConfigReconciler) MachinePoolToBootstrapMapFunc(_ context.Context, o
 	m, ok := o.(*expclusterv1.MachinePool)
 	if !ok {
 		klog.Errorf("Expected a MachinePool but got a %T", o)
+		return nil
 	}
 	configRef := m.Spec.Template.Spec.Bootstrap.ConfigRef
 	if configRef != nil && configRef.GroupVersionKind().GroupKind() == eksbootstrapv1.GroupVersion.WithKind("EKSConfig").GroupKind() {
@@ -403,6 +405,7 @@ func (r *EKSConfigReconciler) ClusterToEKSConfigs(_ context.Context, o client.Ob
 	c, ok := o.(*clusterv1.Cluster)
 	if !ok {
 		klog.Errorf("Expected a Cluster but got a %T", o)
+		return nil
 	}
 
 	selectors := []client.ListOption{

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -400,6 +400,7 @@ func (r *AWSClusterReconciler) requeueAWSClusterForUnpausedCluster(_ context.Con
 		c, ok := o.(*clusterv1.Cluster)
 		if !ok {
 			klog.Errorf("Expected a Cluster but got a %T", o)
+			return nil
 		}
 
 		log := log.WithValues("objectMapper", "clusterToAWSCluster", "cluster", klog.KRef(c.Namespace, c.Name))

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -1001,6 +1001,7 @@ func (r *AWSMachineReconciler) AWSClusterToAWSMachines(log logger.Wrapper) handl
 		c, ok := o.(*infrav1.AWSCluster)
 		if !ok {
 			klog.Errorf("Expected a AWSCluster but got a %T", o)
+			return nil
 		}
 
 		log := log.WithValues("objectMapper", "awsClusterToAWSMachine", "cluster", klog.KRef(c.Namespace, c.Name))
@@ -1030,6 +1031,7 @@ func (r *AWSMachineReconciler) requeueAWSMachinesForUnpausedCluster(log logger.W
 		c, ok := o.(*clusterv1.Cluster)
 		if !ok {
 			klog.Errorf("Expected a Cluster but got a %T", o)
+			return nil
 		}
 
 		log := log.WithValues("objectMapper", "clusterToAWSMachine", "cluster", klog.KRef(c.Namespace, c.Name))

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -370,6 +370,7 @@ func (r *AWSManagedControlPlaneReconciler) ClusterToAWSManagedControlPlane(o cli
 	c, ok := o.(*clusterv1.Cluster)
 	if !ok {
 		klog.Errorf("Expected a Cluster but got a %T", o)
+		return nil
 	}
 
 	if !c.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/exp/controlleridentitycreator/awscontrolleridentity_controller.go
+++ b/exp/controlleridentitycreator/awscontrolleridentity_controller.go
@@ -150,6 +150,7 @@ func (r *AWSControllerIdentityReconciler) managedControlPlaneMap(_ context.Conte
 	managedControlPlane, ok := o.(*ekscontrolplanev1.AWSManagedControlPlane)
 	if !ok {
 		klog.Errorf("Expected a managedControlPlane but got a %T", o)
+		return nil
 	}
 
 	return []ctrl.Request{

--- a/exp/controllers/awsfargatepool_controller.go
+++ b/exp/controllers/awsfargatepool_controller.go
@@ -186,6 +186,7 @@ func managedControlPlaneToFargateProfileMapFunc(c client.Client, log logger.Wrap
 		awsControlPlane, ok := o.(*ekscontrolplanev1.AWSManagedControlPlane)
 		if !ok {
 			klog.Errorf("Expected a AWSManagedControlPlane but got a %T", o)
+			return nil
 		}
 
 		if !awsControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -309,6 +309,7 @@ func managedControlPlaneToManagedMachinePoolMapFunc(c client.Client, gvk schema.
 		awsControlPlane, ok := o.(*ekscontrolplanev1.AWSManagedControlPlane)
 		if !ok {
 			klog.Errorf("Expected a AWSManagedControlPlane but got a %T", o)
+			return nil
 		}
 
 		if !awsControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

First of all, i know the bugfix is fixing a case which theoretically doesn't exists. But for correctness I think it makes sense to fix these type conversions. Otherwise there would be some panic, which also makes sense.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
