### PR TITLE
🐛 fix: staging image build failed due to toolchain directive

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,15 +2,16 @@
 timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - TAG=$_GIT_TAG
     - PULL_BASE_REF=$_PULL_BASE_REF
-    args:
-    - release-staging
+    - DOCKER_BUILDKIT=1
+    args: ['release-staging', '-j', '8', '-O']
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/cluster-api-provider-aws/v2
 
 go 1.21
 
-toolchain go1.21.7
-
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.3
 
 require (

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/cluster-api-provider-aws/hack/tools
 
 go 1.21
 
-toolchain go1.21.7
-
 require (
 	github.com/a8m/envsubst v1.4.2
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

When doing a recent release of CAPA we encountered an issue with the build of the staging image:

```
/workspace/hack/tools/go.mod:5: unknown directive: toolchain
go: errors parsing go.mod:
```

([source](https://console.cloud.google.com/cloud-build/builds;region=global/1057f825-10b2-44d4-9049-b5381d6b9f16?project=k8s-staging-cluster-api-aws))

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

We'll need to update the cloud build config on **main** as well.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove toolchain directive and updated build image
```
