### PR TITLE
:bug: Remove Helm condition for AWS VPC CNI deletion

### DIFF
--- a/docs/book/src/topics/eks/pod-networking.md
+++ b/docs/book/src/topics/eks/pod-networking.md
@@ -97,6 +97,26 @@ spec:
   disableVPCCNI: true
 ```
 
+If you are replacing Amazon VPC CNI with your own helm managed instance, you will need to set `AWSManagedControlPlane.spec.disableVPCCNI` to `true` and add `"prevent-deletion": "true"` label on the Daemonset. This label is needed so `aws-node` daemonset is not reaped during CNI reconciliation.
+
+The following example shows how to label your aws-node Daemonset.
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    ...
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.15.1
+    helm.sh/chart: aws-vpc-cni-1.15.1
+    prevent-deletion: true
+```
+
 > You cannot set **disableVPCCNI** to true if you are using the VPC CNI addon.
 
 Some alternative CNIs provide for the replacement of kube-proxy, such as in [Calico](https://projectcalico.docs.tigera.io/maintenance/ebpf/enabling-ebpf#configure-kube-proxy) and [Cilium](https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/). When enabling the kube-proxy alternative, the kube-proxy installed by EKS must be deleted. This can be done via the **disable** property of **kubeProxy** in **AWSManagedControlPlane**:

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	sigs.k8s.io/cluster-api v1.7.1
 	sigs.k8s.io/cluster-api/test v1.7.1
 	sigs.k8s.io/controller-runtime v0.17.3
-	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -226,6 +225,7 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.22.0 // indirect
+	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kustomize/v5 v5.0.4-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/kustomize/api/konfig"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
@@ -272,22 +271,25 @@ func (s *Service) deleteResource(ctx context.Context, remoteClient client.Client
 			return fmt.Errorf("deleting resource %s: %w", key, err)
 		}
 		s.scope.Debug(fmt.Sprintf("resource %s was not found, no action", key))
-	} else {
-		// resource found, delete if no label or not managed by helm
-		if val, ok := obj.GetLabels()[konfig.ManagedbyLabelKey]; !ok || val != "Helm" {
-			if err := remoteClient.Delete(ctx, obj, &client.DeleteOptions{}); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return fmt.Errorf("deleting %s: %w", key, err)
-				}
-				s.scope.Debug(fmt.Sprintf(
-					"resource %s was not found, not deleted", key))
-			} else {
-				s.scope.Debug(fmt.Sprintf("resource %s was deleted", key))
-			}
-		} else {
-			s.scope.Debug(fmt.Sprintf("resource %s is managed by helm, not deleted", key))
-		}
+		return nil
 	}
-
+	// Don't delete if the `prevent-deletion` label exists. It could be there because CAPA added it (see below),
+	// or because it was added externally, for example if a custom version of AWS CNI was already installed.
+	// Either way, CAPA should not delete such a labelled CNI installation.
+	labels := obj.GetLabels()
+	if _, exists := labels["prevent-deletion"]; exists {
+		s.scope.Debug(fmt.Sprintf("resource %s has 'prevent-deletion' label, skipping deletion", key))
+		return nil
+	}
+	// Delete the resource
+	if err := remoteClient.Delete(ctx, obj, &client.DeleteOptions{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete %s: %w", key, err)
+		}
+		s.scope.Debug(fmt.Sprintf(
+			"resource %s was not found, not deleted", key))
+	} else {
+		s.scope.Debug(fmt.Sprintf("resource %s was deleted", key))
+	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Recently, AWS changed the way VPC CNI is installed from manifest apply to managing it via Helm (ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2763#issuecomment-1908510232). This makes `AWSManagedControlPlane.Spec.VpcCni.Disable` flag obsolete due to the `app.kubernetes.io/managed-by: Helm` condition in deleteCNI flow.

This PR removes that condition to make the flag functional.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [4743](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4743)

**Special notes for your reviewer**:

For users replacing the default VPC CNI with their own helm-managed VPC CNI - They will need to set  `AWSManagedControlPlane.Spec.VpcCni.Disable` to `false` (default) OR set label on VPC CNI resource `"prevent-deletion": "true"`

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Flag to remove the default Helm-managed AWS VPC CNI EKS Addon
```
