### PR TITLE
:bug: Fix Target Group's name exceeding 32 characters

### DIFF
--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -214,6 +214,7 @@ var (
 // This is created first, and the ARN is then passed to the listener.
 type TargetGroupSpec struct {
 	// Name of the TargetGroup. Must be unique over the same group of listeners.
+	// +kubebuilder:validation:MaxLength=32
 	Name string `json:"name"`
 	// Port is the exposed port
 	Port int64 `json:"port"`

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1427,6 +1427,7 @@ spec:
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
+                                  maxLength: 32
                                   type: string
                                 port:
                                   description: Port is the exposed port
@@ -1646,6 +1647,7 @@ spec:
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
+                                  maxLength: 32
                                   type: string
                                 port:
                                   description: Port is the exposed port
@@ -3335,6 +3337,7 @@ spec:
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
+                                  maxLength: 32
                                   type: string
                                 port:
                                   description: Port is the exposed port
@@ -3554,6 +3557,7 @@ spec:
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
+                                  maxLength: 32
                                   type: string
                                 port:
                                   description: Port is the exposed port

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -2369,6 +2369,7 @@ spec:
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
+                                  maxLength: 32
                                   type: string
                                 port:
                                   description: Port is the exposed port
@@ -2588,6 +2589,7 @@ spec:
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
+                                  maxLength: 32
                                   type: string
                                 port:
                                   description: Port is the exposed port

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -239,18 +239,6 @@ func (s *Service) getAdditionalTargetGroupHealthCheck(ln infrav1.AdditionalListe
 	return healthCheck
 }
 
-// getTargetGroupName creates the target group name based on LB Name, when defined, otherwise return
-// the standard name created from the timestamp.
-func (s *Service) getTargetGroupName(lbSpec *infrav1.AWSLoadBalancerSpec, defaultPrefix string, port int64) string {
-	targetName := fmt.Sprintf("%s-%d", defaultPrefix, time.Now().Unix())
-
-	if lbSpec != nil && lbSpec.Name != nil {
-		targetName = fmt.Sprintf("%s-%d", *lbSpec.Name, port)
-	}
-
-	return targetName
-}
-
 func (s *Service) getAPIServerLBSpec(elbName string, lbSpec *infrav1.AWSLoadBalancerSpec) (*infrav1.LoadBalancer, error) {
 	var securityGroupIDs []string
 	if lbSpec != nil {
@@ -266,7 +254,6 @@ func (s *Service) getAPIServerLBSpec(elbName string, lbSpec *infrav1.AWSLoadBala
 
 	// The default API health check is TCP, allowing customization to HTTP or HTTPS when HealthCheckProtocol is set.
 	apiHealthCheck := s.getAPITargetGroupHealthCheck(lbSpec)
-	apiTargetGroupName := s.getTargetGroupName(lbSpec, "apiserver-target", infrav1.DefaultAPIServerPort)
 	res := &infrav1.LoadBalancer{
 		Name:          elbName,
 		Scheme:        scheme,
@@ -276,7 +263,7 @@ func (s *Service) getAPIServerLBSpec(elbName string, lbSpec *infrav1.AWSLoadBala
 				Protocol: infrav1.ELBProtocolTCP,
 				Port:     infrav1.DefaultAPIServerPort,
 				TargetGroup: infrav1.TargetGroupSpec{
-					Name:        apiTargetGroupName,
+					Name:        fmt.Sprintf("apiserver-target-%d", time.Now().Unix()),
 					Port:        infrav1.DefaultAPIServerPort,
 					Protocol:    infrav1.ELBProtocolTCP,
 					VpcID:       s.scope.VPC().ID,
@@ -289,7 +276,6 @@ func (s *Service) getAPIServerLBSpec(elbName string, lbSpec *infrav1.AWSLoadBala
 
 	if lbSpec != nil {
 		for _, listener := range lbSpec.AdditionalListeners {
-			targetGroupName := s.getTargetGroupName(lbSpec, "additional-listener", listener.Port)
 			lnHealthCheck := &infrav1.TargetGroupHealthCheck{
 				Protocol: aws.String(string(listener.Protocol)),
 				Port:     aws.String(strconv.FormatInt(listener.Port, 10)),
@@ -302,7 +288,7 @@ func (s *Service) getAPIServerLBSpec(elbName string, lbSpec *infrav1.AWSLoadBala
 				Protocol: listener.Protocol,
 				Port:     listener.Port,
 				TargetGroup: infrav1.TargetGroupSpec{
-					Name:        targetGroupName,
+					Name:        fmt.Sprintf("additional-listener-%d", time.Now().Unix()),
 					Port:        listener.Port,
 					Protocol:    listener.Protocol,
 					VpcID:       s.scope.VPC().ID,

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -3341,63 +3341,6 @@ func stubGetBaseService(t *testing.T, clusterName string) *Service {
 	}
 }
 
-func TestService_getTargetGroupName(t *testing.T) {
-	type argWant struct {
-		value      string
-		prefixOnly bool
-	}
-	type args struct {
-		lbSpec        *infrav1.AWSLoadBalancerSpec
-		defaultPrefix string
-		port          int64
-	}
-	tests := []struct {
-		name string
-		args args
-		want argWant
-	}{
-		{
-			name: "default name",
-			args: args{
-				lbSpec:        &infrav1.AWSLoadBalancerSpec{},
-				defaultPrefix: "apiserver-target",
-				port:          6443,
-			},
-			want: argWant{
-				value:      "apiserver-target-",
-				prefixOnly: true,
-			},
-		},
-		{
-			name: "custom name",
-			args: args{
-				lbSpec: &infrav1.AWSLoadBalancerSpec{
-					Name: ptr.To("foo"),
-				},
-				defaultPrefix: "api",
-				port:          6443,
-			},
-			want: argWant{
-				value: "foo-6443",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := stubGetBaseService(t, "foo")
-			if tt.want.prefixOnly {
-				if got := s.getTargetGroupName(tt.args.lbSpec, tt.args.defaultPrefix, tt.args.port); !strings.HasPrefix(got, tt.want.value) {
-					t.Errorf("Service.getTargetGroupName() = %v, wantPrefix %v", got, tt.want.value)
-				}
-				return
-			}
-			if got := s.getTargetGroupName(tt.args.lbSpec, tt.args.defaultPrefix, tt.args.port); got != tt.want.value {
-				t.Errorf("Service.getTargetGroupName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestService_getAPITargetGroupHealthCheck(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**: 
Using the LB's name as part of the Target Group's name has the potential of causing failures since both have a limit of 32 characters. For example, using rdossant-installer-04-wn9qs-int as the LB name, will result in the following error
```
time="2024-04-22T22:54:32Z" level=debug msg="\tfailed to create target group for load balancer: ValidationError: Target group name 'rdossant-installer-04-wn9qs-int-6443' cannot be longer than '32' characters"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4947

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Revert a change where the Target Group's name would use the Load Balancer's name as prefix, possibly causing it to exceed the 32 characters limit
```
