### PR TITLE
:bug: Fix OCM client wrapper

### DIFF
--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -344,8 +344,7 @@ func (r *ROSAMachinePoolReconciler) reconcileMachinePoolVersion(machinePoolScope
 	}
 
 	if scheduledUpgrade == nil {
-		rosaOCMClient := ocmClient.(*ocm.Client)
-		scheduledUpgrade, err = rosa.ScheduleNodePoolUpgrade(rosaOCMClient, clusterID, nodePool, version, time.Now())
+		scheduledUpgrade, err = rosa.ScheduleNodePoolUpgrade(ocmClient, clusterID, nodePool, version, time.Now())
 		if err != nil {
 			return fmt.Errorf("failed to schedule nodePool upgrade to version %s: %w", version, err)
 		}

--- a/pkg/rosa/idps.go
+++ b/pkg/rosa/idps.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/ocm"
 )
 
 const (
@@ -14,7 +13,7 @@ const (
 
 // CreateAdminUserIfNotExist creates a new admin user withe username/password in the cluster if username doesn't already exist.
 // the user is granted admin privileges by being added to a special IDP called `cluster-admin` which will be created if it doesn't already exist.
-func CreateAdminUserIfNotExist(client *ocm.Client, clusterID, username, password string) error {
+func CreateAdminUserIfNotExist(client OCMClient, clusterID, username, password string) error {
 	existingClusterAdminIDP, userList, err := findExistingClusterAdminIDP(client, clusterID)
 	if err != nil {
 		return fmt.Errorf("failed to find existing cluster admin IDP: %w", err)
@@ -75,7 +74,7 @@ func CreateAdminUserIfNotExist(client *ocm.Client, clusterID, username, password
 }
 
 // CreateUserIfNotExist creates a new user with `username` and adds it to the group if it doesn't already exist.
-func CreateUserIfNotExist(client *ocm.Client, clusterID string, group, username string) (*cmv1.User, error) {
+func CreateUserIfNotExist(client OCMClient, clusterID string, group, username string) (*cmv1.User, error) {
 	user, err := client.GetUser(clusterID, group, username)
 	if user != nil || err != nil {
 		return user, err

--- a/pkg/rosa/versions.go
+++ b/pkg/rosa/versions.go
@@ -13,7 +13,7 @@ import (
 var MinSupportedVersion = semver.MustParse("4.14.0")
 
 // CheckExistingScheduledUpgrade checks and returns the current upgrade schedule if any.
-func CheckExistingScheduledUpgrade(client *ocm.Client, cluster *cmv1.Cluster) (*cmv1.ControlPlaneUpgradePolicy, error) {
+func CheckExistingScheduledUpgrade(client OCMClient, cluster *cmv1.Cluster) (*cmv1.ControlPlaneUpgradePolicy, error) {
 	upgradePolicies, err := client.GetControlPlaneUpgradePolicies(cluster.ID())
 	if err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ func CheckExistingScheduledUpgrade(client *ocm.Client, cluster *cmv1.Cluster) (*
 }
 
 // ScheduleControlPlaneUpgrade schedules a new control plane upgrade to the specified version at the specified time.
-func ScheduleControlPlaneUpgrade(client *ocm.Client, cluster *cmv1.Cluster, version string, nextRun time.Time, ack bool) (*cmv1.ControlPlaneUpgradePolicy, error) {
+func ScheduleControlPlaneUpgrade(client OCMClient, cluster *cmv1.Cluster, version string, nextRun time.Time, ack bool) (*cmv1.ControlPlaneUpgradePolicy, error) {
 	// earliestNextRun is set to at least 5 min from now by the OCM API.
 	// Set our next run request to something slightly longer than 5min to make sure we account for the latency between when we send this
 	// request and when the server processes it.
@@ -71,7 +71,7 @@ func ScheduleControlPlaneUpgrade(client *ocm.Client, cluster *cmv1.Cluster, vers
 }
 
 // ScheduleNodePoolUpgrade schedules a new nodePool upgrade to the specified version at the specified time.
-func ScheduleNodePoolUpgrade(client *ocm.Client, clusterID string, nodePool *cmv1.NodePool, version string, nextRun time.Time) (*cmv1.NodePoolUpgradePolicy, error) {
+func ScheduleNodePoolUpgrade(client OCMClient, clusterID string, nodePool *cmv1.NodePool, version string, nextRun time.Time) (*cmv1.NodePoolUpgradePolicy, error) {
 	// earliestNextRun is set to at least 5 min from now by the OCM API.
 	// Set our next run request to something slightly longer than 5min to make sure we account for the latency between when we send this
 	// request and when the server processes it.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
Fixing a bug where we called incorrect interface conversion unnecessarily. Change functions to work directly with `OCMClient` and don't convert to `ocm.Client`.

It was caused by my previous PR https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5214 


/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [X] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE

```
