### PR TITLE
:sparkles: Add flags for leaderElection timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,20 +91,23 @@ func init() {
 }
 
 var (
-	enableLeaderElection     bool
-	leaderElectionNamespace  string
-	watchNamespace           string
-	watchFilterValue         string
-	profilerAddress          string
-	awsClusterConcurrency    int
-	instanceStateConcurrency int
-	awsMachineConcurrency    int
-	waitInfraPeriod          time.Duration
-	syncPeriod               time.Duration
-	webhookPort              int
-	webhookCertDir           string
-	healthAddr               string
-	serviceEndpoints         string
+	enableLeaderElection        bool
+	leaderElectionLeaseDuration time.Duration
+	leaderElectionRenewDeadline time.Duration
+	leaderElectionRetryPeriod   time.Duration
+	leaderElectionNamespace     string
+	watchNamespace              string
+	watchFilterValue            string
+	profilerAddress             string
+	awsClusterConcurrency       int
+	instanceStateConcurrency    int
+	awsMachineConcurrency       int
+	waitInfraPeriod             time.Duration
+	syncPeriod                  time.Duration
+	webhookPort                 int
+	webhookCertDir              string
+	healthAddr                  string
+	serviceEndpoints            string
 
 	// maxEKSSyncPeriod is the maximum allowed duration for the sync-period flag when using EKS. It is set to 10 minutes
 	// because during resync it will create a new AWS auth token which can a maximum life of 15 minutes and this ensures
@@ -170,6 +173,9 @@ func main() {
 		Scheme:                     scheme,
 		Metrics:                    diagnosticsOpts,
 		LeaderElection:             enableLeaderElection,
+		LeaseDuration:              &leaderElectionLeaseDuration,
+		RenewDeadline:              &leaderElectionRenewDeadline,
+		RetryPeriod:                &leaderElectionRetryPeriod,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaderElectionID:           "controller-leader-elect-capa",
 		LeaderElectionNamespace:    leaderElectionNamespace,
@@ -492,6 +498,27 @@ func initFlags(fs *pflag.FlagSet) {
 		"leader-elect",
 		false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.",
+	)
+
+	fs.DurationVar(
+		&leaderElectionLeaseDuration,
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)",
+	)
+
+	fs.DurationVar(
+		&leaderElectionRenewDeadline,
+		"leader-elect-renew-deadline",
+		10*time.Second,
+		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)",
+	)
+
+	fs.DurationVar(
+		&leaderElectionRetryPeriod,
+		"leader-elect-retry-period",
+		2*time.Second,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string)",
 	)
 
 	fs.StringVar(


### PR DESCRIPTION


<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Add flags on manager to configure leaseDuration, renewDeadline and RetryPeriod for leader election. Set defaults based on cluster-api. These flags can be useful when the cluster runs on a relatively slow etcd.


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [X] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)

**Release note**:
```release-note
add flags to manager for leaderElection timeouts
```
