### PR TITLE
✨ ROSA: Add version channel Group

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
@@ -82,6 +82,14 @@ spec:
                   rule: self == oldSelf
                 - message: billingAccount must be a valid AWS account ID
                   rule: self.matches('^[0-9]{12}$')
+              channelGroup:
+                default: stable
+                description: OpenShift version channel group, default is stable.
+                enum:
+                - stable
+                - candidate
+                - nightly
+                type: string
               clusterRegistryConfig:
                 description: ClusterRegistryConfig represents registry config used
                   with the cluster.
@@ -794,6 +802,7 @@ spec:
                 type: string
             required:
             - availabilityZones
+            - channelGroup
             - installerRoleARN
             - oidcID
             - region

--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -91,6 +91,12 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	// OpenShift semantic version, for example "4.14.5".
 	Version string `json:"version"`
 
+	// OpenShift version channel group, default is stable.
+	//
+	// +kubebuilder:validation:Enum=stable;candidate;nightly
+	// +kubebuilder:default=stable
+	ChannelGroup string `json:"channelGroup"`
+
 	// VersionGate requires acknowledgment when upgrading ROSA-HCP y-stream versions (e.g., from 4.15 to 4.16).
 	// Default is WaitForAcknowledge.
 	// WaitForAcknowledge: If acknowledgment is required, the upgrade will not proceed until VersionGate is set to Acknowledge or AlwaysAcknowledge.

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -878,7 +878,8 @@ func (r *ROSAControlPlaneReconciler) reconcileClusterAdminPassword(ctx context.C
 
 func validateControlPlaneSpec(ocmClient *ocm.Client, rosaScope *scope.ROSAControlPlaneScope) (string, error) {
 	version := rosaScope.ControlPlane.Spec.Version
-	valid, err := ocmClient.ValidateHypershiftVersion(version, ocm.DefaultChannelGroup)
+	channelGroup := rosaScope.ControlPlane.Spec.ChannelGroup
+	valid, err := ocmClient.ValidateHypershiftVersion(version, channelGroup)
 	if err != nil {
 		return "", fmt.Errorf("failed to check if version is valid: %w", err)
 	}
@@ -902,8 +903,8 @@ func buildOCMClusterSpec(controlPlaneSpec rosacontrolplanev1.RosaControlPlaneSpe
 		DomainPrefix:              controlPlaneSpec.DomainPrefix,
 		Region:                    controlPlaneSpec.Region,
 		MultiAZ:                   true,
-		Version:                   ocm.CreateVersionID(controlPlaneSpec.Version, ocm.DefaultChannelGroup),
-		ChannelGroup:              ocm.DefaultChannelGroup,
+		Version:                   ocm.CreateVersionID(controlPlaneSpec.Version, controlPlaneSpec.ChannelGroup),
+		ChannelGroup:              controlPlaneSpec.ChannelGroup,
 		DisableWorkloadMonitoring: ptr.To(true),
 		DefaultIngress:            ocm.NewDefaultIngressSpec(), // n.b. this is a no-op when it's set to the default value
 		ComputeMachineType:        controlPlaneSpec.DefaultMachinePoolSpec.InstanceType,

--- a/docs/book/src/topics/rosa/upgrades.md
+++ b/docs/book/src/topics/rosa/upgrades.md
@@ -11,6 +11,8 @@ When the versionGate is set to 'Acknowledge', it will revert to 'WaitForAcknowle
 
 The available upgrades versions for the `ROSAControlPlane` will be listed under `ROSAControlPlane.status.availableUpgrades`
 
+The version channel group `ROSAControlPlane.spec.channelGroup` default to stable. However, it can be set to candidate or nightly. Changing the version channel group will change the `ROSAControlPlane.status.availableUpgrades` accordingly. 
+
 The Upgrade state can be checked in the conditions under `ROSAControlPlane.status`.
 
 ## MachinePool Upgrade


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
The PR add the ROSA HCP version channel group; stable, candidate and nightly

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [X] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ROSA-HCP version channel group
```
