### PR TITLE
:bug: fix upgrade of managed node groups using custom AMIs

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -348,6 +348,12 @@ func (s *NodegroupService) reconcileNodegroupVersion(ng *eks.Nodegroup) error {
 		var updateMsg string
 		// Either update k8s version or AMI version
 		switch {
+		case statusLaunchTemplateVersion != nil && *statusLaunchTemplateVersion != *ngLaunchTemplateVersion:
+			input.LaunchTemplate = &eks.LaunchTemplateSpecification{
+				Id:      s.scope.ManagedMachinePool.Status.LaunchTemplateID,
+				Version: statusLaunchTemplateVersion,
+			}
+			updateMsg = fmt.Sprintf("to launch template version %s", *statusLaunchTemplateVersion)
 		case specVersion != nil && ngVersion.LessThan(specVersion):
 			// NOTE: you can only upgrade increments of minor versions. If you want to upgrade 1.14 to 1.16 we
 			// need to go 1.14-> 1.15 and then 1.15 -> 1.16.
@@ -356,12 +362,6 @@ func (s *NodegroupService) reconcileNodegroupVersion(ng *eks.Nodegroup) error {
 		case specAMI != nil && *specAMI != ngAMI:
 			input.ReleaseVersion = specAMI
 			updateMsg = fmt.Sprintf("to AMI version %s", *input.ReleaseVersion)
-		case statusLaunchTemplateVersion != nil && *statusLaunchTemplateVersion != *ngLaunchTemplateVersion:
-			input.LaunchTemplate = &eks.LaunchTemplateSpecification{
-				Id:      s.scope.ManagedMachinePool.Status.LaunchTemplateID,
-				Version: statusLaunchTemplateVersion,
-			}
-			updateMsg = fmt.Sprintf("to launch template version %s", *statusLaunchTemplateVersion)
 		}
 
 		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {


### PR DESCRIPTION
Hello all,

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When using a custom AMI with a launch template, node group upgrades get stuck with the following error message:
```
E0227 15:07:47.415572       1 controller.go:329] "Reconciler error" err=<
	failed to reconcile machine pool for AWSManagedMachinePool dev/pocg1eks80-mmp-infra: failed to reconcile nodegroup version: failed to update EKS nodegroup: InvalidParameterException: Launch template details can't be null for Custom ami type node group
	{
	  RespMetadata: {
	    StatusCode: 400,
	    RequestID: "e8b04ccf-56aa-4bab-b313-0f4b25137e5c"
	  },
	  Message_: "Launch template details can't be null for Custom ami type node group"
	}
 > controller="awsmanagedmachinepool" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSManagedMachinePool" AWSManagedMachinePool="dev/pocg1eks80-mmp-infra" namespace="dev" name="pocg1eks80-mmp-infra" reconcileID="441e08da-f7ba-4fde-af7b-e3eb250aae02"
```

This is because the `specVersion` is checked first in the switch/case, causing the `UpdateNodegroupVersion` function to be called without the launch template details.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/91941d950a27f94c078e4797c12a856f416b39a7/pkg/cloud/services/eks/nodegroup.go#L350-L365

Changing the order of the switch/case makes it possible to upgrade a node group using a custom launch template.

This would fix #4327

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release notes:**
```release-note
fix upgrade of managed node groups using custom AMIs
```
