### PR TITLE
🐛 Fix deregistering of deleted CAPI Machines

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -867,8 +867,8 @@ func (r *AWSMachineReconciler) reconcileLBAttachment(machineScope *scope.Machine
 	elbsvc := r.getELBService(elbScope)
 
 	// In order to prevent sending request to a "not-ready" control plane machines, it is required to remove the machine
-	// from the ELB as soon as the machine gets deleted or when the machine is in a not running state.
-	if !machineScope.AWSMachine.DeletionTimestamp.IsZero() || !machineScope.InstanceIsRunning() {
+	// from the ELB as soon as the machine or infra machine gets deleted or when the machine is in a not running state.
+	if machineScope.AWSMachineIsDeleted() || machineScope.MachineIsDeleted() || !machineScope.InstanceIsRunning() {
 		if elbScope.ControlPlaneLoadBalancer().LoadBalancerType == infrav1.LoadBalancerTypeClassic {
 			machineScope.Debug("deregistering from classic load balancer")
 			return r.deregisterInstanceFromClassicLB(machineScope, elbsvc, i)

--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -360,9 +360,14 @@ func (m *MachineScope) InstanceIsInKnownState() bool {
 	return state != nil && infrav1.InstanceKnownStates.Has(string(*state))
 }
 
-// AWSMachineIsDeleted checks if the machine was deleted.
+// AWSMachineIsDeleted checks if the AWS machine was deleted.
 func (m *MachineScope) AWSMachineIsDeleted() bool {
 	return !m.AWSMachine.ObjectMeta.DeletionTimestamp.IsZero()
+}
+
+// MachineIsDeleted checks if the machine was deleted.
+func (m *MachineScope) MachineIsDeleted() bool {
+	return !m.Machine.ObjectMeta.DeletionTimestamp.IsZero()
 }
 
 // IsEKSManaged checks if the machine is EKS managed.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We have an issue that there is a gap between the CAPI Machine deletion and the AWSMachine deletion. In this timeframe the kube-apiserver to the to be deleted control plane is no longer possible, but the deregistering of the LB member will be performed only for AWSMachine deletions. This PR fixes the gap and also deregisteres the instance if the CAPI Machine is deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4697

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resolved issue where deleted control planes were still registered in the kube-apiserver load balancer, causing potential disruptions.
```

<sub>Tobias Giese <tobias.giese@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>