### PR TITLE
✨ ROSA: Add additionalSecurityGroups field to ROSAMachinePool

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
@@ -47,6 +47,12 @@ spec:
           spec:
             description: RosaMachinePoolSpec defines the desired state of RosaMachinePool.
             properties:
+              additionalSecurityGroups:
+                description: AdditionalSecurityGroups is an optional set of security
+                  groups to associate with all node instances of the machine pool.
+                items:
+                  type: string
+                type: array
               autoRepair:
                 default: false
                 description: AutoRepair specifies whether health checks should be

--- a/exp/api/v1beta2/rosamachinepool_types.go
+++ b/exp/api/v1beta2/rosamachinepool_types.go
@@ -79,6 +79,13 @@ type RosaMachinePoolSpec struct {
 	// +optional
 	TuningConfigs []string `json:"tuningConfigs,omitempty"`
 
+	// AdditionalSecurityGroups is an optional set of security groups to associate
+	// with all node instances of the machine pool.
+	//
+	// +immutable
+	// +optional
+	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
+
 	// ProviderIDList contain a ProviderID for each machine instance that's currently managed by this machine pool.
 	// +optional
 	ProviderIDList []string `json:"providerIDList,omitempty"`

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -1105,6 +1105,11 @@ func (in *RosaMachinePoolSpec) DeepCopyInto(out *RosaMachinePoolSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalSecurityGroups != nil {
+		in, out := &in.AdditionalSecurityGroups, &out.AdditionalSecurityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ProviderIDList != nil {
 		in, out := &in.ProviderIDList, &out.ProviderIDList
 		*out = make([]string, len(*in))


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add additionalSecurityGroups field to ROSAMachinePool
```
