### PR TITLE
:sparkles: Spot instances fallback - WaitingTimeout

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -280,6 +282,9 @@ type SpotMarketOptions struct {
 	// +optional
 	// +kubebuilder:validation:pattern="^[0-9]+(\.[0-9]+)?$"
 	MaxPrice *string `json:"maxPrice,omitempty"`
+	// WaitingTimeout defines the maximum time the user is willing to wait for acquiring a Spot VM instance, after that it will fallback to a regular on-demand instance.
+	// +optional
+	WaitingTimeout time.Duration `json:"waitingTimeout,omitempty"`
 }
 
 // EKSAMILookupType specifies which AWS AMI to use for a AWSMachine and AWSMachinePool.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -2222,6 +2222,7 @@ func Convert_v1beta2_SecurityGroup_To_v1beta1_SecurityGroup(in *v1beta2.Security
 
 func autoConvert_v1beta1_SpotMarketOptions_To_v1beta2_SpotMarketOptions(in *SpotMarketOptions, out *v1beta2.SpotMarketOptions, s conversion.Scope) error {
 	out.MaxPrice = (*string)(unsafe.Pointer(in.MaxPrice))
+	out.WaitingTimeout = time.Duration(in.WaitingTimeout)
 	return nil
 }
 
@@ -2232,6 +2233,7 @@ func Convert_v1beta1_SpotMarketOptions_To_v1beta2_SpotMarketOptions(in *SpotMark
 
 func autoConvert_v1beta2_SpotMarketOptions_To_v1beta1_SpotMarketOptions(in *v1beta2.SpotMarketOptions, out *SpotMarketOptions, s conversion.Scope) error {
 	out.MaxPrice = (*string)(unsafe.Pointer(in.MaxPrice))
+	out.WaitingTimeout = time.Duration(in.WaitingTimeout)
 	return nil
 }
 

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -17,7 +17,11 @@ limitations under the License.
 package v1beta2
 
 import (
+<<<<<<< HEAD
 	"strings"
+=======
+	"time"
+>>>>>>> adad1bff1 (api: add WaitingTimeout in SpotMarketOptions)
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -426,6 +430,9 @@ type SpotMarketOptions struct {
 	// +optional
 	// +kubebuilder:validation:pattern="^[0-9]+(\.[0-9]+)?$"
 	MaxPrice *string `json:"maxPrice,omitempty"`
+	// WaitingTimeout defines the maximum time the user is willing to wait for acquiring a Spot VM instance, after that it will fallback to a regular on-demand instance.
+	// +optional
+	WaitingTimeout time.Duration `json:"waitingTimeout,omitempty"`
 }
 
 // EKSAMILookupType specifies which AWS AMI to use for a AWSMachine and AWSMachinePool.

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -17,11 +17,8 @@ limitations under the License.
 package v1beta2
 
 import (
-<<<<<<< HEAD
 	"strings"
-=======
 	"time"
->>>>>>> adad1bff1 (api: add WaitingTimeout in SpotMarketOptions)
 
 	"k8s.io/apimachinery/pkg/util/sets"
 

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1378,6 +1378,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: The name of the SSH key pair.
@@ -3439,6 +3445,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: The name of the SSH key pair.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -573,6 +573,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: The name of the SSH key pair.
@@ -2353,6 +2359,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: The name of the SSH key pair.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -221,6 +221,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: |-
@@ -851,6 +857,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -330,6 +330,12 @@ spec:
                     description: MaxPrice defines the maximum price the user is willing
                       to pay for Spot VM instances
                     type: string
+                  waitingTimeout:
+                    description: WaitingTimeout defines the maximum time the user
+                      is willing to wait for acquiring a Spot VM instance, after that
+                      it will fallback to a regular on-demand instance.
+                    format: int64
+                    type: integer
                 type: object
               sshKeyName:
                 description: SSHKeyName is the name of the ssh key to attach to the
@@ -1047,6 +1053,12 @@ spec:
                     description: MaxPrice defines the maximum price the user is willing
                       to pay for Spot VM instances
                     type: string
+                  waitingTimeout:
+                    description: WaitingTimeout defines the maximum time the user
+                      is willing to wait for acquiring a Spot VM instance, after that
+                      it will fallback to a regular on-demand instance.
+                    format: int64
+                    type: integer
                 type: object
               sshKeyName:
                 description: SSHKeyName is the name of the ssh key to attach to the

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -345,6 +345,12 @@ spec:
                             description: MaxPrice defines the maximum price the user
                               is willing to pay for Spot VM instances
                             type: string
+                          waitingTimeout:
+                            description: WaitingTimeout defines the maximum time the
+                              user is willing to wait for acquiring a Spot VM instance,
+                              after that it will fallback to a regular on-demand instance.
+                            format: int64
+                            type: integer
                         type: object
                       sshKeyName:
                         description: SSHKeyName is the name of the ssh key to attach
@@ -981,6 +987,12 @@ spec:
                             description: MaxPrice defines the maximum price the user
                               is willing to pay for Spot VM instances
                             type: string
+                          waitingTimeout:
+                            description: WaitingTimeout defines the maximum time the
+                              user is willing to wait for acquiring a Spot VM instance,
+                              after that it will fallback to a regular on-demand instance.
+                            format: int64
+                            type: integer
                         type: object
                       sshKeyName:
                         description: SSHKeyName is the name of the ssh key to attach

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -230,6 +230,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: |-
@@ -847,6 +853,12 @@ spec:
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
                         type: string
+                      waitingTimeout:
+                        description: WaitingTimeout defines the maximum time the user
+                          is willing to wait for acquiring a Spot VM instance, after
+                          that it will fallback to a regular on-demand instance.
+                        format: int64
+                        type: integer
                     type: object
                   sshKeyName:
                     description: |-

--- a/docs/book/src/topics/spot-instances.md
+++ b/docs/book/src/topics/spot-instances.md
@@ -25,6 +25,7 @@ spec:
       instanceType: ${AWS_NODE_MACHINE_TYPE}
       spotMarketOptions:
         maxPrice: ""
+        waitingTimeout: ""
       sshKeyName: ${AWS_SSH_KEY_NAME}
 ```
 Users may also add a `maxPrice` to the options to limit the maximum spend for the instance. It is however, recommended not to set a maxPrice as AWS will cap your spending at the on-demand price if this field is left empty, and you will experience fewer interruptions.
@@ -33,6 +34,14 @@ spec:
   template:
     spotMarketOptions:
       maxPrice: 0.02 # Price in USD per hour (up to 5 decimal places)
+```
+
+Users may also add a `waitingTimeout` to the options to limit waiting time for the Spot instance. After exceeding this timeout a regular ec2 instance will be acquired.
+```yaml
+spec:
+  template:
+    spotMarketOptions:
+      waitingTimeout: "10m" # Time in minutes
 ```
 
 ## Using Spot Instances with AWSManagedMachinePool


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change


**What this PR does / why we need it**:
This feature is adding `WaitingTimeout` for `SpotMarketOptions` that is optional. The `WaitingTimeout` serves as a timeout when no Spot instances are available and after this timeout is reached a regular ec2 instance will be acquired instead.


**Special notes for your reviewer**:

**Checklist**:
- [X] squashed commits
- [X] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
feat: add WaitingTimeout for Spot instances to fallback to a regular ec2 instance
```

