### PR TITLE
🐛 ROSA: Fix autoRepair default value

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
@@ -66,10 +66,10 @@ spec:
                   underlying EC2 instances associated with this machine pool.
                 type: object
               autoRepair:
-                default: false
+                default: true
                 description: |-
                   AutoRepair specifies whether health checks should be enabled for machines
-                  in the NodePool. The default is false.
+                  in the NodePool. The default is true.
                 type: boolean
               autoscaling:
                 description: |-

--- a/exp/api/v1beta2/rosamachinepool_types.go
+++ b/exp/api/v1beta2/rosamachinepool_types.go
@@ -65,8 +65,8 @@ type RosaMachinePoolSpec struct {
 	AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
 
 	// AutoRepair specifies whether health checks should be enabled for machines
-	// in the NodePool. The default is false.
-	// +kubebuilder:default=false
+	// in the NodePool. The default is true.
+	// +kubebuilder:default=true
 	// +optional
 	AutoRepair bool `json:"autoRepair,omitempty"`
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The PR change the machinePool.AutoRepair default value to true as the default value of nodePool.AutoRepair at the OCM API [here](https://api.openshift.com/#/default/get_api_clusters_mgmt_v1_clusters__cluster_id__node_pools) is true. 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X ] squashed commits
- [ ] includes documentation
- [ X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changing the ROSAMachienPool AutoRepair default value to true. 
```
