### PR TITLE
🌱 feat: build amis with vars file

### DIFF
--- a/.github/workflows/build-ami-varsfile.yml
+++ b/.github/workflows/build-ami-varsfile.yml
@@ -1,0 +1,63 @@
+name: build-and-publish-ami-with-vars
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_builder_version:
+        description: "Image builder version"
+        required: true
+        default: 'v0.1.38'
+      target:
+        description: "target os"
+        required: true
+        type: choice
+        options:
+        - ubuntu-2204
+        - ubuntu-2404
+        - flatcar
+      packer_vars:
+        description: "Packer vars (json)"
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  buildandpublish:
+    name: Build and publish CAPA AMIs
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes-sigs/image-builder
+          ref: ${{ inputs.image_builder_version }}
+          fetch-depth: 0
+      - name: Create packer vars file
+        if: inputs.packer_vars != ''
+        env:
+          PACKER_VARS: ${{ inputs.packer_vars }}
+        run: |
+          echo "$PACKER_VARS" | jq -r > ./images/capi/vars.json
+          cat ./images/capi/vars.json
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::819546954734:role/gh-image-builder
+      - name: Install deps
+        run: make deps-ami
+        working-directory: ./images/capi
+      - name: Install Amazon EBS Plugin
+        working-directory: ./images/capi
+        run: ./.local/bin/packer plugins install github.com/hashicorp/amazon
+      - name: Build AMI with vars
+        if: inputs.packer_vars != ''
+        working-directory: ./images/capi
+        run: PACKER_VAR_FILES=vars.json make build-ami-${{ inputs.target }}
+      - name: Build AMI without vars
+        if: inputs.packer_vars == ''
+        working-directory: ./images/capi
+        run: make build-ami-${{ inputs.target }}
+

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -3,6 +3,10 @@ name: build-and-publish-ami
 on:
   workflow_dispatch:
     inputs:
+      image_builder_version:
+        description: "Image builder version"
+        required: true
+        default: 'v0.1.38'
       regions:
         description: 'Publication regions'
         required: true
@@ -47,6 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kubernetes-sigs/image-builder
+          ref: ${{ inputs.image_builder_version }}
           fetch-depth: 0
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

A new GitHub Actions workflow that can be used to build a AMI using a packer vars file passed in as a string. This is in addition to the existing workflow that doesn't allow much customization.

This also pins the version of image-builder we use when building. The version can be changed via inputs to the workflow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #5131
Relates #4984 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New AMI building workflow that allows a packer vars file to be passed in.
```
