### PR TITLE
✨ feat: create vpc objects in explicitly provided availability zones

### DIFF
--- a/api/v1beta1/awscluster_conversion.go
+++ b/api/v1beta1/awscluster_conversion.go
@@ -90,6 +90,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.NetworkSpec.AdditionalControlPlaneIngressRules = restored.Spec.NetworkSpec.AdditionalControlPlaneIngressRules
 	dst.Spec.NetworkSpec.AdditionalNodeIngressRules = restored.Spec.NetworkSpec.AdditionalNodeIngressRules
 	dst.Spec.NetworkSpec.NodePortIngressRuleCidrBlocks = restored.Spec.NetworkSpec.NodePortIngressRuleCidrBlocks
+	dst.Spec.NetworkSpec.VPC.AvailabilityZones = restored.Spec.NetworkSpec.VPC.AvailabilityZones
 
 	if restored.Spec.NetworkSpec.VPC.IPAMPool != nil {
 		if dst.Spec.NetworkSpec.VPC.IPAMPool == nil {

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -2339,6 +2339,7 @@ func autoConvert_v1beta2_VPCSpec_To_v1beta1_VPCSpec(in *v1beta2.VPCSpec, out *VP
 	out.Tags = *(*Tags)(unsafe.Pointer(&in.Tags))
 	out.AvailabilityZoneUsageLimit = (*int)(unsafe.Pointer(in.AvailabilityZoneUsageLimit))
 	out.AvailabilityZoneSelection = (*AZSelectionScheme)(unsafe.Pointer(in.AvailabilityZoneSelection))
+	// WARNING: in.AvailabilityZones requires manual conversion: does not exist in peer-type
 	// WARNING: in.EmptyRoutesDefaultVPCSecurityGroup requires manual conversion: does not exist in peer-type
 	// WARNING: in.PrivateDNSHostnameTypeOnLaunch requires manual conversion: does not exist in peer-type
 	// WARNING: in.ElasticIPPool requires manual conversion: does not exist in peer-type

--- a/api/v1beta2/awscluster_webhook.go
+++ b/api/v1beta2/awscluster_webhook.go
@@ -356,6 +356,10 @@ func (r *AWSCluster) validateNetwork() field.ErrorList {
 		}
 	}
 
+	if err := r.Spec.NetworkSpec.VPC.ValidateAvailabilityZones(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	return allErrs
 }
 

--- a/api/v1beta2/defaults.go
+++ b/api/v1beta2/defaults.go
@@ -18,6 +18,7 @@ package v1beta2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 )
@@ -49,6 +50,15 @@ func SetDefaults_NetworkSpec(obj *NetworkSpec) { //nolint:golint,stylecheck
 					ToPort:      65535,
 				},
 			},
+		}
+	}
+	// If AvailabilityZones are not set, set defaults for AZ selection
+	if obj.VPC.AvailabilityZones == nil {
+		if obj.VPC.AvailabilityZoneUsageLimit == nil {
+			obj.VPC.AvailabilityZoneUsageLimit = ptr.To(3)
+		}
+		if obj.VPC.AvailabilityZoneSelection == nil {
+			obj.VPC.AvailabilityZoneSelection = &AZSelectionSchemeOrdered
 		}
 	}
 }

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -2215,6 +2215,11 @@ func (in *VPCSpec) DeepCopyInto(out *VPCSpec) {
 		*out = new(AZSelectionScheme)
 		**out = **in
 	}
+	if in.AvailabilityZones != nil {
+		in, out := &in.AvailabilityZones, &out.AvailabilityZones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.PrivateDNSHostnameTypeOnLaunch != nil {
 		in, out := &in.PrivateDNSHostnameTypeOnLaunch, &out.PrivateDNSHostnameTypeOnLaunch
 		*out = new(string)

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -674,7 +674,6 @@ spec:
                     description: VPC configuration.
                     properties:
                       availabilityZoneSelection:
-                        default: Ordered
                         description: |-
                           AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                           in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -686,7 +685,6 @@ spec:
                         - Random
                         type: string
                       availabilityZoneUsageLimit:
-                        default: 3
                         description: |-
                           AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                           should be used in a region when automatically creating subnets. If a region has more
@@ -694,6 +692,14 @@ spec:
                           default subnets. Defaults to 3
                         minimum: 1
                         type: integer
+                      availabilityZones:
+                        description: |-
+                          AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                          Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
                       carrierGatewayId:
                         description: |-
                           CarrierGatewayID is the id of the internet gateway associated with the VPC,
@@ -2813,7 +2819,6 @@ spec:
                     description: VPC configuration.
                     properties:
                       availabilityZoneSelection:
-                        default: Ordered
                         description: |-
                           AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                           in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -2825,7 +2830,6 @@ spec:
                         - Random
                         type: string
                       availabilityZoneUsageLimit:
-                        default: 3
                         description: |-
                           AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                           should be used in a region when automatically creating subnets. If a region has more
@@ -2833,6 +2837,14 @@ spec:
                           default subnets. Defaults to 3
                         minimum: 1
                         type: integer
+                      availabilityZones:
+                        description: |-
+                          AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                          Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
                       carrierGatewayId:
                         description: |-
                           CarrierGatewayID is the id of the internet gateway associated with the VPC,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1626,7 +1626,6 @@ spec:
                     description: VPC configuration.
                     properties:
                       availabilityZoneSelection:
-                        default: Ordered
                         description: |-
                           AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                           in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -1638,7 +1637,6 @@ spec:
                         - Random
                         type: string
                       availabilityZoneUsageLimit:
-                        default: 3
                         description: |-
                           AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                           should be used in a region when automatically creating subnets. If a region has more
@@ -1646,6 +1644,14 @@ spec:
                           default subnets. Defaults to 3
                         minimum: 1
                         type: integer
+                      availabilityZones:
+                        description: |-
+                          AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                          Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
                       carrierGatewayId:
                         description: |-
                           CarrierGatewayID is the id of the internet gateway associated with the VPC,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -1214,7 +1214,6 @@ spec:
                             description: VPC configuration.
                             properties:
                               availabilityZoneSelection:
-                                default: Ordered
                                 description: |-
                                   AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                                   in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -1226,7 +1225,6 @@ spec:
                                 - Random
                                 type: string
                               availabilityZoneUsageLimit:
-                                default: 3
                                 description: |-
                                   AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                                   should be used in a region when automatically creating subnets. If a region has more
@@ -1234,6 +1232,14 @@ spec:
                                   default subnets. Defaults to 3
                                 minimum: 1
                                 type: integer
+                              availabilityZones:
+                                description: |-
+                                  AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                                  Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
                               carrierGatewayId:
                                 description: |-
                                   CarrierGatewayID is the id of the internet gateway associated with the VPC,

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -489,6 +490,10 @@ func (r *AWSManagedControlPlane) validateNetwork() field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(ipamPoolField, r.Spec.NetworkSpec.VPC.IPv6.IPAMPool, "ipamPool must have either id or name"))
 	}
 
+	if err := r.Spec.NetworkSpec.VPC.ValidateAvailabilityZones(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	return allErrs
 }
 
@@ -517,6 +522,16 @@ func (*awsManagedControlPlaneWebhook) Default(_ context.Context, obj runtime.Obj
 		r.Spec.IdentityRef = &infrav1.AWSIdentityReference{
 			Kind: infrav1.ControllerIdentityKind,
 			Name: infrav1.AWSClusterControllerIdentityName,
+		}
+	}
+
+	// If AvailabilityZones are not set, set defaults for AZ selection
+	if r.Spec.NetworkSpec.VPC.AvailabilityZones == nil {
+		if r.Spec.NetworkSpec.VPC.AvailabilityZoneUsageLimit == nil {
+			r.Spec.NetworkSpec.VPC.AvailabilityZoneUsageLimit = ptr.To(3)
+		}
+		if r.Spec.NetworkSpec.VPC.AvailabilityZoneSelection == nil {
+			r.Spec.NetworkSpec.VPC.AvailabilityZoneSelection = &infrav1.AZSelectionSchemeOrdered
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4333, continues the work started by @Skarlso in this [PR](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4543) by:
- moving the defaults for `AvailabilityZoneSelection` and `AvailabilityZoneUsageLimit` into defaulting webhooks instead of CRDs
- adding check in validating webhooks for conflicting use of `AvailabilityZoneUsageLimit` and `AvailabilityZoneSelection` with `AvailabilityZones`

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ability to specify Availability Zones from spec.network.vpc in AWSManagedControlPlane, AWSCluster and AWSClusterTemplate CRDs.
```
