### PR TITLE
🐛 Fix pip package name for bastion host OS Ubuntu 20.04

### DIFF
--- a/pkg/cloud/services/userdata/bastion.go
+++ b/pkg/cloud/services/userdata/bastion.go
@@ -26,7 +26,7 @@ curl -s -o $BASTION_BOOTSTRAP_FILE $BASTION_BOOTSTRAP
 chmod +x $BASTION_BOOTSTRAP_FILE
 
 # This gets us far enough in the bastion script to be useful.
-apt-get -y update && apt-get -y install python-pip
+apt-get -y update && apt-get -y install python3-pip
 pip install --upgrade pip &> /dev/null
 
 ./$BASTION_BOOTSTRAP_FILE --enable true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

```
# apt-get -y install python-pip
Reading package lists... Done
Building dependency tree
Reading state information... Done
Package python-pip is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-pip

E: Package 'python-pip' has no installation candidate
```


**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix pip package name for bastion host OS Ubuntu 20.04
```
