### PR TITLE
Add permissions to the GitHub Actions token

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,6 +13,10 @@ on:
           description: 'Run code generation manually from GH CLI'
           required: true
           default: 'Make Generate'
+
+permissions:
+  contents: write # Allow actions to update dependabot PRs
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  checks: write
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Since moving to the Kubernetes GitHub Enterprise account, our GitHub Actions jobs haven't been able to write their status to the API.

This results in the following error on all jobs that run within GitHub Actions:

```
Error: unable to create check run: POST https://api.github.com/repos/kubernetes-sigs/cluster-api-provider-aws/check-runs: 403 Resource not accessible by integration []
```

**Special notes for your reviewer**:

This is similar to the [permissions carried by upstream CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/main/.github/workflows/pr-verify.yaml#L7-L8)


- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
