### PR TITLE
:bug: Remove placeholder CA bundle

### DIFF
--- a/config/crd/patches/webhook_in_awsclustercontrolleridentities.yaml
+++ b/config/crd/patches/webhook_in_awsclustercontrolleridentities.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_awsclusterroleidentities.yaml
+++ b/config/crd/patches/webhook_in_awsclusterroleidentities.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_awsclusters.yaml
+++ b/config/crd/patches/webhook_in_awsclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_awsclustertemplates.yaml
+++ b/config/crd/patches/webhook_in_awsclustertemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_awsmachinepools.yaml
+++ b/config/crd/patches/webhook_in_awsmachinepools.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/config/crd/patches/webhook_in_awsmachines.yaml
+++ b/config/crd/patches/webhook_in_awsmachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_awsmachinetemplates.yaml
+++ b/config/crd/patches/webhook_in_awsmachinetemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_awsmanagedcontrolplanes.yaml
+++ b/config/crd/patches/webhook_in_awsmanagedcontrolplanes.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_eksconfigs.yaml
+++ b/config/crd/patches/webhook_in_eksconfigs.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_eksconfigtemplates.yaml
+++ b/config/crd/patches/webhook_in_eksconfigtemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

Description shamelessly lifted from [the equivalent PR on Cluster API](https://github.com/kubernetes-sigs/cluster-api/pull/10972).

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Starting with Kubernetes 1.31 it won't be possible anymore to continuously apply CRDs that are setting caBundle to an invalid value (in our case `Cg==`). The solution is to simply drop the caBundle field (it was never actually required by kube-apiserver).

For more details see: https://kubernetes.slack.com/archives/C0EG7JC6T/p1722441161968339

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5195 

**Special notes for your reviewer**:

There are other references in the codebase to the string `Cg==`, but it appears to be for zeroing AWS credentials, not for setting the CA bundle.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove placeholder CA bundles from webhook configuration to support Kubernetes 1.31.
```
