### PR TITLE
🐛 Fix subtests running in same environment and reconciliation bug which was not covered because of that

### DIFF
--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -114,7 +114,9 @@ func (s *Service) ReconcileLaunchTemplate(
 			return err
 		}
 		scope.SetLaunchTemplateLatestVersionStatus(launchTemplateVersion)
-		return scope.PatchObject()
+		if err := scope.PatchObject(); err != nil {
+			return err
+		}
 	}
 
 	annotation, err := MachinePoolAnnotationJSON(scope, TagsLastAppliedAnnotation)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I was the author of those tests. They shared one envtest and namespace by mistake, leading to conflicts. After fixing this, luckily, only one new problem appeared which the conflicting tests previously couldn't catch: the reconciliation would return after setting `AWSMachinePool.status.launchTemplateVersion`, but can just continue (else we would have to call 3x `reconcileNormal` in the test to make it all happen). One test was checking for something it didn't even need (again: `AWSMachinePool.status.launchTemplateVersion`).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

n/a

**Special notes for your reviewer**: n/a

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Continue reconciliation after filling an empty `AWSMachinePool.status.launchTemplateVersion` field
```
