### PR TITLE
🐛 fix(addons): add configuration to IsEqual cmp

### DIFF
--- a/pkg/eks/addons/types.go
+++ b/pkg/eks/addons/types.go
@@ -36,7 +36,7 @@ type EKSAddon struct {
 
 // IsEqual determines if 2 EKSAddon are equal.
 func (e *EKSAddon) IsEqual(other *EKSAddon, includeTags bool) bool {
-	//NOTE: we don't compare the ARN as thats only for existing addons
+	//NOTE: we do not compare the ARN as that is only for existing addons
 	if e == other {
 		return true
 	}
@@ -44,6 +44,12 @@ func (e *EKSAddon) IsEqual(other *EKSAddon, includeTags bool) bool {
 		return false
 	}
 	if !cmp.Equal(e.ServiceAccountRoleARN, other.ServiceAccountRoleARN) {
+		return false
+	}
+	if !cmp.Equal(e.Configuration, other.Configuration) {
+		return false
+	}
+	if !cmp.Equal(e.ResolveConflict, other.ResolveConflict) {
 		return false
 	}
 

--- a/pkg/eks/addons/types_test.go
+++ b/pkg/eks/addons/types_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addons
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestAddOnEqual(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	tags := func(s, t string) map[string]string {
+		return map[string]string{
+			s: t,
+		}
+	}
+	g := gomega.NewGomegaWithT(t)
+	tests := []struct {
+		orig        *EKSAddon
+		other       *EKSAddon
+		result      gomega.OmegaMatcher
+		includeTags bool
+	}{
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("c"),
+				ResolveConflict:       ptr("d"),
+				Tags:                  tags("a", "1"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("c"),
+				ResolveConflict:       ptr("d"),
+				Tags:                  tags("a", "1"),
+				Status:                ptr("e"),
+			},
+			result: gomega.BeTrueBecause("addon values are equal (except status)"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("c"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("b"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("c"),
+			},
+			result: gomega.BeFalseBecause("addon version differs"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("c"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("c"),
+				Configuration:         ptr("c"),
+			},
+			result: gomega.BeFalseBecause("addon serviceAccountRoleARN differs"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("c"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("d"),
+			},
+			result: gomega.BeFalseBecause("addon configuration differs"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("c"),
+				ResolveConflict:       ptr("d"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         ptr("d"),
+				ResolveConflict:       ptr("e"),
+			},
+			result: gomega.BeFalseBecause("addon conflict resolution differs"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Tags:                  tags("a", "1"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Tags:                  tags("a", "2"),
+			},
+			result: gomega.BeTrueBecause("addon tags differ but not used for comparison"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Tags:                  tags("a", "1"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Tags:                  tags("a", "2"),
+			},
+			result:      gomega.BeFalseBecause("addon tags differ and used for comparison"),
+			includeTags: true,
+		},
+	}
+
+	for _, test := range tests {
+		g.Expect(test.orig.IsEqual(test.other, test.includeTags)).To(test.result)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently a configuration change of an AddOn is not reconciled by capa and needs manual fixing (e.g. in the AWS console), this PR fixes the behaviour. The PR also adds basic tests for the IsEqual function and its expected results.

**Which issue(s) this PR fixes**

Fixes #5086 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: Include AddOn configuration and conflict resolution for reconciliation
```
