### PR TITLE
✨ ROSA: Add additionalTags API field to ROSAMachinePool

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
@@ -53,6 +53,12 @@ spec:
                 items:
                   type: string
                 type: array
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags are user-defined tags to be added on the
+                  underlying EC2 instances associated with this machine pool.
+                type: object
               autoRepair:
                 default: false
                 description: AutoRepair specifies whether health checks should be
@@ -83,14 +89,13 @@ spec:
                 description: Labels specifies labels for the Kubernetes node objects
                 type: object
               nodeDrainGracePeriod:
-                description: NodeDrainGracePeriod is grace period for how long Pod
+                description: "NodeDrainGracePeriod is grace period for how long Pod
                   Disruption Budget-protected workloads will be respected during upgrades.
                   After this grace period, any workloads protected by Pod Disruption
                   Budgets that have not been successfully drained from a node will
-                  be forcibly evicted. The nodeDrainGracePeriod can be defined in
-                  minutes, hours ex; 30m, 10h. The max value can be assigned is 10080m|168h
-                  (1 week).
-                pattern: ^(([0-9])+[m|h])$
+                  be forcibly evicted. \n Valid values are from 0 to 1 week(10080m|168h)
+                  . 0 or empty value means that the MachinePool can be drained without
+                  any time limitation."
                 type: string
               nodePoolName:
                 description: NodePoolName specifies the name of the nodepool in Rosa

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -22558,7 +22558,7 @@ Tags
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta2.Tags">Tags
 (<code>map[string]string</code> alias)</p></h3>
 <p>
-(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSClusterSpec">AWSClusterSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.BuildParams">BuildParams</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.SecurityGroup">SecurityGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetSpec">SubnetSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.VPCSpec">VPCSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1.AWSIAMRoleSpec">AWSIAMRoleSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1.BootstrapUser">BootstrapUser</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1.AWSIAMRoleSpec">AWSIAMRoleSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1.BootstrapUser">BootstrapUser</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.OIDCIdentityProviderConfig">OIDCIdentityProviderConfig</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta2.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta2.OIDCIdentityProviderConfig">OIDCIdentityProviderConfig</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta2.RosaControlPlaneSpec">RosaControlPlaneSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachinePoolSpec">AWSMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AutoScalingGroup">AutoScalingGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.FargateProfileSpec">FargateProfileSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSMachinePoolSpec">AWSMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AutoScalingGroup">AutoScalingGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.FargateProfileSpec">FargateProfileSpec</a>)
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSClusterSpec">AWSClusterSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.BuildParams">BuildParams</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.SecurityGroup">SecurityGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetSpec">SubnetSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.VPCSpec">VPCSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1.AWSIAMRoleSpec">AWSIAMRoleSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1alpha1.BootstrapUser">BootstrapUser</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1.AWSIAMRoleSpec">AWSIAMRoleSpec</a>, <a href="#bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1.BootstrapUser">BootstrapUser</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta1.OIDCIdentityProviderConfig">OIDCIdentityProviderConfig</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta2.AWSManagedControlPlaneSpec">AWSManagedControlPlaneSpec</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta2.OIDCIdentityProviderConfig">OIDCIdentityProviderConfig</a>, <a href="#controlplane.cluster.x-k8s.io/v1beta2.RosaControlPlaneSpec">RosaControlPlaneSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachinePoolSpec">AWSMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.AutoScalingGroup">AutoScalingGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta1.FargateProfileSpec">FargateProfileSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSMachinePoolSpec">AWSMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSManagedMachinePoolSpec">AWSManagedMachinePoolSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AutoScalingGroup">AutoScalingGroup</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.FargateProfileSpec">FargateProfileSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.RosaMachinePoolSpec">RosaMachinePoolSpec</a>)
 </p>
 <p>
 <p>Tags defines a map of tags.</p>
@@ -25938,6 +25938,20 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>additionalTags</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.Tags">
+Tags
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdditionalTags are user-defined tags to be added on the underlying EC2 instances associated with this machine pool.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>autoRepair</code><br/>
 <em>
 bool
@@ -26011,6 +26025,24 @@ with all node instances of the machine pool.</p>
 <td>
 <em>(Optional)</em>
 <p>ProviderIDList contain a ProviderID for each machine instance that&rsquo;s currently managed by this machine pool.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeDrainGracePeriod</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeDrainGracePeriod is grace period for how long Pod Disruption Budget-protected workloads will be
+respected during upgrades. After this grace period, any workloads protected by Pod Disruption
+Budgets that have not been successfully drained from a node will be forcibly evicted.</p>
+<p>Valid values are from 0 to 1 week(10080m|168h) .
+0 or empty value means that the MachinePool can be drained without any time limitation.</p>
 </td>
 </tr>
 </table>
@@ -26233,6 +26265,20 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>additionalTags</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.Tags">
+Tags
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdditionalTags are user-defined tags to be added on the underlying EC2 instances associated with this machine pool.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>autoRepair</code><br/>
 <em>
 bool
@@ -26306,6 +26352,24 @@ with all node instances of the machine pool.</p>
 <td>
 <em>(Optional)</em>
 <p>ProviderIDList contain a ProviderID for each machine instance that&rsquo;s currently managed by this machine pool.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeDrainGracePeriod</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeDrainGracePeriod is grace period for how long Pod Disruption Budget-protected workloads will be
+respected during upgrades. After this grace period, any workloads protected by Pod Disruption
+Budgets that have not been successfully drained from a node will be forcibly evicted.</p>
+<p>Valid values are from 0 to 1 week(10080m|168h) .
+0 or empty value means that the MachinePool can be drained without any time limitation.</p>
 </td>
 </tr>
 </tbody>

--- a/exp/api/v1beta2/rosamachinepool_types.go
+++ b/exp/api/v1beta2/rosamachinepool_types.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -58,6 +59,11 @@ type RosaMachinePoolSpec struct {
 	// +optional
 	Taints []RosaTaint `json:"taints,omitempty"`
 
+	// AdditionalTags are user-defined tags to be added on the underlying EC2 instances associated with this machine pool.
+	// +immutable
+	// +optional
+	AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
+
 	// AutoRepair specifies whether health checks should be enabled for machines
 	// in the NodePool. The default is false.
 	// +kubebuilder:default=false
@@ -92,11 +98,13 @@ type RosaMachinePoolSpec struct {
 
 	// NodeDrainGracePeriod is grace period for how long Pod Disruption Budget-protected workloads will be
 	// respected during upgrades. After this grace period, any workloads protected by Pod Disruption
-	// Budgets that have not been successfully drained from a node will be forcibly evicted. The nodeDrainGracePeriod
-	// can be defined in minutes, hours ex; 30m, 10h. The max value can be assigned is 10080m|168h (1 week).
-	// +kubebuilder:validation:Pattern="^(([0-9])+[m|h])$"
+	// Budgets that have not been successfully drained from a node will be forcibly evicted.
+	//
+	// Valid values are from 0 to 1 week(10080m|168h) .
+	// 0 or empty value means that the MachinePool can be drained without any time limitation.
+	//
 	// +optional
-	NodeDrainGracePeriod string `json:"nodeDrainGracePeriod,omitempty"`
+	NodeDrainGracePeriod *metav1.Duration `json:"nodeDrainGracePeriod,omitempty"`
 }
 
 // RosaTaint represents a taint to be applied to a node.

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiv1beta2 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
@@ -1095,6 +1096,13 @@ func (in *RosaMachinePoolSpec) DeepCopyInto(out *RosaMachinePoolSpec) {
 		*out = make([]RosaTaint, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalTags != nil {
+		in, out := &in.AdditionalTags, &out.AdditionalTags
+		*out = make(apiv1beta2.Tags, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Autoscaling != nil {
 		in, out := &in.Autoscaling, &out.Autoscaling
 		*out = new(RosaMachinePoolAutoScaling)
@@ -1114,6 +1122,11 @@ func (in *RosaMachinePoolSpec) DeepCopyInto(out *RosaMachinePoolSpec) {
 		in, out := &in.ProviderIDList, &out.ProviderIDList
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.NodeDrainGracePeriod != nil {
+		in, out := &in.NodeDrainGracePeriod, &out.NodeDrainGracePeriod
+		*out = new(v1.Duration)
+		**out = **in
 	}
 }
 

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -2,10 +2,13 @@ package controllers
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
@@ -20,6 +23,12 @@ func TestNodePoolToRosaMachinePoolSpec(t *testing.T) {
 		AutoRepair:    true,
 		InstanceType:  "m5.large",
 		TuningConfigs: []string{"config1"},
+		NodeDrainGracePeriod: &metav1.Duration{
+			Duration: time.Minute * 10,
+		},
+		AdditionalTags: infrav1.Tags{
+			"tag1": "value1",
+		},
 	}
 
 	machinePoolSpec := expclusterv1.MachinePoolSpec{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:
- Add `additionalTags` API field to ROSAMachinePool
- use the correct type `metav1.Duration` for `NodeDrainGracePeriod` field
- fixed reconcileProviderIDList() listing terminated/stopped instances

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [x] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `additionalTags` API field to ROSAMachinePool
```
