### PR TITLE
🐛 fix: s3 bucket in us-east-1 should not set location constraint

### DIFF
--- a/pkg/cloud/services/s3/s3.go
+++ b/pkg/cloud/services/s3/s3.go
@@ -38,6 +38,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/util/system"
 )
 
+// AWSDefaultRegion is the default AWS region.
+const AWSDefaultRegion string = "us-east-1"
+
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
 // One alternative is to have a large list of functions from the ec2 client.
@@ -223,11 +226,13 @@ func (s *Service) Delete(m *scope.MachineScope) error {
 }
 
 func (s *Service) createBucketIfNotExist(bucketName string) error {
-	input := &s3.CreateBucketInput{
-		Bucket: aws.String(bucketName),
-		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
+	input := &s3.CreateBucketInput{Bucket: aws.String(bucketName)}
+
+	// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#AmazonS3-CreateBucket-request-LocationConstraint.
+	if s.scope.Region() != AWSDefaultRegion {
+		input.CreateBucketConfiguration = &s3.CreateBucketConfiguration{
 			LocationConstraint: aws.String(s.scope.Region()),
-		},
+		}
 	}
 
 	_, err := s.S3Client.CreateBucket(input)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The following error is raised when creating a cluster in `us-east-1`:

```sh
E0229 16:32:03.857522 2077184 co[1]ntroller.go:329] "Reconciler error" err=<
	failed to reconcile S3 Bucket for AWSCluster openshift-cluster-api-guests/mrb-capa-00-gr9m7: ensuring bucket exists: creating S3 bucket: InvalidLocationConstraint: The specified location-constraint is not valid
		status code: 400, request id: 3QSJFBYM9H60N3D6, host id: 
 > controller="awscluster" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSCluster" AWSCluster="openshift-cluster-api-guests/mrb-capa-00-gr9m7" namespace="openshift-cluster-api-guests" name="mrb-capa-00-gr9m7" reconcileID="f6b8a66c-108b-4988-9047-0151511fb5bd" 
```

The location constraint must be null when creating buckets in the region `us-east-1`.

"Buckets in Region us-east-1 have a LocationConstraint of null."[1]

[1] https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html#API_GetBucketLocation_ResponseSyntax

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip location constraint configuration when creating a bucket on `us-east-1`.
```
