### PR TITLE
:bug: Fixed RosaMachinePool typo.

### DIFF
--- a/exp/api/v1beta2/conditions_consts.go
+++ b/exp/api/v1beta2/conditions_consts.go
@@ -105,9 +105,9 @@ const (
 
 const (
 	// RosaMachinePoolReadyCondition condition reports on the successful reconciliation of rosa machinepool.
-	RosaMachinePoolReadyCondition clusterv1.ConditionType = "RosaMchinePoolReady"
+	RosaMachinePoolReadyCondition clusterv1.ConditionType = "RosaMachinePoolReady"
 	// RosaMachinePoolUpgradingCondition condition reports whether ROSAMachinePool is upgrading or not.
-	RosaMachinePoolUpgradingCondition clusterv1.ConditionType = "RosaMchinePoolUpgrading"
+	RosaMachinePoolUpgradingCondition clusterv1.ConditionType = "RosaMachinePoolUpgrading"
 
 	// WaitingForRosaControlPlaneReason used when the machine pool is waiting for
 	// ROSA control plane infrastructure to be ready before proceeding.

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -155,7 +155,7 @@ func (r *ROSAMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if !controlPlane.Status.Ready && controlPlane.ObjectMeta.DeletionTimestamp.IsZero() {
 		log.Info("Control plane is not ready yet")
-		err := machinePoolScope.RosaMchinePoolReadyFalse(expinfrav1.WaitingForRosaControlPlaneReason, "")
+		err := machinePoolScope.RosaMachinePoolReadyFalse(expinfrav1.WaitingForRosaControlPlaneReason, "")
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/cloud/scope/rosamachinepool.go
+++ b/pkg/cloud/scope/rosamachinepool.go
@@ -189,9 +189,9 @@ func (s *RosaMachinePoolScope) Namespace() string {
 	return s.Cluster.Namespace
 }
 
-// RosaMchinePoolReadyFalse marks the ready condition false using warning if error isn't
+// RosaMachinePoolReadyFalse marks the ready condition false using warning if error isn't
 // empty.
-func (s *RosaMachinePoolScope) RosaMchinePoolReadyFalse(reason string, err string) error {
+func (s *RosaMachinePoolScope) RosaMachinePoolReadyFalse(reason string, err string) error {
 	severity := clusterv1.ConditionSeverityWarning
 	if err == "" {
 		severity = clusterv1.ConditionSeverityInfo


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR is fixing a `RosaMchinePoolReady` typo.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Discovered issue while working on https://issues.redhat.com/browse/ACM-16063

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed RosaMachinePool typo.

```
