### PR TITLE
🐛 Reconcile target groups and listeners as their own entities

### DIFF
--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -303,6 +303,8 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			mockedCreateLBV2Calls(t, e)
 			mockedDescribeInstanceCall(m)
 			mockedDescribeAvailabilityZones(m, []string{"us-east-1c", "us-east-1a"})
+			mockedDescribeTargetGroupsCall(t, e)
+			mockedDescribeListenersCall(t, e)
 		}
 
 		expect(ec2Mock.EXPECT(), elbv2Mock.EXPECT())

--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -304,7 +304,10 @@ func TestAWSClusterReconcilerIntegrationTests(t *testing.T) {
 			mockedDescribeInstanceCall(m)
 			mockedDescribeAvailabilityZones(m, []string{"us-east-1c", "us-east-1a"})
 			mockedDescribeTargetGroupsCall(t, e)
+			mockedCreateTargetGroupCall(t, e)
+			mockedModifyTargetGroupAttributes(t, e)
 			mockedDescribeListenersCall(t, e)
+			mockedCreateListenerCall(t, e)
 		}
 
 		expect(ec2Mock.EXPECT(), elbv2Mock.EXPECT())

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -29,6 +29,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/test/helpers"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -39,6 +40,7 @@ const DNSName = "www.google.com"
 var (
 	lbName          = aws.String("test-cluster-apiserver")
 	lbArn           = aws.String("loadbalancer::arn")
+	tgArn           = aws.String("arn::target-group")
 	describeLBInput = &elb.DescribeLoadBalancersInput{
 		LoadBalancerNames: aws.StringSlice([]string{"test-cluster-apiserver"}),
 	}
@@ -313,13 +315,75 @@ func mockedDescribeTargetGroupsCall(t *testing.T, m *mocks.MockELBV2APIMockRecor
 					Port:                       new(int64),
 					Protocol:                   new(string),
 					ProtocolVersion:            new(string),
-					TargetGroupArn:             aws.String("arn::targetgroup"),
+					TargetGroupArn:             tgArn,
 					TargetGroupName:            new(string),
 					TargetType:                 new(string),
 					UnhealthyThresholdCount:    new(int64),
 					VpcId:                      new(string),
 				}},
 		}, nil)
+}
+
+func mockedCreateTargetGroupCall(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
+	t.Helper()
+	m.CreateTargetGroup(helpers.PartialMatchCreateTargetGroupInput(t, &elbv2.CreateTargetGroupInput{
+		HealthCheckEnabled:         aws.Bool(true),
+		HealthCheckIntervalSeconds: aws.Int64(infrav1.DefaultAPIServerHealthCheckIntervalSec),
+		HealthCheckPort:            aws.String(infrav1.DefaultAPIServerPortString),
+		HealthCheckProtocol:        aws.String("TCP"),
+		HealthCheckTimeoutSeconds:  aws.Int64(infrav1.DefaultAPIServerHealthCheckTimeoutSec),
+		HealthyThresholdCount:      aws.Int64(infrav1.DefaultAPIServerHealthThresholdCount),
+		// Note: this is treated as a prefix with the partial matcher.
+		Name:     aws.String("apiserver-target"),
+		Port:     aws.Int64(infrav1.DefaultAPIServerPort),
+		Protocol: aws.String("TCP"),
+		Tags: []*elbv2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String("bar-apiserver"),
+			},
+			{
+				Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+				Value: aws.String("owned"),
+			},
+			{
+				Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+				Value: aws.String("apiserver"),
+			},
+		},
+		UnhealthyThresholdCount: aws.Int64(infrav1.DefaultAPIServerUnhealthThresholdCount),
+		VpcId:                   aws.String("vpc-exists"),
+	})).Return(&elbv2.CreateTargetGroupOutput{
+		TargetGroups: []*elbv2.TargetGroup{{
+			HealthCheckEnabled:         aws.Bool(true),
+			HealthCheckIntervalSeconds: aws.Int64(infrav1.DefaultAPIServerHealthCheckIntervalSec),
+			HealthCheckPort:            aws.String(infrav1.DefaultAPIServerPortString),
+			HealthCheckProtocol:        aws.String("TCP"),
+			HealthCheckTimeoutSeconds:  aws.Int64(infrav1.DefaultAPIServerHealthCheckTimeoutSec),
+			HealthyThresholdCount:      aws.Int64(infrav1.DefaultAPIServerHealthThresholdCount),
+			LoadBalancerArns:           []*string{lbArn},
+			Matcher:                    &elbv2.Matcher{},
+			Port:                       aws.Int64(infrav1.DefaultAPIServerPort),
+			Protocol:                   aws.String("TCP"),
+			TargetGroupArn:             tgArn,
+			TargetGroupName:            aws.String("apiserver-target"),
+			UnhealthyThresholdCount:    aws.Int64(infrav1.DefaultAPIServerUnhealthThresholdCount),
+			VpcId:                      aws.String("vpc-exists"),
+		}},
+	}, nil)
+}
+
+func mockedModifyTargetGroupAttributes(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
+	t.Helper()
+	m.ModifyTargetGroupAttributes(gomock.Eq(&elbv2.ModifyTargetGroupAttributesInput{
+		TargetGroupArn: tgArn,
+		Attributes: []*elbv2.TargetGroupAttribute{
+			{
+				Key:   aws.String(infrav1.TargetGroupAttributeEnablePreserveClientIP),
+				Value: aws.String("false"),
+			},
+		},
+	})).Return(nil, nil)
 }
 
 func mockedDescribeListenersCall(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
@@ -330,12 +394,54 @@ func mockedDescribeListenersCall(t *testing.T, m *mocks.MockELBV2APIMockRecorder
 		Return(&elbv2.DescribeListenersOutput{
 			Listeners: []*elbv2.Listener{{
 				DefaultActions: []*elbv2.Action{{
-					TargetGroupArn: aws.String("arn::targetgroup"),
+					TargetGroupArn: aws.String("arn::targetgroup-not-found"),
 				}},
 				ListenerArn:     aws.String("arn::listener"),
 				LoadBalancerArn: lbArn,
 			}},
 		}, nil)
+}
+
+func mockedCreateListenerCall(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
+	t.Helper()
+	m.CreateListener(gomock.Eq(&elbv2.CreateListenerInput{
+		DefaultActions: []*elbv2.Action{
+			{
+				TargetGroupArn: tgArn,
+				Type:           aws.String(elbv2.ActionTypeEnumForward),
+			},
+		},
+		LoadBalancerArn: lbArn,
+		Port:            aws.Int64(infrav1.DefaultAPIServerPort),
+		Protocol:        aws.String("TCP"),
+		Tags: []*elbv2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String("test-cluster-apiserver"),
+			},
+			{
+				Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+				Value: aws.String("owned"),
+			},
+			{
+				Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+				Value: aws.String("apiserver"),
+			},
+		},
+	})).Return(&elbv2.CreateListenerOutput{
+		Listeners: []*elbv2.Listener{
+			{
+				DefaultActions: []*elbv2.Action{
+					{
+						TargetGroupArn: tgArn,
+						Type:           aws.String(elbv2.ActionTypeEnumForward),
+					},
+				},
+				ListenerArn: aws.String("listener::arn"),
+				Port:        aws.Int64(infrav1.DefaultAPIServerPort),
+				Protocol:    aws.String("TCP"),
+			},
+		}}, nil)
 }
 
 func mockedDeleteLBCalls(expectV2Call bool, mv2 *mocks.MockELBV2APIMockRecorder, m *mocks.MockELBAPIMockRecorder) {

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -323,6 +323,7 @@ func mockedDescribeTargetGroupsCall(t *testing.T, m *mocks.MockELBV2APIMockRecor
 }
 
 func mockedDescribeListenersCall(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
+	t.Helper()
 	m.DescribeListeners(gomock.Eq(&elbv2.DescribeListenersInput{
 		LoadBalancerArn: lbArn,
 	})).

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -291,6 +291,52 @@ func mockedCreateLBV2Calls(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
 	})).MaxTimes(1)
 }
 
+func mockedDescribeTargetGroupsCall(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
+	t.Helper()
+	m.DescribeTargetGroups(gomock.Eq(&elbv2.DescribeTargetGroupsInput{
+		LoadBalancerArn: lbArn,
+	})).
+		Return(&elbv2.DescribeTargetGroupsOutput{
+			NextMarker: new(string),
+			TargetGroups: []*elbv2.TargetGroup{
+				{
+					HealthCheckEnabled:         aws.Bool(true),
+					HealthCheckIntervalSeconds: new(int64),
+					HealthCheckPath:            new(string),
+					HealthCheckPort:            new(string),
+					HealthCheckProtocol:        new(string),
+					HealthCheckTimeoutSeconds:  new(int64),
+					HealthyThresholdCount:      new(int64),
+					IpAddressType:              new(string),
+					LoadBalancerArns:           []*string{lbArn},
+					Matcher:                    &elbv2.Matcher{},
+					Port:                       new(int64),
+					Protocol:                   new(string),
+					ProtocolVersion:            new(string),
+					TargetGroupArn:             aws.String("arn::targetgroup"),
+					TargetGroupName:            new(string),
+					TargetType:                 new(string),
+					UnhealthyThresholdCount:    new(int64),
+					VpcId:                      new(string),
+				}},
+		}, nil)
+}
+
+func mockedDescribeListenersCall(t *testing.T, m *mocks.MockELBV2APIMockRecorder) {
+	m.DescribeListeners(gomock.Eq(&elbv2.DescribeListenersInput{
+		LoadBalancerArn: lbArn,
+	})).
+		Return(&elbv2.DescribeListenersOutput{
+			Listeners: []*elbv2.Listener{{
+				DefaultActions: []*elbv2.Action{{
+					TargetGroupArn: aws.String("arn::targetgroup"),
+				}},
+				ListenerArn:     aws.String("arn::listener"),
+				LoadBalancerArn: lbArn,
+			}},
+		}, nil)
+}
+
 func mockedDeleteLBCalls(expectV2Call bool, mv2 *mocks.MockELBV2APIMockRecorder, m *mocks.MockELBAPIMockRecorder) {
 	if expectV2Call {
 		mv2.DescribeLoadBalancers(gomock.Any()).Return(describeLBOutputV2, nil)

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -153,7 +153,6 @@ func (s *Service) reconcileV2LB(lbSpec *infrav1.AWSLoadBalancerSpec) error {
 				return errors.Wrapf(err, "failed to apply security groups to load balancer %q", lb.Name)
 			}
 		}
-
 	} else {
 		s.scope.Trace("Unmanaged control plane load balancer, skipping load balancer configuration", "api-server-elb", lb)
 	}
@@ -1591,7 +1590,7 @@ func (s *Service) reconcileTargetGroupsAndListeners(spec *infrav1.LoadBalancer, 
 
 		var listener *elbv2.Listener
 		for _, l := range existingListeners.Listeners {
-			if l.DefaultActions != nil && l.DefaultActions[0].TargetGroupArn == group.TargetGroupArn {
+			if l.DefaultActions != nil && len(l.DefaultActions) > 0 && l.DefaultActions[0].TargetGroupArn == group.TargetGroupArn {
 				listener = l
 			}
 		}
@@ -1609,7 +1608,7 @@ func (s *Service) reconcileTargetGroupsAndListeners(spec *infrav1.LoadBalancer, 
 	return createdTargetGroups, createdListeners, nil
 }
 
-// createListener creates a single Listener
+// createListener creates a single Listener.
 func (s *Service) createListener(ln infrav1.Listener, group *elbv2.TargetGroup, lbARN string, tags map[string]string) (*elbv2.Listener, error) {
 	listenerInput := &elbv2.CreateListenerInput{
 		DefaultActions: []*elbv2.Action{
@@ -1637,7 +1636,7 @@ func (s *Service) createListener(ln infrav1.Listener, group *elbv2.TargetGroup, 
 	return listener.Listeners[0], nil
 }
 
-// createTargetGroup creates a single Target Group
+// createTargetGroup creates a single Target Group.
 func (s *Service) createTargetGroup(ln infrav1.Listener, tags map[string]string) (*elbv2.TargetGroup, error) {
 	targetGroupInput := &elbv2.CreateTargetGroupInput{
 		Name:                       aws.String(ln.TargetGroup.Name),

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1550,10 +1550,6 @@ func (s *Service) reconcileTargetGroupsAndListeners(lbARN string, spec *infrav1.
 		s.scope.Error(err, "could not describe listeners for load balancer", "arn", lbARN)
 	}
 
-	if len(existingTargetGroups.TargetGroups) == len(existingListeners.Listeners) && len(existingListeners.Listeners) == len(spec.ELBListeners) {
-		return existingTargetGroups.TargetGroups, existingListeners.Listeners, nil
-	}
-
 	createdTargetGroups := make([]*elbv2.TargetGroup, 0, len(spec.ELBListeners))
 	createdListeners := make([]*elbv2.Listener, 0, len(spec.ELBListeners))
 

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -2535,6 +2535,19 @@ func TestReconcileV2LB(t *testing.T) {
 						},
 					}}).
 					Return(&elbv2.ModifyLoadBalancerAttributesOutput{}, nil)
+
+				m.DescribeListeners(gomock.Eq(&elbv2.DescribeListenersInput{
+					LoadBalancerArn: aws.String(elbArn),
+				})).
+					Return(&elbv2.DescribeListenersOutput{
+						Listeners: []*elbv2.Listener{{
+							DefaultActions: []*elbv2.Action{{
+								TargetGroupArn: aws.String("arn::targetgroup"),
+							}},
+							ListenerArn:     aws.String("arn::listener"),
+							LoadBalancerArn: aws.String(elbArn),
+						}},
+					}, nil)
 				m.DescribeLoadBalancerAttributes(&elbv2.DescribeLoadBalancerAttributesInput{LoadBalancerArn: aws.String(elbArn)}).Return(
 					&elbv2.DescribeLoadBalancerAttributesOutput{
 						Attributes: []*elbv2.LoadBalancerAttribute{

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -2198,7 +2198,6 @@ func TestReconcileTargetGroupsAndListeners(t *testing.T) {
 			}
 
 			spec := tc.spec(*loadBalancerSpec)
-			//_, err := s.createLB(&spec, clusterScope.ControlPlaneLoadBalancer())
 			tgs, listeners, err := s.reconcileTargetGroupsAndListeners(&spec, clusterScope.ControlPlaneLoadBalancer())
 			tc.check(t, tgs, listeners, err)
 		})

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -2198,7 +2198,7 @@ func TestReconcileTargetGroupsAndListeners(t *testing.T) {
 			}
 
 			spec := tc.spec(*loadBalancerSpec)
-			tgs, listeners, err := s.reconcileTargetGroupsAndListeners(&spec, clusterScope.ControlPlaneLoadBalancer())
+			tgs, listeners, err := s.reconcileTargetGroupsAndListeners(spec.ARN, &spec, clusterScope.ControlPlaneLoadBalancer())
 			tc.check(t, tgs, listeners, err)
 		})
 	}

--- a/test/helpers/matchers.go
+++ b/test/helpers/matchers.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/golang/mock/gomock"
+)
+
+// PartialMatchCreateTargetGroupInput matches a partial CreateTargetGroupInput struct based on fuzzy matching rules.
+func PartialMatchCreateTargetGroupInput(t *testing.T, i *elbv2.CreateTargetGroupInput) gomock.Matcher {
+	t.Helper()
+	return &createTargetGroupInputPartialMatcher{
+		in: i,
+		t:  t,
+	}
+}
+
+// createTargetGroupInputPartialMatcher conforms to the gomock.Matcher interface in order to implement a match against a partial
+// CreateTargetGroupInput expected value.
+// In particular, the TargetGroupName expected value is used as a prefix, in order to support generated names.
+type createTargetGroupInputPartialMatcher struct {
+	in *elbv2.CreateTargetGroupInput
+	t  *testing.T
+}
+
+func (m *createTargetGroupInputPartialMatcher) Matches(x interface{}) bool {
+	actual, ok := x.(*elbv2.CreateTargetGroupInput)
+	if !ok {
+		return false
+	}
+
+	// Check for a perfect match across all fields first.
+	eq := gomock.Eq(m.in).Matches(actual)
+
+	if !eq && (actual.Name != nil && m.in.Name != nil) {
+		// If the actual name is prefixed with the expected value, then it matches
+		if (*actual.Name != *m.in.Name) && strings.HasPrefix(*actual.Name, *m.in.Name) {
+			return true
+		}
+	}
+
+	return eq
+}
+
+func (m *createTargetGroupInputPartialMatcher) String() string {
+	return fmt.Sprintf("%v (%T)", m.in, m.in)
+}


### PR DESCRIPTION

Signed-off-by: Nolan Brubaker <nolan@nbrubaker.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If a load balancer is created but the calls to create a target group or
listener fails (for example, due to a rate limit), creating the group or
listener is never retried. This results in a load balancer that's
created, but there is nothing attached to it, making it useless.

This change reconciles the target groups and listeners as their own entities, so that even if they fail to create initially, we'll keep retrying.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5002

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
    Reconcile target groups and listeners independently of load balancers to handle failures more gracefully.
```
