### PR TITLE
🌱 test: e2e: make managed suite more robust to errors with Eventually()

### DIFF
--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -137,6 +137,7 @@ variables:
   GC_WORKLOAD: "../../data/gcworkload.yaml"
 
 intervals:
+  default/wait-client-request: ["5m", "5s"]
   default/wait-cluster: ["40m", "10s"]
   default/wait-control-plane: ["35m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]

--- a/test/e2e/suites/managed/addon.go
+++ b/test/e2e/suites/managed/addon.go
@@ -62,8 +62,9 @@ func CheckAddonExistsSpec(ctx context.Context, inputGetter func() CheckAddonExis
 
 	By(fmt.Sprintf("Getting control plane: %s", controlPlaneName))
 	controlPlane := &ekscontrolplanev1.AWSManagedControlPlane{}
-	err := mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: input.Namespace.Name, Name: controlPlaneName}, controlPlane)
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() error {
+		return mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: input.Namespace.Name, Name: controlPlaneName}, controlPlane)
+	}, input.E2EConfig.GetIntervals("", "wait-client-request")...).Should(Succeed(), "eventually failed trying to get the AWSManagedControlPlane")
 
 	By(fmt.Sprintf("Checking EKS addon %s is installed on cluster %s and is active", input.AddonName, input.ClusterName))
 	waitForEKSAddonToHaveStatus(waitForEKSAddonToHaveStatusInput{

--- a/test/e2e/suites/managed/eks_test.go
+++ b/test/e2e/suites/managed/eks_test.go
@@ -22,7 +22,6 @@ package managed
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -75,22 +74,15 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 		})
 
 		ginkgo.By("should set environment variables on the aws-node daemonset")
-		Eventually(func() error {
-			defer ginkgo.GinkgoRecover()
-			CheckAwsNodeEnvVarsSet(ctx, func() UpdateAwsNodeVersionSpecInput {
-				return UpdateAwsNodeVersionSpecInput{
-					E2EConfig:             e2eCtx.E2EConfig,
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-					AWSSession:            e2eCtx.BootstrapUserAWSSession,
-					Namespace:             namespace,
-					ClusterName:           clusterName,
-				}
-			})
-			return nil
-		}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).WithContext(ctx).Should(
-			Succeed(),
-			"Failed to verify AWS Node environment variables after 5 minutes of retries",
-		)
+		CheckAwsNodeEnvVarsSet(ctx, func() UpdateAwsNodeVersionSpecInput {
+			return UpdateAwsNodeVersionSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				AWSSession:            e2eCtx.BootstrapUserAWSSession,
+				Namespace:             namespace,
+				ClusterName:           clusterName,
+			}
+		})
 
 		ginkgo.By("should have the VPC CNI installed")
 		CheckAddonExistsSpec(ctx, func() CheckAddonExistsSpecInput {


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
make managed suite more robust to errors with Eventually()

**Special notes for your reviewer**:
Trying to address issues like the ones seen here: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/5211/pull-cluster-api-provider-aws-e2e-eks/1856371404925046784

```release-note
NONE
```
