### PR TITLE
📖 docs: update release notes with jobs

### DIFF
--- a/docs/book/src/development/releasing.md
+++ b/docs/book/src/development/releasing.md
@@ -94,3 +94,13 @@ Promote the container images from the staging registry to the production registr
     ```
 
 1. Update the Title and Description of the Slack channel to point to the new version.
+
+## Post Release Steps
+
+### Create new Prow jobs
+
+If the release is for a new MAJOR.MINOR version (i.e. not a patch release) then you will need to create a new set of prow jobs for the release branch.
+
+This is done by updating the [test-infra](https://github.com/kubernetes/test-infra) repo. For an example of PR see [this](https://github.com/kubernetes/test-infra/pull/33751) for the v2.7 release series.
+
+Consider removing jobs from an old release as well. We should only keep jobs for 4 release branches.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

Update the release notes to add a reminder that the Prow jobs need to be updated for any new MAJOR.MINOR release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [x] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Release notes include reminder to update Prow jobs.
```
