### PR TITLE
✨ Add natgatewayips as source for ingress rules

### DIFF
--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1970,6 +1970,7 @@ func autoConvert_v1beta2_IngressRule_To_v1beta1_IngressRule(in *v1beta2.IngressR
 	out.IPv6CidrBlocks = *(*[]string)(unsafe.Pointer(&in.IPv6CidrBlocks))
 	out.SourceSecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SourceSecurityGroupIDs))
 	// WARNING: in.SourceSecurityGroupRoles requires manual conversion: does not exist in peer-type
+	// WARNING: in.NatGatewaysIPsSource requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1beta2/awscluster_webhook.go
+++ b/api/v1beta2/awscluster_webhook.go
@@ -264,9 +264,7 @@ func (r *AWSCluster) validateNetwork() field.ErrorList {
 	}
 
 	for _, rule := range r.Spec.NetworkSpec.AdditionalControlPlaneIngressRules {
-		if (rule.CidrBlocks != nil || rule.IPv6CidrBlocks != nil) && (rule.SourceSecurityGroupIDs != nil || rule.SourceSecurityGroupRoles != nil) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("additionalControlPlaneIngressRules"), r.Spec.NetworkSpec.AdditionalControlPlaneIngressRules, "CIDR blocks and security group IDs or security group roles cannot be used together"))
-		}
+		allErrs = append(allErrs, r.validateIngressRule(rule)...)
 	}
 
 	return allErrs
@@ -307,9 +305,7 @@ func (r *AWSCluster) validateControlPlaneLBs() field.ErrorList {
 		}
 
 		for _, rule := range cp.IngressRules {
-			if (rule.CidrBlocks != nil || rule.IPv6CidrBlocks != nil) && (rule.SourceSecurityGroupIDs != nil || rule.SourceSecurityGroupRoles != nil) {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "ingressRules"), r.Spec.ControlPlaneLoadBalancer.IngressRules, "CIDR blocks and security group IDs or security group roles cannot be used together"))
-			}
+			allErrs = append(allErrs, r.validateIngressRule(rule)...)
 		}
 	}
 
@@ -351,11 +347,19 @@ func (r *AWSCluster) validateControlPlaneLBs() field.ErrorList {
 		}
 	}
 
-	for _, rule := range r.Spec.ControlPlaneLoadBalancer.IngressRules {
+	return allErrs
+}
+
+func (r *AWSCluster) validateIngressRule(rule IngressRule) field.ErrorList {
+	var allErrs field.ErrorList
+	if rule.NatGatewaysIPsSource {
+		if rule.CidrBlocks != nil || rule.IPv6CidrBlocks != nil || rule.SourceSecurityGroupIDs != nil || rule.SourceSecurityGroupRoles != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("additionalControlPlaneIngressRules"), r.Spec.NetworkSpec.AdditionalControlPlaneIngressRules, "CIDR blocks and security group IDs or security group roles cannot be used together"))
+		}
+	} else {
 		if (rule.CidrBlocks != nil || rule.IPv6CidrBlocks != nil) && (rule.SourceSecurityGroupIDs != nil || rule.SourceSecurityGroupRoles != nil) {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "ingressRules"), r.Spec.ControlPlaneLoadBalancer.IngressRules, "CIDR blocks and security group IDs or security group roles cannot be used together"))
 		}
 	}
-
 	return allErrs
 }

--- a/api/v1beta2/awscluster_webhook_test.go
+++ b/api/v1beta2/awscluster_webhook_test.go
@@ -409,6 +409,59 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "rejects ingress rules with cidr block, source security group id, role and nat gateway IP source",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						IngressRules: []IngressRule{
+							{
+								Protocol:                 SecurityGroupProtocolTCP,
+								IPv6CidrBlocks:           []string{"test"},
+								SourceSecurityGroupIDs:   []string{"test"},
+								SourceSecurityGroupRoles: []SecurityGroupRole{SecurityGroupBastion},
+								NatGatewaysIPsSource:     true,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects ingress rules with source security role and nat gateway IP source",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						IngressRules: []IngressRule{
+							{
+								Protocol:                 SecurityGroupProtocolTCP,
+								SourceSecurityGroupRoles: []SecurityGroupRole{SecurityGroupBastion},
+								NatGatewaysIPsSource:     true,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects ingress rules with cidr block and nat gateway IP source",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						IngressRules: []IngressRule{
+							{
+								Protocol:             SecurityGroupProtocolTCP,
+								IPv6CidrBlocks:       []string{"test"},
+								NatGatewaysIPsSource: true,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "accepts ingress rules with cidr block",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
@@ -417,6 +470,22 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							{
 								Protocol:   SecurityGroupProtocolTCP,
 								CidrBlocks: []string{"test"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "accepts ingress rules with nat gateway IPs source",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						IngressRules: []IngressRule{
+							{
+								Protocol:             SecurityGroupProtocolTCP,
+								NatGatewaysIPsSource: true,
 							},
 						},
 					},

--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -908,6 +908,10 @@ type IngressRule struct {
 	// The field will be combined with source security group IDs if specified.
 	// +optional
 	SourceSecurityGroupRoles []SecurityGroupRole `json:"sourceSecurityGroupRoles,omitempty"`
+
+	// NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.
+	// +optional
+	NatGatewaysIPsSource bool `json:"natGatewaysIPsSource,omitempty"`
 }
 
 // String returns a string representation of the ingress rule.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -393,6 +393,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        natGatewaysIPsSource:
+                          description: NatGatewaysIPsSource use the NAT gateways IPs
+                            as the source for the ingress rule.
+                          type: boolean
                         protocol:
                           description: Protocol is the protocol for the ingress rule.
                             Accepted values are "-1" (all), "4" (IP in IP),"tcp",
@@ -1887,6 +1891,10 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              natGatewaysIPsSource:
+                                description: NatGatewaysIPsSource use the NAT gateways
+                                  IPs as the source for the ingress rule.
+                                type: boolean
                               protocol:
                                 description: Protocol is the protocol for the ingress
                                   rule. Accepted values are "-1" (all), "4" (IP in
@@ -2343,6 +2351,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        natGatewaysIPsSource:
+                          description: NatGatewaysIPsSource use the NAT gateways IPs
+                            as the source for the ingress rule.
+                          type: boolean
                         protocol:
                           description: Protocol is the protocol for the ingress rule.
                             Accepted values are "-1" (all), "4" (IP in IP),"tcp",
@@ -3850,6 +3862,10 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              natGatewaysIPsSource:
+                                description: NatGatewaysIPsSource use the NAT gateways
+                                  IPs as the source for the ingress rule.
+                                type: boolean
                               protocol:
                                 description: Protocol is the protocol for the ingress
                                   rule. Accepted values are "-1" (all), "4" (IP in

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1164,6 +1164,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        natGatewaysIPsSource:
+                          description: NatGatewaysIPsSource use the NAT gateways IPs
+                            as the source for the ingress rule.
+                          type: boolean
                         protocol:
                           description: Protocol is the protocol for the ingress rule.
                             Accepted values are "-1" (all), "4" (IP in IP),"tcp",
@@ -1329,6 +1333,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        natGatewaysIPsSource:
+                          description: NatGatewaysIPsSource use the NAT gateways IPs
+                            as the source for the ingress rule.
+                          type: boolean
                         protocol:
                           description: Protocol is the protocol for the ingress rule.
                             Accepted values are "-1" (all), "4" (IP in IP),"tcp",
@@ -1910,6 +1918,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        natGatewaysIPsSource:
+                          description: NatGatewaysIPsSource use the NAT gateways IPs
+                            as the source for the ingress rule.
+                          type: boolean
                         protocol:
                           description: Protocol is the protocol for the ingress rule.
                             Accepted values are "-1" (all), "4" (IP in IP),"tcp",
@@ -2833,6 +2845,10 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              natGatewaysIPsSource:
+                                description: NatGatewaysIPsSource use the NAT gateways
+                                  IPs as the source for the ingress rule.
+                                type: boolean
                               protocol:
                                 description: Protocol is the protocol for the ingress
                                   rule. Accepted values are "-1" (all), "4" (IP in

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -756,6 +756,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                natGatewaysIPsSource:
+                                  description: NatGatewaysIPsSource use the NAT gateways
+                                    IPs as the source for the ingress rule.
+                                  type: boolean
                                 protocol:
                                   description: Protocol is the protocol for the ingress
                                     rule. Accepted values are "-1" (all), "4" (IP
@@ -925,6 +929,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                natGatewaysIPsSource:
+                                  description: NatGatewaysIPsSource use the NAT gateways
+                                    IPs as the source for the ingress rule.
+                                  type: boolean
                                 protocol:
                                   description: Protocol is the protocol for the ingress
                                     rule. Accepted values are "-1" (all), "4" (IP
@@ -1511,6 +1519,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                natGatewaysIPsSource:
+                                  description: NatGatewaysIPsSource use the NAT gateways
+                                    IPs as the source for the ingress rule.
+                                  type: boolean
                                 protocol:
                                   description: Protocol is the protocol for the ingress
                                     rule. Accepted values are "-1" (all), "4" (IP


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This PR will allow using nat gateway IPs as sources in ingress rules. In my setup, I need machines to be able to connect to the load balancer through a certain port and I would like the load balancer to only accept traffic for this port from my machines. From the load balancer point of view the connection is made from nat gateway IPs so the CAPA API has to have a setting for this.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add natgatewayips as source for ingress rules
```
