### PR TITLE
🐛 fix(nodegroup): add nil pointer check for nodegroup version

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -333,6 +333,11 @@ func (s *NodegroupService) reconcileNodegroupVersion(ng *eks.Nodegroup) error {
 			return fmt.Errorf("parsing EKS version from spec: %w", err)
 		}
 	}
+
+	// Check for nil pointers before dereferencing
+	if ng.Version == nil {
+		return fmt.Errorf("nodegroup version is nil")
+	}
 	ngVersion := version.MustParseGeneric(*ng.Version)
 	specAMI := s.scope.ManagedMachinePool.Spec.AMIVersion
 	ngAMI := *ng.ReleaseVersion


### PR DESCRIPTION
Added a check to ensure that the nodegroup version is not nil before dereferencing it. This prevents potential runtime panics due to nil pointer dereference.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
-->
/kind bug

**What this PR does / why we need it**:

This PR adds a nil pointer check for the nodegroup version in the `reconcileNodegroupVersion` function. This prevents potential runtime panics caused by dereferencing a nil pointer when the nodegroup version is not set.

**Which issue(s) this PR fixes**:
Fixes #5018

**Special notes for your reviewer**:

This change is essential to ensure the stability of the `reconcileNodegroupVersion` function by preventing nil pointer dereference issues.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix nil pointer dereference in reconcileNodegroupVersion by adding a check for nodegroup version.
```
