### PR TITLE
:bug: fix(EmptyRoutesDefaultVPCSecurityGroup): empty rule should not produce a warning event

### DIFF
--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -440,7 +440,7 @@ func (s *Service) revokeIngressAndEgressRulesFromVPCDefaultSecurityGroup() error
 		},
 	}
 	err = s.revokeSecurityGroupIngressRules(defaultSecurityGroupID, ingressRules)
-	if err != nil && !awserrors.IsPermissionNotFoundError(errors.Cause(err)) {
+	if err != nil {
 		return errors.Wrapf(err, "failed to revoke ingress rules from vpc default security group %q in VPC %q", defaultSecurityGroupID, s.scope.VPC().ID)
 	}
 
@@ -453,7 +453,7 @@ func (s *Service) revokeIngressAndEgressRulesFromVPCDefaultSecurityGroup() error
 		},
 	}
 	err = s.revokeSecurityGroupEgressRules(defaultSecurityGroupID, egressRules)
-	if err != nil && !awserrors.IsPermissionNotFoundError(errors.Cause(err)) {
+	if err != nil {
 		return errors.Wrapf(err, "failed to revoke egress rules from vpc default security group %q in VPC %q", defaultSecurityGroupID, s.scope.VPC().ID)
 	}
 
@@ -514,7 +514,7 @@ func (s *Service) revokeSecurityGroupIngressRules(id string, rules infrav1.Ingre
 		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(s.scope, &rule))
 	}
 
-	if _, err := s.EC2Client.RevokeSecurityGroupIngressWithContext(context.TODO(), input); err != nil {
+	if _, err := s.EC2Client.RevokeSecurityGroupIngressWithContext(context.TODO(), input); err != nil && !awserrors.IsPermissionNotFoundError(errors.Cause(err)) {
 		record.Warnf(s.scope.InfraCluster(), "FailedRevokeSecurityGroupIngressRules", "Failed to revoke security group ingress rules %v for SecurityGroup %q: %v", rules, id, err)
 		return errors.Wrapf(err, "failed to revoke security group %q ingress rules: %v", id, rules)
 	}
@@ -530,7 +530,7 @@ func (s *Service) revokeSecurityGroupEgressRules(id string, rules infrav1.Ingres
 		input.IpPermissions = append(input.IpPermissions, ingressRuleToSDKType(s.scope, &rule))
 	}
 
-	if _, err := s.EC2Client.RevokeSecurityGroupEgressWithContext(context.TODO(), input); err != nil {
+	if _, err := s.EC2Client.RevokeSecurityGroupEgressWithContext(context.TODO(), input); err != nil && !awserrors.IsPermissionNotFoundError(errors.Cause(err)) {
 		record.Warnf(s.scope.InfraCluster(), "FailedRevokeSecurityGroupEgressRules", "Failed to revoke security group egress rules %v for SecurityGroup %q: %v", rules, id, err)
 		return errors.Wrapf(err, "failed to revoke security group %q egress rules: %v", id, rules)
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR fixes warning events produced by EmptyRoutesDefaultVPCSecurityGroup option when default rules are already removed.

Before:

```bash
$ kubectl get events -A --field-selector involvedObject.kind=AWSManagedControlPlane
NAMESPACE     LAST SEEN   TYPE      REASON                                      OBJECT                                        MESSAGE
flux-system   33m         Warning   FailedRevokeSecurityGroupIngressRules       awsmanagedcontrolplane/t00-use1-eks-test-cp   (combined from similar events): Failed to revoke security group ingress rules [protocol=-1/range=[-1--1]/description=] for SecurityGroup "sg-019d09a5f5fdf2671": InvalidPermission.NotFound: The specified rule does not exist in this security group....
flux-system   33m         Warning   FailedRevokeSecurityGroupIngressRules       awsmanagedcontrolplane/t00-use1-eks-test-cp   (combined from similar events): Failed to revoke security group ingress rules [protocol=-1/range=[-1--1]/description=] for SecurityGroup "sg-019d09a5f5fdf2671": InvalidPermission.NotFound: The specified rule does not exist in this security group....
flux-system   33m         Warning   FailedRevokeSecurityGroupEgressRules        awsmanagedcontrolplane/t00-use1-eks-test-cp   (combined from similar events): Failed to revoke security group egress rules [protocol=-1/range=[-1--1]/description=] for SecurityGroup "sg-019d09a5f5fdf2671": InvalidPermission.NotFound: The specified rule does not exist in this security group....
flux-system   33m         Warning   FailedRevokeSecurityGroupEgressRules        awsmanagedcontrolplane/t00-use1-eks-test-cp   (combined from similar events): Failed to revoke security group egress rules [protocol=-1/range=[-1--1]/description=] for SecurityGroup "sg-019d09a5f5fdf2671": InvalidPermission.NotFound: The specified rule does not exist in this security group....
```

After:
```bash
$ kubectl get events -A --field-selector involvedObject.kind=AWSManagedControlPlane
NAMESPACE     LAST SEEN   TYPE      REASON                                      OBJECT                                        MESSAGE
flux-system   4m29s       Normal    SuccessfulRevokeSecurityGroupIngressRules   awsmanagedcontrolplane/t00-use1-eks-test-cp   Revoked security group ingress rules [protocol=-1/range=[-1--1]/description=] for SecurityGroup "sg-019d09a5f5fdf2671"
flux-system   4m29s       Normal    SuccessfulRevokeSecurityGroupEgressRules    awsmanagedcontrolplane/t00-use1-eks-test-cp   Revoked security group egress rules [protocol=-1/range=[-1--1]/description=] for SecurityGroup "sg-019d09a5f5fdf2671"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

