### PR TITLE
🌱 ROSA Modified rosacontrolplane_controller version error messages.

### DIFF
--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -874,10 +874,10 @@ func validateControlPlaneSpec(ocmClient *ocm.Client, rosaScope *scope.ROSAContro
 	version := rosaScope.ControlPlane.Spec.Version
 	valid, err := ocmClient.ValidateHypershiftVersion(version, ocm.DefaultChannelGroup)
 	if err != nil {
-		return "", fmt.Errorf("failed to check if version is valid: %w", err)
+		return "", fmt.Errorf("error validating version in this channelGroup : %w", err)
 	}
 	if !valid {
-		return fmt.Sprintf("version %s is not supported", version), nil
+		return fmt.Sprintf("this version %s is not supported in this channelGroup", version), nil
 	}
 
 	// TODO: add more input validations


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
cleanup

**What this PR does / why we need it**:
The current error messages don't accurately reflect the error.
return fmt.Sprintf("version %s is not supported", version), nil
return "", fmt.Errorf("failed to check if version is valid: %w", err)

Modified the error messages to indicate there's a problem with the combination of version and channelgroup. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
