### PR TITLE
:bug: Write sensitive cloud-init user-data into /etc/cloud/cloud.cfg.d

### DIFF
--- a/docs/book/src/topics/userdata-privacy.md
+++ b/docs/book/src/topics/userdata-privacy.md
@@ -46,11 +46,6 @@ cloudInit:
 cloud-init does not print boothook script errors to the systemd journal. Logs for the script, if it errored can be found in
 `/var/log/cloud-init-output.log`
 
-### Warning messages
-
-Because cloud-init will attempt to read the final file at start, cloud-init will always print a `/etc/secret-userdata.txt cannot be found`
-message. This can be safely ignored.
-
 ### Secrets manager console
 
 The AWS secrets manager console should show secrets being created and deleted, with a lifetime of around a minute. No plaintext secret

--- a/pkg/cloud/services/secretsmanager/secret_fetch_script.go
+++ b/pkg/cloud/services/secretsmanager/secret_fetch_script.go
@@ -46,7 +46,7 @@ if [ "{{.Endpoint}}" != "" ]; then
 fi
 SECRET_PREFIX="{{.SecretPrefix}}"
 CHUNKS="{{.Chunks}}"
-FILE="/etc/secret-userdata.txt"
+FILE="/etc/cloud/cloud.cfg.d/99_kubeadm_bootstrap.cfg"
 FINAL_INDEX=$((CHUNKS - 1))
 
 # Log an error and exit.

--- a/pkg/cloud/services/ssm/secret_fetch_script.go
+++ b/pkg/cloud/services/ssm/secret_fetch_script.go
@@ -46,7 +46,7 @@ if [ "{{.Endpoint}}" != "" ]; then
 fi
 SECRET_PREFIX="{{.SecretPrefix}}"
 CHUNKS="{{.Chunks}}"
-FILE="/etc/secret-userdata.txt"
+FILE="/etc/cloud/cloud.cfg.d/99_kubeadm_bootstrap.cfg"
 FINAL_INDEX=$((CHUNKS - 1))
 
 # Log an error and exit.

--- a/pkg/internal/mime/mime.go
+++ b/pkg/internal/mime/mime.go
@@ -26,15 +26,7 @@ import (
 	"strings"
 )
 
-const (
-	includePart = "file:///etc/secret-userdata.txt\n"
-)
-
 var (
-	includeType = textproto.MIMEHeader{
-		"content-type": {"text/x-include-url"},
-	}
-
 	boothookType = textproto.MIMEHeader{
 		"content-type": {"text/cloud-boothook"},
 	}
@@ -79,16 +71,6 @@ func GenerateInitDocument(secretPrefix string, chunks int32, region string, endp
 		return []byte{}, err
 	}
 	_, err = scriptWriter.Write(scriptBuf.Bytes())
-	if err != nil {
-		return []byte{}, err
-	}
-
-	includeWriter, err := mpWriter.CreatePart(includeType)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	_, err = includeWriter.Write([]byte(includePart))
 	if err != nil {
 		return []byte{}, err
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

The boothook fetches sensitive user-data from an AWS service (Secrets Manager, or SSM Parameter Store). This PR changes the mechanism by the way this user-data is passed to cloud-init once it's fetched.

Previously, the boothook wrote the sensitive user-data to `/etc/secret-userdata.txt`, and cloud-init read it via an `#include` directive.  Now, the boothook writes it to `/etc/cloud/cloud.cfg.d/99_kubeadm_bootstrap.cfg`. The directory is a [well-documented configuration source](https://cloudinit.readthedocs.io/en/latest/explanation/configuration.html#base-configuration) used by cloud-init, and exists wherever cloud-init is installed. The file is given the prefix `99_` to give it high priority over other configuration in that directory.
 
Previously, cloud-init read sensitive user-data from `/etc/secret-userdata.txt` via an `#include` directive. Now, it reads the sensitive user-data simply because it is located in the `/etc/cloud/cloud.cfg.d` directory. Therefore, the `#include` directive is no longer used, and is removed.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4745

**Special notes for your reviewer**:

If we merge this PR, we can revert the workaround introduced in https://github.com/kubernetes-sigs/image-builder/pull/406.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changes the mechanism to pass sensitive user-data to cloud-init, making CAPA compatible with cloud-init v23.3 and newer.
```
