### PR TITLE
🐛 fix: separate control plane logging and vpc config updates

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -121,6 +121,10 @@ func (s *Service) reconcileCluster(ctx context.Context) error {
 		return errors.Wrap(err, "failed reconciling cluster config")
 	}
 
+	if err := s.reconcileLogging(cluster.Logging); err != nil {
+		return errors.Wrap(err, "failed reconciling logging")
+	}
+
 	if err := s.reconcileEKSEncryptionConfig(cluster.EncryptionConfig); err != nil {
 		return errors.Wrap(err, "failed reconciling eks encryption config")
 	}
@@ -230,7 +234,7 @@ func makeEksEncryptionConfigs(encryptionConfig *ekscontrolplanev1.EncryptionConf
 	if encryptionConfig == nil {
 		return cfg
 	}
-	//TODO: change EncryptionConfig so that provider and resources are required  if encruptionConfig is specified
+	// TODO: change EncryptionConfig so that provider and resources are required  if encruptionConfig is specified
 	if encryptionConfig.Provider == nil || len(*encryptionConfig.Provider) == 0 {
 		return cfg
 	}
@@ -312,8 +316,8 @@ func makeEksLogging(loggingSpec *ekscontrolplanev1.ControlPlaneLoggingSpec) *eks
 	if loggingSpec == nil {
 		return nil
 	}
-	var on = true
-	var off = false
+	on := true
+	off := false
 	var enabledTypes []string
 	var disabledTypes []string
 
@@ -413,7 +417,7 @@ func (s *Service) createCluster(eksClusterName string) (*eks.Cluster, error) {
 		conditions.MarkTrue(s.scope.ControlPlane, ekscontrolplanev1.EKSControlPlaneCreatingCondition)
 		record.Eventf(s.scope.ControlPlane, "InitiatedCreateEKSControlPlane", "Initiated creation of a new EKS control plane %s", s.scope.KubernetesClusterName())
 		return true, nil
-	}, awserrors.ResourceNotFound); err != nil { //TODO: change the error that can be retried
+	}, awserrors.ResourceNotFound); err != nil { // TODO: change the error that can be retried
 		record.Warnf(s.scope.ControlPlane, "FailedCreateEKSControlPlane", "Failed to initiate creation of a new EKS control plane: %v", err)
 		return nil, errors.Wrapf(err, "failed to create EKS cluster")
 	}
@@ -449,11 +453,6 @@ func (s *Service) reconcileClusterConfig(cluster *eks.Cluster) error {
 	var needsUpdate bool
 	input := eks.UpdateClusterConfigInput{Name: aws.String(s.scope.KubernetesClusterName())}
 
-	if updateLogging := s.reconcileLogging(cluster.Logging); updateLogging != nil {
-		needsUpdate = true
-		input.Logging = updateLogging
-	}
-
 	updateVpcConfig, err := s.reconcileVpcConfig(cluster.ResourcesVpcConfig)
 	if err != nil {
 		return errors.Wrap(err, "couldn't create vpc config for cluster")
@@ -485,15 +484,39 @@ func (s *Service) reconcileClusterConfig(cluster *eks.Cluster) error {
 	return nil
 }
 
-func (s *Service) reconcileLogging(logging *eks.Logging) *eks.Logging {
+func (s *Service) reconcileLogging(logging *eks.Logging) error {
+	input := eks.UpdateClusterConfigInput{Name: aws.String(s.scope.KubernetesClusterName())}
+
 	for _, logSetup := range logging.ClusterLogging {
 		for _, l := range logSetup.Types {
 			enabled := s.scope.ControlPlane.Spec.Logging.IsLogEnabled(*l)
 			if enabled != *logSetup.Enabled {
-				return makeEksLogging(s.scope.ControlPlane.Spec.Logging)
+				input.Logging = makeEksLogging(s.scope.ControlPlane.Spec.Logging)
 			}
 		}
 	}
+
+	if input.Logging != nil {
+		if err := input.Validate(); err != nil {
+			return errors.Wrap(err, "created invalid UpdateClusterConfigInput")
+		}
+
+		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+			if _, err := s.EKSClient.UpdateClusterConfig(&input); err != nil {
+				if aerr, ok := err.(awserr.Error); ok {
+					return false, aerr
+				}
+				return false, err
+			}
+			conditions.MarkTrue(s.scope.ControlPlane, ekscontrolplanev1.EKSControlPlaneUpdatingCondition)
+			record.Eventf(s.scope.ControlPlane, "InitiatedUpdateEKSControlPlane", "Initiated logging update for EKS control plane %s", s.scope.KubernetesClusterName())
+			return true, nil
+		}); err != nil {
+			record.Warnf(s.scope.ControlPlane, "FailedUpdateEKSControlPlane", "Failed to update EKS control plane logging: %v", err)
+			return errors.Wrapf(err, "failed to update EKS cluster")
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

EKS does not allow for both a VPC config update and a logging update in the same API call. If both of these changes are applied to the spec at once, then the AWSManagedControlPlane will fail to reconcile.

Addresses the restriction in the EKS API by separating logging and vpc config updates into two separate steps.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3553

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Separate Control Plane logging and VPC Config updates to ensure both can be applied
```
