### PR TITLE
:bug: Use Kube v1.29.1 for EKS e2e tests

### DIFF
--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -116,7 +116,7 @@ providers:
         targetName: "cluster-template-eks-control-plane-only-legacy.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.24.4"
+  KUBERNETES_VERSION: "v1.29.1"
   KUBERNETES_VERSION_MANAGEMENT: "v1.28.0" # Kind bootstrap
   EXP_MACHINE_POOL: "true"
   EXP_CLUSTER_RESOURCE_SET: "true"
@@ -126,11 +126,11 @@ variables:
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
   EXP_EKS_IAM: "false"
   EXP_EKS_ADD_ROLES: "false"
-  VPC_ADDON_VERSION: "v1.11.4-eksbuild.1"
-  COREDNS_ADDON_VERSION: "v1.8.7-eksbuild.3"
+  VPC_ADDON_VERSION: "v1.16.2-eksbuild.1"
+  COREDNS_ADDON_VERSION: "v1.11.1-eksbuild.6"
   COREDNS_ADDON_CONFIGURATION: '{"replicaCount":3}'
-  KUBE_PROXY_ADDON_VERSION: "v1.24.7-eksbuild.2"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "1.24.4"
+  KUBE_PROXY_ADDON_VERSION: "v1.29.0-eksbuild.2"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "1.29.1"
   IP_FAMILY: "IPv4"
   CAPA_LOGLEVEL: "4"
   EXP_EXTERNAL_RESOURCE_GC: "true"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

-->

**What this PR does / why we need it**:

Kubernetes v1.24 is entering into an extended support window that adds additional cost for EKS clusters. This PR moves to v1.29.1, the latest version of Kubernetes, in order to avoid that infrastructure cost.

Standard EKS support for this version ends March 23, 2026.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4777 

**Special notes for your reviewer**:

**Checklist**:
- [x] squashed commits
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds or updates e2e tests

**Release note**:

```release-note
NONE
```
