### PR TITLE
:book: Update userdata privacy doc with details on cloud-init and ignition

### DIFF
--- a/docs/book/src/topics/images/amis.md
+++ b/docs/book/src/topics/images/amis.md
@@ -4,6 +4,8 @@ CAPA requires a “machine image” containing pre-installed, matching versions 
 Machine image is either auto-resolved by CAPA to a public AMI that matches the Kubernetes version in `KubeadmControlPlane` or `MachineDeployment` spec,
 or an appropriate custom image ID for the Kubernetes version can be set in `AWSMachineTemplate` spec.
 
+> **Note:** By default, CAPA securely passes sensitive user-data when it creates a machine. This feature depends on cloud-init or ignition being installed on the machine. See [userdata privacy](../userdata-privacy.md#userdata-privacy) for more details.
+
 [Pre-built public AMIs](built-amis.md) are published by the maintainers regularly for each new Kubernetes version.
 
 [Custom images](custom-amis.md) can be created using [image-builder][image-builder] project.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
- Notes CAPA's cloud-init or ignition dependency.
- Notes the maximum cloud-init version.
- Adds a reference from the userdata privacy doc to the ignition doc.

This is a result of today's decision to explicitly call out the implicit cloud-init version dependency in the docs.

Once this merges, I will rebase #4746, and update the documented cloud-init version.
 
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [x] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
