### PR TITLE
🐛 There is no need to check instance refresh if ASG is not found (cherry-pick to release-2.3)

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -1091,7 +1091,7 @@ func TestServiceCanStartASGInstanceRefresh(t *testing.T) {
 				m.DescribeInstanceRefreshesWithContext(context.TODO(), gomock.Eq(&autoscaling.DescribeInstanceRefreshesInput{
 					AutoScalingGroupName: aws.String("machinePoolName"),
 				})).
-					Return(nil, awserrors.NewNotFound("not found"))
+					Return(nil, awserrors.NewConflict("some error"))
 			},
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
-->

**What this PR does / why we need it**:

Cherry-pick https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4662 (@fiunchinho)

The only conflict was a simulated error type in the unit test.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip instance refresh attempt if ASG does not yet exist
```
