### PR TITLE
Remove GetPolicy IAM call when attaching to role

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -419,15 +419,6 @@ func (t Template) ControllersPolicyEKS() *iamv1.PolicyDocument {
 		},
 		{
 			Action: iamv1.Actions{
-				"iam:GetPolicy",
-			},
-			Resource: iamv1.Resources{
-				t.generateAWSManagedPolicyARN(eksClusterPolicyName),
-			},
-			Effect: iamv1.EffectAllow,
-		},
-		{
-			Action: iamv1.Actions{
 				"eks:DescribeCluster",
 				"eks:ListClusters",
 				"eks:CreateCluster",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -341,11 +341,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -341,11 +341,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -354,11 +354,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -346,11 +346,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -349,11 +349,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -349,11 +349,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -341,11 +341,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -341,11 +341,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -341,11 +341,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_iam_role_creation.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_iam_role_creation.yaml
@@ -1,0 +1,477 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  AWSIAMInstanceProfileControlPlane:
+    Properties:
+      InstanceProfileName: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      Roles:
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::InstanceProfile
+  AWSIAMInstanceProfileControllers:
+    Properties:
+      InstanceProfileName: controllers.cluster-api-provider-aws.sigs.k8s.io
+      Roles:
+      - Ref: AWSIAMRoleControllers
+    Type: AWS::IAM::InstanceProfile
+  AWSIAMInstanceProfileNodes:
+    Properties:
+      InstanceProfileName: nodes.cluster-api-provider-aws.sigs.k8s.io
+      Roles:
+      - Ref: AWSIAMRoleNodes
+    Type: AWS::IAM::InstanceProfile
+  AWSIAMManagedPolicyCloudProviderControlPlane:
+    Properties:
+      Description: For the Kubernetes Cloud Provider AWS Control Plane
+      ManagedPolicyName: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeLaunchConfigurations
+          - autoscaling:DescribeTags
+          - ec2:AssignIpv6Addresses
+          - ec2:DescribeInstances
+          - ec2:DescribeImages
+          - ec2:DescribeRegions
+          - ec2:DescribeRouteTables
+          - ec2:DescribeSecurityGroups
+          - ec2:DescribeSubnets
+          - ec2:DescribeVolumes
+          - ec2:CreateSecurityGroup
+          - ec2:CreateTags
+          - ec2:CreateVolume
+          - ec2:ModifyInstanceAttribute
+          - ec2:ModifyVolume
+          - ec2:AttachVolume
+          - ec2:AuthorizeSecurityGroupIngress
+          - ec2:CreateRoute
+          - ec2:DeleteRoute
+          - ec2:DeleteSecurityGroup
+          - ec2:DeleteVolume
+          - ec2:DetachVolume
+          - ec2:RevokeSecurityGroupIngress
+          - ec2:DescribeVpcs
+          - elasticloadbalancing:AddTags
+          - elasticloadbalancing:AttachLoadBalancerToSubnets
+          - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
+          - elasticloadbalancing:SetSecurityGroups
+          - elasticloadbalancing:CreateLoadBalancer
+          - elasticloadbalancing:CreateLoadBalancerPolicy
+          - elasticloadbalancing:CreateLoadBalancerListeners
+          - elasticloadbalancing:ConfigureHealthCheck
+          - elasticloadbalancing:DeleteLoadBalancer
+          - elasticloadbalancing:DeleteLoadBalancerListeners
+          - elasticloadbalancing:DescribeLoadBalancers
+          - elasticloadbalancing:DescribeLoadBalancerAttributes
+          - elasticloadbalancing:DetachLoadBalancerFromSubnets
+          - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+          - elasticloadbalancing:ModifyLoadBalancerAttributes
+          - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+          - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
+          - elasticloadbalancing:CreateListener
+          - elasticloadbalancing:CreateTargetGroup
+          - elasticloadbalancing:DeleteListener
+          - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DeregisterTargets
+          - elasticloadbalancing:DescribeListeners
+          - elasticloadbalancing:DescribeLoadBalancerPolicies
+          - elasticloadbalancing:DescribeTargetGroups
+          - elasticloadbalancing:DescribeTargetHealth
+          - elasticloadbalancing:ModifyListener
+          - elasticloadbalancing:ModifyTargetGroup
+          - elasticloadbalancing:RegisterTargets
+          - elasticloadbalancing:SetLoadBalancerPoliciesOfListener
+          - iam:CreateServiceLinkedRole
+          - kms:DescribeKey
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyCloudProviderNodes:
+    Properties:
+      Description: For the Kubernetes Cloud Provider AWS nodes
+      ManagedPolicyName: nodes.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - ec2:AssignIpv6Addresses
+          - ec2:DescribeInstances
+          - ec2:DescribeRegions
+          - ec2:CreateTags
+          - ec2:DescribeTags
+          - ec2:DescribeNetworkInterfaces
+          - ec2:DescribeInstanceTypes
+          - ecr:GetAuthorizationToken
+          - ecr:BatchCheckLayerAvailability
+          - ecr:GetDownloadUrlForLayer
+          - ecr:GetRepositoryPolicy
+          - ecr:DescribeRepositories
+          - ecr:ListImages
+          - ecr:BatchGetImage
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - secretsmanager:DeleteSecret
+          - secretsmanager:GetSecretValue
+          Effect: Allow
+          Resource:
+          - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        - Action:
+          - ssm:UpdateInstanceInformation
+          - ssmmessages:CreateControlChannel
+          - ssmmessages:CreateDataChannel
+          - ssmmessages:OpenControlChannel
+          - ssmmessages:OpenDataChannel
+          - s3:GetEncryptionConfiguration
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControlPlane
+      - Ref: AWSIAMRoleNodes
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllers:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - ec2:DescribeIpamPools
+          - ec2:AllocateIpamPoolCidr
+          - ec2:AttachNetworkInterface
+          - ec2:DetachNetworkInterface
+          - ec2:AllocateAddress
+          - ec2:AssignIpv6Addresses
+          - ec2:AssignPrivateIpAddresses
+          - ec2:UnassignPrivateIpAddresses
+          - ec2:AssociateRouteTable
+          - ec2:AssociateVpcCidrBlock
+          - ec2:AttachInternetGateway
+          - ec2:AuthorizeSecurityGroupIngress
+          - ec2:CreateCarrierGateway
+          - ec2:CreateInternetGateway
+          - ec2:CreateEgressOnlyInternetGateway
+          - ec2:CreateNatGateway
+          - ec2:CreateNetworkInterface
+          - ec2:CreateRoute
+          - ec2:CreateRouteTable
+          - ec2:CreateSecurityGroup
+          - ec2:CreateSubnet
+          - ec2:CreateTags
+          - ec2:CreateVpc
+          - ec2:CreateVpcEndpoint
+          - ec2:DisassociateVpcCidrBlock
+          - ec2:ModifyVpcAttribute
+          - ec2:ModifyVpcEndpoint
+          - ec2:DeleteCarrierGateway
+          - ec2:DeleteInternetGateway
+          - ec2:DeleteEgressOnlyInternetGateway
+          - ec2:DeleteNatGateway
+          - ec2:DeleteRouteTable
+          - ec2:ReplaceRoute
+          - ec2:DeleteSecurityGroup
+          - ec2:DeleteSubnet
+          - ec2:DeleteTags
+          - ec2:DeleteVpc
+          - ec2:DeleteVpcEndpoints
+          - ec2:DescribeAccountAttributes
+          - ec2:DescribeAddresses
+          - ec2:DescribeAvailabilityZones
+          - ec2:DescribeCarrierGateways
+          - ec2:DescribeInstances
+          - ec2:DescribeInstanceTypes
+          - ec2:DescribeInternetGateways
+          - ec2:DescribeEgressOnlyInternetGateways
+          - ec2:DescribeInstanceTypes
+          - ec2:DescribeImages
+          - ec2:DescribeNatGateways
+          - ec2:DescribeNetworkInterfaces
+          - ec2:DescribeNetworkInterfaceAttribute
+          - ec2:DescribeRouteTables
+          - ec2:DescribeSecurityGroups
+          - ec2:DescribeSubnets
+          - ec2:DescribeVpcs
+          - ec2:DescribeDhcpOptions
+          - ec2:DescribeVpcAttribute
+          - ec2:DescribeVpcEndpoints
+          - ec2:DescribeVolumes
+          - ec2:DescribeTags
+          - ec2:DetachInternetGateway
+          - ec2:DisassociateRouteTable
+          - ec2:DisassociateAddress
+          - ec2:ModifyInstanceAttribute
+          - ec2:ModifyNetworkInterfaceAttribute
+          - ec2:ModifySubnetAttribute
+          - ec2:ReleaseAddress
+          - ec2:RevokeSecurityGroupIngress
+          - ec2:RunInstances
+          - ec2:TerminateInstances
+          - tag:GetResources
+          - elasticloadbalancing:AddTags
+          - elasticloadbalancing:CreateLoadBalancer
+          - elasticloadbalancing:ConfigureHealthCheck
+          - elasticloadbalancing:DeleteLoadBalancer
+          - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DescribeLoadBalancers
+          - elasticloadbalancing:DescribeLoadBalancerAttributes
+          - elasticloadbalancing:DescribeTargetGroups
+          - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
+          - elasticloadbalancing:SetSecurityGroups
+          - elasticloadbalancing:DescribeTags
+          - elasticloadbalancing:ModifyLoadBalancerAttributes
+          - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+          - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+          - elasticloadbalancing:RemoveTags
+          - elasticloadbalancing:SetSubnets
+          - elasticloadbalancing:ModifyTargetGroupAttributes
+          - elasticloadbalancing:CreateTargetGroup
+          - elasticloadbalancing:DescribeListeners
+          - elasticloadbalancing:CreateListener
+          - elasticloadbalancing:DescribeTargetHealth
+          - elasticloadbalancing:RegisterTargets
+          - elasticloadbalancing:DeleteListener
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeInstanceRefreshes
+          - ec2:CreateLaunchTemplate
+          - ec2:CreateLaunchTemplateVersion
+          - ec2:DescribeLaunchTemplates
+          - ec2:DescribeLaunchTemplateVersions
+          - ec2:DeleteLaunchTemplate
+          - ec2:DeleteLaunchTemplateVersions
+          - ec2:DescribeKeyPairs
+          - ec2:ModifyInstanceMetadataOptions
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - autoscaling:CreateAutoScalingGroup
+          - autoscaling:UpdateAutoScalingGroup
+          - autoscaling:CreateOrUpdateTags
+          - autoscaling:StartInstanceRefresh
+          - autoscaling:DeleteAutoScalingGroup
+          - autoscaling:DeleteTags
+          Effect: Allow
+          Resource:
+          - arn:*:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: autoscaling.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: elasticloadbalancing.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: spot.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot
+        - Action:
+          - iam:PassRole
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/*.cluster-api-provider-aws.sigs.k8s.io
+        - Action:
+          - secretsmanager:CreateSecret
+          - secretsmanager:DeleteSecret
+          - secretsmanager:TagResource
+          Effect: Allow
+          Resource:
+          - arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMManagedPolicyControllersEKS:
+    Properties:
+      Description: For the Kubernetes Cluster API Provider AWS Controllers
+      ManagedPolicyName: controllers-eks.cluster-api-provider-aws.sigs.k8s.io
+      PolicyDocument:
+        Statement:
+        - Action:
+          - ssm:GetParameter
+          Effect: Allow
+          Resource:
+          - arn:*:ssm:*:*:parameter/aws/service/eks/optimized-ami/*
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: eks.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: eks-nodegroup.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: eks-fargate.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
+        - Action:
+          - iam:ListOpenIDConnectProviders
+          - iam:GetOpenIDConnectProvider
+          - iam:CreateOpenIDConnectProvider
+          - iam:AddClientIDToOpenIDConnectProvider
+          - iam:UpdateOpenIDConnectProviderThumbprint
+          - iam:DeleteOpenIDConnectProvider
+          - iam:TagOpenIDConnectProvider
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - iam:GetRole
+          - iam:ListAttachedRolePolicies
+          - iam:DetachRolePolicy
+          - iam:DeleteRole
+          - iam:CreateRole
+          - iam:TagRole
+          - iam:AttachRolePolicy
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/*
+        - Action:
+          - eks:DescribeCluster
+          - eks:ListClusters
+          - eks:CreateCluster
+          - eks:TagResource
+          - eks:UpdateClusterVersion
+          - eks:DeleteCluster
+          - eks:UpdateClusterConfig
+          - eks:UntagResource
+          - eks:UpdateNodegroupVersion
+          - eks:DescribeNodegroup
+          - eks:DeleteNodegroup
+          - eks:UpdateNodegroupConfig
+          - eks:CreateNodegroup
+          - eks:AssociateEncryptionConfig
+          - eks:ListIdentityProviderConfigs
+          - eks:AssociateIdentityProviderConfig
+          - eks:DescribeIdentityProviderConfig
+          - eks:DisassociateIdentityProviderConfig
+          Effect: Allow
+          Resource:
+          - arn:*:eks:*:*:cluster/*
+          - arn:*:eks:*:*:nodegroup/*/*/*
+        - Action:
+          - ec2:AssociateVpcCidrBlock
+          - ec2:DisassociateVpcCidrBlock
+          - eks:ListAddons
+          - eks:CreateAddon
+          - eks:DescribeAddonVersions
+          - eks:DescribeAddon
+          - eks:DeleteAddon
+          - eks:UpdateAddon
+          - eks:TagResource
+          - eks:DescribeFargateProfile
+          - eks:CreateFargateProfile
+          - eks:DeleteFargateProfile
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - iam:PassRole
+          Condition:
+            StringEquals:
+              iam:PassedToService: eks.amazonaws.com
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - kms:CreateGrant
+          - kms:DescribeKey
+          Condition:
+            ForAnyValue:StringLike:
+              kms:ResourceAliases: alias/cluster-api-provider-aws-*
+          Effect: Allow
+          Resource:
+          - '*'
+        Version: 2012-10-17
+      Roles:
+      - Ref: AWSIAMRoleControllers
+      - Ref: AWSIAMRoleControlPlane
+    Type: AWS::IAM::ManagedPolicy
+  AWSIAMRoleControlPlane:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: 2012-10-17
+      RoleName: control-plane.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role
+  AWSIAMRoleControllers:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: 2012-10-17
+      RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role
+  AWSIAMRoleEKSControlPlane:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - eks.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+      RoleName: eks-controlplane.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role
+  AWSIAMRoleNodes:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+      - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      RoleName: nodes.cluster-api-provider-aws.sigs.k8s.io
+    Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -341,11 +341,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -349,11 +349,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -352,11 +352,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -341,11 +341,6 @@ Resources:
           Resource:
           - arn:*:iam::*:role/*
         - Action:
-          - iam:GetPolicy
-          Effect: Allow
-          Resource:
-          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - Action:
           - eks:DescribeCluster
           - eks:ListClusters
           - eks:CreateCluster

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template_test.go
@@ -114,6 +114,15 @@ func TestRenderCloudformation(t *testing.T) {
 			},
 		},
 		{
+			fixture: "with_eks_iam_role_creation",
+			template: func() Template {
+				t := NewTemplate()
+				t.Spec.Nodes.EC2ContainerRegistryReadOnly = true
+				t.Spec.EKS.AllowIAMRoleCreation = true
+				return t
+			},
+		},
+		{
 			fixture: "with_eks_kms_prefix",
 			template: func() Template {
 				t := NewTemplate()

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
@@ -791,25 +791,16 @@ func mockedEKSControlPlaneIAMRole(g *WithT, iamRec *mock_iamauth.MockIAMAPIMockR
 		}, nil
 	})
 
-	iamRec.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+	listAttachedPoliciesCall := iamRec.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
 		RoleName: aws.String("test-cluster-iam-service-role"),
 	}).After(createRoleCall).Return(&iam.ListAttachedRolePoliciesOutput{
 		AttachedPolicies: []*iam.AttachedPolicy{},
 	}, nil)
 
-	getPolicyCall := iamRec.GetPolicy(&iam.GetPolicyInput{
-		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"),
-	}).Return(&iam.GetPolicyOutput{
-		// This policy is predefined by AWS
-		Policy: &iam.Policy{
-			// Fields are not used. Our code only checks for existence of the policy.
-		},
-	}, nil)
-
 	iamRec.AttachRolePolicy(&iam.AttachRolePolicyInput{
 		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"),
 		RoleName:  aws.String("test-cluster-iam-service-role"),
-	}).After(getPolicyCall).Return(&iam.AttachRolePolicyOutput{}, nil)
+	}).After(listAttachedPoliciesCall).Return(&iam.AttachRolePolicyOutput{}, nil)
 }
 
 func mockedEKSCluster(g *WithT, eksRec *mock_eksiface.MockEKSAPIMockRecorder, iamRec *mock_iamauth.MockIAMAPIMockRecorder, ec2Rec *mocks.MockEC2APIMockRecorder, stsRec *mock_stsiface.MockSTSAPIMockRecorder, awsNodeRec *mock_services.MockAWSNodeInterfaceMockRecorder, kubeProxyRec *mock_services.MockKubeProxyInterfaceMockRecorder, iamAuthenticatorRec *mock_services.MockIAMAuthenticatorInterfaceMockRecorder) {

--- a/pkg/cloud/services/eks/iam/iam.go
+++ b/pkg/cloud/services/eks/iam/iam.go
@@ -66,19 +66,6 @@ func (s *IAMService) GetIAMRole(name string) (*iam.Role, error) {
 	return out.Role, nil
 }
 
-func (s *IAMService) getIAMPolicy(policyArn string) (*iam.Policy, error) {
-	input := &iam.GetPolicyInput{
-		PolicyArn: &policyArn,
-	}
-
-	out, err := s.IAMClient.GetPolicy(input)
-	if err != nil {
-		return nil, err
-	}
-
-	return out.Policy, nil
-}
-
 func (s *IAMService) getIAMRolePolicies(roleName string) ([]*string, error) {
 	input := &iam.ListAttachedRolePoliciesInput{
 		RoleName: &roleName,
@@ -149,12 +136,6 @@ func (s *IAMService) EnsurePoliciesAttached(role *iam.Role, policies []*string) 
 	for _, policy := range policies {
 		found := findStringInSlice(existingPolices, *policy)
 		if !found {
-			// Make sure policy exists before attaching
-			_, err := s.getIAMPolicy(*policy)
-			if err != nil {
-				return false, errors.Wrapf(err, "error getting policy %s", *policy)
-			}
-
 			updatedPolicies = true
 			err = s.attachIAMRolePolicy(*role.RoleName, *policy)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Alternative solution to #5265 that uses principle of least privilege by removing the need for `iam:GetPolicy` entirely. If the policy doesn't exist, assume that the AttachPolicy call will fail rather than attempting to fetch it before attachment. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5254

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove GetPolicy IAM call when attaching to role
```
