### PR TITLE
🐛 ROSA: fix ROSAMachinePool.Spec.UpdateConfig causing unnecessary update calls

### DIFF
--- a/exp/api/v1beta2/rosamachinepool_webhook.go
+++ b/exp/api/v1beta2/rosamachinepool_webhook.go
@@ -5,8 +5,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -127,4 +130,17 @@ func validateImmutable(old, updated interface{}, name string) field.ErrorList {
 
 // Default implements admission.Defaulter.
 func (r *ROSAMachinePool) Default() {
+	if r.Spec.NodeDrainGracePeriod == nil {
+		r.Spec.NodeDrainGracePeriod = &metav1.Duration{}
+	}
+
+	if r.Spec.UpdateConfig == nil {
+		r.Spec.UpdateConfig = &RosaUpdateConfig{}
+	}
+	if r.Spec.UpdateConfig.RollingUpdate == nil {
+		r.Spec.UpdateConfig.RollingUpdate = &RollingUpdate{
+			MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+			MaxSurge:       ptr.To(intstr.FromInt32(1)),
+		}
+	}
 }

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -28,7 +29,8 @@ func TestNodePoolToRosaMachinePoolSpec(t *testing.T) {
 		},
 		UpdateConfig: &expinfrav1.RosaUpdateConfig{
 			RollingUpdate: &expinfrav1.RollingUpdate{
-				MaxSurge: &intstr.IntOrString{IntVal: 3},
+				MaxSurge:       ptr.To(intstr.FromInt32(3)),
+				MaxUnavailable: ptr.To(intstr.FromInt32(5)),
 			},
 		},
 	}
@@ -44,5 +46,5 @@ func TestNodePoolToRosaMachinePoolSpec(t *testing.T) {
 
 	expectedSpec := nodePoolToRosaMachinePoolSpec(nodePoolSpec)
 
-	g.Expect(expectedSpec).To(Equal(rosaMachinePoolSpec))
+	g.Expect(rosaMachinePoolSpec).To(BeComparableTo(expectedSpec, cmpopts.EquateEmpty()))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4998 introduced new `UpdateConfig` field to ROSAMachinePool which is causing unnecessary update calls. related to https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4977

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
