### PR TITLE
:book: Clarify that the ROSA provider is currently for ROSA HCP clusters

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
@@ -73,8 +73,8 @@ spec:
                 type: array
               billingAccount:
                 description: |-
-                  BillingAccount is an optional AWS account to use for billing the subscription fees for ROSA clusters.
-                  The cost of running each ROSA cluster will be billed to the infrastructure account in which the cluster
+                  BillingAccount is an optional AWS account to use for billing the subscription fees for ROSA HCP clusters.
+                  The cost of running each ROSA HCP cluster will be billed to the infrastructure account in which the cluster
                   is running.
                 type: string
                 x-kubernetes-validations:
@@ -563,8 +563,8 @@ spec:
                 - message: oidcID is immutable
                   rule: self == oldSelf
               provisionShardID:
-                description: ProvisionShardID defines the shard where rosa control
-                  plane components will be hosted.
+                description: ProvisionShardID defines the shard where ROSA hosted
+                  control plane components will be hosted.
                 type: string
                 x-kubernetes-validations:
                 - message: provisionShardID is immutable

--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -154,8 +154,8 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	// WorkerRoleARN is an AWS IAM role that will be attached to worker instances.
 	WorkerRoleARN string `json:"workerRoleARN"`
 
-	// BillingAccount is an optional AWS account to use for billing the subscription fees for ROSA clusters.
-	// The cost of running each ROSA cluster will be billed to the infrastructure account in which the cluster
+	// BillingAccount is an optional AWS account to use for billing the subscription fees for ROSA HCP clusters.
+	// The cost of running each ROSA HCP cluster will be billed to the infrastructure account in which the cluster
 	// is running.
 	//
 	// +kubebuilder:validation:Optional
@@ -202,7 +202,7 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	// +optional
 	AuditLogRoleARN string `json:"auditLogRoleARN,omitempty"`
 
-	// ProvisionShardID defines the shard where rosa control plane components will be hosted.
+	// ProvisionShardID defines the shard where ROSA hosted control plane components will be hosted.
 	//
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="provisionShardID is immutable"
 	// +optional

--- a/docs/book/src/topics/rosa/creating-a-cluster.md
+++ b/docs/book/src/topics/rosa/creating-a-cluster.md
@@ -1,8 +1,8 @@
-# Creating a ROSA cluster
+# Creating a ROSA HCP cluster
 
 ## Permissions
 ### Authentication using service account credentials
-CAPA controller requires service account credentials to be able to provision ROSA clusters:
+CAPA controller requires service account credentials to be able to provision ROSA HCP clusters:
 1. Visit [https://console.redhat.com/iam/service-accounts](https://console.redhat.com/iam/service-accounts) and create a service account. If you already have a service account, you can skip this step.
 
    For every newly created service account, make sure to activate the account using the [ROSA command line tool](https://github.com/openshift/rosa). First, log in using your newly created service account
@@ -87,9 +87,9 @@ The SSO offline token is being deprecated and it is recommended to use service a
 
 ## Prerequisites
 
-Follow the guide [here](https://docs.aws.amazon.com/ROSA/latest/userguide/getting-started-hcp.html) up until [Step 3](https://docs.aws.amazon.com/ROSA/latest/userguide/getting-started-hcp.html#getting-started-hcp-step-3) 
+Follow the guide [here](https://docs.aws.amazon.com/ROSA/latest/userguide/getting-started-hcp.html) up until [Step 3](https://docs.aws.amazon.com/ROSA/latest/userguide/getting-started-hcp.html#getting-started-hcp-step-3)
 to install the required tools and setup the prerequisite infrastructure.
-Once Step 3 is done, you will be ready to proceed with creating a ROSA cluster using cluster-api.
+Once Step 3 is done, you will be ready to proceed with creating a ROSA HCP cluster using cluster-api.
 
 ## Creating the cluster
 
@@ -106,11 +106,11 @@ Once Step 3 is done, you will be ready to proceed with creating a ROSA cluster u
     export OPERATOR_ROLES_PREFIX="capi-rosa-quickstart"  # prefix used to create operator roles with `rosa create operator-roles --prefix <PREFIX_NAME>`
 
     # subnet IDs created earlier
-    export PUBLIC_SUBNET_ID="subnet-0b54a1111111111111"   
+    export PUBLIC_SUBNET_ID="subnet-0b54a1111111111111"
     export PRIVATE_SUBNET_ID="subnet-05e72222222222222"
     ```
 
-1. Render the cluster manifest using the ROSA cluster template:
+1. Render the cluster manifest using the ROSA HCP cluster template:
     ```shell
     clusterctl generate cluster <cluster-name> --from templates/cluster-template-rosa.yaml > rosa-capi-cluster.yaml
     ```
@@ -128,7 +128,7 @@ Once Step 3 is done, you will be ready to proceed with creating a ROSA cluster u
     ...
     ```
 
-1. Provide an AWS identity reference  
+1. Provide an AWS identity reference
     ```yaml
     apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: ROSAControlPlane

--- a/docs/book/src/topics/rosa/enabling.md
+++ b/docs/book/src/topics/rosa/enabling.md
@@ -1,6 +1,6 @@
 # Enabling ROSA Support
 
-To enable support for ROSA clusters, the ROSA feature flag must be set to true. This can be done using the **EXP_ROSA** environment variable.
+To enable support for ROSA HCP clusters, the ROSA feature flag must be set to true. This can be done using the **EXP_ROSA** environment variable.
 
 Make sure to set up your AWS environment first as described [here](https://cluster-api.sigs.k8s.io/user/quick-start.html).
 ```shell

--- a/docs/book/src/topics/rosa/external-auth.md
+++ b/docs/book/src/topics/rosa/external-auth.md
@@ -1,6 +1,6 @@
 # External Auth Providers (BYOI)
 
-ROSA allows you to Bring Your Own Identity (BYOI) to manage and authenticate cluster users.
+ROSA HCP allows you to Bring Your Own Identity (BYOI) to manage and authenticate cluster users.
 
 ## Enabling
 
@@ -16,7 +16,7 @@ spec:
   ....
 ```
 
-Note: This feauture requires OpenShift version `4.15.5` or newer.
+Note: This feature requires OpenShift version `4.15.5` or newer.
 
 ## Usage
 

--- a/docs/book/src/topics/rosa/support.md
+++ b/docs/book/src/topics/rosa/support.md
@@ -1,6 +1,6 @@
 # Create issue for ROSA
 
-When creating issue for ROSA-HCP cluster, include the logs for the capa-controller-manager and capi-controller-manager deployment pods. The logs can be saved to text file using the commands below. Also include the yaml files for all the resources used to create the ROSA cluster:
+When creating issue for ROSA HCP cluster, include the logs for the capa-controller-manager and capi-controller-manager deployment pods. The logs can be saved to text file using the commands below. Also include the yaml files for all the resources used to create the ROSA HCP cluster:
 - `Cluster`
 - `ROSAControlPlane`
 - `MachinePool`


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The more explicit product name is ROSA HCP, see issue for more details

**Which issue(s) this PR fixes**:
Fixes #5257

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)

**Release note**:
```release-note
NONE
```
