### PR TITLE
🐛 Filter out AWS internal tags when reconciling

### DIFF
--- a/pkg/cloud/tags/tags.go
+++ b/pkg/cloud/tags/tags.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -30,6 +31,10 @@ import (
 	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+)
+
+const (
+	AwsInternalTagPrefix = "aws:" // AwsInternalTagPrefix is the prefix for AWS internal tags, which are reserved for internal AWS use.
 )
 
 var (
@@ -99,7 +104,10 @@ func WithEC2(ec2client ec2iface.EC2API) BuilderOption {
 			// For testing, we need sorted keys
 			sortedKeys := make([]string, 0, len(tags))
 			for k := range tags {
-				sortedKeys = append(sortedKeys, k)
+				// We want to filter out the tag keys that start with `aws:` as they are reserved for internal AWS use.
+				if !strings.HasPrefix(k, AwsInternalTagPrefix) {
+					sortedKeys = append(sortedKeys, k)
+				}
 			}
 			sort.Strings(sortedKeys)
 
@@ -127,10 +135,12 @@ func WithEKS(eksclient eksiface.EKSAPI) BuilderOption {
 	return func(b *Builder) {
 		b.applyFunc = func(params *infrav1.BuildParams) error {
 			tags := infrav1.Build(*params)
-
 			eksTags := make(map[string]*string, len(tags))
 			for k, v := range tags {
-				eksTags[k] = aws.String(v)
+				// We want to filter out the tag keys that start with `aws:` as they are reserved for internal AWS use.
+				if !strings.HasPrefix(k, AwsInternalTagPrefix) {
+					eksTags[k] = aws.String(v)
+				}
 			}
 
 			tagResourcesInput := &eks.TagResourceInput{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Tags that start with `aws:` are considered internal AWS tags and can't be add or removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5120

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Filter out AWS internal tags when reconciling AWS infra
```
