### PR TITLE
🐛 fix(awscluster): update with secondary control plane load balancer

### DIFF
--- a/api/v1beta2/awscluster_webhook.go
+++ b/api/v1beta2/awscluster_webhook.go
@@ -180,16 +180,16 @@ func (r *AWSCluster) validateControlPlaneLoadBalancerUpdate(oldlb, newlb *AWSLoa
 					newlb.Name, "field is immutable"),
 			)
 		}
-	}
 
-	// Block the update for Protocol :
-	// - if it was not set in old spec but added in new spec
-	// - if it was set in old spec but changed in new spec
-	if !cmp.Equal(newlb.HealthCheckProtocol, oldlb.HealthCheckProtocol) {
-		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "healthCheckProtocol"),
-				newlb.HealthCheckProtocol, "field is immutable once set"),
-		)
+		// Block the update for Protocol :
+		// - if it was not set in old spec but added in new spec
+		// - if it was set in old spec but changed in new spec
+		if !cmp.Equal(newlb.HealthCheckProtocol, oldlb.HealthCheckProtocol) {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "healthCheckProtocol"),
+					newlb.HealthCheckProtocol, "field is immutable once set"),
+			)
+		}
 	}
 
 	return allErrs

--- a/api/v1beta2/awscluster_webhook_test.go
+++ b/api/v1beta2/awscluster_webhook_test.go
@@ -985,6 +985,20 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Should pass if old secondary lb is absent",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					SecondaryControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
+						Name: ptr.To("test-lb"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Should pass if controlPlaneLoadBalancer healthcheckprotocol is same after update",
 			oldCluster: &AWSCluster{
 				Spec: AWSClusterSpec{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The PR fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5247.

Adding a secondary load balancer to existing aws cluster.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
1. fixed adding a secondary load balancer to existing aws cluster
```
