### PR TITLE
🐛 Updating verify kubectl version script

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -14,27 +14,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This has been copied from https://github.com/kubernetes-sigs/cluster-api/blob/v1.6.0/hack/ensure-kubectl.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+
+# shellcheck source=./hack/utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KUBECTL_VERSION=v1.19.0
-GOARCH="$(go env GOARCH)"
-GOOS="$(go env GOOS)"
+MINIMUM_KUBECTL_VERSION=v1.28.0
+goarch="$(go env GOARCH)"
+goos="$(go env GOOS)"
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version() {
 
   # If kubectl is not available on the path, get it
   if ! [ -x "$(command -v kubectl)" ]; then
-    if [ "$GOOS" == "linux" ] || [ "$GOOS" == "darwin" ]; then
+    if [ "$goos" == "linux" ] || [ "$goos" == "darwin" ]; then
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi
       echo 'kubectl not found, installing'
-      curl -sLo "${GOPATH_BIN}/kubectl" "https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/${GOOS}/${GOARCH}/kubectl"
+      curl -sLo "${GOPATH_BIN}/kubectl" "https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/${goos}/${goarch}/kubectl"
       chmod +x "${GOPATH_BIN}/kubectl"
+      verify_gopath_bin
     else
       echo "Missing required binary in path: kubectl"
       return 2
@@ -42,7 +53,7 @@ verify_kubectl_version() {
   fi
 
   local kubectl_version
-  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short 2>/dev/null `# "--short" was removed` || kubectl version --client)"
+  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client)"
   if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kubectl version: ${kubectl_version[2]}.

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 The Kubernetes Authors.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This has been copied from https://github.com/kubernetes-sigs/cluster-api/blob/release-1.1/hack/utils.sh
+# This has been copied from https://github.com/kubernetes-sigs/cluster-api/blob/v1.6.0/hack/utils.sh
 
 # get_root_path returns the root path of the project source tree
 get_root_path() {
     git rev-parse --show-toplevel
 }
 
-# cd_root_path cds to the root path of the project source tree
-cd_root_path() {
-    cd "$(get_root_path)" || exit
-}
+# ensure GOPATH/bin is in PATH as we may install binaries to that directory in
+# other ensure-* scripts, and expect them to be found in PATH later on
+verify_gopath_bin() {
+    local gopath_bin
 
+    gopath_bin="$(go env GOPATH)/bin"
+    if ! printenv PATH | grep -q "${gopath_bin}"; then
+        cat <<EOF
+error: \$GOPATH/bin=${gopath_bin} is not in your PATH.
+See https://go.dev/doc/gopath_code for more instructions.
+EOF
+        return 2
+    fi
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4719

**Special notes for your reviewer**:

This PR is a pre-requisite to fix the blocked CI of #4710. 

Essentially, the `--short` flag has been deprecated and removed from v1.29.
To keep backward compatibility, although the infra image has already `kubectl` baked in, the `--output=yaml` flag is used as a replacement.

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
NONE
```
