### PR TITLE
✨ Set Paused condition on reconciled resources status upon reconciliation being paused

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -59,9 +59,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/ssm"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/userdata"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/util/paused"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -183,11 +183,6 @@ func (r *AWSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	if annotations.IsPaused(cluster, awsMachine) {
-		log.Info("AWSMachine or linked Cluster is marked as paused. Won't reconcile")
-		return ctrl.Result{}, nil
-	}
-
 	log = log.WithValues("cluster", klog.KObj(cluster))
 
 	infraCluster, err := r.getInfraCluster(ctx, log, cluster, awsMachine)
@@ -200,6 +195,10 @@ func (r *AWSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	infrav1.SetDefaults_AWSMachineSpec(&awsMachine.Spec)
+
+	if isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, awsMachine); err != nil || isPaused || conditionChanged {
+		return ctrl.Result{}, err
+	}
 
 	// Create the machine scope
 	machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
@@ -254,7 +253,7 @@ func (r *AWSMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 			&infrav1.AWSCluster{},
 			handler.EnqueueRequestsFromMapFunc(AWSClusterToAWSMachines),
 		).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
 		WithEventFilter(
 			predicate.Funcs{
 				// Avoid reconciling if the event triggering the reconciliation is related to incremental status updates

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -2356,8 +2356,10 @@ func TestAWSMachineReconcilerReconcile(t *testing.T) {
 					ClusterName: "capi-test",
 				},
 			},
-			ownerCluster: &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "capi-test-1"}},
-			expectError:  false,
+			ownerCluster: &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "capi-test-1"}, Spec: clusterv1.ClusterSpec{
+				InfrastructureRef: &corev1.ObjectReference{Name: "foo"},
+			}},
+			expectError: false,
 		},
 		{
 			name: "Should not Reconcile if AWSManagedControlPlane is not ready",
@@ -2641,6 +2643,15 @@ func TestAWSMachineReconcilerReconcileDefaultsToLoadBalancerTypeClassic(t *testi
 				SecureSecretsBackend: infrav1.SecretBackendSecretsManager,
 				SecretPrefix:         "prefix",
 				SecretCount:          1000,
+			},
+		},
+		Status: infrav1.AWSMachineStatus{
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   "Paused",
+					Status: corev1.ConditionFalse,
+					Reason: "NotPaused",
+				},
 			},
 		},
 	}

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -51,9 +51,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/network"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/securitygroup"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/util/paused"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
-	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -169,7 +169,7 @@ func (r *AWSManagedControlPlaneReconciler) SetupWithManager(ctx context.Context,
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(awsManagedControlPlane).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
 		Build(r)
 
 	if err != nil {
@@ -237,9 +237,8 @@ func (r *AWSManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 
 	log = log.WithValues("cluster", klog.KObj(cluster))
 
-	if capiannotations.IsPaused(cluster, awsManagedControlPlane) {
-		log.Info("Reconciliation is paused for this object")
-		return ctrl.Result{}, nil
+	if isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, awsManagedControlPlane); err != nil || isPaused || conditionChanged {
+		return ctrl.Result{}, err
 	}
 
 	managedScope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/util/paused"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -69,7 +70,7 @@ func (r *ROSAMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ct
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&expinfrav1.ROSAMachinePool{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
 		Watches(
 			&expclusterv1.MachinePool{},
 			handler.EnqueueRequestsFromMapFunc(machinePoolToInfrastructureMapFunc(gvk)),
@@ -118,9 +119,8 @@ func (r *ROSAMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	if annotations.IsPaused(cluster, rosaMachinePool) {
-		log.Info("Reconciliation is paused for this object")
-		return ctrl.Result{}, nil
+	if isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, rosaMachinePool); err != nil || isPaused || conditionChanged {
+		return ctrl.Result{}, err
 	}
 
 	log = log.WithValues("cluster", klog.KObj(cluster))

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -372,6 +372,20 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 			cp.Status.Ready = true
 			g.Expect(mpPh.Patch(ctx, cp)).To(Succeed())
 			g.Expect(err).ShouldNot(HaveOccurred())
+
+			// patch status conditions
+			rmpPh, err := patch.NewHelper(test.old, testEnv)
+			test.old.Status.Conditions = clusterv1.Conditions{
+				{
+					Type:   "Paused",
+					Status: corev1.ConditionFalse,
+					Reason: "NotPaused",
+				},
+			}
+
+			g.Expect(rmpPh.Patch(ctx, test.old)).To(Succeed())
+			g.Expect(err).ShouldNot(HaveOccurred())
+
 			// patching is not reliably synchronous
 			time.Sleep(50 * time.Millisecond)
 

--- a/util/paused/paused.go
+++ b/util/paused/paused.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is a copy of the paused helpers from cluster-api, without the
+// v1beta2conditions requirement. Once the v1beta2conditions migration is
+// complete, we will want to use the upstream package.
+
+// Package paused implements paused helper functions.
+package paused
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
+)
+
+// ConditionSetter combines the client.Object and Setter interface.
+type ConditionSetter interface {
+	conditions.Setter
+	client.Object
+}
+
+// EnsurePausedCondition sets the paused condition on the object and returns if it should be considered as paused.
+func EnsurePausedCondition(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, obj ConditionSetter) (isPaused bool, conditionChanged bool, err error) {
+	oldCondition := conditions.Get(obj, clusterv1.PausedV1Beta2Condition)
+	newCondition := pausedCondition(c.Scheme(), cluster, obj, clusterv1.PausedV1Beta2Condition)
+
+	isPaused = newCondition.Status == corev1.ConditionTrue
+
+	log := ctrl.LoggerFrom(ctx)
+
+	// Return early if the paused condition did not change.
+	if oldCondition != nil && conditions.HasSameState(oldCondition, &newCondition) {
+		if isPaused {
+			log.V(6).Info("Reconciliation is paused for this object", "reason", newCondition.Message)
+		}
+		return isPaused, false, nil
+	}
+
+	patchHelper, err := patch.NewHelper(obj, c)
+	if err != nil {
+		return isPaused, false, err
+	}
+
+	if isPaused {
+		log.V(4).Info("Pausing reconciliation for this object", "reason", newCondition.Message)
+	} else {
+		log.V(4).Info("Unpausing reconciliation for this object")
+	}
+
+	conditions.Set(obj, &newCondition)
+
+	if err := patchHelper.Patch(ctx, obj, patch.WithOwnedV1Beta2Conditions{Conditions: []string{
+		clusterv1.PausedV1Beta2Condition,
+	}}); err != nil {
+		return isPaused, false, err
+	}
+
+	return isPaused, true, nil
+}
+
+// pausedCondition sets the paused condition on the object and returns if it should be considered as paused.
+func pausedCondition(scheme *runtime.Scheme, cluster *clusterv1.Cluster, obj ConditionSetter, targetConditionType string) clusterv1.Condition {
+	if (cluster != nil && cluster.Spec.Paused) || annotations.HasPaused(obj) {
+		var messages []string
+		if cluster != nil && cluster.Spec.Paused {
+			messages = append(messages, "Cluster spec.paused is set to true")
+		}
+		if annotations.HasPaused(obj) {
+			kind := "Object"
+			if gvk, err := apiutil.GVKForObject(obj, scheme); err == nil {
+				kind = gvk.Kind
+			}
+			messages = append(messages, fmt.Sprintf("%s has the cluster.x-k8s.io/paused annotation", kind))
+		}
+
+		return clusterv1.Condition{
+			Type:    clusterv1.ConditionType(targetConditionType),
+			Status:  corev1.ConditionTrue,
+			Reason:  clusterv1.PausedV1Beta2Reason,
+			Message: strings.Join(messages, ", "),
+		}
+	}
+
+	return clusterv1.Condition{
+		Type:   clusterv1.ConditionType(targetConditionType),
+		Status: corev1.ConditionFalse,
+		Reason: clusterv1.NotPausedV1Beta2Reason,
+	}
+}

--- a/util/paused/paused_test.go
+++ b/util/paused/paused_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package paused implements paused helper functions.
+package paused
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/test/builder"
+)
+
+func TestEnsurePausedCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(builder.AddTransitionV1Beta2ToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+
+	// Cluster Case 1: unpaused
+	normalCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-cluster",
+			Namespace: "default",
+		},
+	}
+
+	// Cluster Case 2: paused
+	pausedCluster := normalCluster.DeepCopy()
+	pausedCluster.Spec.Paused = true
+
+	// Object case 1: unpaused
+	obj := &builder.Phase1Obj{ObjectMeta: metav1.ObjectMeta{
+		Name:      "some-object",
+		Namespace: "default",
+	}}
+
+	// Object case 2: paused
+	pausedObj := obj.DeepCopy()
+	pausedObj.SetAnnotations(map[string]string{clusterv1.PausedAnnotation: ""})
+
+	tests := []struct {
+		name         string
+		cluster      *clusterv1.Cluster
+		object       ConditionSetter
+		wantIsPaused bool
+	}{
+		{
+			name:         "unpaused cluster and unpaused object",
+			cluster:      normalCluster.DeepCopy(),
+			object:       obj.DeepCopy(),
+			wantIsPaused: false,
+		},
+		{
+			name:         "paused cluster and unpaused object",
+			cluster:      pausedCluster.DeepCopy(),
+			object:       obj.DeepCopy(),
+			wantIsPaused: true,
+		},
+		{
+			name:         "unpaused cluster and paused object",
+			cluster:      normalCluster.DeepCopy(),
+			object:       pausedObj.DeepCopy(),
+			wantIsPaused: true,
+		},
+		{
+			name:         "paused cluster and paused object",
+			cluster:      pausedCluster.DeepCopy(),
+			object:       pausedObj.DeepCopy(),
+			wantIsPaused: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&clusterv1.Cluster{}, &builder.Phase1Obj{}).
+				WithObjects(tt.object, tt.cluster).Build()
+
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(tt.object), tt.object)).To(Succeed())
+
+			// The first run should set the condition.
+			gotIsPaused, gotConditionChanged, err := EnsurePausedCondition(ctx, c, tt.cluster, tt.object)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(gotConditionChanged).To(BeTrue(), "The first reconcile should set the Paused condition")
+			g.Expect(gotIsPaused).To(Equal(tt.wantIsPaused))
+
+			// The second reconcile should be a no-op.
+			gotIsPaused, gotConditionChanged, err = EnsurePausedCondition(ctx, c, tt.cluster, tt.object)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(gotConditionChanged).To(BeFalse(), "The second reconcile should not change the Paused condition")
+			g.Expect(gotIsPaused).To(Equal(tt.wantIsPaused))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

edit (@damdo):
To follow the recent updates in the CAPI Provider contract for InfraMachines: https://github.com/kubernetes-sigs/cluster-api/pull/11275 we should set the `Paused=true` condition on the resource's status to acknowledge we detected the addition of the `cluster.x-k8s.io/paused` annotation on a resource and paused its reconciliation to fulfill the user's request.

AWSManagedCluster is handled in a separate PR as there are API changes involved. See #5394

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set Paused condition on reconciled resources status upon pausing reconciliation (CAPI provider contract change)
```
