### PR TITLE
✨refactor: update to use new community ami account

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ cluster on AWS.
 
 - Native Kubernetes manifests and API
 - Manages the bootstrapping of VPCs, gateways, security groups and instances.
-- Choice of Linux distribution among Amazon Linux 2, CentOS 7, Ubuntu and Flatcar
-  using [pre-baked AMIs][published_amis].
+- Choice of Linux distribution using [pre-baked AMIs][published_amis].
 - Deploys Kubernetes control planes into private subnets with a separate
   bastion server.
 - Doesn't use SSH for bootstrapping nodes.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cluster on AWS.
 
 - Native Kubernetes manifests and API
 - Manages the bootstrapping of VPCs, gateways, security groups and instances.
-- Choice of Linux distribution among Amazon Linux 2, CentOS 7, Ubuntu(18.04, 20.04) and Flatcar
+- Choice of Linux distribution among Amazon Linux 2, CentOS 7, Ubuntu and Flatcar
   using [pre-baked AMIs][published_amis].
 - Deploys Kubernetes control planes into private subnets with a separate
   bastion server.

--- a/cmd/clusterawsadm/ami/helper.go
+++ b/cmd/clusterawsadm/ami/helper.go
@@ -38,7 +38,7 @@ const (
 )
 
 func getSupportedOsList() []string {
-	return []string{"centos-7", "ubuntu-22.04", "ubuntu-18.04", "ubuntu-20.04", "amazon-2", "flatcar-stable"}
+	return []string{"centos-7", "ubuntu-24.04", "ubuntu-22.04", "amazon-2", "flatcar-stable", "rhel-8"}
 }
 
 func getimageRegionList() []string {

--- a/cmd/clusterawsadm/cmd/ami/common/copy.go
+++ b/cmd/clusterawsadm/cmd/ami/common/copy.go
@@ -40,8 +40,8 @@ func CopyAMICmd() *cobra.Command {
 		`),
 		Example: cmd.Examples(`
 		# Copy AMI from the default AWS account where AMIs are stored.
-		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2, flatcar-stable
-		clusterawsadm ami copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
+		# Available os options: centos-7, ubuntu-24.04, ubuntu-22.04, amazon-2, flatcar-stable
+		clusterawsadm ami copy --kubernetes-version=v1.30.1 --os=ubuntu-22.04  --region=us-west-2
 
 		# owner-id and dry-run flags are optional. region can be set via flag or env
 		clusterawsadm ami copy --os centos-7 --kubernetes-version=v1.19.4 --owner-id=111111111111 --dry-run
@@ -81,7 +81,6 @@ func CopyAMICmd() *cobra.Command {
 				SourceRegion:      sourceRegion,
 			},
 			)
-
 			if err != nil {
 				fmt.Print(err)
 				return err

--- a/cmd/clusterawsadm/cmd/ami/common/encryptedcopy.go
+++ b/cmd/clusterawsadm/cmd/ami/common/encryptedcopy.go
@@ -45,7 +45,7 @@ func EncryptedCopyAMICmd() *cobra.Command {
 		`),
 		Example: cmd.Examples(`
 		# Create an encrypted AMI:
-		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2, flatcar-stable
+		# Available os options: centos-7, ubuntu-24.04, ubuntu-22.04, amazon-2, flatcar-stable
 		clusterawsadm ami encrypted-copy --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
 
 		# owner-id and dry-run flags are optional. region can be set via flag or env

--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -51,7 +51,7 @@ func ListAMICmd() *cobra.Command {
 		`),
 		Example: cmd.Examples(`
 		# List AMIs from the default AWS account where AMIs are stored.
-		# Available os options: centos-7, ubuntu-18.04, ubuntu-20.04, amazon-2, flatcar-stable
+		# Available os options: centos-7, ubuntu-24.04, ubuntu-22.04, amazon-2, flatcar-stable
 		clusterawsadm ami list --kubernetes-version=v1.18.12 --os=ubuntu-20.04  --region=us-west-2
 		# To list all supported AMIs in all supported Kubernetes versions, regions, and linux distributions:
 		clusterawsadm ami list

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -106,11 +106,13 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, awsMachine, ns, secret)).To(Succeed())
 		})
 
-		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{NetworkSpec: infrav1.NetworkSpec{Subnets: []infrav1.SubnetSpec{
-			{
-				ID:               "subnet-1",
-				AvailabilityZone: "us-east-1a",
-			}},
+		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{NetworkSpec: infrav1.NetworkSpec{
+			Subnets: []infrav1.SubnetSpec{
+				{
+					ID:               "subnet-1",
+					AvailabilityZone: "us-east-1a",
+				},
+			},
 		}}})
 		g.Expect(err).To(BeNil())
 		cs.Cluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
@@ -131,7 +133,8 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			},
 			infrav1.SecurityGroupControlPlane: {
 				ID: "3",
-			}}
+			},
+		}
 		ms, err := getMachineScope(cs, awsMachine)
 		g.Expect(err).To(BeNil())
 
@@ -162,9 +165,11 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 
 		_, err = reconciler.reconcileNormal(ctx, ms, cs, cs, cs, cs)
 		g.Expect(err).To(BeNil())
-		expectConditions(g, ms.AWSMachine, []conditionAssertion{{infrav1.SecurityGroupsReadyCondition, corev1.ConditionTrue, "", ""},
+		expectConditions(g, ms.AWSMachine, []conditionAssertion{
+			{infrav1.SecurityGroupsReadyCondition, corev1.ConditionTrue, "", ""},
 			{infrav1.InstanceReadyCondition, corev1.ConditionTrue, "", ""},
-			{infrav1.ELBAttachedCondition, corev1.ConditionTrue, "", ""}})
+			{infrav1.ELBAttachedCondition, corev1.ConditionTrue, "", ""},
+		})
 		g.Expect(ms.AWSMachine.Finalizers).Should(ContainElement(infrav1.MachineFinalizer))
 	})
 	t.Run("Should successfully reconcile control plane machine deletion", func(t *testing.T) {
@@ -236,7 +241,8 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 		g.Expect(err).To(BeNil())
 		expectConditions(g, ms.AWSMachine, []conditionAssertion{
 			{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletedReason},
-			{infrav1.ELBAttachedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletedReason}})
+			{infrav1.ELBAttachedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletedReason},
+		})
 		g.Expect(ms.AWSMachine.Finalizers).ShouldNot(ContainElement(infrav1.MachineFinalizer))
 	})
 	t.Run("Should fail reconciling control-plane machine creation while attaching load balancer", func(t *testing.T) {
@@ -280,11 +286,13 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, awsMachine, ns, secret)).To(Succeed())
 		})
 
-		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{NetworkSpec: infrav1.NetworkSpec{Subnets: []infrav1.SubnetSpec{
-			{
-				ID:               "subnet-1",
-				AvailabilityZone: "us-east-1a",
-			}},
+		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{NetworkSpec: infrav1.NetworkSpec{
+			Subnets: []infrav1.SubnetSpec{
+				{
+					ID:               "subnet-1",
+					AvailabilityZone: "us-east-1a",
+				},
+			},
 		}}})
 		g.Expect(err).To(BeNil())
 		cs.Cluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
@@ -305,7 +313,8 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			},
 			infrav1.SecurityGroupControlPlane: {
 				ID: "3",
-			}}
+			},
+		}
 		ms, err := getMachineScope(cs, awsMachine)
 		g.Expect(err).To(BeNil())
 
@@ -411,8 +420,10 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 
 		_, err = reconciler.reconcileDelete(ms, cs, cs, cs, cs)
 		g.Expect(err).Should(HaveOccurred())
-		expectConditions(g, ms.AWSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, "DeletingFailed"},
-			{infrav1.ELBAttachedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletedReason}})
+		expectConditions(g, ms.AWSMachine, []conditionAssertion{
+			{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, "DeletingFailed"},
+			{infrav1.ELBAttachedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletedReason},
+		})
 		g.Expect(ms.AWSMachine.Finalizers).ShouldNot(ContainElement(infrav1.MachineFinalizer))
 	})
 }
@@ -572,11 +583,11 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("owner-id"),
-				Values: aws.StringSlice([]string{"258751437250"}),
+				Values: aws.StringSlice([]string{"819546954734"}),
 			},
 			{
 				Name:   aws.String("name"),
-				Values: aws.StringSlice([]string{"capa-ami-ubuntu-18.04-?test-*"}),
+				Values: aws.StringSlice([]string{"capa-ami-ubuntu-24.04-?test-*"}),
 			},
 			{
 				Name:   aws.String("architecture"),
@@ -590,7 +601,8 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 				Name:   aws.String("virtualization-type"),
 				Values: aws.StringSlice([]string{"hvm"}),
 			},
-		}})).Return(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
+		},
+	})).Return(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 		{
 			ImageId:      aws.String("latest"),
 			CreationDate: aws.String("2019-02-08T17:02:31.000Z"),
@@ -639,7 +651,8 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 					},
 				},
 			},
-		}}, nil).MaxTimes(3)
+		},
+	}, nil).MaxTimes(3)
 	m.DescribeNetworkInterfaceAttributeWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String("eni-1"),
 		Attribute:          aws.String("groupSet"),

--- a/docs/book/src/SUMMARY_SUFFIX.md
+++ b/docs/book/src/SUMMARY_SUFFIX.md
@@ -3,6 +3,7 @@
   - [Developing E2E tests](./development/e2e.md)
   - [Coding Conventions](./development/conventions.md)
   - [Try unreleased changes with Nightly Builds](./development/nightlies.md)
+  - [Publishing AMIs](./development/amis.md)
 - [CRD Reference](./crd/index.md)
 - [Reference](./topics/reference/reference.md)
   - [Glossary](./topics/reference/glossary.md)

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -6576,6 +6576,17 @@ VpcCni
 </tr>
 <tr>
 <td>
+<code>restrictPrivateSubnets</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>RestrictPrivateSubnets indicates that the EKS control plane should only use private subnets.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>kubeProxy</code><br/>
 <em>
 <a href="#controlplane.cluster.x-k8s.io/v1beta2.KubeProxy">
@@ -6975,6 +6986,17 @@ VpcCni
 <td>
 <em>(Optional)</em>
 <p>VpcCni is used to set configuration options for the VPC CNI plugin</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>restrictPrivateSubnets</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>RestrictPrivateSubnets indicates that the EKS control plane should only use private subnets.</p>
 </td>
 </tr>
 <tr>
@@ -17072,7 +17094,13 @@ int64
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;AL2_ARM_64&#34;</p></td>
+<tbody><tr><td><p>&#34;AL2023_ARM_64_STANDARD&#34;</p></td>
+<td><p>Al2023Arm64 is the AL2023 Arm AMI type.</p>
+</td>
+</tr><tr><td><p>&#34;AL2023_x86_64_STANDARD&#34;</p></td>
+<td><p>Al2023x86_64 is the AL2023 x86-64 AMI type.</p>
+</td>
+</tr><tr><td><p>&#34;AL2_ARM_64&#34;</p></td>
 <td><p>Al2Arm64 is the Arm AMI type.</p>
 </td>
 </tr><tr><td><p>&#34;AL2_x86_64&#34;</p></td>
@@ -17080,12 +17108,6 @@ int64
 </td>
 </tr><tr><td><p>&#34;AL2_x86_64_GPU&#34;</p></td>
 <td><p>Al2x86_64GPU is the x86-64 GPU AMI type.</p>
-</td>
-<tr><td><p>&#34;AL2023_ARM_64_STANDARD&#34;</p></td>
-<td><p>Al2023Arm64 is the AL2023 Arm AMI type.</p>
-</td>
-</tr><tr><td><p>&#34;AL2023_x86_64_STANDARD&#34;</p></td>
-<td><p>Al2023x86_64 is the AL2023 x86 AMI type.</p>
 </td>
 </tr></tbody>
 </table>
@@ -19005,6 +19027,20 @@ default value is ELBProtocolSSL</p>
 </tr>
 <tr>
 <td>
+<code>healthCheck</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.TargetGroupHealthCheckAPISpec">
+TargetGroupHealthCheckAPISpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HealthCheck sets custom health check configuration to the API target group.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>additionalSecurityGroups</code><br/>
 <em>
 []string
@@ -19275,6 +19311,20 @@ Precedence for this setting is as follows:
 </tr>
 <tr>
 <td>
+<code>elasticIpPool</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.ElasticIPPool">
+ElasticIPPool
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ElasticIPPool is the configuration to allocate Public IPv4 address (Elastic IP/EIP) from user-defined pool.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>additionalSecurityGroups</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSResourceReference">
@@ -19478,6 +19528,18 @@ PrivateDNSName
 <td>
 <em>(Optional)</em>
 <p>PrivateDNSName is the options for the instance hostname.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacityReservationId</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.</p>
 </td>
 </tr>
 </table>
@@ -19669,6 +19731,20 @@ Precedence for this setting is as follows:
 </tr>
 <tr>
 <td>
+<code>elasticIpPool</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.ElasticIPPool">
+ElasticIPPool
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ElasticIPPool is the configuration to allocate Public IPv4 address (Elastic IP/EIP) from user-defined pool.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>additionalSecurityGroups</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSResourceReference">
@@ -19872,6 +19948,18 @@ PrivateDNSName
 <td>
 <em>(Optional)</em>
 <p>PrivateDNSName is the options for the instance hostname.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacityReservationId</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.</p>
 </td>
 </tr>
 </tbody>
@@ -20279,6 +20367,20 @@ Precedence for this setting is as follows:
 </tr>
 <tr>
 <td>
+<code>elasticIpPool</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.ElasticIPPool">
+ElasticIPPool
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ElasticIPPool is the configuration to allocate Public IPv4 address (Elastic IP/EIP) from user-defined pool.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>additionalSecurityGroups</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSResourceReference">
@@ -20482,6 +20584,18 @@ PrivateDNSName
 <td>
 <em>(Optional)</em>
 <p>PrivateDNSName is the options for the instance hostname.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacityReservationId</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.</p>
 </td>
 </tr>
 </table>
@@ -20877,6 +20991,20 @@ ELBProtocol
 <td>
 <p>Protocol sets the protocol for the additional listener.
 Currently only TCP is supported.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>healthCheck</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.TargetGroupHealthCheckAdditionalSpec">
+TargetGroupHealthCheckAdditionalSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HealthCheck sets the optional custom health check configuration to the API target group.</p>
 </td>
 </tr>
 </tbody>
@@ -21474,6 +21602,58 @@ will use AWS Secrets Manager instead.</p>
 <p>
 <p>ELBScheme defines the scheme of a load balancer.</p>
 </p>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.ElasticIPPool">ElasticIPPool
+</h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSMachineSpec">AWSMachineSpec</a>, <a href="#infrastructure.cluster.x-k8s.io/v1beta2.VPCSpec">VPCSpec</a>)
+</p>
+<p>
+<p>ElasticIPPool allows configuring a Elastic IP pool for resources allocating
+public IPv4 addresses on public subnets.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>publicIpv4Pool</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PublicIpv4Pool sets a custom Public IPv4 Pool used to create Elastic IP address for resources
+created in public IPv4 subnets. Every IPv4 address, Elastic IP, will be allocated from the custom
+Public IPv4 pool that you brought to AWS, instead of Amazon-provided pool. The public IPv4 pool
+resource ID starts with &lsquo;ipv4pool-ec2&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>publicIpv4PoolFallbackOrder</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.PublicIpv4PoolFallbackOrder">
+PublicIpv4PoolFallbackOrder
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PublicIpv4PoolFallBackOrder defines the fallback action when the Public IPv4 Pool has been exhausted,
+no more IPv4 address available in the pool.</p>
+<p>When set to &lsquo;amazon-pool&rsquo;, the controller check if the pool has available IPv4 address, when pool has reached the
+IPv4 limit, the address will be claimed from Amazon-pool (default).</p>
+<p>When set to &lsquo;none&rsquo;, the controller will fail the Elastic IP allocation when the publicIpv4Pool is exhausted.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta2.Filter">Filter
 </h3>
 <p>
@@ -21977,6 +22157,18 @@ int64
 The field will be combined with source security group IDs if specified.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>natGatewaysIPsSource</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta2.IngressRules">IngressRules
@@ -22323,6 +22515,18 @@ bool
 <td>
 <em>(Optional)</em>
 <p>PublicIPOnLaunch is the option to associate a public IP on instance launch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacityReservationId</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.</p>
 </td>
 </tr>
 </tbody>
@@ -22890,6 +23094,16 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.PublicIpv4PoolFallbackOrder">PublicIpv4PoolFallbackOrder
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.ElasticIPPool">ElasticIPPool</a>)
+</p>
+<p>
+<p>PublicIpv4PoolFallbackOrder defines the list of available fallback action when the PublicIpv4Pool is exhausted.
+&lsquo;none&rsquo; let the controllers return failures when the PublicIpv4Pool is exhausted - no more IPv4 available.
+&lsquo;amazon-pool&rsquo; let the controllers to skip the PublicIpv4Pool and use the Amazon pool, the default.</p>
+</p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta2.ResourceLifecycle">ResourceLifecycle
 (<code>string</code> alias)</p></h3>
 <p>
@@ -22991,6 +23205,18 @@ string
 </td>
 <td>
 <p>Name defines name of S3 Bucket to be created.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bestEffortDeleteObjects</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BestEffortDeleteObjects defines whether access/permission errors during object deletion should be ignored.</p>
 </td>
 </tr>
 </tbody>
@@ -23118,6 +23344,15 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.SubnetSchemaType">SubnetSchemaType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.VPCSpec">VPCSpec</a>)
+</p>
+<p>
+<p>SubnetSchemaType specifies how given network should be divided on subnets
+in the VPC depending on the number of AZs.</p>
+</p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta2.SubnetSpec">SubnetSpec
 </h3>
 <p>
@@ -23260,6 +23495,49 @@ Tags
 <p>Tags is a collection of tags describing the resource.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>zoneType</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.ZoneType">
+ZoneType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ZoneType defines the type of the zone where the subnet is created.</p>
+<p>The valid values are availability-zone, local-zone, and wavelength-zone.</p>
+<p>Subnet with zone type availability-zone (regular) is always selected to create cluster
+resources, like Load Balancers, NAT Gateways, Contol Plane nodes, etc.</p>
+<p>Subnet with zone type local-zone or wavelength-zone is not eligible to automatically create
+regular cluster resources.</p>
+<p>The public subnet in availability-zone or local-zone is associated with regular public
+route table with default route entry to a Internet Gateway.</p>
+<p>The public subnet in wavelength-zone is associated with a carrier public
+route table with default route entry to a Carrier Gateway.</p>
+<p>The private subnet in the availability-zone is associated with a private route table with
+the default route entry to a NAT Gateway created in that zone.</p>
+<p>The private subnet in the local-zone or wavelength-zone is associated with a private route table with
+the default route entry re-using the NAT Gateway in the Region (preferred from the
+parent zone, the zone type availability-zone in the region, or first table available).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>parentZoneName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ParentZoneName is the zone name where the current subnet&rsquo;s zone is tied when
+the zone is a Local Zone.</p>
+<p>The subnets in Local Zone or Wavelength Zone locations consume the ParentZoneName
+to select the correct private route table to egress traffic to the internet.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta2.Subnets">Subnets
@@ -23357,6 +23635,195 @@ int64
 </em>
 </td>
 <td>
+</td>
+</tr>
+<tr>
+<td>
+<code>unhealthyThresholdCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.TargetGroupHealthCheckAPISpec">TargetGroupHealthCheckAPISpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.AWSLoadBalancerSpec">AWSLoadBalancerSpec</a>)
+</p>
+<p>
+<p>TargetGroupHealthCheckAPISpec defines the optional health check settings for the API target group.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>intervalSeconds</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The approximate amount of time, in seconds, between health checks of an individual
+target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeoutSeconds</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The amount of time, in seconds, during which no response from a target means
+a failed health check.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>thresholdCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of consecutive health check successes required before considering
+a target healthy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>unhealthyThresholdCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of consecutive health check failures required before considering
+a target unhealthy.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.TargetGroupHealthCheckAdditionalSpec">TargetGroupHealthCheckAdditionalSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.AdditionalListenerSpec">AdditionalListenerSpec</a>)
+</p>
+<p>
+<p>TargetGroupHealthCheckAdditionalSpec defines the optional health check settings for the additional target groups.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>protocol</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The protocol to use to health check connect with the target. When not specified the Protocol
+will be the same of the listener.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The port the load balancer uses when performing health checks for additional target groups. When
+not specified this value will be set for the same of listener port.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>path</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The destination for health checks on the targets when using the protocol HTTP or HTTPS,
+otherwise the path will be ignored.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>intervalSeconds</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The approximate amount of time, in seconds, between health checks of an individual
+target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeoutSeconds</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The amount of time, in seconds, during which no response from a target means
+a failed health check.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>thresholdCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of consecutive health check successes required before considering
+a target healthy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>unhealthyThresholdCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of consecutive health check failures required before considering
+a target unhealthy.</p>
 </td>
 </tr>
 </tbody>
@@ -23479,6 +23946,22 @@ Mutually exclusive with IPAMPool.</p>
 </tr>
 <tr>
 <td>
+<code>secondaryCidrBlocks</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.VpcCidrBlock">
+[]VpcCidrBlock
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecondaryCidrBlocks are additional CIDR blocks to be associated when the provider creates a managed VPC.
+Defaults to none. Mutually exclusive with IPAMPool. This makes sense to use if, for example, you want to use
+a separate IP range for pods (e.g. Cilium ENI mode).</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ipamPool</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.IPAMPool">
@@ -23516,6 +23999,19 @@ string
 <td>
 <em>(Optional)</em>
 <p>InternetGatewayID is the id of the internet gateway associated with the VPC.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>carrierGatewayId</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CarrierGatewayID is the id of the internet gateway associated with the VPC,
+for carrier network (Wavelength Zones).</p>
 </td>
 </tr>
 <tr>
@@ -23591,6 +24087,40 @@ string
 <p>PrivateDNSHostnameTypeOnLaunch is the type of hostname to assign to instances in the subnet at launch.
 For IPv4-only and dual-stack (IPv4 and IPv6) subnets, an instance DNS name can be based on the instance IPv4 address (ip-name)
 or the instance ID (resource-name). For IPv6 only subnets, an instance DNS name must be based on the instance ID (resource-name).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>elasticIpPool</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.ElasticIPPool">
+ElasticIPPool
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ElasticIPPool contains specific configuration to allocate Public IPv4 address (Elastic IP) from user-defined pool
+brought to AWS for core infrastructure resources, like NAT Gateways and Public Network Load Balancers for
+the API Server.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subnetSchema</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetSchemaType">
+SubnetSchemaType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubnetSchema specifies how CidrBlock should be divided on subnets in the VPC depending on the number of AZs.
+PreferPrivate - one private subnet for each AZ plus one other subnet that will be further sub-divided for the public subnets.
+PreferPublic - have the reverse logic of PreferPrivate, one public subnet for each AZ plus one other subnet
+that will be further sub-divided for the private subnets.
+Defaults to PreferPrivate</p>
 </td>
 </tr>
 </tbody>
@@ -23709,6 +24239,43 @@ The key must already exist and be accessible by the controller.</p>
 <p>
 <p>VolumeType describes the EBS volume type.
 See: <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html</a></p>
+</p>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.VpcCidrBlock">VpcCidrBlock
+</h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.VPCSpec">VPCSpec</a>)
+</p>
+<p>
+<p>VpcCidrBlock defines the CIDR block and settings to associate with the managed VPC. Currently, only IPv4 is supported.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ipv4CidrBlock</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>IPv4CidrBlock is the IPv4 CIDR block to associate with the managed VPC.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.ZoneType">ZoneType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetSpec">SubnetSpec</a>)
+</p>
+<p>
+<p>ZoneType defines listener AWS Availability Zone type.</p>
 </p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta2.ASGStatus">ASGStatus
 (<code>string</code> alias)</p></h3>
@@ -23975,6 +24542,20 @@ Volume
 <td>
 <em>(Optional)</em>
 <p>RootVolume encapsulates the configuration options for the root volume</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nonRootVolumes</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.Volume">
+[]Volume
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Configuration options for the non root storage volumes.</p>
 </td>
 </tr>
 <tr>
@@ -26078,7 +26659,13 @@ int64
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;AL2_ARM_64&#34;</p></td>
+<tbody><tr><td><p>&#34;AL2023_ARM_64_STANDARD&#34;</p></td>
+<td><p>Al2023Arm64 is the AL2023 Arm AMI type.</p>
+</td>
+</tr><tr><td><p>&#34;AL2023_x86_64_STANDARD&#34;</p></td>
+<td><p>Al2023x86_64 is the AL2023 x86-64 AMI type.</p>
+</td>
+</tr><tr><td><p>&#34;AL2_ARM_64&#34;</p></td>
 <td><p>Al2Arm64 is the Arm AMI type.</p>
 </td>
 </tr><tr><td><p>&#34;AL2_x86_64&#34;</p></td>
@@ -26675,7 +27262,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>AutoRepair specifies whether health checks should be enabled for machines
-in the NodePool. The default is false.</p>
+in the NodePool. The default is true.</p>
 </td>
 </tr>
 <tr>
@@ -26758,6 +27345,20 @@ respected during upgrades. After this grace period, any workloads protected by P
 Budgets that have not been successfully drained from a node will be forcibly evicted.</p>
 <p>Valid values are from 0 to 1 week(10080m|168h) .
 0 or empty value means that the MachinePool can be drained without any time limitation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>updateConfig</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.RosaUpdateConfig">
+RosaUpdateConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpdateConfig specifies update configurations.</p>
 </td>
 </tr>
 </table>
@@ -26845,6 +27446,66 @@ int64
 <em>(Optional)</em>
 <p>The amount of capacity as a percentage in ASG that must remain healthy
 during an instance refresh. The default is 90.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.RollingUpdate">RollingUpdate
+</h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.RosaUpdateConfig">RosaUpdateConfig</a>)
+</p>
+<p>
+<p>RollingUpdate specifies MaxUnavailable &amp; MaxSurge number of nodes during update.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>maxUnavailable</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxUnavailable is the maximum number of nodes that can be unavailable during the update.
+Value can be an absolute number (ex: 5) or a percentage of desired nodes (ex: 10%).
+Absolute number is calculated from percentage by rounding down.</p>
+<p>MaxUnavailable can not be 0 if MaxSurge is 0, default is 0.
+Both MaxUnavailable &amp; MaxSurge must use the same units (absolute value or percentage).</p>
+<p>Example: when MaxUnavailable is set to 30%, old nodes can be deleted down to 70% of
+desired nodes immediately when the rolling update starts. Once new nodes
+are ready, more old nodes be deleted, followed by provisioning new nodes,
+ensuring that the total number of nodes available at all times during the
+update is at least 70% of desired nodes.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxSurge</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxSurge is the maximum number of nodes that can be provisioned above the desired number of nodes.
+Value can be an absolute number (ex: 5) or a percentage of desired nodes (ex: 10%).
+Absolute number is calculated from percentage by rounding up.</p>
+<p>MaxSurge can not be 0 if MaxUnavailable is 0, default is 1.
+Both MaxSurge &amp; MaxUnavailable must use the same units (absolute value or percentage).</p>
+<p>Example: when MaxSurge is set to 30%, new nodes can be provisioned immediately
+when the rolling update starts, such that the total number of old and new
+nodes do not exceed 130% of desired nodes. Once old nodes have been
+deleted, new nodes can be provisioned, ensuring that total number of nodes
+running at any time during the update is at most 130% of desired nodes.</p>
 </td>
 </tr>
 </tbody>
@@ -27002,7 +27663,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>AutoRepair specifies whether health checks should be enabled for machines
-in the NodePool. The default is false.</p>
+in the NodePool. The default is true.</p>
 </td>
 </tr>
 <tr>
@@ -27085,6 +27746,20 @@ respected during upgrades. After this grace period, any workloads protected by P
 Budgets that have not been successfully drained from a node will be forcibly evicted.</p>
 <p>Valid values are from 0 to 1 week(10080m|168h) .
 0 or empty value means that the MachinePool can be drained without any time limitation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>updateConfig</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.RosaUpdateConfig">
+RosaUpdateConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpdateConfig specifies update configurations.</p>
 </td>
 </tr>
 </tbody>
@@ -27225,6 +27900,38 @@ Kubernetes core/v1.TaintEffect
 <td>
 <p>The effect of the taint on pods that do not tolerate the taint.
 Valid effects are NoSchedule, PreferNoSchedule and NoExecute.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta2.RosaUpdateConfig">RosaUpdateConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#infrastructure.cluster.x-k8s.io/v1beta2.RosaMachinePoolSpec">RosaMachinePoolSpec</a>)
+</p>
+<p>
+<p>RosaUpdateConfig specifies update configuration</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>rollingUpdate</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.RollingUpdate">
+RollingUpdate
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RollingUpdate specifies MaxUnavailable &amp; MaxSurge number of nodes during update.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/book/src/development/amis.md
+++ b/docs/book/src/development/amis.md
@@ -1,30 +1,82 @@
 # Publish AMIs
 
-Publishing new AMIs is currently a manual process but it will be automated in th every near future (see [this issue](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1982) for progress).
+Publishing new AMIs is done via manually invoking a GitHub Actions workflow. 
 
-## Pre-reqs
+> NOTE: the plan is to ultimately fully automate the process in the future (see [this issue](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1982) for progress).
 
-- You must have admin access to the CNCF AWAS account used for the AMIs (819546954734)
+> NOTE: there are some issues with the RHEL based images at present.
 
-## Process
+## Get build inputs
+
+For a new Kubernetes version that you want to build an AMI for you will need to determine the following values:
+
+| Input             | Description |
+| ----------------- | ----------- |
+| kubernetes_semver      | The semver version of k8s you want to build an AMI for. In format vMAJOR.MINOR.PATCH. |
+| kubernetes_series      | The release series for the Kubernetes version. In format vMAJOR.MINOR.                |
+| kubernetes_deb_version | The version of the debian package for the release.                                    |
+| kubernetes_rpm_version | The version of the rpm package for the release                                        |
+| kubernetes_cni_semver  | The version of CNI to include. It needs to match the k8s release.                     |
+| kubernetes_cni_deb_version | The version of the debian package for the CNI release to use                      |
+| crictl_version         | The vesion of the cri-tools package to install into the AMI                           |
+
+You can determine these values directly or by looking at the publish debian apt repositories for the k8s release.
+
+## Build
+
+### Using GitHub Actions Workflow
+
+To build the AMI using GitHub actions you must have write access to the CAPA repository (i.e. be a maintainer or part of release team).
+
+To build the new version:
+
+1. Got to the GitHub Action
+2. Click the **Start Workflow** button
+3. Fill in the details of the build
+4. Click **Run**
+
+### Manually
+
+> **WARNING: the manual process should only be followed in exceptional circumstances.
+
+To build manually you must have admin access to the CNCF AWS account used for the AMIs.
+
+The steps to build manually are:
 
 1. Clone [image-builder](https://github.com/kubernetes-sigs/image-builder)
 2. Open a terminal
-3. Set the AWS environment variables for the AMI account
+3. Set the AWS environment variables for the CAPA AMI account
 4. Change directory into `images/capi`
-5. Install dependencies by running:
+5. Create a new file called `vars.json` with the following content (substituing the values with the build inputs):
+
+```json
+{
+    "kubernetes_rpm_version": "<INSERT_INPUT_VALUE>",
+    "kubernetes_semver": "<INSERT_INPUT_VALUE>",
+    "kubernetes_series": "<INSERT_INPUT_VALUE>",
+    "kubernetes_deb_version": "<INSERT_INPUT_VALUE>",
+    "kubernetes_cni_semver": "<INSERT_INPUT_VALUE>",
+    "kubernetes_cni_deb_version": "<INSERT_INPUT_VALUE>",
+    "crictl_version": "<INSERT_INPUT_VALUE>"
+}
+```
+6. Install dependencies by running:
 
 ```shell
 make deps-ami
 ```
 
-6. Build the AMIs using:
+7. Build the AMIs using:
 
 ```shell
-make build-ami-ubuntu-2004
-make build-ami-ubuntu-2204
-make build-ami-ubuntu-2404
-make build-ami-flatcar
-make build-ami-rhel-8
+PACKER_VAR_FILES=vars.json make build-ami-ubuntu-2204
+PACKER_VAR_FILES=vars.json make build-ami-ubuntu-2404
+PACKER_VAR_FILES=vars.json make build-ami-flatcar
+PACKER_VAR_FILES=vars.json make build-ami-rhel-8
 ```
-> NOTE: there are some issues with the RHEL based images at present.
+## Additional Information
+
+- The AMIs are hosted in a CNCF owned AWS account (819546954734).
+- The AWS resources that are needed to support the GitHub Actions workflow are created via terraform. Source is [here](https://github.com/kubernetes/k8s.io/tree/main/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami).
+- OIDC and IAM Roles are used to grant access via short lived credentials to the GitHub Action workflow instance when it runs.
+

--- a/docs/book/src/development/amis.md
+++ b/docs/book/src/development/amis.md
@@ -1,0 +1,30 @@
+# Publish AMIs
+
+Publishing new AMIs is currently a manual process but it will be automated in th every near future (see [this issue](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1982) for progress).
+
+## Pre-reqs
+
+- You must have admin access to the CNCF AWAS account used for the AMIs (819546954734)
+
+## Process
+
+1. Clone [image-builder](https://github.com/kubernetes-sigs/image-builder)
+2. Open a terminal
+3. Set the AWS environment variables for the AMI account
+4. Change directory into `images/capi`
+5. Install dependencies by running:
+
+```shell
+make deps-ami
+```
+
+6. Build the AMIs using:
+
+```shell
+make build-ami-ubuntu-2004
+make build-ami-ubuntu-2204
+make build-ami-ubuntu-2404
+make build-ami-flatcar
+make build-ami-rhel-8
+```
+> NOTE: there are some issues with the RHEL based images at present.

--- a/docs/book/src/topics/images/amis.md
+++ b/docs/book/src/topics/images/amis.md
@@ -1,11 +1,18 @@
 # AWS Machine Images for CAPA Clusters
 
 CAPA requires a “machine image” containing pre-installed, matching versions of kubeadm and kubelet.
-Machine image is either auto-resolved by CAPA to a public AMI that matches the Kubernetes version in `KubeadmControlPlane` or `MachineDeployment` spec,
-or an appropriate custom image ID for the Kubernetes version can be set in `AWSMachineTemplate` spec.
 
-[Pre-built public AMIs](built-amis.md) are published by the maintainers regularly for each new Kubernetes version.
+## EKS Clusters
 
-[Custom images](custom-amis.md) can be created using [image-builder][image-builder] project.
+For an EKS cluster the default behaviour is to retieve the AMI to use from SSM. This is so the recommended Amazon Linux AMI is used (see [here](https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html)).
+
+Instead of using the auto resolved AMIs an appropriate custom image ID for the Kubernetes version can be set in `AWSMachineTemplate` spec.
+
+## Non-EKS Clusters
+
+By default the machine image is auto-resolved by CAPA to a public AMI that matches the Kubernetes version in `KubeadmControlPlane` or `MachineDeployment` spec. These AMIs are published in a community owned AWS account. See [pre-built public AMIs](built-amis.md) for details of the CAPA project published images.
+
+> IMPORTANT:
+> The project doesn't recommend using the public AMIs for production use. Instead its recommended that you build your own AMIs for the Kubernetes versions you want to use. The AMI can then be specified in the `AWSMachineTemplate` spec. [Custom images](custom-amis.md) can be created using [image-builder][image-builder] project.
 
 [image-builder]: https://github.com/kubernetes-sigs/image-builder

--- a/docs/book/src/topics/images/built-amis.md
+++ b/docs/book/src/topics/images/built-amis.md
@@ -9,7 +9,7 @@ New AMIs are built on a best effort basis when a new Kubernetes version is relea
 - When there is a new k8s release series then any AMIs no longer covered by the previous point will be deleted. For example, when v1.31.0 is published then any AMIs for the v1.28 release series will be deleted.
 - Existing AMIs are not updated for security fixes and it is recommended to always use the latest patch version for the Kubernetes version you want to run.
 
-> NOTE: As the old community images where located in an AWS account that the project no longer has access to and because those AMIs have been automatically deleted we have started publishing images again from v1.29.9
+> NOTE: As the old community images were located in an AWS account that the project no longer has access to and because those AMIs have been automatically deleted, we have started publishing images again starting from Kubernetes v1.29.9.
 
 ## Finding AMIs
 
@@ -21,7 +21,7 @@ If you are using a version of clusterawsadm prior to v2.6.2 then you will need t
 - Ubuntu (ubuntu-22.04, ubuntu-24.04)
 - Flatcar (flatcar-stable)
 
-> Note: Centos (centos-7) and Amazon Linux 2 (amazon-2) where supported but there are some issues with the AMI build that need fixing.
+> Note: Centos (centos-7) and Amazon Linux 2 (amazon-2) where supported but there are some issues with the AMI build that need fixing. See this [issue](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5142) for details.
 
 ## Supported AWS Regions
 - ap-northeast-1

--- a/docs/book/src/topics/images/built-amis.md
+++ b/docs/book/src/topics/images/built-amis.md
@@ -1,18 +1,27 @@
 # Pre-built Kubernetes AMIs
 
-New AMIs are built on a best effort basis when a new Kubernetes version is released.  for each supported OS distribution and then published to supported regions.
+New AMIs are built on a best effort basis when a new Kubernetes version is released for each supported OS distribution and then published to supported regions.
+
+## AMI Publication Policy
+
+- AMIs should only be used for non-production usage. For production environments we recommend that you build and maintain your own AMIs using the image-builder project.
+- AMIs will only be published for the latest release series and 2 previous release series. For example, if the current release series is v1.30 then AMIs will only be published for v1.30, v1.29, v1.28.
+- When there is a new k8s release series then any AMIs no longer covered by the previous point will be deleted. For example, when v1.31.0 is published then any AMIs for the v1.28 release series will be deleted.
+- Existing AMIs are not updated for security fixes and it is recommended to always use the latest patch version for the Kubernetes version you want to run.
+
+> NOTE: As the old community images where located in an AWS account that the project no longer has access to and because those AMIs have been automatically deleted we have started publishing images again from v1.29.9
+
+## Finding AMIs
 
 `clusterawsadm ami list` command lists pre-built reference AMIs by Kubernetes version, OS, or AWS region. See [clusterawsadm ami list](https://cluster-api-aws.sigs.k8s.io/clusterawsadm/clusterawsadm_ami_list.html) for details.
 
 If you are using a version of clusterawsadm prior to v2.6.2 then you will need to explicitly specify the owner-id for the community account: `clusterawsadm ami list --owner-id 819546954734`.
 
-> **Note:**  These images are not updated for security fixes and it is recommended to always use the latest patch version for the Kubernetes version you want to run. For production environments, it is highly recommended to build and use your own custom images.
-
 ## Supported OS Distributions
-- Amazon Linux 2 (amazon-2)
-- Ubuntu (ubuntu-20.04, ubuntu-22.04, ubuntu-24.04)
-- Centos (centos-7)
+- Ubuntu (ubuntu-22.04, ubuntu-24.04)
 - Flatcar (flatcar-stable)
+
+> Note: Centos (centos-7) and Amazon Linux 2 (amazon-2) where supported but there are some issues with the AMI build that need fixing.
 
 ## Supported AWS Regions
 - ap-northeast-1

--- a/docs/book/src/topics/images/built-amis.md
+++ b/docs/book/src/topics/images/built-amis.md
@@ -1,15 +1,16 @@
 # Pre-built Kubernetes AMIs
 
-New AMIs are built whenever a new Kubernetes version is released for each supported OS distribution and then published to supported regions.
+New AMIs are built on a best effort basis when a new Kubernetes version is released.  for each supported OS distribution and then published to supported regions.
 
-`clusterawsadm ami list` command lists pre-built reference AMIs by Kubernetes version, OS, or AWS region.
-See [clusterawsadm ami list](https://cluster-api-aws.sigs.k8s.io/clusterawsadm/clusterawsadm_ami_list.html) for details.
+`clusterawsadm ami list` command lists pre-built reference AMIs by Kubernetes version, OS, or AWS region. See [clusterawsadm ami list](https://cluster-api-aws.sigs.k8s.io/clusterawsadm/clusterawsadm_ami_list.html) for details.
+
+If you are using a version of clusterawsadm prior to v2.6.2 then you will need to explicitly specify the owner-id for the community account: `clusterawsadm ami list --owner-id 819546954734`.
 
 > **Note:**  These images are not updated for security fixes and it is recommended to always use the latest patch version for the Kubernetes version you want to run. For production environments, it is highly recommended to build and use your own custom images.
 
 ## Supported OS Distributions
 - Amazon Linux 2 (amazon-2)
-- Ubuntu (ubuntu-20.04, ubuntu-22.04)
+- Ubuntu (ubuntu-20.04, ubuntu-22.04, ubuntu-24.04)
 - Centos (centos-7)
 - Flatcar (flatcar-stable)
 
@@ -29,84 +30,3 @@ See [clusterawsadm ami list](https://cluster-api-aws.sigs.k8s.io/clusterawsadm/c
 - us-east-2
 - us-west-1
 - us-west-2
-
-## Most recent AMIs
-<table id="amis" class="display" style="width:100%"></table>
-
-<script>
-  const amisURL = "https://d2jcv1y6kf3xwc.cloudfront.net/amis.json";
-  const SEARCH_HOTKEY_KEYCODE = 83;
-
-  // hasFocus returns true if the table search is active
-  function hasFocus() {
-    const tableSearchBar = document.querySelector("#amis_filter > label > input[type=search]");
-    return (tableSearchBar === document.activeElement);
-  }
-
-  // Prevent the mdbook search event listener capturing the 's' key, so users can search for example 'eu-west-1
-  function resetKeyHandler(e) {
-    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || e.target.type === 'textarea' || e.target.type === 'text') { return; }
-
-    if (e.keyCode === SEARCH_HOTKEY_KEYCODE && hasFocus()) {
-        e.stopPropagation();
-    }
-  }
-
-  // Insert the event listener when the document is ready
-  $(function() {
-    document.addEventListener('keydown', function (e) { resetKeyHandler(e); }, true);
-  });
-
-  // Table display function
-  function amiListToTable(data) {
-    const items = data.items.map(
-      item => {
-
-        url = `https://console.aws.amazon.com/ec2/v2/home?region=${item.spec.region}#Images:visibility=public-images;search=${item.spec.imageID};sort=name`
-
-        imageText = `<a href="${url}">${item.spec.imageID}</a>`
-
-        return [
-          item.metadata.name,
-          item.spec.os,
-          item.spec.region,
-          item.spec.kubernetesVersion,
-          imageText,
-          item.metadata.creationTimestamp,
-        ]
-      }
-    )
-
-    $(document).ready(function() {
-      const table = $('#amis').DataTable({
-        data: items,
-        columns: [
-          {title: "Name"},
-          {title: "OS"},
-          {title: "Region"},
-          {title: "Kubernetes Version"},
-          {title: "Image ID"},
-          {title: "Creation Date"},
-        ]
-      })
-
-      table
-        .order([3, 'dsc'], [2, 'asc'], [1, 'asc'])
-        .draw();
-    });
-  }
-
-
-  // Lazy fetch the URL
-  fetch(amisURL, {
-    mode: 'cors'
-  })
-  .then(response => response.json())
-  .then(data => amiListToTable(data))
-  .catch((error) => console.error('Error:', error));
-</script>
-
-If you want to query any other AMI which is not listed in the table, then use below command
-```
-clusterawsadm ami list --kubernetes-version <some-k8s-version> --region <supported-aws-region> --os <supported-os-name>
-```

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -60,7 +60,7 @@ const (
 	ubuntuOwnerIDUsGov = "513442679011"
 
 	// Description regex for fetching Ubuntu AMIs for bastion host.
-	ubuntuImageDescription = "Canonical??Ubuntu??20.04?LTS??amd64?focal?image*"
+	ubuntuImageDescription = "Canonical??Ubuntu??24.04?LTS??amd64?noble?image*"
 
 	// defaultMachineAMILookupBaseOS is the default base operating system to use
 	// when looking up machine AMIs.

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -49,9 +49,9 @@ const (
 	// Arm64ArchitectureTag is the reference AWS uses for arm64 architecture images.
 	Arm64ArchitectureTag = "arm64"
 
-	// DefaultMachineAMIOwnerID is a heptio/VMware owned account. Please see:
-	// https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/487
-	DefaultMachineAMIOwnerID = "258751437250"
+	// DefaultMachineAMIOwnerID is a CNCF owned account. This was previously a VMWare owned account
+	// but the project lost access to it. See the k8s.io repo for the infra definition.
+	DefaultMachineAMIOwnerID = "819546954734"
 
 	// ubuntuOwnerID is Ubuntu owned account. Please see:
 	// https://ubuntu.com/server/docs/cloud-images/amazon-ec2
@@ -64,12 +64,12 @@ const (
 
 	// defaultMachineAMILookupBaseOS is the default base operating system to use
 	// when looking up machine AMIs.
-	defaultMachineAMILookupBaseOS = "ubuntu-18.04"
+	defaultMachineAMILookupBaseOS = "ubuntu-24.04"
 
 	// DefaultAmiNameFormat is defined in the build/ directory of this project.
 	// The pattern is:
 	// 1. the string value `capa-ami-`
-	// 2. the baseOS of the AMI, for example: ubuntu-18.04, centos-7, amazon-2
+	// 2. the baseOS of the AMI, for example: ubuntu-24.04, centos-7, amazon-2
 	// 3. the kubernetes version as defined by the packages produced by kubernetes/release with or without v as a prefix, for example: 1.13.0, 1.12.5-mybuild.1, v1.17.3
 	// 4. a `-` followed by any additional characters.
 	DefaultAmiNameFormat = "capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*"

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -1115,7 +1115,7 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "1.16.1")
+				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-24.04", "1.16.1")
 				if err != nil {
 					t.Fatalf("Failed to process ami format: %v", err)
 				}
@@ -1268,7 +1268,7 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "1.16.1")
+				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-24.04", "1.16.1")
 				if err != nil {
 					t.Fatalf("Failed to process ami format: %v", err)
 				}
@@ -1422,7 +1422,7 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-18.04", "1.16.1")
+				amiName, err := GenerateAmiName("capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*", "ubuntu-24.04", "1.16.1")
 				if err != nil {
 					t.Fatalf("Failed to process ami format: %v", err)
 				}

--- a/pkg/cloud/services/userdata/bastion.go
+++ b/pkg/cloud/services/userdata/bastion.go
@@ -26,7 +26,7 @@ curl -s -o $BASTION_BOOTSTRAP_FILE $BASTION_BOOTSTRAP
 chmod +x $BASTION_BOOTSTRAP_FILE
 
 # This gets us far enough in the bastion script to be useful.
-apt-get -y update && apt-get -y install python-pip
+apt-get -y update && apt-get -y install python3-pip
 pip install --upgrade pip &> /dev/null
 
 ./$BASTION_BOOTSTRAP_FILE --enable true

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -176,10 +176,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.30.2"
-  KUBERNETES_VERSION: "v1.26.6"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.26.6"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.25.12"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.29.8"
+  KUBERNETES_VERSION: "v1.29.9"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.29.9"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.29.8"
   # Pre and post 1.23 Kubernetes versions are being used for CSI upgrade tests
   PRE_1_23_KUBERNETES_VERSION: "v1.22.17"
   POST_1_23_KUBERNETES_VERSION: "v1.23.15"
@@ -190,11 +190,11 @@ variables:
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_MACHINE_TYPE_VCPU_USAGE: 2
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.29.1"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.29.9"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "3"
   ETCD_VERSION_UPGRADE_TO: "3.5.11-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.9.4"
+  COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
   MULTI_TENANCY_ROLE_NAME: "multi-tenancy-role"
   MULTI_TENANCY_NESTED_ROLE_NAME: "multi-tenancy-nested-role"
   IP_FAMILY: "IPv4"
@@ -206,7 +206,7 @@ variables:
   INIT_WITH_BINARY_V1BETA1: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/clusterctl-{OS}-{ARCH}"
   # INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_KUBERNETES_VERSION: "v1.25.12"
+  INIT_WITH_KUBERNETES_VERSION: "v1.29.8"
   EXP_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_EXTERNAL_RESOURCE_GC: "true"

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -36,8 +36,8 @@ import (
 // Constants.
 const (
 	DefaultSSHKeyPairName                = "cluster-api-provider-aws-sigs-k8s-io"
-	AMIPrefix                            = "capa-ami-ubuntu-18.04-"
-	DefaultImageLookupOrg                = "258751437250"
+	AMIPrefix                            = "capa-ami-ubuntu-24.04-"
+	DefaultImageLookupOrg                = "819546954734"
 	KubernetesVersion                    = "KUBERNETES_VERSION"
 	KubernetesVersionManagement          = "KUBERNETES_VERSION_MANAGEMENT"
 	CNIPath                              = "CNI"

--- a/test/e2e/suites/unmanaged/helpers_test.go
+++ b/test/e2e/suites/unmanaged/helpers_test.go
@@ -529,7 +529,7 @@ func makeJoinBootstrapConfigTemplate(namespace, name string) *bootstrapv1.Kubead
 					JoinConfiguration: &bootstrapv1.JoinConfiguration{
 						NodeRegistration: bootstrapv1.NodeRegistrationOptions{
 							Name:             "{{ ds.meta_data.local_hostname }}",
-							KubeletExtraArgs: map[string]string{"cloud-provider": "aws"},
+							KubeletExtraArgs: map[string]string{"cloud-provider": "external"},
 						},
 					},
 				},

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_clusterclass_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_clusterclass_test.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework] [ClusterClass]", fun
 		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
 	})
 
-	ginkgo.Describe("Self Hosted Spec [ClusterClass]", func() {
+	ginkgo.PDescribe("Self Hosted Spec [ClusterClass]", func() {
 		ginkgo.BeforeEach(func() {
 			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
 			requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1, EventBridgeRules: 50}
@@ -65,12 +65,14 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework] [ClusterClass]", fun
 		})
 	})
 
-	ginkgo.Describe("Cluster Upgrade Spec - HA control plane with workers [K8s-Upgrade] [ClusterClass]", func() {
+	ginkgo.PDescribe("Cluster Upgrade Spec - HA control plane with workers [K8s-Upgrade] [ClusterClass]", func() {
 		ginkgo.BeforeEach(func() {
-			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
-			requiredResources = &shared.TestResource{EC2Normal: 5 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2, EventBridgeRules: 50}
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-cluster-upgrade-clusterclass-test")
-			Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			if !e2eCtx.Settings.SkipQuotas {
+				// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+				requiredResources = &shared.TestResource{EC2Normal: 5 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2, EventBridgeRules: 50}
+				requiredResources.WriteRequestedResources(e2eCtx, "capi-cluster-upgrade-clusterclass-test")
+				Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			}
 		})
 
 		capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
@@ -87,16 +89,20 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework] [ClusterClass]", fun
 		})
 
 		ginkgo.AfterEach(func() {
-			shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			if !e2eCtx.Settings.SkipQuotas {
+				shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			}
 		})
 	})
 
 	ginkgo.Describe("ClusterClass Changes Spec - SSA immutability checks [ClusterClass]", func() {
 		ginkgo.BeforeEach(func() {
-			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
-			requiredResources = &shared.TestResource{EC2Normal: 5 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2, EventBridgeRules: 50}
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-cluster-ssa-clusterclass-test")
-			Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			if !e2eCtx.Settings.SkipQuotas {
+				// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+				requiredResources = &shared.TestResource{EC2Normal: 5 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2, EventBridgeRules: 50}
+				requiredResources.WriteRequestedResources(e2eCtx, "capi-cluster-ssa-clusterclass-test")
+				Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			}
 		})
 
 		capi_e2e.ClusterClassChangesSpec(ctx, func() capi_e2e.ClusterClassChangesSpecInput {
@@ -133,7 +139,9 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework] [ClusterClass]", fun
 		})
 
 		ginkgo.AfterEach(func() {
-			shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			if !e2eCtx.Settings.SkipQuotas {
+				shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			}
 		})
 	})
 })

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -88,10 +88,12 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 
 	ginkgo.Describe("Self Hosted Spec", func() {
 		ginkgo.BeforeEach(func() {
-			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
-			requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1, EventBridgeRules: 50}
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-clusterctl-self-hosted-test")
-			Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			if !e2eCtx.Settings.SkipQuotas {
+				// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+				requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 1, EventBridgeRules: 50}
+				requiredResources.WriteRequestedResources(e2eCtx, "capi-clusterctl-self-hosted-test")
+				Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			}
 		})
 
 		capi_e2e.SelfHostedSpec(ctx, func() capi_e2e.SelfHostedSpecInput {
@@ -105,16 +107,20 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 			}
 		})
 		ginkgo.AfterEach(func() {
-			shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			if !e2eCtx.Settings.SkipQuotas {
+				shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			}
 		})
 	})
 
-	ginkgo.Describe("Clusterctl Upgrade Spec [from latest v1beta1 release to v1beta2]", func() {
+	ginkgo.PDescribe("Clusterctl Upgrade Spec [from latest v1beta1 release to v1beta2]", func() {
 		ginkgo.BeforeEach(func() {
-			// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
-			requiredResources = &shared.TestResource{EC2Normal: 5 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2, EventBridgeRules: 50}
-			requiredResources.WriteRequestedResources(e2eCtx, "capi-clusterctl-upgrade-test-v1beta1-to-v1beta2")
-			Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			if !e2eCtx.Settings.SkipQuotas {
+				// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.
+				requiredResources = &shared.TestResource{EC2Normal: 5 * e2eCtx.Settings.InstanceVCPU, IGW: 2, NGW: 2, VPC: 2, ClassicLB: 2, EIP: 2, EventBridgeRules: 50}
+				requiredResources.WriteRequestedResources(e2eCtx, "capi-clusterctl-upgrade-test-v1beta1-to-v1beta2")
+				Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+			}
 		})
 
 		capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
@@ -135,7 +141,9 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 			}
 		})
 		ginkgo.AfterEach(func() {
-			shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			if !e2eCtx.Settings.SkipQuotas {
+				shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+			}
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates to the project to start using the new CNCF owned AWS account for publishing AMIs. The code has had the old VMWare account removed and the new account ID added. Additionally the docs have been updated including clarifying that the public AMIs should only be used for non-production usage.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #5131
Relates #4984 
Fixes #5161 

**Special notes for your reviewer**:

A new GitHub Actions workflow (see #5138 ) can be invoked to publish new images. Also #5169 will be done as a follow-up.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [X] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required
A new community owned AWS account is now being used for publishing AMIs. The old account owner by a company is no longer accessible and the images are being automatically deleted by AWS. Support for ubuntu 18.04 & 20.04 has been dropped and ubuntu 24.04 is now the default OS if no OS is supplied.
```
