### PR TITLE
:seedling: Add debugging information for test image upload

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -696,6 +696,7 @@ func ensureTestImageUploaded(e2eCtx *E2EContext) error {
 	}
 
 	imageSha := strings.ReplaceAll(strings.TrimSuffix(stdOut.String(), "\n"), "'", "")
+	fmt.Fprint(GinkgoWriter, "got container SHA")
 
 	ecrImageName := repoName + ":e2e"
 	cmd = exec.Command("docker", "tag", imageSha, ecrImageName) //nolint:gosec
@@ -703,6 +704,7 @@ func ensureTestImageUploaded(e2eCtx *E2EContext) error {
 	if err != nil {
 		return err
 	}
+	fmt.Fprint(GinkgoWriter, "tagged ECR image")
 
 	outToken, err := ecrSvc.GetAuthorizationToken(&ecrpublic.GetAuthorizationTokenInput{})
 	if err != nil {
@@ -722,12 +724,15 @@ func ensureTestImageUploaded(e2eCtx *E2EContext) error {
 	if err != nil {
 		return err
 	}
+	fmt.Fprint(GinkgoWriter, "logged in to public.ecr.aws")
 
 	cmd = exec.Command("docker", "push", ecrImageName)
 	err = cmd.Run()
 	if err != nil {
 		return err
 	}
+	fmt.Fprintf(GinkgoWriter, "pushed e2e image %q\n", ecrImageName)
+
 	e2eCtx.E2EConfig.Variables["CAPI_IMAGES_REGISTRY"] = repoName
 	e2eCtx.E2EConfig.Variables["E2E_IMAGE_TAG"] = "e2e"
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Prints out information about the process to upload the e2e image to ECR.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
