### PR TITLE
DNM: e2e-eks: debug EKS invalid awsmanagedmachinepool spec.roleName

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <img src="https://bestpractices.coreinfrastructure.org/projects/5688/badge"></a>
 </p>
 
-------
+-------
 
 Kubernetes-native declarative infrastructure for AWS.
 


### PR DESCRIPTION
Debug EKS e2e issue:
```
[managed] [general] [ipv6] EKS cluster tests [It] should create a cluster and add nodes
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/common.go:231
  [FAILED] Unexpected error:
      <errors.aggregate | len:1, cap:1>: 
      admission webhook "validation.awsmanagedmachinepool.infrastructure.cluster.x-k8s.io" denied the request: AWSManagedMachinePool.infrastructure.cluster.x-k8s.io "eks-nodes-14zug4-pool-0" is invalid: spec.roleName: Invalid value: "": field is immutable
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/5093/pull-cluster-api-provider-aws-e2e-eks/1849186934245560320

/hold