### PR TITLE
:bug: Create a `aws.Config` with region to be able to work different AWS partition (like gov cloud or china AWS partition)

### DIFF
--- a/pkg/cloud/identity/identity_test.go
+++ b/pkg/cloud/identity/identity_test.go
@@ -61,6 +61,7 @@ func TestAWSStaticPrincipalTypeProvider(t *testing.T) {
 	roleProvider := &AWSRolePrincipalTypeProvider{
 		credentials:    nil,
 		Principal:      roleIdentity,
+		region:         "us-west-2",
 		sourceProvider: staticProvider,
 		stsClient:      stsMock,
 	}
@@ -78,6 +79,7 @@ func TestAWSStaticPrincipalTypeProvider(t *testing.T) {
 	roleProvider2 := &AWSRolePrincipalTypeProvider{
 		credentials:    nil,
 		Principal:      roleIdentity2,
+		region:         "us-west-2",
 		sourceProvider: roleProvider,
 		stsClient:      stsMock,
 	}

--- a/pkg/cloud/scope/session_test.go
+++ b/pkg/cloud/scope/session_test.go
@@ -228,7 +228,7 @@ func TestPrincipalParsing(t *testing.T) {
 				Namespace: "default",
 			},
 		},
-		AWSCluster: &infrav1.AWSCluster{},
+		AWSCluster: &infrav1.AWSCluster{Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}},
 	},
 	)
 
@@ -489,7 +489,7 @@ func TestPrincipalParsing(t *testing.T) {
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			tc.setup(t, k8sClient)
 			clusterScope.AWSCluster = &tc.awsCluster
-			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope, logger.NewLogger(klog.Background()))
+			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope, clusterScope.Region(), logger.NewLogger(klog.Background()))
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected an error but didn't get one")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When creating  `aws.Config` without specifying a region the AWS SDK will by default call AWS commercial partition (known as just `aws`) .

 If you wanna use a different AWS partition (https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html  and https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html )   like for example `aws-cn` and provide static access keys to the user that is in `aws-cn` partition then the controller fails with error since  AWS SDK tries to validate the access keys in `aws` commercial partition.
 ```
 
  > controller="awscluster" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSCluster" AWSCluster="org-giantswarm/galaxy" namespace="org-giantswarm" name="galaxy" reconcileID="e4da8234-95e0-476b-868f-d7c4aeda498c"
E0306 10:02:50.109642       1 controller.go:324] "Reconciler error" err=<
	error getting infra provider cluster or control plane object: failed to create aws session: Failed to retrieve identity credentials: InvalidClientTokenId: The security token included in the request is invalid.
		status code: 403, request id: 391bd0ff-52b9-412d-8d03-82aa8d720bd5
 > controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="org-giantswarm/galaxy-control-plane-12c432c9-qrtwx" namespace="org-giantswarm" name="galaxy-control-plane-12c432c9-qrtwx" reconcileID="74834d11-ff72-464a-b63c-df993020ad38"
E0306 10:02:50.187222       1 controller.go:324] "Reconciler error" err=<
	error getting infra provider cluster or control plane object: failed to create aws session: Failed to retrieve identity credentials: InvalidClientTokenId: The security token included in the request is invalid.
		status code: 403, request id: 63ba0c98-c34e-42c4-a276-4fbccc855908
 > controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="org-giantswarm/galaxy-control-plane-12c432c9-hpgm5" namespace="org-giantswarm" name="galaxy-control-plane-12c432c9-hpgm5" reconcileID="9246fa92-2b5f-40ab-8e82-5ca5cc464133"
E0306 10:02:50.202148       1 controller.go:324] "Reconciler error" err=<
	error getting infra provider cluster or control plane object: failed to create aws session: Failed to retrieve identity credentials: InvalidClientTokenId: The security token included in the request is invalid.
		status code: 403, request id: 2ff4274b-1075-454f-ad2a-9002de92f501
 > controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="org-giantswarm/galaxy-control-plane-12c432c9-bdtfw" namespace="org-giantswarm" name="galaxy-control-plane-12c432c9-bdtfw" reconcileID="80073767-a7ff-44b0-b866-7ef1d16c676d"
E0306 10:08:18.496207       1 controller.go:324] "Reconciler error" err=<
	failed to create scope: failed to create aws session: Failed to retrieve identity credentials: InvalidClientTokenId: The security token included in the request is invalid.
		status code: 403, request id: b1c30992-fdce-48e9-a66b-f951a4fd223d
	sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope.NewClusterScope
		/workspace/pkg/cloud/scope/cluster.go:76
	sigs.k8s.io/cluster-api-provider-aws/v2/controllers.(*AWSClusterReconciler).Reconcile
		/workspace/controllers/awscluster_controller.go:173
```
 
 When the `aws.Config` is created with the proper region then the AWS SDK will connect to the right aws partition and correctly check for the validity of the static access key. And this is exactly what this PR fixes
 

- [x] squashed commits

**Release note**:
```release-note
Create `aws.Config` with a region to be able to work with different AWS partitions
```
