### PR TITLE
🐛 [RELEASE-2.3] Changes to release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 # https://suva.sh/posts/well-documented-makefiles
 
 # Go
-GO_VERSION ?=1.21.7
-GO_CONTAINER_IMAGE ?= public.ecr.aws/docker/library/golang:$(GO_VERSION)
+GO_VERSION ?=1.21.5
+GO_CONTAINER_IMAGE ?= golang:$(GO_VERSION)
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts
@@ -610,12 +610,11 @@ release-binary: $(RELEASE_DIR) versions.mk build-toolchain ## Release binary
 		-e CGO_ENABLED=0 \
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
-		--mount=source=gocache,target=/go/pkg/mod \
-		--mount=source=gocache,target=/root/.cache/go-build \
+		-e GOCACHE=/tmp/ \
+		--user $$(id -u):$$(id -g) \
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
-		$(TOOLCHAIN_IMAGE) \
-		git config --global --add safe.directory /workspace; \
+		$(GO_CONTAINER_IMAGE) \
 		go build -ldflags '$(LDFLAGS) -extldflags "-static"' \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH)$(EXT) $(RELEASE_BINARY)
 

--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240210-29014a6e3a'
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240210-29014a6e3a'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/docs/triage-party/Dockerfile
+++ b/docs/triage-party/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-FROM golang:1.21.7  as builder
+FROM golang:1.21.5  as builder
 
 RUN go get github.com/google/triage-party/cmd/server
 RUN go install github.com/google/triage-party/cmd/server@latest

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/cluster-api-provider-aws/v2
 
 go 1.21
 
+toolchain go1.21.5
+
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.3
 
 require (

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -29,9 +29,9 @@ EOF
   fi
 
   local go_version
-  IFS=" " read -ra go_version <<< "$(go version)"
+  IFS=" " read -ra go_version <<<"$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.21.7
+  minimum_go_version=go1.21.5
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/cluster-api-provider-aws/hack/tools
 
 go 1.21
 
+toolchain go1.21.5
+
 require (
 	github.com/a8m/envsubst v1.4.2
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.21.7"
+    GO_VERSION = "1.21.5"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Changes from the failed releases:

- Including the toolchain directive
- Bumping the GCB image so that it has a newer Go version (that understands the toolchain directive)
- Changing the clusterawsadm build to be inline with CAPI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Relates #4812 

**Special notes for your reviewer**:

This re-adds some of the changes from #4803 (by @damdo ) with changes to GCB.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Various changes to the releases process.
```
