### PR TITLE
⚠️ Stop serving v1beta1 API types

### DIFF
--- a/api/v1beta1/awscluster_types.go
+++ b/api/v1beta1/awscluster_types.go
@@ -222,6 +222,7 @@ type S3Bucket struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsclusters,scope=Namespaced,categories=cluster-api,shortName=awsc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSCluster belongs"
@@ -240,6 +241,7 @@ type AWSCluster struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSClusterList contains a list of AWSCluster.
 type AWSClusterList struct {

--- a/api/v1beta1/awsclustertemplate_types.go
+++ b/api/v1beta1/awsclustertemplate_types.go
@@ -28,6 +28,7 @@ type AWSClusterTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsclustertemplates,scope=Namespaced,categories=cluster-api,shortName=awsct
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of AWSClusterTemplate"
 

--- a/api/v1beta1/awsidentity_types.go
+++ b/api/v1beta1/awsidentity_types.go
@@ -70,6 +70,7 @@ type AWSRoleSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsclusterstaticidentities,scope=Cluster,categories=cluster-api,shortName=awssi
 
 // AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API
@@ -83,6 +84,7 @@ type AWSClusterStaticIdentity struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSClusterStaticIdentityList contains a list of AWSClusterStaticIdentity.
 type AWSClusterStaticIdentityList struct {
@@ -103,6 +105,7 @@ type AWSClusterStaticIdentitySpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsclusterroleidentities,scope=Cluster,categories=cluster-api,shortName=awsri
 
 // AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API
@@ -116,6 +119,7 @@ type AWSClusterRoleIdentity struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSClusterRoleIdentityList contains a list of AWSClusterRoleIdentity.
 type AWSClusterRoleIdentityList struct {
@@ -146,6 +150,7 @@ type AWSClusterRoleIdentitySpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsclustercontrolleridentities,scope=Cluster,categories=cluster-api,shortName=awsci
 
 // AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API
@@ -159,6 +164,7 @@ type AWSClusterControllerIdentity struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSClusterControllerIdentityList contains a list of AWSClusterControllerIdentity.
 type AWSClusterControllerIdentityList struct {

--- a/api/v1beta1/awsmachine_types.go
+++ b/api/v1beta1/awsmachine_types.go
@@ -258,6 +258,7 @@ type AWSMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsmachines,scope=Namespaced,categories=cluster-api,shortName=awsm
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSMachine belongs"
@@ -286,6 +287,7 @@ func (r *AWSMachine) SetConditions(conditions clusterv1.Conditions) {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSMachineList contains a list of Amazon EC2 machines.
 type AWSMachineList struct {

--- a/api/v1beta1/awsmachinetemplate_types.go
+++ b/api/v1beta1/awsmachinetemplate_types.go
@@ -38,6 +38,7 @@ type AWSMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsmachinetemplates,scope=Namespaced,categories=cluster-api,shortName=awsmt
 
 // AWSMachineTemplate is the schema for the Amazon EC2 Machine Templates API.
@@ -50,6 +51,7 @@ type AWSMachineTemplate struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSMachineTemplateList contains a list of AWSMachineTemplate.
 type AWSMachineTemplateList struct {

--- a/bootstrap/eks/api/v1beta1/eksconfig_types.go
+++ b/bootstrap/eks/api/v1beta1/eksconfig_types.go
@@ -88,6 +88,7 @@ type EKSConfigStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=eksconfigs,scope=Namespaced,categories=cluster-api,shortName=eksc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Bootstrap configuration is ready"
@@ -113,6 +114,7 @@ func (r *EKSConfig) SetConditions(conditions clusterv1.Conditions) {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // EKSConfigList contains a list of EKSConfig.
 type EKSConfigList struct {

--- a/bootstrap/eks/api/v1beta1/eksconfigtemplate_types.go
+++ b/bootstrap/eks/api/v1beta1/eksconfigtemplate_types.go
@@ -31,6 +31,7 @@ type EKSConfigTemplateResource struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=eksconfigtemplates,scope=Namespaced,categories=cluster-api,shortName=eksct
 
 // EKSConfigTemplate is the Amazon EKS Bootstrap Configuration Template API.
@@ -42,6 +43,7 @@ type EKSConfigTemplate struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // EKSConfigTemplateList contains a list of Amazon EKS Bootstrap Configuration Templates.
 type EKSConfigTemplateList struct {

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigs.yaml
@@ -165,7 +165,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigtemplates.yaml
@@ -102,7 +102,7 @@ spec:
             - template
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     schema:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1620,7 +1620,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
@@ -107,7 +107,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
@@ -165,7 +165,7 @@ spec:
             - roleARN
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -860,7 +860,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
@@ -115,7 +115,7 @@ spec:
             - secretRef
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -442,7 +442,7 @@ spec:
             - template
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources: {}
   - additionalPrinterColumns:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsfargateprofiles.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsfargateprofiles.yaml
@@ -187,7 +187,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -481,7 +481,7 @@ spec:
                 type: integer
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -485,7 +485,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -420,7 +420,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -462,7 +462,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
@@ -276,6 +276,7 @@ type AWSManagedControlPlaneStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsmanagedcontrolplanes,shortName=awsmcp,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AWSManagedControl belongs"
@@ -294,6 +295,7 @@ type AWSManagedControlPlane struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSManagedControlPlaneList contains a list of Amazon EKS Managed Control Planes.
 type AWSManagedControlPlaneList struct {

--- a/exp/api/v1beta1/awsfargateprofile_types.go
+++ b/exp/api/v1beta1/awsfargateprofile_types.go
@@ -123,6 +123,7 @@ type FargateProfileStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsfargateprofiles,scope=Namespaced,categories=cluster-api,shortName=awsfp
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="AWSFargateProfile ready status"
@@ -149,6 +150,7 @@ func (r *AWSFargateProfile) SetConditions(conditions clusterv1.Conditions) {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSFargateProfileList contains a list of FargateProfiles.
 type AWSFargateProfileList struct {

--- a/exp/api/v1beta1/awsmachinepool_types.go
+++ b/exp/api/v1beta1/awsmachinepool_types.go
@@ -183,6 +183,7 @@ type AWSMachinePoolInstanceStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=awsmachinepools,scope=Namespaced,categories=cluster-api,shortName=awsmp
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
@@ -201,6 +202,7 @@ type AWSMachinePool struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSMachinePoolList contains a list of AWSMachinePool.
 type AWSMachinePoolList struct {

--- a/exp/api/v1beta1/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta1/awsmanagedmachinepool_types.go
@@ -234,6 +234,7 @@ type AWSManagedMachinePoolStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:resource:path=awsmanagedmachinepools,scope=Namespaced,categories=cluster-api,shortName=awsmmp
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="MachinePool ready status"
@@ -259,6 +260,7 @@ func (r *AWSManagedMachinePool) SetConditions(conditions clusterv1.Conditions) {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // AWSManagedMachinePoolList contains a list of AWSManagedMachinePools.
 type AWSManagedMachinePoolList struct {


### PR DESCRIPTION
We've been maintaining conversion from v1beta1 from more than 1 year, stop serving these types in the next release, and remove them in 2.5

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

/kind api-change


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
v1beta1 types are not going to be served any longer and will be removed in the next release
```
