### PR TITLE
🐛 subnets: use "owned" k8s tag value for managed subnets.

### DIFF
--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -1004,7 +1004,7 @@ func mockedCallsForMissingEverything(m *mocks.MockEC2APIMockRecorder, e *mocks.M
 					},
 					{
 						Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-						Value: aws.String("shared"),
+						Value: aws.String("owned"),
 					},
 					{
 						Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -1035,7 +1035,7 @@ func mockedCallsForMissingEverything(m *mocks.MockEC2APIMockRecorder, e *mocks.M
 				},
 				{
 					Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-					Value: aws.String("shared"),
+					Value: aws.String("owned"),
 				},
 				{
 					Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -1071,7 +1071,7 @@ func mockedCallsForMissingEverything(m *mocks.MockEC2APIMockRecorder, e *mocks.M
 					},
 					{
 						Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-						Value: aws.String("shared"),
+						Value: aws.String("owned"),
 					},
 					{
 						Key:   aws.String("kubernetes.io/role/elb"),
@@ -1102,7 +1102,7 @@ func mockedCallsForMissingEverything(m *mocks.MockEC2APIMockRecorder, e *mocks.M
 				},
 				{
 					Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-					Value: aws.String("shared"),
+					Value: aws.String("owned"),
 				},
 				{
 					Key:   aws.String("kubernetes.io/role/elb"),

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
@@ -358,7 +358,7 @@ func mockedCallsForMissingEverything(ec2Rec *mocks.MockEC2APIMockRecorder, subne
 						},
 						{
 							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-							Value: aws.String("shared"),
+							Value: aws.String("owned"),
 						},
 						{
 							Key:   aws.String(kubernetesRoleTagKey),
@@ -390,7 +390,7 @@ func mockedCallsForMissingEverything(ec2Rec *mocks.MockEC2APIMockRecorder, subne
 					},
 					{
 						Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-						Value: aws.String("shared"),
+						Value: aws.String("owned"),
 					},
 					{
 						Key:   aws.String("kubernetes.io/role/elb"),

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -631,7 +631,11 @@ func (s *Service) getSubnetTagParams(unmanagedVPC bool, id string, public bool, 
 			}
 		}
 		// Add tag needed for Service type=LoadBalancer
-		additionalTags[infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName())] = string(infrav1.ResourceLifecycleShared)
+		if unmanagedVPC {
+			additionalTags[infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName())] = string(infrav1.ResourceLifecycleShared)
+		} else {
+			additionalTags[infrav1.ClusterAWSCloudProviderTagKey(s.scope.KubernetesClusterName())] = string(infrav1.ResourceLifecycleOwned)
+		}
 	}
 
 	if !unmanagedVPC {

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -1345,7 +1345,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -1391,7 +1391,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -1584,7 +1584,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -1639,7 +1639,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -1758,7 +1758,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -1842,7 +1842,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -1981,7 +1981,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -2036,7 +2036,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -2095,7 +2095,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -2150,7 +2150,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -2254,7 +2254,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -2309,7 +2309,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -2400,7 +2400,7 @@ func TestReconcileSubnets(t *testing.T) {
 									},
 									{
 										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-										Value: aws.String("shared"),
+										Value: aws.String("owned"),
 									},
 								},
 							},
@@ -2439,7 +2439,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -2542,7 +2542,7 @@ func TestReconcileSubnets(t *testing.T) {
 									},
 									{
 										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-										Value: aws.String("shared"),
+										Value: aws.String("owned"),
 									},
 								},
 							},
@@ -2581,7 +2581,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -2711,7 +2711,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-eks-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -2766,7 +2766,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-eks-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -2813,7 +2813,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-eks-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/elb"),
@@ -2880,7 +2880,7 @@ func TestReconcileSubnets(t *testing.T) {
 								},
 								{
 									Key:   aws.String("kubernetes.io/cluster/test-eks-cluster"),
-									Value: aws.String("shared"),
+									Value: aws.String("owned"),
 								},
 								{
 									Key:   aws.String("kubernetes.io/role/internal-elb"),
@@ -3803,7 +3803,7 @@ func TestService_retrieveZoneInfo(t *testing.T) {
 func stubGetTags(prefix, role, zone string, isEdge bool) []*ec2.Tag {
 	tags := []*ec2.Tag{
 		{Key: aws.String("Name"), Value: aws.String(fmt.Sprintf("%s-subnet-%s-%s", prefix, role, zone))},
-		{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("shared")},
+		{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("owned")},
 	}
 	// tags are returned ordered, inserting LB subnets to prevent diffs...
 	if !isEdge {


### PR DESCRIPTION
The "shared" value will be used for unmanaged subnets.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Tag managed subnets with "kubernetes.io/cluster/<clusterID>: owned" tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5050

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix managed subnet tagging with "owned" value for "kubernetes.io/cluster/<clusterID>" tag.
```
