### PR TITLE
:bug: fix: properly restart cloud-init

### DIFF
--- a/pkg/cloud/services/secretsmanager/secret_fetch_script.go
+++ b/pkg/cloud/services/secretsmanager/secret_fetch_script.go
@@ -231,6 +231,7 @@ if [ ${GUNZIP_RETURN} -ne 0 ]; then
 fi
 
 log::info "restarting cloud-init"
-systemctl restart cloud-init
+rm -rf /var/lib/cloud/instances
+cloud-init clean --reboot
 log::success_exit
 `

--- a/pkg/cloud/services/ssm/secret_fetch_script.go
+++ b/pkg/cloud/services/ssm/secret_fetch_script.go
@@ -196,6 +196,7 @@ if [ ${GUNZIP_RETURN} -ne 0 ]; then
 fi
 
 log::info "restarting cloud-init"
-systemctl restart cloud-init
+rm -rf /var/lib/cloud/instances
+cloud-init clean --reboot
 log::success_exit
 `


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind fix

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

It seems that `systemctl restart clout-init` is no longer sufficient to start the cloud-init process again with the secret userdata. After some googling I found the following steps to restart it without needing to reboot the machine.  The step comes from here https://cloudinit.readthedocs.io/en/latest/howto/rerun_cloud_init.html

We should move towards an approach that doesn't require a restart of cloud-init to handle secret userdata.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5115

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: uses different commands to restart cloud-init
```
