### PR TITLE
🐛 Mark `S3BucketCreated` condition ready after successful reconciliation

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -358,6 +358,7 @@ func (r *AWSClusterReconciler) reconcileNormal(clusterScope *scope.ClusterScope)
 		conditions.MarkFalse(awsCluster, infrav1.S3BucketReadyCondition, infrav1.S3BucketFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile S3 Bucket for AWSCluster %s/%s", awsCluster.Namespace, awsCluster.Name)
 	}
+	conditions.MarkTrue(awsCluster, infrav1.S3BucketReadyCondition)
 
 	for _, subnet := range clusterScope.Subnets().FilterPrivate() {
 		found := false


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The ready condition never gets set. This was likely just a minor oversight in the initial implementation. I noticed because we had a temporary failure where CAPA didn't remove the non-ready mark for the condition after having successfully reconciled the bucket later.

I left out amending any test since there seems to be no full reconciliation test for bucket-backed cluster creation.

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Mark `S3BucketCreated` condition ready after successful reconciliation
```
