### PR TITLE
:sparkles: Implement support for EFA interface type

### DIFF
--- a/api/v1beta1/awscluster_conversion.go
+++ b/api/v1beta1/awscluster_conversion.go
@@ -59,6 +59,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Status.Bastion.PlacementGroupPartition = restored.Status.Bastion.PlacementGroupPartition
 		dst.Status.Bastion.PrivateDNSName = restored.Status.Bastion.PrivateDNSName
 		dst.Status.Bastion.PublicIPOnLaunch = restored.Status.Bastion.PublicIPOnLaunch
+		dst.Status.Bastion.NetworkInterfaceType = restored.Status.Bastion.NetworkInterfaceType
 		dst.Status.Bastion.CapacityReservationID = restored.Status.Bastion.CapacityReservationID
 		dst.Status.Bastion.MarketType = restored.Status.Bastion.MarketType
 	}

--- a/api/v1beta1/awsmachine_conversion.go
+++ b/api/v1beta1/awsmachine_conversion.go
@@ -43,6 +43,7 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.SecurityGroupOverrides = restored.Spec.SecurityGroupOverrides
 	dst.Spec.CapacityReservationID = restored.Spec.CapacityReservationID
 	dst.Spec.MarketType = restored.Spec.MarketType
+	dst.Spec.NetworkInterfaceType = restored.Spec.NetworkInterfaceType
 	if restored.Spec.ElasticIPPool != nil {
 		if dst.Spec.ElasticIPPool == nil {
 			dst.Spec.ElasticIPPool = &infrav1.ElasticIPPool{}
@@ -106,6 +107,7 @@ func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Template.Spec.SecurityGroupOverrides = restored.Spec.Template.Spec.SecurityGroupOverrides
 	dst.Spec.Template.Spec.CapacityReservationID = restored.Spec.Template.Spec.CapacityReservationID
 	dst.Spec.Template.Spec.MarketType = restored.Spec.Template.Spec.MarketType
+	dst.Spec.Template.Spec.NetworkInterfaceType = restored.Spec.Template.Spec.NetworkInterfaceType
 	if restored.Spec.Template.Spec.ElasticIPPool != nil {
 		if dst.Spec.Template.Spec.ElasticIPPool == nil {
 			dst.Spec.Template.Spec.ElasticIPPool = &infrav1.ElasticIPPool{}

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1415,6 +1415,7 @@ func autoConvert_v1beta2_AWSMachineSpec_To_v1beta1_AWSMachineSpec(in *v1beta2.AW
 	out.RootVolume = (*Volume)(unsafe.Pointer(in.RootVolume))
 	out.NonRootVolumes = *(*[]Volume)(unsafe.Pointer(&in.NonRootVolumes))
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
+	// WARNING: in.NetworkInterfaceType requires manual conversion: does not exist in peer-type
 	out.UncompressedUserData = (*bool)(unsafe.Pointer(in.UncompressedUserData))
 	if err := Convert_v1beta2_CloudInit_To_v1beta1_CloudInit(&in.CloudInit, &out.CloudInit, s); err != nil {
 		return err
@@ -2026,6 +2027,7 @@ func autoConvert_v1beta2_Instance_To_v1beta1_Instance(in *v1beta2.Instance, out 
 	out.RootVolume = (*Volume)(unsafe.Pointer(in.RootVolume))
 	out.NonRootVolumes = *(*[]Volume)(unsafe.Pointer(&in.NonRootVolumes))
 	out.NetworkInterfaces = *(*[]string)(unsafe.Pointer(&in.NetworkInterfaces))
+	// WARNING: in.NetworkInterfaceType requires manual conversion: does not exist in peer-type
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.AvailabilityZone = in.AvailabilityZone
 	out.SpotMarketOptions = (*SpotMarketOptions)(unsafe.Pointer(in.SpotMarketOptions))

--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -54,6 +54,16 @@ const (
 	IgnitionStorageTypeOptionUnencryptedUserData = IgnitionStorageTypeOption("UnencryptedUserData")
 )
 
+// NetworkInterfaceType is the type of network interface.
+type NetworkInterfaceType string
+
+const (
+	// NetworkInterfaceTypeENI means the network interface type is Elastic Network Interface.
+	NetworkInterfaceTypeENI NetworkInterfaceType = NetworkInterfaceType("interface")
+	// NetworkInterfaceTypeEFAWithENAInterface means the network interface type is Elastic Fabric Adapter with Elastic Network Adapter.
+	NetworkInterfaceTypeEFAWithENAInterface NetworkInterfaceType = NetworkInterfaceType("efa")
+)
+
 // AWSMachineSpec defines the desired state of an Amazon EC2 instance.
 type AWSMachineSpec struct {
 	// ProviderID is the unique identifier as specified by the cloud provider.
@@ -152,6 +162,12 @@ type AWSMachineSpec struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=2
 	NetworkInterfaces []string `json:"networkInterfaces,omitempty"`
+
+	// NetworkInterfaceType is the interface type of the primary network Interface.
+	// If not specified, AWS applies a default value.
+	// +kubebuilder:validation:Enum=interface;efa
+	// +optional
+	NetworkInterfaceType NetworkInterfaceType `json:"networkInterfaceType,omitempty"`
 
 	// UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance.
 	// cloud-init has built-in support for gzip-compressed user data

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -217,6 +217,9 @@ type Instance struct {
 	// Specifies ENIs attached to instance
 	NetworkInterfaces []string `json:"networkInterfaces,omitempty"`
 
+	// NetworkInterfaceType is the interface type of the primary network Interface.
+	NetworkInterfaceType NetworkInterfaceType `json:"networkInterfaceType,omitempty"`
+
 	// The tags associated with the instance.
 	Tags map[string]string `json:"tags,omitempty"`
 

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1223,6 +1223,10 @@ spec:
                     - Spot
                     - CapacityBlock
                     type: string
+                  networkInterfaceType:
+                    description: NetworkInterfaceType is the interface type of the
+                      primary network Interface.
+                    type: string
                   networkInterfaces:
                     description: Specifies ENIs attached to instance
                     items:
@@ -3275,6 +3279,10 @@ spec:
                     - OnDemand
                     - Spot
                     - CapacityBlock
+                    type: string
+                  networkInterfaceType:
+                    description: NetworkInterfaceType is the interface type of the
+                      primary network Interface.
                     type: string
                   networkInterfaces:
                     description: Specifies ENIs attached to instance

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -2190,6 +2190,10 @@ spec:
                     - Spot
                     - CapacityBlock
                     type: string
+                  networkInterfaceType:
+                    description: NetworkInterfaceType is the interface type of the
+                      primary network Interface.
+                    type: string
                   networkInterfaces:
                     description: Specifies ENIs attached to instance
                     items:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -891,6 +891,14 @@ spec:
                 - Spot
                 - CapacityBlock
                 type: string
+              networkInterfaceType:
+                description: |-
+                  NetworkInterfaceType is the interface type of the primary network Interface.
+                  If not specified, AWS applies a default value.
+                enum:
+                - interface
+                - efa
+                type: string
               networkInterfaces:
                 description: |-
                   NetworkInterfaces is a list of ENIs to associate with the instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -825,6 +825,14 @@ spec:
                         - Spot
                         - CapacityBlock
                         type: string
+                      networkInterfaceType:
+                        description: |-
+                          NetworkInterfaceType is the interface type of the primary network Interface.
+                          If not specified, AWS applies a default value.
+                        enum:
+                        - interface
+                        - efa
+                        type: string
                       networkInterfaces:
                         description: |-
                           NetworkInterfaces is a list of ENIs to associate with the instance.

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -113,11 +113,12 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte, use
 	s.scope.Debug("Creating an instance for a machine")
 
 	input := &infrav1.Instance{
-		Type:              scope.AWSMachine.Spec.InstanceType,
-		IAMProfile:        scope.AWSMachine.Spec.IAMInstanceProfile,
-		RootVolume:        scope.AWSMachine.Spec.RootVolume.DeepCopy(),
-		NonRootVolumes:    scope.AWSMachine.Spec.NonRootVolumes,
-		NetworkInterfaces: scope.AWSMachine.Spec.NetworkInterfaces,
+		Type:                 scope.AWSMachine.Spec.InstanceType,
+		IAMProfile:           scope.AWSMachine.Spec.IAMInstanceProfile,
+		RootVolume:           scope.AWSMachine.Spec.RootVolume.DeepCopy(),
+		NonRootVolumes:       scope.AWSMachine.Spec.NonRootVolumes,
+		NetworkInterfaces:    scope.AWSMachine.Spec.NetworkInterfaces,
+		NetworkInterfaceType: scope.AWSMachine.Spec.NetworkInterfaceType,
 	}
 
 	// Make sure to use the MachineScope here to get the merger of AWSCluster and AWSMachine tags
@@ -582,6 +583,10 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 				AssociatePublicIpAddress: i.PublicIPOnLaunch,
 			},
 		}
+	}
+
+	if i.NetworkInterfaceType != "" {
+		input.NetworkInterfaces[0].InterfaceType = aws.String(string(i.NetworkInterfaceType))
 	}
 
 	if i.IAMProfile != "" {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR adds a new enum field to AWSMachineSpec called NetworkInterfaceType that configures the type of the first interface (also called primary interface) on the created instance. 

The two values are:
NetworkInterfaceTypeENI: The network interface will be ENI. Currently, AWS defaults to this type when not specified.
NetworkInterfaceTypeEFAWithENAInterface: This option sets up both ENA (for IP networking) and EFA interface for HPC connections.

<!-- Enter a description of the change and why this change is needed -->

Fixes #3035

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for creating instances with elastic fabric adapter interface type.
```
