### PR TITLE
🌱 chore: title verifier update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,11 +28,14 @@ Fixes #
 **Special notes for your reviewer**:
 
 **Checklist**:
-<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->
+<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 
+
+ Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
+-->
 
 - [ ] squashed commits
 - [ ] includes documentation
-- [ ] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
+- [ ] includes emoji in title 
 - [ ] adds unit tests
 - [ ] adds or updates e2e tests
 

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -4,16 +4,15 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-
 jobs:
   verify:
     runs-on: ubuntu-latest
     name: verify PR contents
     steps:
-    - name: Verifier action
-      id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@012269a88fa4c034a0acf1ba84c26b195c0dbab4 # tag=v0.4.3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+
+    - name: Check if PR title is valid
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        ./hack/verify-pr-title.sh "${PR_TITLE}"

--- a/hack/verify-pr-title.sh
+++ b/hack/verify-pr-title.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define regex patterns
+WIP_REGEX="^\W?WIP\W"
+TAG_REGEX="^\[[[:alnum:]\._-]*\]"
+PR_TITLE="$1"
+
+# Trim WIP and tags from title
+trimmed_title=$(echo "$PR_TITLE" | sed -E "s/$WIP_REGEX//" | sed -E "s/$TAG_REGEX//" | xargs)
+
+# Normalize common emojis in text form to actual emojis
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:warning:/⚠/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:sparkles:/✨/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:bug:/🐛/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:book:/📖/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:rocket:/🚀/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:seedling:/🌱/g")
+
+# Check PR type prefix
+if [[ "$trimmed_title" =~ ^(⚠|✨|🐛|📖|🚀|🌱) ]]; then
+    echo "PR title is valid: $trimmed_title"
+else
+    echo "Error: No matching PR type indicator found in title."
+    echo "You need to have one of these as the prefix of your PR title:"
+    echo "- Breaking change: ⚠ (:warning:)"
+    echo "- Non-breaking feature: ✨ (:sparkles:)"
+    echo "- Patch fix: 🐛 (:bug:)"
+    echo "- Docs: 📖 (:book:)"
+    echo "- Release: 🚀 (:rocket:)"
+    echo "- Infra/Tests/Other: 🌱 (:seedling:)"
+    exit 1
+fi
+
+# Check that PR title does not contain Issue or PR number
+if [[ "$trimmed_title" =~ \#[0-9]+ ]]; then
+    echo "Error: PR title should not contain issue or PR number."
+    echo "Issue numbers belong in the PR body as either \"Fixes #XYZ\" (if it closes the issue or PR), or something like \"Related to #XYZ\" (if it's just related)."
+    exit 1
+fi


### PR DESCRIPTION




**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Updates the PR title checker to be inline with upstream CAPI. Also, this will help with some PR failures with auth.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [x] includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update PR verifier to be inline with upstream CAPI.
```
