### PR TITLE
:sparkles: Addons: Add functionality for resolveConflicts: PRESERVE

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2228,10 +2228,11 @@ spec:
                       default: overwrite
                       description: |-
                         ConflictResolution is used to declare what should happen if there
-                        are parameter conflicts. Defaults to none
+                        are parameter conflicts. Defaults to overwrite
                       enum:
                       - overwrite
                       - none
+                      - preserve
                       type: string
                     name:
                       description: Name is the name of the addon

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
@@ -73,10 +73,11 @@ spec:
                               default: overwrite
                               description: |-
                                 ConflictResolution is used to declare what should happen if there
-                                are parameter conflicts. Defaults to none
+                                are parameter conflicts. Defaults to overwrite
                               enum:
                               - overwrite
                               - none
+                              - preserve
                               type: string
                             name:
                               description: Name is the name of the addon

--- a/controlplane/eks/api/v1beta2/types.go
+++ b/controlplane/eks/api/v1beta2/types.go
@@ -134,9 +134,9 @@ type Addon struct {
 	// +optional
 	Configuration string `json:"configuration,omitempty"`
 	// ConflictResolution is used to declare what should happen if there
-	// are parameter conflicts. Defaults to none
+	// are parameter conflicts. Defaults to overwrite
 	// +kubebuilder:default=overwrite
-	// +kubebuilder:validation:Enum=overwrite;none
+	// +kubebuilder:validation:Enum=overwrite;none;preserve
 	ConflictResolution *AddonResolution `json:"conflictResolution,omitempty"`
 	// ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account
 	// +optional
@@ -154,6 +154,10 @@ var (
 	// AddonResolutionNone indicates that if there are parameter conflicts then
 	// resolution will not be done and an error will be reported.
 	AddonResolutionNone = AddonResolution("none")
+
+	// AddonResolutionPreserve indicates that if there are parameter conflicts then
+	// resolution will result in preserving the existing value
+	AddonResolutionPreserve = AddonResolution("preserve")
 )
 
 // AddonStatus defines the status for an addon.

--- a/docs/book/src/topics/eks/addons.md
+++ b/docs/book/src/topics/eks/addons.md
@@ -23,8 +23,15 @@ spec:
       conflictResolution: "overwrite"
 ```
 
+Valid values are:
+```
+none
+overwrite
+preserve
+```
+
 _Note_: For `conflictResolution` `overwrite` is the **default** behaviour. That means, if not otherwise specified, it's
-set to `overwrite`.
+set to `overwrite`. Review [API Documentation](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html#AmazonEKS-CreateAddon-request-resolveConflicts) for detailed behavior.
 
 Additionally, there is a cluster [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors)
 called [eks-managedmachinepool-vpccni](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template-eks-managedmachinepool-vpccni.yaml) that you can use with **clusterctl**:
@@ -45,6 +52,8 @@ To update the version of an addon you need to edit the `AWSManagedControlPlane` 
       conflictResolution: "overwrite"
 ...
 ```
+
+_Note_: For `conflictResolution` `none`, updating may fail if a change was made to the addon that is unexpected by EKS. Review [API Documentation](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html#AmazonEKS-UpdateAddon-request-resolveConflicts) for detailed behavior on conflict resolution.
 
 ## Deleting Addons
 

--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -235,8 +235,13 @@ func convertConflictResolution(conflict ekscontrolplanev1.AddonResolution) (*str
 	case ekscontrolplanev1.AddonResolutionPreserve:
 		return aws.String(string(ekstypes.ResolveConflictsPreserve)), nil
 
+	// Defaulting to behavior "Overwrite" as documented
 	default:
+<<<<<<< HEAD
 		return aws.String(string(ekstypes.ResolveConflictsOverwrite)), fmt.Errorf("failed to determine adddonResolution; defaulting to Overwrite")
+=======
+		return aws.String(eks.ResolveConflictsOverwrite), fmt.Errorf("failed to determine adddonResolution; defaulting to Overwrite")
+>>>>>>> 820ee8734 (updated documentation and code to reflect kubebuilder behavior)
 	}
 }
 

--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -237,11 +237,7 @@ func convertConflictResolution(conflict ekscontrolplanev1.AddonResolution) (*str
 
 	// Defaulting to behavior "Overwrite" as documented
 	default:
-<<<<<<< HEAD
 		return aws.String(string(ekstypes.ResolveConflictsOverwrite)), fmt.Errorf("failed to determine adddonResolution; defaulting to Overwrite")
-=======
-		return aws.String(eks.ResolveConflictsOverwrite), fmt.Errorf("failed to determine adddonResolution; defaulting to Overwrite")
->>>>>>> 820ee8734 (updated documentation and code to reflect kubebuilder behavior)
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Added support for resolveConflicts.PRESERVE ([API Reference](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html)). This is helpful if users are migrating an existing cluster to Cluster API and do not have their existing Addon Configs specified, or if an out of band change is made to an Addon (eg. configMap change) and the user wants to preserve it.

The schema for conflictResolution had listed `none` as the default behavior. I updated the docs and code to reflect that. 
*
*Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
