### PR TITLE
🌱 ROSA: Add capa agent and version to ocm client config

### DIFF
--- a/pkg/rosa/client.go
+++ b/pkg/rosa/client.go
@@ -17,6 +17,7 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/util/system"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/version"
 )
 
 const (
@@ -24,6 +25,7 @@ const (
 	ocmAPIURLKey       = "ocmApiUrl"
 	ocmClientIDKey     = "ocmClientID"
 	ocmClientSecretKey = "ocmClientSecret"
+	capaAgentName      = "CAPA"
 )
 
 // NewOCMClient creates a new OCM client.
@@ -34,7 +36,9 @@ func NewOCMClient(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (
 	}
 
 	ocmConfig := ocmcfg.Config{
-		URL: url,
+		URL:       url,
+		UserAgent: capaAgentName,
+		Version:   version.Get().GitVersion,
 	}
 
 	if clientID != "" && clientSecret != "" {
@@ -62,7 +66,8 @@ func newOCMRawConnection(ctx context.Context, rosaScope *scope.ROSAControlPlaneS
 
 	connBuilder := sdk.NewConnectionBuilder().
 		Logger(ocmSdkLogger).
-		URL(url)
+		URL(url).
+		Agent(capaAgentName + "/" + version.Get().GitVersion + " " + sdk.DefaultAgent)
 
 	if clientID != "" && clientSecret != "" {
 		connBuilder.Client(clientID, clientSecret)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind support
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Set the ROSA client user agent and version configuration. This is needed so that the CAPA provider can be correctly identified in ROSA logs.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [X] squashed commits
- [ ] includes documentation
- [X] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
