### PR TITLE
:sparkles: *: add OWNERS for ROSA

### DIFF
--- a/config/crd/bases/OWNERS
+++ b/config/crd/bases/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+filters:
+  "^.*rosa.*\\.yaml$":
+    approvers:
+      - muraee
+      - stevekuznetsov

--- a/controllers/OWNERS
+++ b/controllers/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+filters:
+  "^rosa.*\\.go$":
+    approvers:
+      - muraee
+      - stevekuznetsov

--- a/controlplane/rosa/OWNERS
+++ b/controlplane/rosa/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+approvers:
+  - muraee
+  - stevekuznetsov

--- a/docs/book/src/topics/rosa/OWNERS
+++ b/docs/book/src/topics/rosa/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+approvers:
+  - muraee
+  - stevekuznetsov

--- a/exp/api/v1beta2/OWNERS
+++ b/exp/api/v1beta2/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+filters:
+  "^(rosa|zz_).*\\.go$":
+    approvers:
+      - muraee
+      - stevekuznetsov

--- a/exp/controllers/OWNERS
+++ b/exp/controllers/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+filters:
+  "^rosa.*\\.go$":
+    approvers:
+      - muraee
+      - stevekuznetsov

--- a/pkg/cloud/scope/OWNERS
+++ b/pkg/cloud/scope/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+filters:
+  "^rosa.*\\.go$":
+    approvers:
+      - muraee
+      - stevekuznetsov

--- a/pkg/rosa/OWNERS
+++ b/pkg/rosa/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+approvers:
+  - muraee
+  - stevekuznetsov

--- a/templates/OWNERS
+++ b/templates/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: <https://git.k8s.io/community/contributors/guide/owners.md>
+
+filters:
+  "^.*rosa.*\\.yaml$":
+    approvers:
+      - muraee
+      - stevekuznetsov


### PR DESCRIPTION
The folks working on building out ROSA functionality would like to be able to iterate without needing to pull in top-level approvers for ROSA-isolated changes.

```release-note
NONE
```