### PR TITLE
:sparkles: Remove ingress and egress rules from vpc default security group

### DIFF
--- a/api/v1beta1/awscluster_conversion.go
+++ b/api/v1beta1/awscluster_conversion.go
@@ -90,7 +90,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 		restoreIPAMPool(restored.Spec.NetworkSpec.VPC.IPv6.IPAMPool, dst.Spec.NetworkSpec.VPC.IPv6.IPAMPool)
 	}
 
-	dst.Spec.NetworkSpec.AdditionalControlPlaneIngressRules = restored.Spec.NetworkSpec.AdditionalControlPlaneIngressRules
+	dst.Spec.NetworkSpec.VPC.EmptyRoutesDefaultVPCSecurityGroup = restored.Spec.NetworkSpec.VPC.EmptyRoutesDefaultVPCSecurityGroup
 
 	// Restore SubnetSpec.ResourceID field, if any.
 	for _, subnet := range restored.Spec.NetworkSpec.Subnets {

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -2284,6 +2284,7 @@ func autoConvert_v1beta2_VPCSpec_To_v1beta1_VPCSpec(in *v1beta2.VPCSpec, out *VP
 	out.Tags = *(*Tags)(unsafe.Pointer(&in.Tags))
 	out.AvailabilityZoneUsageLimit = (*int)(unsafe.Pointer(in.AvailabilityZoneUsageLimit))
 	out.AvailabilityZoneSelection = (*AZSelectionScheme)(unsafe.Pointer(in.AvailabilityZoneSelection))
+	// WARNING: in.EmptyRoutesDefaultVPCSecurityGroup requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -323,6 +323,18 @@ type VPCSpec struct {
 	// +kubebuilder:default=Ordered
 	// +kubebuilder:validation:Enum=Ordered;Random
 	AvailabilityZoneSelection *AZSelectionScheme `json:"availabilityZoneSelection,omitempty"`
+
+	// EmptyRoutesDefaultVPCSecurityGroup specifies whether the default VPC security group ingress
+	// and egress rules should be removed.
+	//
+	// By default, when creating a VPC, AWS creates a security group called `default` with ingress and egress
+	// rules that allow traffic from anywhere. The group could be used as a potential surface attack and
+	// it's generally suggested that the group rules are removed or modified appropriately.
+	//
+	// NOTE: This only applies when the VPC is managed by the Cluster API AWS controller.
+	//
+	// +optional
+	EmptyRoutesDefaultVPCSecurityGroup bool `json:"emptyRoutesDefaultVPCSecurityGroup,omitempty"`
 }
 
 // String returns a string representation of the VPC.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -569,6 +569,17 @@ spec:
                           provider creates a managed VPC. Defaults to 10.0.0.0/16.
                           Mutually exclusive with IPAMPool.
                         type: string
+                      emptyRoutesDefaultVPCSecurityGroup:
+                        description: "EmptyRoutesDefaultVPCSecurityGroup specifies
+                          whether the default VPC security group ingress and egress
+                          rules should be removed. \n By default, when creating a
+                          VPC, AWS creates a security group called `default` with
+                          ingress and egress rules that allow traffic from anywhere.
+                          The group could be used as a potential surface attack and
+                          it's generally suggested that the group rules are removed
+                          or modified appropriately. \n NOTE: This only applies when
+                          the VPC is managed by the Cluster API AWS controller."
+                        type: boolean
                       id:
                         description: ID is the vpc-id of the VPC this provider should
                           use to create resources.
@@ -2155,6 +2166,17 @@ spec:
                           provider creates a managed VPC. Defaults to 10.0.0.0/16.
                           Mutually exclusive with IPAMPool.
                         type: string
+                      emptyRoutesDefaultVPCSecurityGroup:
+                        description: "EmptyRoutesDefaultVPCSecurityGroup specifies
+                          whether the default VPC security group ingress and egress
+                          rules should be removed. \n By default, when creating a
+                          VPC, AWS creates a security group called `default` with
+                          ingress and egress rules that allow traffic from anywhere.
+                          The group could be used as a potential surface attack and
+                          it's generally suggested that the group rules are removed
+                          or modified appropriately. \n NOTE: This only applies when
+                          the VPC is managed by the Cluster API AWS controller."
+                        type: boolean
                       id:
                         description: ID is the vpc-id of the VPC this provider should
                           use to create resources.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1401,6 +1401,17 @@ spec:
                           provider creates a managed VPC. Defaults to 10.0.0.0/16.
                           Mutually exclusive with IPAMPool.
                         type: string
+                      emptyRoutesDefaultVPCSecurityGroup:
+                        description: "EmptyRoutesDefaultVPCSecurityGroup specifies
+                          whether the default VPC security group ingress and egress
+                          rules should be removed. \n By default, when creating a
+                          VPC, AWS creates a security group called `default` with
+                          ingress and egress rules that allow traffic from anywhere.
+                          The group could be used as a potential surface attack and
+                          it's generally suggested that the group rules are removed
+                          or modified appropriately. \n NOTE: This only applies when
+                          the VPC is managed by the Cluster API AWS controller."
+                        type: boolean
                       id:
                         description: ID is the vpc-id of the VPC this provider should
                           use to create resources.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -1014,6 +1014,18 @@ spec:
                                   when the provider creates a managed VPC. Defaults
                                   to 10.0.0.0/16. Mutually exclusive with IPAMPool.
                                 type: string
+                              emptyRoutesDefaultVPCSecurityGroup:
+                                description: "EmptyRoutesDefaultVPCSecurityGroup specifies
+                                  whether the default VPC security group ingress and
+                                  egress rules should be removed. \n By default, when
+                                  creating a VPC, AWS creates a security group called
+                                  `default` with ingress and egress rules that allow
+                                  traffic from anywhere. The group could be used as
+                                  a potential surface attack and it's generally suggested
+                                  that the group rules are removed or modified appropriately.
+                                  \n NOTE: This only applies when the VPC is managed
+                                  by the Cluster API AWS controller."
+                                type: boolean
                               id:
                                 description: ID is the vpc-id of the VPC this provider
                                   should use to create resources.

--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -205,3 +205,16 @@ func IsIgnorableSecurityGroupError(err error) error {
 	}
 	return nil
 }
+
+// IsPermissionNotFoundError returns whether the error is InvalidPermission.NotFound.
+func IsPermissionNotFoundError(err error) bool {
+	if code, ok := Code(err); ok {
+		switch code {
+		case PermissionNotFound:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/pkg/cloud/filter/ec2.go
+++ b/pkg/cloud/filter/ec2.go
@@ -166,3 +166,10 @@ func (ec2Filters) IgnoreLocalZones() *ec2.Filter {
 		Values: aws.StringSlice([]string{"opt-in-not-required"}),
 	}
 }
+
+func (ec2Filters) SecurityGroupName(name string) *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String("group-name"),
+		Values: aws.StringSlice([]string{name}),
+	}
+}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

We want to secure the VPC as much as possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4675 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove ingress and egress rules from vpc default security group
```
