### PR TITLE
:warning: templates: use NLB as Control Plane Load Balancer type

### DIFF
--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -26,6 +26,9 @@ metadata:
 spec:
   region: "${AWS_REGION}"
   sshKeyName: "${AWS_SSH_KEY_NAME}"
+  controlPlaneLoadBalancer:
+    loadBalancerType: nlb
+    healthCheckProtocol: HTTPS
   s3Bucket:
     controlPlaneIAMInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
     name: "${AWS_S3_BUCKET_NAME}"

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -24,6 +24,9 @@ kind: AWSCluster
 metadata:
   name: "${CLUSTER_NAME}"
 spec:
+  controlPlaneLoadBalancer:
+    loadBalancerType: nlb
+    healthCheckProtocol: HTTPS
   region: "${AWS_REGION}"
   sshKeyName: "${AWS_SSH_KEY_NAME}"
 ---

--- a/templates/cluster-template-multitenancy-clusterclass.yaml
+++ b/templates/cluster-template-multitenancy-clusterclass.yaml
@@ -150,7 +150,10 @@ metadata:
   name: multi-tenancy
 spec:
   template:
-    spec: {}
+    spec:
+      controlPlaneLoadBalancer:
+        loadBalancerType: nlb
+        healthCheckProtocol: HTTPS
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-simple-clusterclass.yaml
+++ b/templates/cluster-template-simple-clusterclass.yaml
@@ -159,7 +159,10 @@ metadata:
   name: quick-start
 spec:
   template:
-    spec: { }
+    spec:
+      controlPlaneLoadBalancer:
+        loadBalancerType: nlb
+        healthCheckProtocol: HTTPS
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -24,6 +24,9 @@ kind: AWSCluster
 metadata:
   name: "${CLUSTER_NAME}"
 spec:
+  controlPlaneLoadBalancer:
+    loadBalancerType: nlb
+    healthCheckProtocol: HTTPS
   region: "${AWS_REGION}"
   sshKeyName: "${AWS_SSH_KEY_NAME}"
 ---


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR changes the type of loadbalancer used for controlPlane to NLB (Network Load Balancer) in the templates for CAPA.
This change is necessary in supporting k8s >= 1.30 since the AWS Classic Load Balancer has been deprecated for a while, and starting from K8s 1.30, the cyphersuite required by go to interact with the Classic LB has been removed. See https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5139 for more details and reasoning.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
templates: start explicitly using NLB (Network Load Balancer) + HTTPS checks for the Control Plane Load Balancer
```
