### PR TITLE
✨ Filter CNI subnets when creating EKS NodeGroup

### DIFF
--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -510,6 +510,17 @@ func (s Subnets) FilterPrivate() (res Subnets) {
 	return
 }
 
+// FilterNonCni returns the subnets that are NOT intended for usage with the CNI pod network
+// (i.e. do NOT have the `sigs.k8s.io/cluster-api-provider-aws/association=secondary` tag).
+func (s Subnets) FilterNonCni() (res Subnets) {
+	for _, x := range s {
+		if x.Tags[NameAWSSubnetAssociation] != SecondarySubnetTagValue {
+			res = append(res, x)
+		}
+	}
+	return
+}
+
 // FilterPublic returns a slice containing all subnets marked as public.
 func (s Subnets) FilterPublic() (res Subnets) {
 	for _, x := range s {

--- a/pkg/cloud/scope/shared.go
+++ b/pkg/cloud/scope/shared.go
@@ -122,6 +122,7 @@ func (p *defaultSubnetPlacementStrategy) getSubnetsForAZs(azs []string, controlP
 				subnets = subnets.FilterPublic()
 			case expinfrav1.AZSubnetTypePrivate:
 				subnets = subnets.FilterPrivate()
+				subnets = subnets.FilterNonCni()
 			}
 		}
 		if len(subnets) == 0 {

--- a/pkg/cloud/scope/shared_test.go
+++ b/pkg/cloud/scope/shared_test.go
@@ -182,6 +182,14 @@ func TestSubnetPlacement(t *testing.T) {
 					AvailabilityZone: "eu-west-1c",
 					IsPublic:         false,
 				},
+				infrav1.SubnetSpec{
+					ID:               "subnet-az6",
+					AvailabilityZone: "eu-west-1c",
+					IsPublic:         false,
+					Tags: infrav1.Tags{
+						infrav1.NameAWSSubnetAssociation: infrav1.SecondarySubnetTagValue,
+					},
+				},
 			},
 			logger:            logger.NewLogger(klog.Background()),
 			expectedSubnetIDs: []string{"subnet-az3"},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Not sure if this is a bug or a feature. I don't think it's intended for nodes to land on the subnets intended for CNI, but if it is then I can also change this PR to add another `AZSubnetType`.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests - _I've updated the unit test_
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Exclude CNI subnets when creating EKS NodeGroup with private availability zone subnet type.
```
