### PR TITLE
🌱 chore: change name of prevent deletion label

### DIFF
--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -24,6 +24,12 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+const (
+	// PreventDeletionLabel can be used in situations where preventing delation is allowed. The docs
+	// and the CRD will call this out where its allowed.
+	PreventDeletionLabel = "aws.cluster.x-k8s.io/prevent-deletion"
+)
+
 // AWSResourceReference is a reference to a specific AWS resource by ID or filters.
 // Only one of ID or Filters may be specified. Specifying more than one will result in
 // a validation error.

--- a/docs/book/src/topics/eks/pod-networking.md
+++ b/docs/book/src/topics/eks/pod-networking.md
@@ -97,7 +97,7 @@ spec:
   disableVPCCNI: true
 ```
 
-If you are replacing Amazon VPC CNI with your own helm managed instance, you will need to set `AWSManagedControlPlane.spec.disableVPCCNI` to `true` and add `"prevent-deletion": "true"` label on the Daemonset. This label is needed so `aws-node` daemonset is not reaped during CNI reconciliation.
+If you are replacing Amazon VPC CNI with your own helm managed instance, you will need to set `AWSManagedControlPlane.spec.disableVPCCNI` to `true` and add `"aws.cluster.x-k8s.io/prevent-deletion": "true"` label on the Daemonset. This label is needed so `aws-node` daemonset is not reaped during CNI reconciliation.
 
 The following example shows how to label your aws-node Daemonset.
 
@@ -114,7 +114,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/version: v1.15.1
     helm.sh/chart: aws-vpc-cni-1.15.1
-    prevent-deletion: true
+    aws.cluster.x-k8s.io/prevent-deletion: true
 ```
 
 > You cannot set **disableVPCCNI** to true if you are using the VPC CNI addon.

--- a/pkg/cloud/services/awsnode/cni.go
+++ b/pkg/cloud/services/awsnode/cni.go
@@ -273,12 +273,12 @@ func (s *Service) deleteResource(ctx context.Context, remoteClient client.Client
 		s.scope.Debug(fmt.Sprintf("resource %s was not found, no action", key))
 		return nil
 	}
-	// Don't delete if the `prevent-deletion` label exists. It could be there because CAPA added it (see below),
+	// Don't delete if the "PreventDeletionLabel" label exists. It could be there because CAPA added it (see below),
 	// or because it was added externally, for example if a custom version of AWS CNI was already installed.
 	// Either way, CAPA should not delete such a labelled CNI installation.
 	labels := obj.GetLabels()
-	if _, exists := labels["prevent-deletion"]; exists {
-		s.scope.Debug(fmt.Sprintf("resource %s has 'prevent-deletion' label, skipping deletion", key))
+	if _, exists := labels[infrav1.PreventDeletionLabel]; exists {
+		s.scope.Debug(fmt.Sprintf("resource %s has '%s' label, skipping deletion", key, infrav1.PreventDeletionLabel))
 		return nil
 	}
 	// Delete the resource


### PR DESCRIPTION



**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Small change to prefix the label that prevents deletion of the VPC CNI to be prefixed with an CAPA prefix. This is just to ensure that we make it as specific to CAPA as possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is a follow-up to #5009 . I thought about this after it merged.

@jas-nik - would love to get your thoughts on making the label name more specific to CAPA.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change prevenet deletion label to be specific to CAPA.
```
