### PR TITLE
✨ Log full ARN in GC error messages

### DIFF
--- a/pkg/cloud/services/gc/ec2.go
+++ b/pkg/cloud/services/gc/ec2.go
@@ -37,7 +37,7 @@ func (s *Service) deleteSecurityGroups(ctx context.Context, resources []*AWSReso
 
 		groupID := strings.ReplaceAll(resource.ARN.Resource, "security-group/", "")
 		if err := s.deleteSecurityGroup(ctx, groupID); err != nil {
-			return fmt.Errorf("deleting security group %s: %w", groupID, err)
+			return fmt.Errorf("deleting security group %q with ID %s: %w", resource.ARN, groupID, err)
 		}
 	}
 	s.scope.Debug("Finished processing resources for security group deletion")

--- a/pkg/cloud/services/gc/loadbalancer.go
+++ b/pkg/cloud/services/gc/loadbalancer.go
@@ -70,9 +70,8 @@ func (s *Service) deleteTargetGroups(ctx context.Context, resources []*AWSResour
 			continue
 		}
 
-		name := strings.ReplaceAll(resource.ARN.Resource, "targetgroup/", "")
 		if err := s.deleteTargetGroup(ctx, resource.ARN.String()); err != nil {
-			return fmt.Errorf("deleting target group %s: %w", name, err)
+			return fmt.Errorf("deleting target group %q: %w", resource.ARN, err)
 		}
 	}
 	s.scope.Debug("Finished processing resources for target group deletion")


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Log messages are currently unactionable because only an ID is given:

```
capa-controller-manager-6df7759674-hpchv manager 2023-12-21T10:17:16.005130350+01:00 	failed delete reconcile for gc service: deleting resources: deleting security group sg-084aa1bd14358af73: deleting security group: DependencyViolation: resource sg-084aa1bd14358af73 has a dependent object
```

At least the region is needed for humans to follow up. Else you'd have to loop through your AWS accounts and regions to find the ID, which is cumbersome.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Log full ARN in GC error messages
```
