### PR TITLE
✨ ROSA: Add ProvisionShardID API field to ROSAControlPlane

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
@@ -214,6 +214,13 @@ spec:
               oidcID:
                 description: The ID of the OpenID Connect Provider.
                 type: string
+              provisionShardID:
+                description: ProvisionShardID defines the shard where rosa control
+                  plane components will be hosted.
+                type: string
+                x-kubernetes-validations:
+                - message: provisionShardID is immutable
+                  rule: self == oldSelf
               region:
                 description: The AWS Region the cluster lives in.
                 type: string

--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -139,6 +139,12 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	// +optional
 	AuditLogRoleARN string `json:"auditLogRoleARN,omitempty"`
 
+	// ProvisionShardID defines the shard where rosa control plane components will be hosted.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="provisionShardID is immutable"
+	// +optional
+	ProvisionShardID string `json:"provisionShardID,omitempty"`
+
 	// CredentialsSecretRef references a secret with necessary credentials to connect to the OCM API.
 	// The secret should contain the following data keys:
 	// - ocmToken: eyJhbGciOiJIUzI1NiIsI....

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -615,6 +615,12 @@ func buildOCMClusterSpec(controPlaneSpec rosacontrolplanev1.RosaControlPlaneSpec
 		ocmClusterSpec.MinReplicas = computeAutoscaling.MinReplicas
 	}
 
+	if controPlaneSpec.ProvisionShardID != "" {
+		ocmClusterSpec.CustomProperties = map[string]string{
+			"provision_shard_id": controPlaneSpec.ProvisionShardID,
+		}
+	}
+
 	return ocmClusterSpec, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add `ProvisionShardID` API field to ROSAControlPlane
```
