### PR TITLE
:sparkles: Introduce AWSMachine and AWSCluster feature gates

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - args:
         - "--leader-elect"
-        - "--feature-gates=EKS=${CAPA_EKS:=true},EKSEnableIAM=${CAPA_EKS_IAM:=false},EKSAllowAddRoles=${CAPA_EKS_ADD_ROLES:=false},EKSFargate=${EXP_EKS_FARGATE:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true},BootstrapFormatIgnition=${EXP_BOOTSTRAP_FORMAT_IGNITION:=false},ExternalResourceGC=${EXP_EXTERNAL_RESOURCE_GC:=false},AlternativeGCStrategy=${EXP_ALTERNATIVE_GC_STRATEGY:=false},TagUnmanagedNetworkResources=${TAG_UNMANAGED_NETWORK_RESOURCES:=true},ROSA=${EXP_ROSA:=false}"
+        - "--feature-gates=EKS=${CAPA_EKS:=true},EKSEnableIAM=${CAPA_EKS_IAM:=false},EKSAllowAddRoles=${CAPA_EKS_ADD_ROLES:=false},EKSFargate=${EXP_EKS_FARGATE:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true},BootstrapFormatIgnition=${EXP_BOOTSTRAP_FORMAT_IGNITION:=false},ExternalResourceGC=${EXP_EXTERNAL_RESOURCE_GC:=false},AlternativeGCStrategy=${EXP_ALTERNATIVE_GC_STRATEGY:=false},TagUnmanagedNetworkResources=${TAG_UNMANAGED_NETWORK_RESOURCES:=true},ROSA=${EXP_ROSA:=false},AWSMachine=${CAPA_AWS_MACHINE:=true},AWSCluster=${CAPA_AWS_CLUSTER:=true}"
         - "--v=${CAPA_LOGLEVEL:=0}"
         - "--diagnostics-address=${CAPA_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPA_INSECURE_DIAGNOSTICS:=false}"

--- a/docs/book/src/topics/reference/reference.md
+++ b/docs/book/src/topics/reference/reference.md
@@ -16,3 +16,5 @@
 | AlternativeGCStrategy         | EXP_ALTERNATIVE_GC_STRATEGY       | false   |
 | TagUnmanagedNetworkResources  | TAG_UNMANAGED_NETWORK_RESOURCES   | true    |
 | ROSA                          | EXP_ROSA                          | false   |
+| AWSMachine                    | CAPA_AWS_MACHINE                  | true    |
+| AWSCluster                    | CAPA_AWS_CLUSTER                  | true    |

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -86,6 +86,16 @@ const (
 	// owner: @enxebre
 	// alpha: v2.2
 	ROSA featuregate.Feature = "ROSA"
+
+	// AWSMachine is used to control AWSMachine reconciler
+	// owner: @mzazrivec
+	// beta: v2.7
+	AWSMachine featuregate.Feature = "AWSMachine"
+
+	// AWSCluster is used to control AWSCluster reconciler
+	// owner: @mzazrivec
+	// beta: v2.7
+	AWSCluster featuregate.Feature = "AWSCluster"
 )
 
 func init() {
@@ -108,4 +118,6 @@ var defaultCAPAFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AlternativeGCStrategy:         {Default: false, PreRelease: featuregate.Alpha},
 	TagUnmanagedNetworkResources:  {Default: true, PreRelease: featuregate.Alpha},
 	ROSA:                          {Default: false, PreRelease: featuregate.Alpha},
+	AWSMachine:                    {Default: true, PreRelease: featuregate.Beta},
+	AWSCluster:                    {Default: true, PreRelease: featuregate.Beta},
 }

--- a/test/e2e/shared/workload.go
+++ b/test/e2e/shared/workload.go
@@ -187,3 +187,23 @@ func ValidateAlternativeGCStrategyDisabled(dep *appsv1.Deployment) error {
 	}
 	return fmt.Errorf("fail to validate AlternativeGCStrategy set to false")
 }
+
+// ValidateAWSClusterEnabled validates AWSCluster in CAPA controller manager args field is set to true.
+func ValidateAWSClusterEnabled(dep *appsv1.Deployment) error {
+	for _, arg := range dep.Spec.Template.Spec.Containers[0].Args {
+		if strings.Contains(arg, "feature-gates") && strings.Contains(arg, "AWSCluster=true") {
+			return nil
+		}
+	}
+	return fmt.Errorf("fail to validate AWSCluster set to true")
+}
+
+// ValidateAWSMachineEnabled validates AWSMachine in CAPA controller manager args field is set to true.
+func ValidateAWSMachineEnabled(dep *appsv1.Deployment) error {
+	for _, arg := range dep.Spec.Template.Spec.Containers[0].Args {
+		if strings.Contains(arg, "feature-gates") && strings.Contains(arg, "AWSMachine=true") {
+			return nil
+		}
+	}
+	return fmt.Errorf("fail to validate AWSMachine set to true")
+}

--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -221,4 +221,18 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 			shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
 		})
 	})
+
+	ginkgo.Describe("Feature Flags", func() {
+		ginkgo.It("AWSMachine and AWSCluster are enabled by default", func() {
+			deployment, getErr := shared.GetDeployment(ctx, shared.GetDeploymentInput{
+				Getter:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+				Name:      "capa-controller-manager",
+				Namespace: "capa-system",
+			})
+
+			Expect(getErr).To(BeNil())
+			Expect(shared.ValidateAWSClusterEnabled(deployment)).To(BeNil())
+			Expect(shared.ValidateAWSMachineEnabled(deployment)).To(BeNil())
+		})
+	})
 })


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added AWSMachine and AWSCluster feature flags to control AWSMachineReconciler and AWSClusterReconciler.
```
