### PR TITLE
EKS Security Group tag updation from AWSManagedControlPlane

### DIFF
--- a/pkg/cloud/services/eks/securitygroup.go
+++ b/pkg/cloud/services/eks/securitygroup.go
@@ -19,6 +19,8 @@ package eks
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -73,10 +75,83 @@ func (s *Service) reconcileSecurityGroups(cluster *eks.Cluster) error {
 		return fmt.Errorf("describing EKS cluster security group: %w", err)
 	}
 
-	s.scope.ControlPlane.Status.Network.SecurityGroups[ekscontrolplanev1.SecurityGroupCluster] = infrav1.SecurityGroup{
+	clusterSecurityGroup := infrav1.SecurityGroup{
 		ID:   aws.StringValue(cluster.ResourcesVpcConfig.ClusterSecurityGroupId),
 		Name: *output.SecurityGroups[0].GroupName,
 		Tags: converters.TagsToMap(output.SecurityGroups[0].Tags),
+	}
+	s.scope.ControlPlane.Status.Network.SecurityGroups[ekscontrolplanev1.SecurityGroupCluster] = clusterSecurityGroup
+
+	additionalTags := s.scope.ControlPlane.Spec.AdditionalTags
+	if !reflect.DeepEqual(sg.Tags, desiredTags(sg.Tags, additionalTags)) {
+		if err = s.updateTagsForEKSManagedSecurityGroup(&sg.ID, sg.Tags, desiredTags(sg.Tags, additionalTags)); err != nil {
+			return err
+		}
+	}
+
+	if !reflect.DeepEqual(clusterSecurityGroup.Tags, desiredTags(clusterSecurityGroup.Tags, additionalTags)) {
+		if err = s.updateTagsForEKSManagedSecurityGroup(&clusterSecurityGroup.ID, clusterSecurityGroup.Tags, desiredTags(clusterSecurityGroup.Tags, additionalTags)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// desiredTags will return the default tags of EKS cluster with the spec.additionalTags from AWSManagedControlPlane
+func desiredTags(existingTags, additionalTags infrav1.Tags) infrav1.Tags {
+	merged := make(infrav1.Tags)
+
+	for key, value := range existingTags {
+		// since the cluster is created/managed by CAPA, existing tags will contain the default EKS security group tags
+		if key == "aws:eks:cluster-name" || key == "Name" || strings.Contains(key, infrav1.NameKubernetesAWSCloudProviderPrefix) {
+			merged[key] = value
+		}
+	}
+
+	// additional tags from spec.additionalTags of AWSManagedControlPlane will be added/updated to desired tags considering them as source of truth
+	for key, value := range additionalTags {
+		merged[key] = value
+	}
+
+	return merged
+}
+
+// updateTagsForEKSManagedSecurityGroup will update the tags in the EKS security group with the desired tags via create/update/delete operations
+func (s *Service) updateTagsForEKSManagedSecurityGroup(securityGroupID *string, existingTags, desiredTags infrav1.Tags) error {
+	tagsToDelete, newTags := getTagUpdates(existingTags, desiredTags)
+
+	// Create tags for updating or adding
+	if len(newTags) > 0 {
+		desiredTags := converters.MapToTags(newTags)
+		_, err := s.EC2Client.CreateTags(&ec2.CreateTagsInput{
+			Resources: []*string{securityGroupID},
+			Tags:      desiredTags,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create/update tags: %v", err)
+		}
+	}
+
+	// Delete tags
+	if len(tagsToDelete) > 0 {
+		var ec2TagKeys []*ec2.Tag
+		for _, key := range tagsToDelete {
+			// the default tags added to EKS cluster via AWS will not be deleted
+			if key != "aws:eks:cluster-name" && key != "Name" && !strings.Contains(key, infrav1.NameKubernetesAWSCloudProviderPrefix) {
+				ec2TagKeys = append(ec2TagKeys, &ec2.Tag{
+					Key: aws.String(key),
+				})
+			}
+		}
+
+		_, err := s.EC2Client.DeleteTags(&ec2.DeleteTagsInput{
+			Resources: []*string{securityGroupID},
+			Tags:      ec2TagKeys,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete tags: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**


/kind feature
/kind bug


**What this PR does / why we need it**:

This PR implements the functionality of having the same tags everywhere in EKS cluster which are provided in `spec.additionalTags` section of `AWSManagedControlPlane` to the default cluster security group of EKS created by AWS.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

For this bug: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5223