### PR TITLE
🐛 Standardize cluster name in Fargate role names to avoid errors on mismatch between Cluster CR and EKS cluster name

### DIFF
--- a/pkg/cloud/services/eks/roles.go
+++ b/pkg/cloud/services/eks/roles.go
@@ -183,7 +183,7 @@ func (s *NodegroupService) reconcileNodegroupIAMRole() error {
 			s.scope.Info("no EKS nodegroup role specified, using role based on nodegroup name")
 			roleName, err = eks.GenerateEKSName(
 				"nodegroup-iam-service-role",
-				fmt.Sprintf("%s-%s", s.scope.ClusterName(), s.scope.NodegroupName()),
+				fmt.Sprintf("%s-%s", s.scope.KubernetesClusterName(), s.scope.NodegroupName()),
 				maxIAMRoleNameLength,
 			)
 			if err != nil {

--- a/pkg/cloud/services/eks/roles.go
+++ b/pkg/cloud/services/eks/roles.go
@@ -183,7 +183,7 @@ func (s *NodegroupService) reconcileNodegroupIAMRole() error {
 			s.scope.Info("no EKS nodegroup role specified, using role based on nodegroup name")
 			roleName, err = eks.GenerateEKSName(
 				"nodegroup-iam-service-role",
-				fmt.Sprintf("%s-%s", s.scope.KubernetesClusterName(), s.scope.NodegroupName()),
+				fmt.Sprintf("%s-%s", s.scope.ClusterName(), s.scope.NodegroupName()),
 				maxIAMRoleNameLength,
 			)
 			if err != nil {
@@ -304,7 +304,7 @@ func (s *FargateService) reconcileFargateIAMRole() (requeue bool, err error) {
 			s.scope.Info("no EKS fargate role specified, using role based on fargate profile name")
 			roleName, err = eks.GenerateEKSName(
 				"fargate",
-				fmt.Sprintf("%s-%s", s.scope.KubernetesClusterName(), s.scope.FargateProfile.Spec.ProfileName),
+				fmt.Sprintf("%s-%s", s.scope.ClusterName(), s.scope.FargateProfile.Spec.ProfileName),
 				maxIAMRoleNameLength,
 			)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

The validating webhook https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/abe918cfe1038c714792860b23632e38c7e0438f/exp/api/v1beta2/awsfargateprofile_webhook.go#L83-L90 uses the Fargate profile's `spec.clusterName` in order to generate the role name.

This differs from the EKS role service which instead uses the `scope.KubernetesClusterName()`.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/abe918cfe1038c714792860b23632e38c7e0438f/pkg/cloud/services/eks/roles.go#L304-L309

The problem comes from the scenario where the cluster resource is named one thing (i.e. `foo`) but was created in EKS using some prefixes (i.e. `default_foo-control-plane`). If this is the case, the CAPA controller will fail to validate its own change.

```
E0904 05:13:30.268899       1 controller.go:329] "Reconciler error" err="failed to patch AWSFargateProfile default/foo-fargate-0: admission webhook \"validation.awsfargateprofile.infrastructure.cluster.x-k8s.io\" denied the request: AWSFargateProfile.infrastructure.cluster.x-k8s.io \"foo-fargate-0\" is invalid: spec: Invalid value: v1beta2.FargateProfileSpec{ClusterName:\"foo\", ProfileName:\"default_foo-fargate-0\", SubnetIDs:[]string(nil), AdditionalTags:v1beta2.Tags(nil), RoleName:\"default_foo-control-plane-default_foo-fargate-0_fargate\", Selectors:[]v1beta2.FargateSelector{v1beta2.FargateSelector{Labels:map[string]string(nil), Namespace:\"bar\"}}}: is immutable" controller="awsfargateprofile" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSFargateProfile" AWSFargateProfile="default/foo-fargate-0" namespace="default" name="foo-fargate-0" reconcileID="f043997e-5aaf-4b20-a810-7d84e957dd71"
```

> Note the `RoleName` looks iffy and that this is from using the `eks.GenerateEKSName()` with the EKS cluster's _actual_ name (`scope.KubernetesClusterName()`).: `default_foo-control-plane-default_foo-fargate-0_fargate`

Also, changing the fargate profile's `.spec.clusterName` to match the `scope.KubernetesClusterName()` will fail if this does not match the custom resource's `metadata.name`.

```
capa-controller-manager-6644fb894c-nvqwd manager I0904 05:43:23.906142       1 awsfargatepool_controller.go:87] "Failed to retrieve Cluster from AWSFargateProfile" controller="awsfargateprofile" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSFargateProfile" AWSFargateProfile="default/manager-fargate-2" namespace="default" name="manager-fargate-2" reconcileID="557ca8d1-9108-4c81-89f5-86989f90811f"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Fargate: Standardize cluster name in role names to avoid errors on mismatch between Cluster CR and EKS cluster name
```
