### PR TITLE
🐛 Fix cluster deletion when using BYO AWS infra mode and Secondary CIDR

### DIFF
--- a/pkg/cloud/services/network/secondarycidr.go
+++ b/pkg/cloud/services/network/secondarycidr.go
@@ -79,6 +79,11 @@ func (s *Service) associateSecondaryCidrs() error {
 }
 
 func (s *Service) disassociateSecondaryCidrs() error {
+	// If the VPC is unmanaged or not yet populated, return early.
+	if s.scope.VPC().IsUnmanaged(s.scope.Name()) || s.scope.VPC().ID == "" {
+		return nil
+	}
+
 	secondaryCidrBlocks := s.scope.AllSecondaryCidrBlocks()
 	if len(secondaryCidrBlocks) == 0 {
 		return nil


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

Currently, cluster deletion is failing when using BYO AWS infra mode (https://cluster-api-aws.sigs.k8s.io/topics/bring-your-own-aws-infrastructure.html#tagging-aws-resources) with:
```
Events:
  Type     Reason                           Age                       From            Message
  ----     ------                           ----                      ----            -------
  Warning  FailedDisassociateSecondaryCidr  2m27s (x3471 over 3h21m)  aws-controller  (combined from similar events): Failed disassociating secondary CIDR "100.64.0.0/16" from VPC InvalidCidrBlock.InUse: The vpc vpc-021b2fd5f5a7df0bc currently has a subnet within CIDR block 100.64.0.0/16
           status code: 400, request id: fdddb61f-a01f-49ed-90a7-0489532ad351
```

While using the BYO AWS infra mode, VPC secondary CIDRs shouldn't be disassociated during cluster deletion.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cluster deletion when using BYO AWS infra mode and Secondary CIDR
```
