### PR TITLE
:bug: Handle nil ControlPlaneRef

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -1231,6 +1231,10 @@ func (r *AWSMachineReconciler) ensureInstanceMetadataOptions(ec2svc services.EC2
 func (r *AWSMachineReconciler) getControlPlane(ctx context.Context, log *logger.Logger, cluster *clusterv1.Cluster) (*unstructured.Unstructured, error) {
 	var ns string
 
+	if cluster.Spec.ControlPlaneRef == nil {
+		return &unstructured.Unstructured{}, nil
+	}
+
 	if ns = cluster.Spec.ControlPlaneRef.Namespace; ns == "" {
 		ns = cluster.Namespace
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Cluster.Spec.ControlPlaneRef is an optional field. getControlPlaneRef panics if it is nil. Handle this by supplying an empty struct, which appears to be expected based on the unit test:
https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/bc1d3b165d13afb69f523d1172f0f5415392104a/controllers/awsmachine_controller_test.go#L421



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4818

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
