### PR TITLE
📖 Improve ROSA quickstart with MachinePool and troubleshooting guide

### DIFF
--- a/docs/book/src/topics/rosa/enabling.md
+++ b/docs/book/src/topics/rosa/enabling.md
@@ -4,5 +4,34 @@ To enable support for ROSA clusters, the ROSA feature flag must be set to true. 
 
 ```shell
 export EXP_ROSA="true"
+export EXP_MACHINE_POOL="true"
 clusterctl init --infrastructure aws
+```
+
+## Troubleshooting
+To check the feature-gates for the Cluster API controller run the following command:
+
+```shell
+$ kubectl get deploy capi-controller-manager -n capi-system -o yaml
+```
+the feature gate container arg should have `MachinePool=true` as shown below.
+
+```yaml
+spec:
+  containers:
+  - args:
+    - --feature-gates=MachinePool=true,ClusterTopology=true,...
+```
+
+To check the feature-gates for the Cluster API AWS controller run the following command:
+```shell
+$ kubectl get deploy capa-controller-manager -n capa-system -o yaml
+```
+the feature gate arg should have `ROSA=true` as shown below.
+
+```yaml
+spec:
+  containers:
+  - args:
+    - --feature-gates=ROSA=true,...
 ```


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Enable the machinePool feature in order to be able to use ROSA machine pool feature

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4774

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
