### PR TITLE
:bug: Update filenames for released binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,12 +48,12 @@ archives:
 - id: clusterctl-aws
   builds:
   - clusterctl-aws
-  name_template: "clusterctl-aws_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+  name_template: "clusterctl-aws-{{ .Os }}-{{ .Arch }}"
   format: binary
 - id: clusterawsadm
   builds:
   - clusterawsadm
-  name_template: "clusterawsadm_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+  name_template: "clusterawsadm-{{ .Os }}-{{ .Arch }}"
   format: binary
 
 release:


### PR DESCRIPTION
This change only updates the binary naming template to match previous
releases. There is still an issue of building the same binary twice
under two different names.


**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Releases prior to implementing goreleaser used the `clusterawsadm-{{ .Os }}-{{ .Platform}}` format. See [v2.4.0](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/tag/v2.4.0) as an example of this format.

This does _not_ address the issue of building the same binary twice. We still need to address whether we would like to use `clusterctl-aws` or `clusterawsadm` going forward. ~~I will create an issue to track this.~~ See #5056 for tackling the double binary problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed released binary name template.
```
