### PR TITLE
✨ Skip AWSCluster deletion reconciliation once CAPA finalizer is gone

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -200,6 +200,11 @@ func (r *AWSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *scope.ClusterScope) error {
+	if !controllerutil.ContainsFinalizer(clusterScope.AWSCluster, infrav1.ClusterFinalizer) {
+		clusterScope.Info("No finalizer on AWSCluster, skipping deletion reconciliation")
+		return nil
+	}
+
 	clusterScope.Info("Reconciling AWSCluster delete")
 
 	ec2svc := r.getEC2Service(clusterScope)

--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -374,6 +374,7 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, &awsCluster, controllerIdentity, ns)).To(Succeed())
 		})
 
+		awsCluster.Finalizers = []string{infrav1.ClusterFinalizer}
 		cs, err := getClusterScope(awsCluster)
 		g.Expect(err).To(BeNil())
 

--- a/controllers/awscluster_controller_unit_test.go
+++ b/controllers/awscluster_controller_unit_test.go
@@ -401,6 +401,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 			t.Run("Should successfully delete AWSCluster with Cluster Finalizer removed", func(t *testing.T) {
 				g := NewWithT(t)
 				awsCluster := getAWSCluster("test", "test")
+				awsCluster.Finalizers = []string{infrav1.ClusterFinalizer}
 				csClient := setup(t, &awsCluster)
 				defer teardown()
 				deleteCluster()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Once CAPA is done with deletion reconciliation, it removes its own finalizer. Other operators however may still have finalizers on the `AWSCluster` object and the object may remain until those external operators are done with deletion. CAPA should not unnecessarily keep reconciling the object.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Skip AWSCluster deletion reconciliation once CAPA finalizer is gone
```
