### PR TITLE
:bug: ROSA: Apply CAPI machinepool changes to ROSAMachinePool

### DIFF
--- a/templates/cluster-template-rosa-machinepool.yaml
+++ b/templates/cluster-template-rosa-machinepool.yaml
@@ -57,7 +57,7 @@ metadata:
   name: "${CLUSTER_NAME}-pool-0"
 spec:
   clusterName: "${CLUSTER_NAME}"
-  replicas: 1
+  replicas: 3
   template:
     spec:
       clusterName: "${CLUSTER_NAME}"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->
/kind bug

**What this PR does / why we need it**:

Apply CAPI machinepool changes to ROSAMachinePool when ROSAMachinePool is not managed by (external) autoscaler.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Apply CAPI machinepool changes to ROSAMachinePool

```
