### PR TITLE
✨ ROSA: Reconcile ROSAMachinePool.spec.ProviderIDList

### DIFF
--- a/pkg/cloud/scope/machine.go
+++ b/pkg/cloud/scope/machine.go
@@ -19,7 +19,6 @@ package scope
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -142,7 +141,7 @@ func (m *MachineScope) GetProviderID() string {
 
 // SetProviderID sets the AWSMachine providerID in spec.
 func (m *MachineScope) SetProviderID(instanceID, availabilityZone string) {
-	providerID := fmt.Sprintf("aws:///%s/%s", availabilityZone, instanceID)
+	providerID := GenerateProviderID(availabilityZone, instanceID)
 	m.AWSMachine.Spec.ProviderID = ptr.To[string](providerID)
 }
 

--- a/pkg/cloud/scope/providerid.go
+++ b/pkg/cloud/scope/providerid.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scope
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -123,4 +124,15 @@ func (p *ProviderID) Validate() bool {
 // Deprecated: This method is going to be removed in a future release.
 func (p *ProviderID) IndexKey() string {
 	return p.String()
+}
+
+// ProviderIDPrefix is the prefix of AWS resource IDs to form the Kubernetes Provider ID.
+// NOTE: this format matches the 2 slashes format used in cloud-provider and cluster-autoscaler.
+const ProviderIDPrefix = "aws://"
+
+// GenerateProviderID generates a valid AWS Node/Machine ProviderID field.
+//
+// By default, the last id provided is used as identifier (last part).
+func GenerateProviderID(ids ...string) string {
+	return fmt.Sprintf("%s/%s", ProviderIDPrefix, strings.Join(ids, "/"))
 }

--- a/pkg/cloud/scope/providerid_test.go
+++ b/pkg/cloud/scope/providerid_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGenerateProviderID(t *testing.T) {
+	testCases := []struct {
+		ids []string
+
+		expectedProviderID string
+	}{
+		{
+			ids: []string{
+				"eu-west-1a",
+				"instance-id",
+			},
+			expectedProviderID: "aws:///eu-west-1a/instance-id",
+		},
+		{
+			ids: []string{
+				"eu-west-1a",
+				"test-id1",
+				"test-id2",
+				"instance-id",
+			},
+			expectedProviderID: "aws:///eu-west-1a/test-id1/test-id2/instance-id",
+		},
+	}
+
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		providerID := GenerateProviderID(tc.ids...)
+
+		g.Expect(providerID).To(Equal(tc.expectedProviderID))
+	}
+}

--- a/pkg/cloud/scope/rosamachinepool.go
+++ b/pkg/cloud/scope/rosamachinepool.go
@@ -19,13 +19,16 @@ package scope
 import (
 	"context"
 
+	awsclient "github.com/aws/aws-sdk-go/aws/client"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/throttle"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -42,6 +45,8 @@ type RosaMachinePoolScopeParams struct {
 	RosaMachinePool *expinfrav1.ROSAMachinePool
 	MachinePool     *expclusterv1.MachinePool
 	ControllerName  string
+
+	Endpoints []ServiceEndpoint
 }
 
 // NewRosaMachinePoolScope creates a new Scope from the supplied parameters.
@@ -70,7 +75,7 @@ func NewRosaMachinePoolScope(params RosaMachinePoolScopeParams) (*RosaMachinePoo
 		return nil, errors.Wrap(err, "failed to init MachinePool patch helper")
 	}
 
-	return &RosaMachinePoolScope{
+	scope := &RosaMachinePoolScope{
 		Logger:                     *params.Logger,
 		Client:                     params.Client,
 		patchHelper:                ammpHelper,
@@ -81,8 +86,21 @@ func NewRosaMachinePoolScope(params RosaMachinePoolScopeParams) (*RosaMachinePoo
 		RosaMachinePool: params.RosaMachinePool,
 		MachinePool:     params.MachinePool,
 		controllerName:  params.ControllerName,
-	}, nil
+	}
+
+	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, scope, params.ControlPlane.Spec.Region, params.Endpoints, params.Logger)
+	if err != nil {
+		return nil, errors.Errorf("failed to create aws session: %v", err)
+	}
+
+	scope.session = session
+	scope.serviceLimiters = serviceLimiters
+
+	return scope, nil
 }
+
+var _ cloud.Session = &RosaMachinePoolScope{}
+var _ cloud.SessionMetadata = &RosaMachinePoolScope{}
 
 // RosaMachinePoolScope defines the basic context for an actuator to operate upon.
 type RosaMachinePoolScope struct {
@@ -95,6 +113,9 @@ type RosaMachinePoolScope struct {
 	ControlPlane    *rosacontrolplanev1.ROSAControlPlane
 	RosaMachinePool *expinfrav1.ROSAMachinePool
 	MachinePool     *expclusterv1.MachinePool
+
+	session         awsclient.ConfigProvider
+	serviceLimiters throttle.ServiceLimiters
 
 	controllerName string
 }
@@ -137,6 +158,34 @@ func (s *RosaMachinePoolScope) ControllerName() string {
 
 func (s *RosaMachinePoolScope) GetSetter() conditions.Setter {
 	return s.RosaMachinePool
+}
+
+// ServiceLimiter implements cloud.Session.
+func (s *RosaMachinePoolScope) ServiceLimiter(service string) *throttle.ServiceLimiter {
+	if sl, ok := s.serviceLimiters[service]; ok {
+		return sl
+	}
+	return nil
+}
+
+// Session implements cloud.Session.
+func (s *RosaMachinePoolScope) Session() awsclient.ConfigProvider {
+	return s.session
+}
+
+// IdentityRef implements cloud.SessionMetadata.
+func (s *RosaMachinePoolScope) IdentityRef() *v1beta2.AWSIdentityReference {
+	return s.ControlPlane.Spec.IdentityRef
+}
+
+// InfraClusterName implements cloud.SessionMetadata.
+func (s *RosaMachinePoolScope) InfraClusterName() string {
+	return s.ControlPlane.Name
+}
+
+// Namespace implements cloud.SessionMetadata.
+func (s *RosaMachinePoolScope) Namespace() string {
+	return s.Cluster.Namespace
 }
 
 // RosaMchinePoolReadyFalse marks the ready condition false using warning if error isn't

--- a/pkg/rosa/helpers.go
+++ b/pkg/rosa/helpers.go
@@ -1,0 +1,23 @@
+package rosa
+
+import (
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// IsNodePoolReady checkes whether the nodepool is provisoned and all replicas are available.
+// If autosacling is enabled, NodePool must have replicas >= autosacling.MinReplica to be considered ready.
+func IsNodePoolReady(nodePool *cmv1.NodePool) bool {
+	if nodePool.Status().Message() != "" {
+		return false
+	}
+
+	if nodePool.Replicas() != 0 {
+		return nodePool.Replicas() == nodePool.Status().CurrentReplicas()
+	}
+
+	if nodePool.Autoscaling() != nil {
+		return nodePool.Status().CurrentReplicas() >= nodePool.Autoscaling().MinReplica()
+	}
+
+	return false
+}

--- a/pkg/rosa/versions.go
+++ b/pkg/rosa/versions.go
@@ -1,6 +1,7 @@
 package rosa
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/blang/semver"
@@ -27,7 +28,8 @@ func CheckExistingScheduledUpgrade(client *ocm.Client, cluster *cmv1.Cluster) (*
 // ScheduleControlPlaneUpgrade schedules a new control plane upgrade to the specified version at the specified time.
 func ScheduleControlPlaneUpgrade(client *ocm.Client, cluster *cmv1.Cluster, version string, nextRun time.Time) (*cmv1.ControlPlaneUpgradePolicy, error) {
 	// earliestNextRun is set to at least 5 min from now by the OCM API.
-	// we set it to 6 min here to account for latencty.
+	// Set our next run request to something slightly longer than 5min to make sure we account for the latency between when we send this
+	// request and when the server processes it.
 	earliestNextRun := time.Now().Add(time.Minute * 6)
 	if nextRun.Before(earliestNextRun) {
 		nextRun = earliestNextRun
@@ -43,6 +45,35 @@ func ScheduleControlPlaneUpgrade(client *ocm.Client, cluster *cmv1.Cluster, vers
 		return nil, err
 	}
 	return client.ScheduleHypershiftControlPlaneUpgrade(cluster.ID(), upgradePolicy)
+}
+
+// ScheduleNodePoolUpgrade schedules a new nodePool upgrade to the specified version at the specified time.
+func ScheduleNodePoolUpgrade(client *ocm.Client, clusterID string, nodePool *cmv1.NodePool, version string, nextRun time.Time) (*cmv1.NodePoolUpgradePolicy, error) {
+	// earliestNextRun is set to at least 5 min from now by the OCM API.
+	// Set our next run request to something slightly longer than 5min to make sure we account for the latency between when we send this
+	// request and when the server processes it.
+	earliestNextRun := time.Now().Add(time.Minute * 6)
+	if nextRun.Before(earliestNextRun) {
+		nextRun = earliestNextRun
+	}
+
+	upgradePolicy, err := cmv1.NewNodePoolUpgradePolicy().
+		UpgradeType(cmv1.UpgradeTypeNodePool).
+		NodePoolID(nodePool.ID()).
+		ScheduleType(cmv1.ScheduleTypeManual).
+		Version(version).
+		NextRun(nextRun).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	scheduledUpgrade, err := client.ScheduleNodePoolUpgrade(clusterID, nodePool.ID(), upgradePolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to schedule nodePool upgrade to version %s: %w", version, err)
+	}
+
+	return scheduledUpgrade, nil
 }
 
 // machinepools can be created with a minimal of two minor versions from the control plane.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
`spec.ProviderIDList` is required to fulfill CAPI MachniePool contract so the CAPI controller can match then to Nodes and report readiness.

depends on https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4804

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reconcile ROSAMachinePool.spec.ProviderIDList
```
