### PR TITLE
🐛 fix: self hosted e2e test

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -215,7 +215,7 @@ variables:
 intervals:
   default/wait-cluster: ["35m", "10s"]
   default/wait-control-plane: ["35m", "10s"]
-  default/wait-worker-nodes: ["20m", "10s"]
+  default/wait-worker-nodes: ["30m", "10s"]
   conformance/wait-control-plane: ["35m", "10s"]
   conformance/wait-worker-nodes: ["35m", "10s"]
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
@@ -10,7 +10,7 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      - 192.168.0.0/16
+        - 192.168.0.0/16
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
@@ -48,16 +48,16 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.local_hostname }}"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.local_hostname }}"
     preKubeadmCommands:
-    - mkdir -p /opt/cluster-api
-    - ctr -n k8s.io images pull "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}"
-    - ctr -n k8s.io images tag "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}" gcr.io/k8s-staging-cluster-api/capa-manager:e2e
+      - mkdir -p /opt/cluster-api
+      - ctr -n k8s.io images pull "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}"
+      - ctr -n k8s.io images tag "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}" gcr.io/k8s-staging-cluster-api/capa-manager:e2e
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -76,8 +76,6 @@ spec:
       iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
       sshKeyName: ${AWS_SSH_KEY_NAME}
-      rootVolume:
-        size: 10
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -124,10 +122,10 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.local_hostname }}"
       preKubeadmCommands:
-      - ctr -n k8s.io images pull "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}"
-      - ctr -n k8s.io images tag "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}" gcr.io/k8s-staging-cluster-api/capa-manager:e2e
+        - ctr -n k8s.io images pull "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}"
+        - ctr -n k8s.io images tag "${CAPI_IMAGES_REGISTRY}:${E2E_IMAGE_TAG}" gcr.io/k8s-staging-cluster-api/capa-manager:e2e
 ---
 apiVersion: v1
 data: ${CNI_RESOURCES}
@@ -144,8 +142,8 @@ spec:
     matchLabels:
       cni: ${CLUSTER_NAME}-crs-0
   resources:
-  - kind: ConfigMap
-    name: cni-${CLUSTER_NAME}-crs-0
+    - kind: ConfigMap
+      name: cni-${CLUSTER_NAME}-crs-0
   strategy: ApplyOnce
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
@@ -157,8 +155,8 @@ spec:
     matchLabels:
       ccm: external
   resources:
-  - kind: ConfigMap
-    name: cloud-controller-manager-addon
+    - kind: ConfigMap
+      name: cloud-controller-manager-addon
   strategy: ApplyOnce
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
@@ -170,8 +168,8 @@ spec:
     matchLabels:
       csi: external
   resources:
-  - kind: ConfigMap
-    name: aws-ebs-csi-driver-addon
+    - kind: ConfigMap
+      name: aws-ebs-csi-driver-addon
   strategy: ApplyOnce
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
@@ -76,6 +76,8 @@ spec:
       iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
       sshKeyName: ${AWS_SSH_KEY_NAME}
+      rootVolume:
+        size: 10
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - ../limit-az
 patchesStrategicMerge:
   - patches/image-injection.yaml
+  - patches/root-volume-size.yaml

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/patches/root-volume-size.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/patches/root-volume-size.yaml
@@ -1,0 +1,9 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      rootVolume:
+        size: 10


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The self hosted e2e was failing as the control plane node was encountering disk pressure. This caused CAPA to be evicted and the CAPA images on the original node where deleted to reclaim disk space. When CAPA moved back to the node the image couldn't be found.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5252 

**Special notes for your reviewer**:

Tested this locally:

![image](https://github.com/user-attachments/assets/b1831d5a-3cfd-4fd7-b449-43020c88fa85)


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix self hosted e2e test caused by disk pressure.
```
