### PR TITLE
🌱 chore: remove rhel from image build workflow

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -37,7 +37,7 @@ jobs:
   buildandpublish:
     strategy:
       matrix:
-        target: ['ubuntu-2204', 'ubuntu-2404', 'flatcar', 'rhel-8']
+        target: ['ubuntu-2204', 'ubuntu-2404', 'flatcar']
       max-parallel: 1
       fail-fast: false
     name: Build and publish CAPA AMIs


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

This removes rhel-8 from the image builder workflow as there are issues with the target currently with target in image-builder for AMIs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is only a temporary solution.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
