### PR TITLE
✨ ROSA: Generate CAPI kubeconfig secret

### DIFF
--- a/pkg/cloud/scope/rosacontrolplane.go
+++ b/pkg/cloud/scope/rosacontrolplane.go
@@ -18,6 +18,7 @@ package scope
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -107,6 +108,15 @@ func (s *ROSAControlPlaneScope) CredentialsSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.ControlPlane.Spec.CredentialsSecretRef.Name,
+			Namespace: s.ControlPlane.Namespace,
+		},
+	}
+}
+
+func (s *ROSAControlPlaneScope) ClusterAdminPasswordSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-admin-password", s.Cluster.Name),
 			Namespace: s.ControlPlane.Namespace,
 		},
 	}

--- a/pkg/rosa/client.go
+++ b/pkg/rosa/client.go
@@ -16,20 +16,20 @@ const (
 	ocmAPIURLKey = "ocmApiUrl"
 )
 
-type rosaClient struct {
+type RosaClient struct {
 	ocm       *sdk.Connection
 	rosaScope *scope.ROSAControlPlaneScope
 }
 
 // NewRosaClientWithConnection creates a client with a preexisting connection for testing purposes.
-func NewRosaClientWithConnection(connection *sdk.Connection, rosaScope *scope.ROSAControlPlaneScope) *rosaClient {
-	return &rosaClient{
+func NewRosaClientWithConnection(connection *sdk.Connection, rosaScope *scope.ROSAControlPlaneScope) *RosaClient {
+	return &RosaClient{
 		ocm:       connection,
 		rosaScope: rosaScope,
 	}
 }
 
-func NewRosaClient(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (*rosaClient, error) {
+func NewRosaClient(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (*RosaClient, error) {
 	var token string
 	var ocmAPIUrl string
 
@@ -70,20 +70,20 @@ func NewRosaClient(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) 
 		return nil, fmt.Errorf("failed to create ocm connection: %w", err)
 	}
 
-	return &rosaClient{
+	return &RosaClient{
 		ocm:       connection,
 		rosaScope: rosaScope,
 	}, nil
 }
 
-func (c *rosaClient) Close() error {
+func (c *RosaClient) Close() error {
 	return c.ocm.Close()
 }
 
-func (c *rosaClient) GetConnectionURL() string {
+func (c *RosaClient) GetConnectionURL() string {
 	return c.ocm.URL()
 }
 
-func (c *rosaClient) GetConnectionTokens() (string, string, error) {
+func (c *RosaClient) GetConnectionTokens() (string, string, error) {
 	return c.ocm.Tokens()
 }

--- a/pkg/rosa/clusters.go
+++ b/pkg/rosa/clusters.go
@@ -10,7 +10,8 @@ const (
 	rosaCreatorArnProperty = "rosa_creator_arn"
 )
 
-func (c *rosaClient) CreateCluster(spec *cmv1.Cluster) (*cmv1.Cluster, error) {
+// CreateCluster creates a new ROSA cluster using the specified spec.
+func (c *RosaClient) CreateCluster(spec *cmv1.Cluster) (*cmv1.Cluster, error) {
 	cluster, err := c.ocm.ClustersMgmt().V1().Clusters().
 		Add().
 		Body(spec).
@@ -23,7 +24,8 @@ func (c *rosaClient) CreateCluster(spec *cmv1.Cluster) (*cmv1.Cluster, error) {
 	return clusterObject, nil
 }
 
-func (c *rosaClient) DeleteCluster(clusterID string) error {
+// DeleteCluster deletes the ROSA cluster.
+func (c *RosaClient) DeleteCluster(clusterID string) error {
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().
 		Cluster(clusterID).
 		Delete().
@@ -36,7 +38,8 @@ func (c *rosaClient) DeleteCluster(clusterID string) error {
 	return nil
 }
 
-func (c *rosaClient) GetCluster() (*cmv1.Cluster, error) {
+// GetCluster retrieves the ROSA/OCM cluster object.
+func (c *RosaClient) GetCluster() (*cmv1.Cluster, error) {
 	clusterKey := c.rosaScope.RosaClusterName()
 	query := fmt.Sprintf("%s AND (id = '%s' OR name = '%s' OR external_id = '%s')",
 		getClusterFilter(c.rosaScope.ControlPlane.Spec.CreatorARN),

--- a/pkg/rosa/idps.go
+++ b/pkg/rosa/idps.go
@@ -1,0 +1,165 @@
+package rosa
+
+import (
+	"fmt"
+	"net/http"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// ListIdentityProviders retrieves the list of identity providers.
+func (c *RosaClient) ListIdentityProviders(clusterID string) ([]*cmv1.IdentityProvider, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).
+		IdentityProviders().
+		List().Page(1).Size(-1).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	return response.Items().Slice(), nil
+}
+
+// CreateIdentityProvider adds a new identity provider to the cluster.
+func (c *RosaClient) CreateIdentityProvider(clusterID string, idp *cmv1.IdentityProvider) (*cmv1.IdentityProvider, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).
+		IdentityProviders().
+		Add().Body(idp).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+	return response.Body(), nil
+}
+
+// GetHTPasswdUserList retrieves the list of users of the provided _HTPasswd_ identity provider.
+func (c *RosaClient) GetHTPasswdUserList(clusterID, htpasswdIDPId string) (*cmv1.HTPasswdUserList, error) {
+	listResponse, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+		IdentityProviders().IdentityProvider(htpasswdIDPId).HtpasswdUsers().List().Send()
+	if err != nil {
+		if listResponse.Error().Status() == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, handleErr(listResponse.Error(), err)
+	}
+
+	return listResponse.Items(), nil
+}
+
+// AddHTPasswdUser adds a new user to the provided _HTPasswd_ identity provider.
+func (c *RosaClient) AddHTPasswdUser(username, password, clusterID, idpID string) error {
+	htpasswdUser, _ := cmv1.NewHTPasswdUser().Username(username).Password(password).Build()
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+		IdentityProviders().IdentityProvider(idpID).HtpasswdUsers().Add().Body(htpasswdUser).Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+
+	return nil
+}
+
+const (
+	clusterAdminUserGroup = "cluster-admins"
+	clusterAdminIDPname   = "cluster-admin"
+)
+
+// CreateAdminUserIfNotExist creates a new admin user withe username/password in the cluster if username doesn't already exist.
+// the user is granted admin privileges by being added to a special IDP called `cluster-admin` which will be created if it doesn't already exist.
+func (c *RosaClient) CreateAdminUserIfNotExist(clusterID, username, password string) error {
+	existingClusterAdminIDP, userList, err := c.findExistingClusterAdminIDP(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to find existing cluster admin IDP: %w", err)
+	}
+	if existingClusterAdminIDP != nil {
+		if hasUser(username, userList) {
+			// user already exist in the cluster
+			return nil
+		}
+	}
+
+	// Add admin user to the cluster-admins group:
+	user, err := c.CreateUserIfNotExist(clusterID, clusterAdminUserGroup, username)
+	if err != nil {
+		return fmt.Errorf("failed to add user '%s' to cluster '%s': %s",
+			username, clusterID, err)
+	}
+
+	if existingClusterAdminIDP != nil {
+		// add htpasswd user to existing idp
+		err := c.AddHTPasswdUser(username, password, clusterID, existingClusterAdminIDP.ID())
+		if err != nil {
+			return fmt.Errorf("failed to add htpassawoed user cluster-admin to existing idp: %s", existingClusterAdminIDP.ID())
+		}
+
+		return nil
+	}
+
+	// No ClusterAdmin IDP exists, create an Htpasswd IDP
+	htpasswdIDP := cmv1.NewHTPasswdIdentityProvider().Users(cmv1.NewHTPasswdUserList().Items(
+		cmv1.NewHTPasswdUser().Username(username).Password(password),
+	))
+	clusterAdminIDP, err := cmv1.NewIdentityProvider().
+		Type(cmv1.IdentityProviderTypeHtpasswd).
+		Name(clusterAdminIDPname).
+		Htpasswd(htpasswdIDP).
+		Build()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create '%s' identity provider for cluster '%s'",
+			clusterAdminIDPname,
+			clusterID,
+		)
+	}
+
+	// Add HTPasswd IDP to cluster
+	_, err = c.CreateIdentityProvider(clusterID, clusterAdminIDP)
+	if err != nil {
+		// since we could not add the HTPasswd IDP to the cluster, roll back and remove the cluster admin
+		if err := c.DeleteUser(clusterID, clusterAdminUserGroup, user.ID()); err != nil {
+			return fmt.Errorf("failed to revert the admin user for cluster '%s': %w",
+				clusterID, err)
+		}
+		return fmt.Errorf("failed to create identity cluster-admin idp: %w", err)
+	}
+
+	return nil
+}
+
+func (c *RosaClient) findExistingClusterAdminIDP(clusterID string) (
+	htpasswdIDP *cmv1.IdentityProvider, userList *cmv1.HTPasswdUserList, reterr error) {
+	idps, err := c.ListIdentityProviders(clusterID)
+	if err != nil {
+		reterr = fmt.Errorf("failed to get identity providers for cluster '%s': %v", clusterID, err)
+		return
+	}
+
+	for _, idp := range idps {
+		if idp.Name() == clusterAdminIDPname {
+			itemUserList, err := c.GetHTPasswdUserList(clusterID, idp.ID())
+			if err != nil {
+				reterr = fmt.Errorf("failed to get user list of the HTPasswd IDP of '%s: %s': %v", idp.Name(), clusterID, err)
+				return
+			}
+
+			htpasswdIDP = idp
+			userList = itemUserList
+			return
+		}
+	}
+
+	return
+}
+
+func hasUser(username string, userList *cmv1.HTPasswdUserList) bool {
+	hasUser := false
+	userList.Each(func(user *cmv1.HTPasswdUser) bool {
+		if user.Username() == username {
+			hasUser = true
+			return false
+		}
+		return true
+	})
+	return hasUser
+}

--- a/pkg/rosa/nodepools.go
+++ b/pkg/rosa/nodepools.go
@@ -2,7 +2,8 @@ package rosa
 
 import cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
-func (c *rosaClient) CreateNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
+// CreateNodePool adds a new node pool to the cluster.
+func (c *RosaClient) CreateNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
 		NodePools().
@@ -14,7 +15,8 @@ func (c *rosaClient) CreateNodePool(clusterID string, nodePool *cmv1.NodePool) (
 	return response.Body(), nil
 }
 
-func (c *rosaClient) GetNodePools(clusterID string) ([]*cmv1.NodePool, error) {
+// GetNodePools retrieves the list of node pools in the cluster.
+func (c *RosaClient) GetNodePools(clusterID string) ([]*cmv1.NodePool, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
 		NodePools().
@@ -26,7 +28,8 @@ func (c *rosaClient) GetNodePools(clusterID string) ([]*cmv1.NodePool, error) {
 	return response.Items().Slice(), nil
 }
 
-func (c *rosaClient) GetNodePool(clusterID string, nodePoolID string) (*cmv1.NodePool, bool, error) {
+// GetNodePool retrieves the details of the specified node pool.
+func (c *RosaClient) GetNodePool(clusterID string, nodePoolID string) (*cmv1.NodePool, bool, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
 		NodePools().
@@ -42,7 +45,8 @@ func (c *rosaClient) GetNodePool(clusterID string, nodePoolID string) (*cmv1.Nod
 	return response.Body(), true, nil
 }
 
-func (c *rosaClient) UpdateNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
+// UpdateNodePool updates the specified node pool.
+func (c *RosaClient) UpdateNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
 		NodePools().NodePool(nodePool.ID()).
@@ -54,7 +58,8 @@ func (c *rosaClient) UpdateNodePool(clusterID string, nodePool *cmv1.NodePool) (
 	return response.Body(), nil
 }
 
-func (c *rosaClient) DeleteNodePool(clusterID string, nodePoolID string) error {
+// DeleteNodePool deletes the specified node pool.
+func (c *RosaClient) DeleteNodePool(clusterID string, nodePoolID string) error {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
 		NodePools().NodePool(nodePoolID).

--- a/pkg/rosa/oauth.go
+++ b/pkg/rosa/oauth.go
@@ -1,0 +1,114 @@
+package rosa
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	restclient "k8s.io/client-go/rest"
+)
+
+type TokenResponse struct {
+	AccessToken string
+	ExpiresIn   time.Duration
+}
+
+// RequestToken requests an OAuth access token for the specified API server using username/password credentials.
+// returns a TokenResponse which contains the AccessToken and the ExpiresIn duration.
+func RequestToken(ctx context.Context, apiURL, username, password string, config *restclient.Config) (*TokenResponse, error) {
+	clientID := "openshift-challenging-client"
+	oauthURL, err := buildOauthURL(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build oauth url: %w", err)
+	}
+
+	tokenReqURL := fmt.Sprintf("%s/oauth/authorize?response_type=token&client_id=%s", oauthURL, clientID)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenReqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("Authorization", getBasicHeader(username, password))
+	// this is a required header by the openshift oauth server to prevent CORS errors.
+	// see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/authentication_and_authorization/understanding-authentication#oauth-token-requests_understanding-authentication
+	request.Header.Set("X-CSRF-Token", "1")
+
+	transport, err := restclient.TransportFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// don't resolve redirects and return the response instead
+		return http.ErrUseLastResponse
+	}
+
+	resp, err := httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send token request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		return nil, fmt.Errorf("expected status code %d, but got %d", http.StatusFound, resp.StatusCode)
+	}
+
+	// extract access_token & expires_in from redirect URL
+	tokenResponse, err := extractTokenResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract access token from redirect url")
+	}
+
+	return tokenResponse, nil
+}
+
+func getBasicHeader(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+}
+
+func buildOauthURL(apiURL string) (string, error) {
+	parsedURL, err := url.ParseRequestURI(apiURL)
+	if err != nil {
+		return "", err
+	}
+	host, _, err := net.SplitHostPort(parsedURL.Host)
+	if err != nil {
+		return "", err
+	}
+	parsedURL.Host = host
+
+	oauthURL := strings.Replace(parsedURL.String(), "api", "oauth", 1)
+	return oauthURL, nil
+}
+
+func extractTokenResponse(resp *http.Response) (*TokenResponse, error) {
+	location, err := resp.Location()
+	if err != nil {
+		return nil, err
+	}
+
+	fragments, err := url.ParseQuery(location.Fragment)
+	if err != nil {
+		return nil, err
+	}
+	if len(fragments["access_token"]) == 0 {
+		return nil, fmt.Errorf("access_token not found")
+	}
+
+	expiresIn, err := strconv.Atoi(fragments.Get("expires_in"))
+	if err != nil || expiresIn == 0 {
+		expiresIn = 86400 // default to 1 day
+	}
+
+	return &TokenResponse{
+		AccessToken: fragments.Get("access_token"),
+		ExpiresIn:   time.Second * time.Duration(expiresIn),
+	}, nil
+}

--- a/pkg/rosa/users.go
+++ b/pkg/rosa/users.go
@@ -1,0 +1,58 @@
+package rosa
+
+import (
+	"fmt"
+	"net/http"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// CreateUserIfNotExist creates a new user with `username` and adds it to the group if it doesn't already exist.
+func (c *RosaClient) CreateUserIfNotExist(clusterID string, group, username string) (*cmv1.User, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).
+		Groups().Group(group).
+		Users().User(username).
+		Get().
+		Send()
+	if err == nil {
+		return response.Body(), nil
+	} else if response.Error().Status() != http.StatusNotFound {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	user, err := cmv1.NewUser().ID(username).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create user '%s' for cluster '%s'", username, clusterID)
+	}
+
+	return c.CreateUser(clusterID, group, user)
+}
+
+// CreateUser adds a new user to the group.
+func (c *RosaClient) CreateUser(clusterID string, group string, user *cmv1.User) (*cmv1.User, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).
+		Groups().Group(group).
+		Users().
+		Add().Body(user).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+	return response.Body(), nil
+}
+
+// DeleteUser deletes the user from the cluster.
+func (c *RosaClient) DeleteUser(clusterID string, group string, username string) error {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).
+		Groups().Group(group).
+		Users().User(username).
+		Delete().
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR generates a kubeconfig secret for ROSA clusters according to CAPI [contract ](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/cluster)
Secret name | Field name | Content
-- | -- | --
\<cluster-name>-kubeconfig | value | base64 encoded kubeconfig


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4734

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Generate CAPI kubeconfig secret for ROSA clusters
```
