### PR TITLE
:sparkles: return set of issues when EKS Node Group is in degraded state

### DIFF
--- a/pkg/cloud/services/eks/nodegroup_test.go
+++ b/pkg/cloud/services/eks/nodegroup_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eks
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+)
+
+func TestSetStatus(t *testing.T) {
+	g := NewWithT(t)
+	degraded := eks.NodegroupStatusDegraded
+	code := eks.NodegroupIssueCodeAsgInstanceLaunchFailures
+	message := "VcpuLimitExceeded"
+	resourceID := "my-worker-nodes"
+
+	s := &NodegroupService{
+		scope: &scope.ManagedMachinePoolScope{
+			ManagedMachinePool: &v1beta2.AWSManagedMachinePool{
+				Status: v1beta2.AWSManagedMachinePoolStatus{
+					Ready: false,
+				},
+			},
+		},
+	}
+
+	issue := &eks.Issue{
+		Code:        &code,
+		Message:     &message,
+		ResourceIds: []*string{&resourceID},
+	}
+	ng := &eks.Nodegroup{
+		Status: &degraded,
+		Health: &eks.NodegroupHealth{
+			Issues: []*eks.Issue{issue},
+		},
+	}
+
+	err := s.setStatus(ng)
+	g.Expect(err).ToNot(BeNil())
+	// ensure machine pool status values are set as expected
+	g.Expect(*s.scope.ManagedMachinePool.Status.FailureMessage).To(ContainSubstring(issue.GoString()))
+	g.Expect(s.scope.ManagedMachinePool.Status.Ready).To(BeFalse())
+	g.Expect(*s.scope.ManagedMachinePool.Status.FailureReason).To(Equal(capierrors.InsufficientResourcesMachineError))
+}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
We need this PR because when node groups go in to a degraded state no relevant information is returned to the user.  This PR implements code that returns a set of health issues reported for the given node group so a user can have an understanding of what went wrong. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Return detailed error message to user when EKS NodeGroup goes in to a Degraded state
```
