### PR TITLE
🌱 Avoid panicking in after-suite test code, improve logging

### DIFF
--- a/test/e2e/shared/aws_helpers.go
+++ b/test/e2e/shared/aws_helpers.go
@@ -54,7 +54,7 @@ func WaitForLoadBalancerToExistForService(input WaitForLoadBalancerToExistForSer
 			Type:             input.Type,
 		})
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "error getting loadbalancer arns: %v\n", err)
+			fmt.Fprintf(GinkgoWriter, "Error getting loadbalancer arns: %v\n", err)
 
 			return false
 		}
@@ -89,7 +89,7 @@ func GetLoadBalancerARNs(input GetLoadBalancerARNsInput) ([]string, error) {
 
 	descOutput, err := DescribeResourcesByTags(*descInput)
 	if err != nil {
-		fmt.Fprintf(GinkgoWriter, "error querying resources by tags: %v\n", err)
+		fmt.Fprintf(GinkgoWriter, "Error querying resources by tags: %v\n", err)
 		return nil, fmt.Errorf("describing resource tags: %w", err)
 	}
 
@@ -97,8 +97,8 @@ func GetLoadBalancerARNs(input GetLoadBalancerARNsInput) ([]string, error) {
 	for _, resARN := range descOutput.ARNs {
 		parsedArn, err := arn.Parse(resARN)
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "error parsing arn %s: %v\n", resARN, err)
-			return nil, fmt.Errorf("parsing resource arn %s: %w", resARN, err)
+			fmt.Fprintf(GinkgoWriter, "Error parsing arn %q: %v\n", resARN, err)
+			return nil, fmt.Errorf("parsing resource arn %q: %w", resARN, err)
 		}
 
 		if parsedArn.Service != "elasticloadbalancing" {

--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -163,7 +163,7 @@ func DumpMachine(ctx context.Context, e2eCtx *E2EContext, machine infrav1.AWSMac
 	machineLogBase := path.Join(logPath, "instances", machine.Namespace, machine.Name)
 	metaLog := path.Join(machineLogBase, "instance.log")
 	if err := os.MkdirAll(filepath.Dir(metaLog), 0750); err != nil {
-		fmt.Fprintf(GinkgoWriter, "couldn't create directory for file: path=%s, err=%s", metaLog, err)
+		fmt.Fprintf(GinkgoWriter, "Couldn't create directory for file: path=%q, err=%s\n", metaLog, err)
 	}
 	f, err := os.OpenFile(metaLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) //nolint:gosec
 	if err != nil {

--- a/test/e2e/shared/identity.go
+++ b/test/e2e/shared/identity.go
@@ -88,6 +88,10 @@ func CleanupStaticCredentials(ctx context.Context, e2eCtx *E2EContext) {
 	}
 
 	By(fmt.Sprintf("Deleting AWSClusterStaticIdentity %s", idName))
+	if e2eCtx.Environment.BootstrapClusterProxy == nil {
+		Fail("Couldn't clean up static credentials: no bootstrap cluster proxy was set up (please look at previous errors; likely no bootstrap cluster could be created)")
+		return
+	}
 	client := e2eCtx.Environment.BootstrapClusterProxy.GetClient()
 	Eventually(func() error {
 		return client.Delete(ctx, id)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

If a test failed, the dumping code may not have AWS clients yet and then panicked. This shifts the attention to a large stack trace instead of the actual, previous failures.

Also some logging improvements: start sentences with uppercase, use newlines.


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
