### PR TITLE
✨ feat(addons): add updateAddonTagsWithLatestVersion to set addon tags to latest version

### DIFF
--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
@@ -924,6 +924,8 @@ func mockedEKSCluster(g *WithT, eksRec *mock_eksiface.MockEKSAPIMockRecorder, ia
 		ClusterName: aws.String("test-cluster"),
 	}).Return(&eks.ListAddonsOutput{}, nil)
 
+	eksRec.DescribeAddonVersions(&eks.DescribeAddonVersionsInput{}).Return(&eks.DescribeAddonVersionsOutput{}, nil)
+
 	awsNodeRec.ReconcileCNI(gomock.Any()).Return(nil)
 	kubeProxyRec.ReconcileKubeProxy(gomock.Any()).Return(nil)
 	iamAuthenticatorRec.ReconcileIAMAuthenticator(gomock.Any()).Return(nil)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

- Feature enhancement: Adds support for specifying the latest version of EKS addons in AWSManagedControlPlane.
- Improves user experience: Automatically resolves the versioning of addons by fetching the latest supported versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5184

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:

```release-note
feat: Support installing the latest supported version of EKS addons by specifying version: latest in AWSManagedControlPlane.
```
