### PR TITLE
Non-breaking feature: create vpc objects in explicitly provided availability zones

### DIFF
--- a/api/v1beta1/awscluster_conversion.go
+++ b/api/v1beta1/awscluster_conversion.go
@@ -86,6 +86,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.NetworkSpec.AdditionalControlPlaneIngressRules = restored.Spec.NetworkSpec.AdditionalControlPlaneIngressRules
 	dst.Spec.NetworkSpec.NodePortIngressRuleCidrBlocks = restored.Spec.NetworkSpec.NodePortIngressRuleCidrBlocks
+	dst.Spec.NetworkSpec.VPC.AvailabilityZones = restored.Spec.NetworkSpec.VPC.AvailabilityZones
 
 	if restored.Spec.NetworkSpec.VPC.IPAMPool != nil {
 		if dst.Spec.NetworkSpec.VPC.IPAMPool == nil {

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -2317,6 +2317,7 @@ func autoConvert_v1beta2_VPCSpec_To_v1beta1_VPCSpec(in *v1beta2.VPCSpec, out *VP
 	out.Tags = *(*Tags)(unsafe.Pointer(&in.Tags))
 	out.AvailabilityZoneUsageLimit = (*int)(unsafe.Pointer(in.AvailabilityZoneUsageLimit))
 	out.AvailabilityZoneSelection = (*AZSelectionScheme)(unsafe.Pointer(in.AvailabilityZoneSelection))
+	// WARNING: in.AvailabilityZones requires manual conversion: does not exist in peer-type
 	// WARNING: in.EmptyRoutesDefaultVPCSecurityGroup requires manual conversion: does not exist in peer-type
 	// WARNING: in.PrivateDNSHostnameTypeOnLaunch requires manual conversion: does not exist in peer-type
 	// WARNING: in.ElasticIPPool requires manual conversion: does not exist in peer-type

--- a/api/v1beta2/awscluster_webhook.go
+++ b/api/v1beta2/awscluster_webhook.go
@@ -298,6 +298,10 @@ func (r *AWSCluster) validateNetwork() field.ErrorList {
 		}
 	}
 
+	if err := r.Spec.NetworkSpec.VPC.ValidateAvailabilityZones(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	return allErrs
 }
 

--- a/api/v1beta2/defaults.go
+++ b/api/v1beta2/defaults.go
@@ -18,6 +18,7 @@ package v1beta2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 )
@@ -49,6 +50,15 @@ func SetDefaults_NetworkSpec(obj *NetworkSpec) { //nolint:golint,stylecheck
 					ToPort:      65535,
 				},
 			},
+		}
+	}
+	// If AvailabilityZones are not set, set defaults for AZ selection
+	if obj.VPC.AvailabilityZones == nil {
+		if obj.VPC.AvailabilityZoneUsageLimit == nil {
+			obj.VPC.AvailabilityZoneUsageLimit = ptr.To(3)
+		}
+		if obj.VPC.AvailabilityZoneSelection == nil {
+			obj.VPC.AvailabilityZoneSelection = &AZSelectionSchemeOrdered
 		}
 	}
 }

--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 )
 
@@ -442,7 +443,7 @@ type VPCSpec struct {
 	// should be used in a region when automatically creating subnets. If a region has more
 	// than this number of AZs then this number of AZs will be picked randomly when creating
 	// default subnets. Defaults to 3
-	// +kubebuilder:default=3
+	// +optional
 	// +kubebuilder:validation:Minimum=1
 	AvailabilityZoneUsageLimit *int `json:"availabilityZoneUsageLimit,omitempty"`
 
@@ -451,9 +452,15 @@ type VPCSpec struct {
 	// Ordered - selects based on alphabetical order
 	// Random - selects AZs randomly in a region
 	// Defaults to Ordered
-	// +kubebuilder:default=Ordered
+	// +optional
 	// +kubebuilder:validation:Enum=Ordered;Random
 	AvailabilityZoneSelection *AZSelectionScheme `json:"availabilityZoneSelection,omitempty"`
+
+	// AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+	// Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 
 	// EmptyRoutesDefaultVPCSecurityGroup specifies whether the default VPC security group ingress
 	// and egress rules should be removed.
@@ -523,6 +530,15 @@ func (v *VPCSpec) GetPublicIpv4Pool() *string {
 	}
 	if v.ElasticIPPool.PublicIpv4Pool != nil {
 		return v.ElasticIPPool.PublicIpv4Pool
+	}
+	return nil
+}
+
+// ValidateAvailabilityZones returns an error if the availability zones field combination is invalid.
+func (v *VPCSpec) ValidateAvailabilityZones() *field.Error {
+	if len(v.AvailabilityZones) > 0 && (v.AvailabilityZoneSelection != nil || v.AvailabilityZoneUsageLimit != nil) {
+		availabilityZonesField := field.NewPath("spec", "network", "vpc", "availabilityZones")
+		return field.Invalid(availabilityZonesField, v.AvailabilityZoneSelection, "availabilityZones cannot be set if availabilityZoneUsageLimit and availabilityZoneSelection are set")
 	}
 	return nil
 }

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -2202,6 +2202,11 @@ func (in *VPCSpec) DeepCopyInto(out *VPCSpec) {
 		*out = new(AZSelectionScheme)
 		**out = **in
 	}
+	if in.AvailabilityZones != nil {
+		in, out := &in.AvailabilityZones, &out.AvailabilityZones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.PrivateDNSHostnameTypeOnLaunch != nil {
 		in, out := &in.PrivateDNSHostnameTypeOnLaunch, &out.PrivateDNSHostnameTypeOnLaunch
 		*out = new(string)

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -605,7 +605,6 @@ spec:
                     description: VPC configuration.
                     properties:
                       availabilityZoneSelection:
-                        default: Ordered
                         description: |-
                           AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                           in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -617,7 +616,6 @@ spec:
                         - Random
                         type: string
                       availabilityZoneUsageLimit:
-                        default: 3
                         description: |-
                           AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                           should be used in a region when automatically creating subnets. If a region has more
@@ -625,6 +623,14 @@ spec:
                           default subnets. Defaults to 3
                         minimum: 1
                         type: integer
+                      availabilityZones:
+                        description: |-
+                          AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                          Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
                       carrierGatewayId:
                         description: |-
                           CarrierGatewayID is the id of the internet gateway associated with the VPC,
@@ -2648,7 +2654,6 @@ spec:
                     description: VPC configuration.
                     properties:
                       availabilityZoneSelection:
-                        default: Ordered
                         description: |-
                           AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                           in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -2660,7 +2665,6 @@ spec:
                         - Random
                         type: string
                       availabilityZoneUsageLimit:
-                        default: 3
                         description: |-
                           AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                           should be used in a region when automatically creating subnets. If a region has more
@@ -2668,6 +2672,14 @@ spec:
                           default subnets. Defaults to 3
                         minimum: 1
                         type: integer
+                      availabilityZones:
+                        description: |-
+                          AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                          Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
                       carrierGatewayId:
                         description: |-
                           CarrierGatewayID is the id of the internet gateway associated with the VPC,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1545,7 +1545,6 @@ spec:
                     description: VPC configuration.
                     properties:
                       availabilityZoneSelection:
-                        default: Ordered
                         description: |-
                           AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                           in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -1557,7 +1556,6 @@ spec:
                         - Random
                         type: string
                       availabilityZoneUsageLimit:
-                        default: 3
                         description: |-
                           AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                           should be used in a region when automatically creating subnets. If a region has more
@@ -1565,6 +1563,14 @@ spec:
                           default subnets. Defaults to 3
                         minimum: 1
                         type: integer
+                      availabilityZones:
+                        description: |-
+                          AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                          Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
                       carrierGatewayId:
                         description: |-
                           CarrierGatewayID is the id of the internet gateway associated with the VPC,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -1143,7 +1143,6 @@ spec:
                             description: VPC configuration.
                             properties:
                               availabilityZoneSelection:
-                                default: Ordered
                                 description: |-
                                   AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs
                                   in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:
@@ -1155,7 +1154,6 @@ spec:
                                 - Random
                                 type: string
                               availabilityZoneUsageLimit:
-                                default: 3
                                 description: |-
                                   AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that
                                   should be used in a region when automatically creating subnets. If a region has more
@@ -1163,6 +1161,14 @@ spec:
                                   default subnets. Defaults to 3
                                 minimum: 1
                                 type: integer
+                              availabilityZones:
+                                description: |-
+                                  AvailabilityZones defines a list of Availability Zones in which to create network resources in.
+                                  Cannot be defined at the same time as AvailabilityZoneSelection and AvailabilityZoneUsageLimit.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
                               carrierGatewayId:
                                 description: |-
                                   CarrierGatewayID is the id of the internet gateway associated with the VPC,

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -474,6 +475,10 @@ func (r *AWSManagedControlPlane) validateNetwork() field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(ipamPoolField, r.Spec.NetworkSpec.VPC.IPv6.IPAMPool, "ipamPool must have either id or name"))
 	}
 
+	if err := r.Spec.NetworkSpec.VPC.ValidateAvailabilityZones(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	return allErrs
 }
 
@@ -497,6 +502,16 @@ func (r *AWSManagedControlPlane) Default() {
 		r.Spec.IdentityRef = &infrav1.AWSIdentityReference{
 			Kind: infrav1.ControllerIdentityKind,
 			Name: infrav1.AWSClusterControllerIdentityName,
+		}
+	}
+
+	// If AvailabilityZones are not set, set defaults for AZ selection
+	if r.Spec.NetworkSpec.VPC.AvailabilityZones == nil {
+		if r.Spec.NetworkSpec.VPC.AvailabilityZoneUsageLimit == nil {
+			r.Spec.NetworkSpec.VPC.AvailabilityZoneUsageLimit = ptr.To(3)
+		}
+		if r.Spec.NetworkSpec.VPC.AvailabilityZoneSelection == nil {
+			r.Spec.NetworkSpec.VPC.AvailabilityZoneSelection = &infrav1.AZSelectionSchemeOrdered
 		}
 	}
 

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -247,32 +247,18 @@ func (s *Service) reconcileZoneInfo(subnets infrav1.Subnets) error {
 }
 
 func (s *Service) getDefaultSubnets() (infrav1.Subnets, error) {
-	zones, err := s.getAvailableZones()
-	if err != nil {
-		return nil, err
-	}
+	var (
+		// By default, take the set availability zones. If they are not defined,
+		// fall back to `availabilityZoneUsageLimit`/`availabilityZoneSelection`
+		zones = s.scope.VPC().AvailabilityZones
+		err   error
+	)
 
-	maxZones := defaultMaxNumAZs
-	if s.scope.VPC().AvailabilityZoneUsageLimit != nil {
-		maxZones = *s.scope.VPC().AvailabilityZoneUsageLimit
-	}
-	selectionScheme := infrav1.AZSelectionSchemeOrdered
-	if s.scope.VPC().AvailabilityZoneSelection != nil {
-		selectionScheme = *s.scope.VPC().AvailabilityZoneSelection
-	}
-
-	if len(zones) > maxZones {
-		s.scope.Debug("region has more than AvailabilityZoneUsageLimit availability zones, picking zones to use", "region", s.scope.Region(), "AvailabilityZoneUsageLimit", maxZones)
-		if selectionScheme == infrav1.AZSelectionSchemeRandom {
-			rand.Shuffle(len(zones), func(i, j int) {
-				zones[i], zones[j] = zones[j], zones[i]
-			})
+	if len(zones) == 0 {
+		zones, err = s.selectZones()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to select availability zones")
 		}
-		if selectionScheme == infrav1.AZSelectionSchemeOrdered {
-			sort.Strings(zones)
-		}
-		zones = zones[:maxZones]
-		s.scope.Debug("zones selected", "region", s.scope.Region(), "zones", zones)
 	}
 
 	// 1 private subnet for each AZ plus 1 other subnet that will be further sub-divided for the public subnets or vice versa if
@@ -360,6 +346,37 @@ func (s *Service) getDefaultSubnets() (infrav1.Subnets, error) {
 	}
 
 	return subnets, nil
+}
+
+func (s *Service) selectZones() ([]string, error) {
+	zones, err := s.getAvailableZones()
+	if err != nil {
+		return nil, err
+	}
+
+	maxZones := defaultMaxNumAZs
+	if s.scope.VPC().AvailabilityZoneUsageLimit != nil {
+		maxZones = *s.scope.VPC().AvailabilityZoneUsageLimit
+	}
+	selectionScheme := infrav1.AZSelectionSchemeOrdered
+	if s.scope.VPC().AvailabilityZoneSelection != nil {
+		selectionScheme = *s.scope.VPC().AvailabilityZoneSelection
+	}
+
+	if len(zones) > maxZones {
+		s.scope.Debug("region has more than AvailabilityZoneUsageLimit availability zones, picking zones to use", "region", s.scope.Region(), "AvailabilityZoneUsageLimit", maxZones)
+		if selectionScheme == infrav1.AZSelectionSchemeRandom {
+			rand.Shuffle(len(zones), func(i, j int) {
+				zones[i], zones[j] = zones[j], zones[i]
+			})
+		} else if selectionScheme == infrav1.AZSelectionSchemeOrdered {
+			sort.Strings(zones)
+		}
+		zones = zones[:maxZones]
+		s.scope.Debug("zones selected", "region", s.scope.Region(), "zones", zones)
+	}
+
+	return zones, nil
 }
 
 func (s *Service) deleteSubnets() error {

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -3827,6 +3827,156 @@ func TestReconcileSubnets(t *testing.T) {
 					After(zone2PrivateSubnet)
 			},
 		},
+		{
+			name: "Managed VPC, no subnets exist, one az is explicitly defined, expect one private and one public from default",
+			input: NewClusterScope().WithNetwork(&infrav1.NetworkSpec{
+				VPC: infrav1.VPCSpec{
+					ID: subnetsVPCID,
+					Tags: infrav1.Tags{
+						infrav1.ClusterTagKey("test-cluster"): "owned",
+					},
+					CidrBlock:         defaultVPCCidr,
+					AvailabilityZones: []string{"us-east-1b"},
+				},
+				Subnets: []infrav1.SubnetSpec{},
+			}),
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				describeCall := m.DescribeSubnetsWithContext(context.TODO(), gomock.Eq(&ec2.DescribeSubnetsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name:   aws.String("state"),
+							Values: []*string{aws.String("pending"), aws.String("available")},
+						},
+						{
+							Name:   aws.String("vpc-id"),
+							Values: []*string{aws.String(subnetsVPCID)},
+						},
+					},
+				})).Return(&ec2.DescribeSubnetsOutput{}, nil)
+
+				m.DescribeAvailabilityZonesWithContext(context.TODO(), gomock.Any()).
+					Return(&ec2.DescribeAvailabilityZonesOutput{
+						AvailabilityZones: []*ec2.AvailabilityZone{
+							{
+								ZoneName: aws.String("us-east-1b"),
+								ZoneType: aws.String("availability-zone"),
+							},
+						},
+					}, nil).Times(3) // called once by getAvailableZones, and twice by createSubnet (one private, one public)
+
+				m.DescribeRouteTablesWithContext(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{}, nil)
+
+				m.DescribeNatGatewaysPagesWithContext(context.TODO(),
+					gomock.Eq(&ec2.DescribeNatGatewaysInput{
+						Filter: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
+						},
+					}),
+					gomock.Any()).Return(nil)
+
+				zone1PublicSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
+					VpcId:            aws.String(subnetsVPCID),
+					CidrBlock:        aws.String("10.0.0.0/17"),
+					AvailabilityZone: aws.String("us-east-1b"),
+					TagSpecifications: []*ec2.TagSpecification{
+						{
+							ResourceType: aws.String("subnet"),
+							Tags: []*ec2.Tag{
+								{
+									Key:   aws.String("Name"),
+									Value: aws.String("test-cluster-subnet-public-us-east-1b"),
+								},
+								{
+									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+									Value: aws.String("owned"),
+								},
+								{
+									Key:   aws.String("kubernetes.io/role/elb"),
+									Value: aws.String("1"),
+								},
+								{
+									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+									Value: aws.String("owned"),
+								},
+								{
+									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+									Value: aws.String("public"),
+								},
+							},
+						},
+					},
+				})).Return(&ec2.CreateSubnetOutput{
+					Subnet: &ec2.Subnet{
+						VpcId:               aws.String(subnetsVPCID),
+						SubnetId:            aws.String("subnet-1"),
+						CidrBlock:           aws.String("10.0.0.0/17"),
+						AvailabilityZone:    aws.String("us-east-1b"),
+						MapPublicIpOnLaunch: aws.Bool(false),
+					},
+				}, nil).After(describeCall)
+
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).After(zone1PublicSubnet)
+
+				m.ModifySubnetAttributeWithContext(context.TODO(), &ec2.ModifySubnetAttributeInput{
+					MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
+						Value: aws.Bool(true),
+					},
+					SubnetId: aws.String("subnet-1"),
+				}).Return(&ec2.ModifySubnetAttributeOutput{}, nil).After(zone1PublicSubnet)
+
+				zone1PrivateSubnet := m.CreateSubnetWithContext(context.TODO(), gomock.Eq(&ec2.CreateSubnetInput{
+					VpcId:            aws.String(subnetsVPCID),
+					CidrBlock:        aws.String("10.0.128.0/17"),
+					AvailabilityZone: aws.String("us-east-1b"),
+					TagSpecifications: []*ec2.TagSpecification{
+						{
+							ResourceType: aws.String("subnet"),
+							Tags: []*ec2.Tag{
+								{
+									Key:   aws.String("Name"),
+									Value: aws.String("test-cluster-subnet-private-us-east-1b"),
+								},
+								{
+									Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+									Value: aws.String("owned"),
+								},
+								{
+									Key:   aws.String("kubernetes.io/role/internal-elb"),
+									Value: aws.String("1"),
+								},
+								{
+									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+									Value: aws.String("owned"),
+								},
+								{
+									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+									Value: aws.String("private"),
+								},
+							},
+						},
+					},
+				})).Return(&ec2.CreateSubnetOutput{
+					Subnet: &ec2.Subnet{
+						VpcId:               aws.String(subnetsVPCID),
+						SubnetId:            aws.String("subnet-2"),
+						CidrBlock:           aws.String("10.0.128.0/17"),
+						AvailabilityZone:    aws.String("us-east-1b"),
+						MapPublicIpOnLaunch: aws.Bool(false),
+					},
+				}, nil).After(zone1PublicSubnet)
+
+				m.WaitUntilSubnetAvailableWithContext(context.TODO(), gomock.Any()).
+					After(zone1PrivateSubnet)
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4333, continues the work started by @Skarlso in this https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4543 by:

- moving the defaults for `AvailabilityZoneSelection` and `AvailabilityZoneUsageLimit` into defaulting webhooks instead of CRDs
- adding check in validating webhooks for conflicting use of `AvailabilityZoneUsageLimit` and `AvailabilityZoneSelection` with `AvailabilityZones`

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ability to specify Availability Zones from spec.network.vpc in AWSManagedControlPlane, AWSCluster and AWSClusterTemplate CRDs.
```
