### PR TITLE
🐛: elbv2: skip adding security groups to NLB in secret regions

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1788,7 +1788,7 @@ func shouldReconcileSGs(scope scope.ELBScope, lb *infrav1.LoadBalancer, specSGs 
 	// Once created without a security group, the NLB can never have any added.
 	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html)
 	if lb.LoadBalancerType == infrav1.LoadBalancerTypeNLB && len(lb.SecurityGroupIDs) == 0 {
-		scope.Info("Pre-existing NLB %s without security groups, cannot reconcile security groups.", lb.Name)
+		scope.Info("Pre-existing NLB without security groups, cannot reconcile security groups.", "elb-name", lb.Name)
 		return false
 	}
 	if !sets.NewString(lb.SecurityGroupIDs...).Equal(sets.NewString(specSGs...)) {

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -64,6 +64,9 @@ const apiServerTargetGroupPrefix = "apiserver-target-"
 // listeners.
 const additionalTargetGroupPrefix = "additional-listener-"
 
+// cantAttachSGToNLBRegions is a set of regions that do not support Security Groups in NLBs.
+var cantAttachSGToNLBRegions = sets.New("us-iso-east-1", "us-iso-west-1", "us-isob-east-1")
+
 // ReconcileLoadbalancers reconciles the load balancers for the given cluster.
 func (s *Service) ReconcileLoadbalancers() error {
 	s.scope.Debug("Reconciling load balancers")
@@ -393,6 +396,11 @@ func (s *Service) createLB(spec *infrav1.LoadBalancer, lbSpec *infrav1.AWSLoadBa
 
 	if s.scope.VPC().IsIPv6Enabled() {
 		input.IpAddressType = aws.String("dualstack")
+	}
+
+	// TODO: remove when security groups on NLBs is supported in all regions.
+	if cantAttachSGToNLBRegions.Has(s.scope.Region()) {
+		input.SecurityGroups = nil
 	}
 
 	// Allocate custom addresses (Elastic IP) to internet-facing Load Balancers, when defined.
@@ -1788,7 +1796,11 @@ func shouldReconcileSGs(scope scope.ELBScope, lb *infrav1.LoadBalancer, specSGs 
 	// Once created without a security group, the NLB can never have any added.
 	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html)
 	if lb.LoadBalancerType == infrav1.LoadBalancerTypeNLB && len(lb.SecurityGroupIDs) == 0 {
-		scope.Info("Pre-existing NLB without security groups, cannot reconcile security groups.", "elb-name", lb.Name)
+		if cantAttachSGToNLBRegions.Has(scope.Region()) {
+			scope.Info("Region doesn't support NLB security groups, cannot reconcile security groups.", "region", scope.Region(), "elb-name", lb.Name)
+		} else {
+			scope.Info("Pre-existing NLB without security groups, cannot reconcile security groups.", "elb-name", lb.Name)
+		}
 		return false
 	}
 	if !sets.NewString(lb.SecurityGroupIDs...).Equal(sets.NewString(specSGs...)) {


### PR DESCRIPTION
Secret regions don't yet support security groups for NLBs.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

C2S/SC2S regions do not support security groups on Network load balancers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5029 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: do not attach security groups for Network Load Balancers in secret regions.
```
