### PR TITLE
:sparkles: Add version channelGroup for Rosa Machine Pool

### DIFF
--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -52,6 +52,20 @@ const (
 	AlwaysAcknowledge VersionGateAckType = "AlwaysAcknowledge"
 )
 
+// ChannelGroupType specifies the OpenShift version channel group.
+type ChannelGroupType string
+
+const (
+	// Stable channel group is the default channel group for stable releases.
+	Stable ChannelGroupType = "stable"
+
+	// Candidate channel group is for testing candidate builds.
+	Candidate ChannelGroupType = "candidate"
+
+	// Nightly channel group is for testing nigtly builds.
+	Nightly ChannelGroupType = "nightly"
+)
+
 // RosaControlPlaneSpec defines the desired state of ROSAControlPlane.
 type RosaControlPlaneSpec struct { //nolint: maligned
 	// Cluster name must be valid DNS-1035 label, so it must consist of lower case alphanumeric
@@ -95,7 +109,7 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	//
 	// +kubebuilder:validation:Enum=stable;candidate;nightly
 	// +kubebuilder:default=stable
-	ChannelGroup string `json:"channelGroup"`
+	ChannelGroup ChannelGroupType `json:"channelGroup"`
 
 	// VersionGate requires acknowledgment when upgrading ROSA-HCP y-stream versions (e.g., from 4.15 to 4.16).
 	// Default is WaitForAcknowledge.

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -891,7 +891,7 @@ func (r *ROSAControlPlaneReconciler) reconcileClusterAdminPassword(ctx context.C
 
 func validateControlPlaneSpec(ocmClient rosa.OCMClient, rosaScope *scope.ROSAControlPlaneScope) (string, error) {
 	version := rosaScope.ControlPlane.Spec.Version
-	channelGroup := rosaScope.ControlPlane.Spec.ChannelGroup
+	channelGroup := string(rosaScope.ControlPlane.Spec.ChannelGroup)
 	valid, err := ocmClient.ValidateHypershiftVersion(version, channelGroup)
 	if err != nil {
 		return "", fmt.Errorf("failed to check if version is valid: %w", err)
@@ -916,8 +916,8 @@ func buildOCMClusterSpec(controlPlaneSpec rosacontrolplanev1.RosaControlPlaneSpe
 		DomainPrefix:              controlPlaneSpec.DomainPrefix,
 		Region:                    controlPlaneSpec.Region,
 		MultiAZ:                   true,
-		Version:                   ocm.CreateVersionID(controlPlaneSpec.Version, controlPlaneSpec.ChannelGroup),
-		ChannelGroup:              controlPlaneSpec.ChannelGroup,
+		Version:                   ocm.CreateVersionID(controlPlaneSpec.Version, string(controlPlaneSpec.ChannelGroup)),
+		ChannelGroup:              string(controlPlaneSpec.ChannelGroup),
 		DisableWorkloadMonitoring: ptr.To(true),
 		DefaultIngress:            ocm.NewDefaultIngressSpec(), // n.b. this is a no-op when it's set to the default value
 		ComputeMachineType:        controlPlaneSpec.DefaultMachinePoolSpec.InstanceType,

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -76,7 +76,7 @@ func TestNodePoolToRosaMachinePoolSpec(t *testing.T) {
 		Replicas: ptr.To[int32](2),
 	}
 
-	nodePoolBuilder := nodePoolBuilder(rosaMachinePoolSpec, machinePoolSpec)
+	nodePoolBuilder := nodePoolBuilder(rosaMachinePoolSpec, machinePoolSpec, rosacontrolplanev1.Stable)
 	nodePoolSpec, err := nodePoolBuilder.Build()
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -285,7 +285,7 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 			result: ctrl.Result{RequeueAfter: time.Second * 60},
 			expect: func(m *mocks.MockOCMClientMockRecorder) {
 				m.GetNodePool(gomock.Any(), gomock.Any()).DoAndReturn(func(clusterId string, nodePoolID string) (*cmv1.NodePool, bool, error) {
-					nodePoolBuilder := nodePoolBuilder(rosaMachinePool(1).Spec, ownerMachinePool(1).Spec)
+					nodePoolBuilder := nodePoolBuilder(rosaMachinePool(1).Spec, ownerMachinePool(1).Spec, rosacontrolplanev1.Stable)
 					nodePool, err := nodePoolBuilder.ID("node-pool-1").Build()
 					g.Expect(err).To(BeNil())
 					return nodePool, true, nil
@@ -323,7 +323,7 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 			result: ctrl.Result{},
 			expect: func(m *mocks.MockOCMClientMockRecorder) {
 				m.GetNodePool(gomock.Any(), gomock.Any()).DoAndReturn(func(clusterId string, nodePoolID string) (*cmv1.NodePool, bool, error) {
-					nodePoolBuilder := nodePoolBuilder(rosaMachinePool(2).Spec, ownerMachinePool(2).Spec)
+					nodePoolBuilder := nodePoolBuilder(rosaMachinePool(2).Spec, ownerMachinePool(2).Spec, rosacontrolplanev1.Stable)
 					statusBuilder := (&cmv1.NodePoolStatusBuilder{}).CurrentReplicas(1)
 					autoscalingBuilder := (&cmv1.NodePoolAutoscalingBuilder{}).MinReplica(1).MaxReplica(1)
 					nodePool, err := nodePoolBuilder.ID("node-pool-1").Autoscaling(autoscalingBuilder).Replicas(1).Status(statusBuilder).Build()
@@ -463,7 +463,7 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 		nodePoolName := "node-pool-1"
 		expect := func(m *mocks.MockOCMClientMockRecorder) {
 			m.GetNodePool(gomock.Any(), gomock.Any()).DoAndReturn(func(clusterId string, nodePoolID string) (*cmv1.NodePool, bool, error) {
-				nodePoolBuilder := nodePoolBuilder(mp.Spec, omp.Spec)
+				nodePoolBuilder := nodePoolBuilder(mp.Spec, omp.Spec, rosacontrolplanev1.Stable)
 				nodePool, err := nodePoolBuilder.ID(nodePoolName).Build()
 				g.Expect(err).NotTo(HaveOccurred())
 				return nodePool, true, nil


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
Follow up to https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5279

 The PR add the ROSA HCP version channel group; stable, candidate and nightly for `RosaMachinePools`

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [X] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ROSA-HCP version channel group for Machine Pools
```
