### PR TITLE
🐛 [release-2.5] fix: self hosted e2e test caused by disk pressure.

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -215,7 +215,7 @@ variables:
 intervals:
   default/wait-cluster: ["35m", "10s"]
   default/wait-control-plane: ["35m", "10s"]
-  default/wait-worker-nodes: ["20m", "10s"]
+  default/wait-worker-nodes: ["30m", "10s"]
   conformance/wait-control-plane: ["35m", "10s"]
   conformance/wait-worker-nodes: ["35m", "10s"]
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - ../limit-az
 patchesStrategicMerge:
   - patches/image-injection.yaml
+  - patches/root-volume-size.yaml

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/patches/root-volume-size.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/patches/root-volume-size.yaml
@@ -1,0 +1,9 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      rootVolume:
+        size: 10


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:

The self hosted e2e was failing as the control plane node was encountering disk pressure. This caused CAPA to be evicted and the CAPA images on the original node where deleted to reclaim disk space. When CAPA moved back to the node the image couldn't be found.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change the self hosted e2e template to give more disk space
```
