### PR TITLE
🐛 fix(securitygroups): Look up unmanaged NAT Gateway IPs, so provider doesn't add 0.0.0.0/0 SG rule

### DIFF
--- a/controllers/awscluster_controller_test.go
+++ b/controllers/awscluster_controller_test.go
@@ -776,6 +776,17 @@ func mockedDeleteInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 }
 
 func mockedVPCCallsForExistingVPCAndSubnets(m *mocks.MockEC2APIMockRecorder) {
+	m.DescribeNatGatewaysPagesWithContext(context.TODO(), gomock.Eq(&ec2.DescribeNatGatewaysInput{
+		Filter: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String("vpc-exists")},
+			},
+			{
+				Name:   aws.String("state"),
+				Values: aws.StringSlice([]string{ec2.VpcStatePending, ec2.VpcStateAvailable}),
+			},
+		}}), gomock.Any()).Return(nil)
 	m.CreateTagsWithContext(context.TODO(), gomock.Eq(&ec2.CreateTagsInput{
 		Resources: aws.StringSlice([]string{"subnet-1"}),
 		Tags: []*ec2.Tag{

--- a/pkg/cloud/services/network/natgateways.go
+++ b/pkg/cloud/services/network/natgateways.go
@@ -41,6 +41,10 @@ import (
 func (s *Service) reconcileNatGateways() error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
 		s.scope.Trace("Skipping NAT gateway reconcile in unmanaged mode")
+		_, err := s.updateNatGatewayIPs(s.scope.TagUnmanagedNetworkResources())
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -66,43 +70,10 @@ func (s *Service) reconcileNatGateways() error {
 		return nil
 	}
 
-	existing, err := s.describeNatGatewaysBySubnet()
+	subnetIDs, err := s.updateNatGatewayIPs(true)
 	if err != nil {
 		return err
 	}
-
-	natGatewaysIPs := []string{}
-	subnetIDs := []string{}
-
-	for _, sn := range s.scope.Subnets().FilterPublic().FilterNonCni() {
-		if sn.GetResourceID() == "" {
-			continue
-		}
-
-		if ngw, ok := existing[sn.GetResourceID()]; ok {
-			if len(ngw.NatGatewayAddresses) > 0 && ngw.NatGatewayAddresses[0].PublicIp != nil {
-				natGatewaysIPs = append(natGatewaysIPs, *ngw.NatGatewayAddresses[0].PublicIp)
-			}
-			// Make sure tags are up to date.
-			if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
-				buildParams := s.getNatGatewayTagParams(*ngw.NatGatewayId)
-				tagsBuilder := tags.New(&buildParams, tags.WithEC2(s.EC2Client))
-				if err := tagsBuilder.Ensure(converters.TagsToMap(ngw.Tags)); err != nil {
-					return false, err
-				}
-				return true, nil
-			}, awserrors.ResourceNotFound); err != nil {
-				record.Warnf(s.scope.InfraCluster(), "FailedTagNATGateway", "Failed to tag managed NAT Gateway %q: %v", *ngw.NatGatewayId, err)
-				return errors.Wrapf(err, "failed to tag nat gateway %q", *ngw.NatGatewayId)
-			}
-
-			continue
-		}
-
-		subnetIDs = append(subnetIDs, sn.GetResourceID())
-	}
-
-	s.scope.SetNatGatewaysIPs(natGatewaysIPs)
 
 	// Batch the creation of NAT gateways
 	if len(subnetIDs) > 0 {
@@ -131,6 +102,49 @@ func (s *Service) reconcileNatGateways() error {
 	}
 
 	return nil
+}
+
+func (s *Service) updateNatGatewayIPs(updateTags bool) ([]string, error) {
+	existing, err := s.describeNatGatewaysBySubnet()
+	if err != nil {
+		return nil, err
+	}
+
+	natGatewaysIPs := []string{}
+	subnetIDs := []string{}
+
+	for _, sn := range s.scope.Subnets().FilterPublic().FilterNonCni() {
+		if sn.GetResourceID() == "" {
+			continue
+		}
+
+		if ngw, ok := existing[sn.GetResourceID()]; ok {
+			if len(ngw.NatGatewayAddresses) > 0 && ngw.NatGatewayAddresses[0].PublicIp != nil {
+				natGatewaysIPs = append(natGatewaysIPs, *ngw.NatGatewayAddresses[0].PublicIp)
+			}
+			if updateTags {
+				// Make sure tags are up to date.
+				if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+					buildParams := s.getNatGatewayTagParams(*ngw.NatGatewayId)
+					tagsBuilder := tags.New(&buildParams, tags.WithEC2(s.EC2Client))
+					if err := tagsBuilder.Ensure(converters.TagsToMap(ngw.Tags)); err != nil {
+						return false, err
+					}
+					return true, nil
+				}, awserrors.ResourceNotFound); err != nil {
+					record.Warnf(s.scope.InfraCluster(), "FailedTagNATGateway", "Failed to tag managed NAT Gateway %q: %v", *ngw.NatGatewayId, err)
+					return nil, errors.Wrapf(err, "failed to tag nat gateway %q", *ngw.NatGatewayId)
+				}
+			}
+
+			continue
+		}
+
+		subnetIDs = append(subnetIDs, sn.GetResourceID())
+	}
+
+	s.scope.SetNatGatewaysIPs(natGatewaysIPs)
+	return subnetIDs, nil
 }
 
 func (s *Service) deleteNatGateways() error {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes an issue that caused the provider to add a security group rule allowing all addresses (`0.0.0.0/0`) access to the workload cluster API Server, if a cluster was created on an unmanaged VPC. The rule would be added even if the user had provided a list of source address in `spec.controlPlaneLoadBalancer.ingressRules`.

The rule was being added so the kubelets could reach the API, but `0.0.0.0/0` was a fall back source if the NAT Gateway IPs were not (yet) known. Prior to this PR, In the case of unmanaged VPC, the NAT Gateways IPs were never retrieved so `getIngressRulesToAllowKubeletToAccessTheControlPlaneLB()` in [securitygroups.go](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/pkg/cloud/services/securitygroup/securitygroups.go#L929) would always fall back to using `0.0.0.0/0`.

**Which issue(s) this PR fixes** :
Fixes #5196

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Action Required: If deploying clusters to an existing VPC (not managed by the AWS provider), the provider will no longer automatically create a security group rule allowing traffic from all addresses (`0.0.0.0/0`). You may need to update `AWSCluster.spec.controlPlaneLoadBalancer.ingressRules` with the source address of your Management Cluster.
```
