### PR TITLE
🌱 Publish nightly manifests to the new staging bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ endif
 # Release variables
 
 STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api-aws
-STAGING_BUCKET ?= artifacts.k8s-staging-cluster-api-aws.appspot.com
+STAGING_BUCKET ?= k8s-staging-cluster-api-aws
 BUCKET ?= $(STAGING_BUCKET)
 PROD_REGISTRY := registry.k8s.io/cluster-api-aws
 REGISTRY ?= $(STAGING_REGISTRY)
@@ -631,6 +631,8 @@ release-alias-tag: # Adds the tag to the last build tag.
 
 .PHONY: upload-staging-artifacts
 upload-staging-artifacts: ## Upload release artifacts to the staging bucket
+	# Example manifest location: https://storage.googleapis.com/k8s-staging-cluster-api-aws/components/nightly_main_20240425/infrastructure-components.yaml
+	# Please note that these files are deleted after a certain period, at the time of this writing 60 days after file creation.
 	gsutil cp $(RELEASE_DIR)/* gs://$(BUCKET)/components/$(RELEASE_ALIAS_TAG)
 
 IMAGE_PATCH_DIR := $(ARTIFACTS)/image-patch


### PR DESCRIPTION
**What type of PR is this?**
/kind support

**What this PR does / why we need it**:

Opening this as per discussion at: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4949#issuecomment-2072971287

This PR starts publishing the nightly artifacts to the k8s-staging-cluster-api-aws bucket, instead of to the artifacts.k8s-staging-cluster-api-aws.appspot.com.

The latter is the backing bucket of the google container registry and will go away eventually when we migrate from the container registry to the artifact registry. It was never meant to be used to store files that are not part of container images.

Please note that the new location has a retention of 60 days (as of now). But that should be okay for nightly manifests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
