### PR TITLE
🐛 fix: eks e2e with coredns addon

### DIFF
--- a/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-control-plane-only-withaddon.yaml
@@ -40,10 +40,6 @@ spec:
     - name: "vpc-cni"
       version: "${VPC_ADDON_VERSION}"
       conflictResolution: "overwrite"
-    - name: "coredns"
-      version: "${COREDNS_ADDON_VERSION}"
-      conflictResolution: "overwrite"
-      configuration: '${COREDNS_ADDON_CONFIGURATION}'
   identityRef:
     kind: AWSClusterStaticIdentity
     name: e2e-account

--- a/test/e2e/suites/managed/eks_test.go
+++ b/test/e2e/suites/managed/eks_test.go
@@ -37,12 +37,11 @@ import (
 // General EKS e2e test.
 var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 	var (
-		namespace        *corev1.Namespace
-		ctx              context.Context
-		specName         = "cluster"
-		clusterName      string
-		cniAddonName     = "vpc-cni"
-		corednsAddonName = "coredns"
+		namespace    *corev1.Namespace
+		ctx          context.Context
+		specName     = "cluster"
+		clusterName  string
+		cniAddonName = "vpc-cni"
 	)
 
 	shared.ConditionalIt(runGeneralTests, "should create a cluster and add nodes", func() {
@@ -71,7 +70,7 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 				Namespace:                namespace,
 				ClusterName:              clusterName,
 				Flavour:                  EKSControlPlaneOnlyWithAddonFlavor,
-				ControlPlaneMachineCount: 1, //NOTE: this cannot be zero as clusterctl returns an error
+				ControlPlaneMachineCount: 1, // NOTE: this cannot be zero as clusterctl returns an error
 				WorkerMachineCount:       0,
 			}
 		})
@@ -104,20 +103,6 @@ var _ = ginkgo.Describe("[managed] [general] EKS cluster tests", func() {
 				ClusterName:           clusterName,
 				AddonName:             cniAddonName,
 				AddonVersion:          e2eCtx.E2EConfig.GetVariable(shared.CNIAddonVersion),
-			}
-		})
-
-		ginkgo.By("should have the Coredns addon installed")
-		CheckAddonExistsSpec(ctx, func() CheckAddonExistsSpecInput {
-			return CheckAddonExistsSpecInput{
-				E2EConfig:             e2eCtx.E2EConfig,
-				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-				AWSSession:            e2eCtx.BootstrapUserAWSSession,
-				Namespace:             namespace,
-				ClusterName:           clusterName,
-				AddonName:             corednsAddonName,
-				AddonVersion:          e2eCtx.E2EConfig.GetVariable(shared.CorednsAddonVersion),
-				AddonConfiguration:    e2eCtx.E2EConfig.GetVariable(shared.CorednsAddonConfiguration),
 			}
 		})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The behaviour of EKS has changed in relation to addons when there are no nodes. Previously when enabling the coredns addon in a cluster with no nodes it would have a status of 'DOWNGRADED'. But recently AWS made a change and the status now shows as `UPDATING` with a failed health check.

To get the e2e passing the coredns addon has been removed from the AWSManagedControlPlane used in the test. We will need to follow up on this with a change to the addons reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5237 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the eks e2e test after change in behaviour of EKS addons.
```
