### PR TITLE
✨ Add non root volumes to AWSMachinePool

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -738,6 +738,50 @@ spec:
                   name:
                     description: The name of the launch template.
                     type: string
+                  nonRootVolumes:
+                    description: Configuration options for the non root storage volumes.
+                    items:
+                      description: Volume encapsulates the configuration options for
+                        the storage device.
+                      properties:
+                        deviceName:
+                          description: Device name
+                          type: string
+                        encrypted:
+                          description: Encrypted is whether the volume should be encrypted
+                            or not.
+                          type: boolean
+                        encryptionKey:
+                          description: |-
+                            EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.
+                            If Encrypted is set and this is omitted, the default AWS key will be used.
+                            The key must already exist and be accessible by the controller.
+                          type: string
+                        iops:
+                          description: IOPS is the number of IOPS requested for the
+                            disk. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        size:
+                          description: |-
+                            Size specifies size (in Gi) of the storage device.
+                            Must be greater than the image snapshot size or 8 (whichever is greater).
+                          format: int64
+                          minimum: 8
+                          type: integer
+                        throughput:
+                          description: Throughput to provision in MiB/s supported
+                            for the volume type. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        type:
+                          description: Type is the type of the volume (e.g. gp2, io1,
+                            etc...).
+                          type: string
+                      required:
+                      - size
+                      type: object
+                    type: array
                   privateDnsName:
                     description: PrivateDNSName is the options for the instance hostname.
                     properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -730,6 +730,50 @@ spec:
                   name:
                     description: The name of the launch template.
                     type: string
+                  nonRootVolumes:
+                    description: Configuration options for the non root storage volumes.
+                    items:
+                      description: Volume encapsulates the configuration options for
+                        the storage device.
+                      properties:
+                        deviceName:
+                          description: Device name
+                          type: string
+                        encrypted:
+                          description: Encrypted is whether the volume should be encrypted
+                            or not.
+                          type: boolean
+                        encryptionKey:
+                          description: |-
+                            EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.
+                            If Encrypted is set and this is omitted, the default AWS key will be used.
+                            The key must already exist and be accessible by the controller.
+                          type: string
+                        iops:
+                          description: IOPS is the number of IOPS requested for the
+                            disk. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        size:
+                          description: |-
+                            Size specifies size (in Gi) of the storage device.
+                            Must be greater than the image snapshot size or 8 (whichever is greater).
+                          format: int64
+                          minimum: 8
+                          type: integer
+                        throughput:
+                          description: Throughput to provision in MiB/s supported
+                            for the volume type. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        type:
+                          description: Type is the type of the volume (e.g. gp2, io1,
+                            etc...).
+                          type: string
+                      required:
+                      - size
+                      type: object
+                    type: array
                   privateDnsName:
                     description: PrivateDNSName is the options for the instance hostname.
                     properties:

--- a/exp/api/v1beta1/conversion.go
+++ b/exp/api/v1beta1/conversion.go
@@ -18,11 +18,12 @@ package v1beta1
 
 import (
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
 	infrav1beta1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
-	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
-	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
 // ConvertTo converts the v1beta1 AWSMachinePool receiver to a v1beta2 AWSMachinePool.
@@ -56,6 +57,7 @@ func (src *AWSMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.Spec.DefaultInstanceWarmup = restored.Spec.DefaultInstanceWarmup
+	dst.Spec.AWSLaunchTemplate.NonRootVolumes = restored.Spec.AWSLaunchTemplate.NonRootVolumes
 
 	return nil
 }
@@ -101,6 +103,7 @@ func (src *AWSManagedMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.AWSLaunchTemplate = restored.Spec.AWSLaunchTemplate
 		}
 		dst.Spec.AWSLaunchTemplate.InstanceMetadataOptions = restored.Spec.AWSLaunchTemplate.InstanceMetadataOptions
+		dst.Spec.AWSLaunchTemplate.NonRootVolumes = restored.Spec.AWSLaunchTemplate.NonRootVolumes
 
 		if restored.Spec.AWSLaunchTemplate.PrivateDNSName != nil {
 			dst.Spec.AWSLaunchTemplate.PrivateDNSName = restored.Spec.AWSLaunchTemplate.PrivateDNSName

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -402,6 +402,7 @@ func autoConvert_v1beta2_AWSLaunchTemplate_To_v1beta1_AWSLaunchTemplate(in *v1be
 	out.ImageLookupBaseOS = in.ImageLookupBaseOS
 	out.InstanceType = in.InstanceType
 	out.RootVolume = (*apiv1beta2.Volume)(unsafe.Pointer(in.RootVolume))
+	// WARNING: in.NonRootVolumes requires manual conversion: does not exist in peer-type
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))
 	out.VersionNumber = (*int64)(unsafe.Pointer(in.VersionNumber))
 	out.AdditionalSecurityGroups = *(*[]apiv1beta2.AWSResourceReference)(unsafe.Pointer(&in.AdditionalSecurityGroups))

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -96,6 +96,10 @@ type AWSLaunchTemplate struct {
 	// +optional
 	RootVolume *infrav1.Volume `json:"rootVolume,omitempty"`
 
+	// Configuration options for the non root storage volumes.
+	// +optional
+	NonRootVolumes []infrav1.Volume `json:"nonRootVolumes,omitempty"`
+
 	// SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string
 	// (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
 	// +optional

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -96,6 +96,13 @@ func (in *AWSLaunchTemplate) DeepCopyInto(out *AWSLaunchTemplate) {
 		*out = new(apiv1beta2.Volume)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NonRootVolumes != nil {
+		in, out := &in.NonRootVolumes, &out.NonRootVolumes
+		*out = make([]apiv1beta2.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.SSHKeyName != nil {
 		in, out := &in.SSHKeyName, &out.SSHKeyName
 		*out = new(string)

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -520,6 +520,8 @@ func (s *Service) createLaunchTemplateData(scope scope.LaunchTemplateScope, imag
 	data.InstanceMarketOptions = getLaunchTemplateInstanceMarketOptionsRequest(scope.GetLaunchTemplate().SpotMarketOptions)
 	data.PrivateDnsNameOptions = getLaunchTemplatePrivateDNSNameOptionsRequest(scope.GetLaunchTemplate().PrivateDNSName)
 
+	blockDeviceMappings := []*ec2.LaunchTemplateBlockDeviceMappingRequest{}
+
 	// Set up root volume
 	if lt.RootVolume != nil {
 		rootDeviceName, err := s.checkRootVolume(lt.RootVolume, *data.ImageId)
@@ -530,9 +532,18 @@ func (s *Service) createLaunchTemplateData(scope scope.LaunchTemplateScope, imag
 		lt.RootVolume.DeviceName = aws.StringValue(rootDeviceName)
 
 		req := volumeToLaunchTemplateBlockDeviceMappingRequest(lt.RootVolume)
-		data.BlockDeviceMappings = []*ec2.LaunchTemplateBlockDeviceMappingRequest{
-			req,
-		}
+		blockDeviceMappings = append(blockDeviceMappings, req)
+	}
+
+	for vi := range lt.NonRootVolumes {
+		nonRootVolume := lt.NonRootVolumes[vi]
+
+		blockDeviceMapping := volumeToLaunchTemplateBlockDeviceMappingRequest(&nonRootVolume)
+		blockDeviceMappings = append(blockDeviceMappings, blockDeviceMapping)
+	}
+
+	if len(blockDeviceMappings) > 0 {
+		data.BlockDeviceMappings = blockDeviceMappings
 	}
 
 	data.TagSpecifications = s.buildLaunchTemplateTagSpecificationRequest(scope, userDataSecretKey)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Adding non root volumes is already possible for the control-plane by [specifying them in the AWSMachineTemplate](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/63c66352579ef08bd365abd529e1924cde6f0d26/api/v1beta2/awsmachine_types.go#L143), but only the RootVolume can be specified for AWSMachinePools. This PR adds this feature for the machine pools as well.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add NonRootVolumes to AWSMachinePool launch template. 
```
