### PR TITLE
🌱 fix: run ami builds sequentially

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -36,8 +36,10 @@ permissions:
 jobs:
   buildandpublish:
     strategy:
-        matrix:
-            target: ['ubuntu-2204', 'ubuntu-2404', 'flatcar', 'rhel-8']
+      matrix:
+        target: ['ubuntu-2204', 'ubuntu-2404', 'flatcar', 'rhel-8']
+      max-parallel: 1
+      fail-fast: false
     name: Build and publish CAPA AMIs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Change the AMI build workflow to run the matrix entries sequentially instead of all parallel. This should stop them getting cancelled due to exceeding resource limits.

Fail fast has also been set to false so that if one of the metrix jobs fails the others continue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
