### PR TITLE
WIP: 🐛 Add missing Controllers IAM for ManagedMachinePools 

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -409,6 +409,20 @@ func (t Template) ControllersPolicyEKS() *iamv1.PolicyDocument {
 		})
 	}
 
+	if !t.Spec.EKS.ManagedMachinePools.Disabled {
+		statements = append(statements, iamv1.StatementEntry{
+			Action: iamv1.Actions{
+				"iam:GetPolicy",
+			},
+			Resources: iamv1.Resources{
+				"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+			        "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+				"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+			}
+			Effect: iamv1.EffectAllow
+		})
+	}
+
 	statements = append(statements, []iamv1.StatementEntry{
 		{
 			Action: allowedIAMActions,


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
When creating a `AWSManagedMachinePool`, the controller lacks necessary IAM permissions. This aims to fix that by optionally including these permissions when  the configuration has not disabled this feature gate.

```
failed to reconcile machine pool for AWSManagedMachinePool cluster-foo/cluster-pool-0: error ensuring policies are attached: [arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly]: error getting policy arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy: AccessDenied: User: arn:aws:sts::1234567890:assumed-role/controllers.cluster-api-provider-aws.sigs.k8s.io/00000000000 is not authorized to perform: iam:GetPolicy on resource: policy arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy because no identity-based policy allows the iam:GetPolicy action
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits
- [ ] includes documentation
- [X] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes missing `iam:GetPolicy` controller permissions when using managed machine pools.
```
