### PR TITLE
:seedling: Align dependabot config with upstream cluster-api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,31 @@
 version: 2
 updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+        interval: "weekly"
+    commit-message:
+        prefix: ":seedling:"
+    labels:
+      - "kind/cleanup"
+      - "area/ci"
+      - "ok-to-test"
+      - "release-note-none"
+
+  # Main Go module
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: ":seedling:"
     labels:
       - "kind/cleanup"
+      - "area/dependency"
+      - "ok-to-test"
+      - "release-note-none"
     groups:
       dependencies:
         patterns:
@@ -15,22 +33,33 @@ updates:
     ignore:
       # Ignore Cluster-API as its upgraded manually.
       - dependency-name: "sigs.k8s.io/cluster-api*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "go.etcd.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "google.golang.org/grpc"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
+      - dependency-name: "sigs.k8s.io/kustomize/api"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: ":seedling:"
     labels:
       - "kind/cleanup"
+      - "area/dependency"
+      - "ok-to-test"
+      - "release-note-none"
     groups:
       dependencies:
         patterns:
@@ -41,10 +70,14 @@ updates:
     directory: "/hack/tools"
     schedule:
       interval: "weekly"
+      day: "wednesday"
     commit-message:
       prefix: ":seedling:"
     labels:
       - "kind/cleanup"
+      - "area/dependency"
+      - "ok-to-test"
+      - "release-note-none"
     groups:
       dependencies:
         patterns:
@@ -52,35 +85,33 @@ updates:
     ignore:
       # Ignore Cluster-API as its upgraded manually.
       - dependency-name: "sigs.k8s.io/cluster-api*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
       - dependency-name: "k8s.io/*"
-      # Ignore controller-tools as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-tools"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "go.etcd.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "google.golang.org/grpc"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
+      - dependency-name: "sigs.k8s.io/kustomize/api"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
 
   - package-ecosystem: "docker"
     directory: "/hack/tools"
     schedule:
       interval: "weekly"
+      day: "wednesday"
     commit-message:
       prefix: ":seedling:"
     labels:
       - "kind/cleanup"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: ":seedling:"
-    labels:
-      - "kind/cleanup"
+      - "area/dependency"
+      - "ok-to-test"
+      - "release-note-none"
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

/kind cleanup

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
