### PR TITLE
:sparkles: Allow disabling controllers

### DIFF
--- a/controllers/disabled_controllers.go
+++ b/controllers/disabled_controllers.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TODO: EKS and ROSA are excluded from this list for the time being because they are behind feature gates.
+// They should be added to this list when they graduate.
+const (
+	Unmanaged = "unmanaged"
+)
+
+// disabledControllers tracks which controllers are disabled.
+// A value of `false` (default) means a controller is _enabled_.
+var disabledControllers = map[string]bool{
+	Unmanaged: false,
+}
+
+var notValidErr = "%q is not a valid controller name"
+
+// IsDisabled checks if a controller is disabled.
+// If the name provided is not in the map, this will return 'false'.
+func IsDisabled(name string) bool {
+	return disabledControllers[name]
+}
+
+// GetValidNames returns a list of controller names that are valid to disable.
+func GetValidNames() []string {
+	ret := make([]string, 0, len(disabledControllers))
+	for name := range disabledControllers {
+		ret = append(ret, name)
+	}
+	return ret
+}
+
+// ValidateNamesAndDisable validates a list of controller names against the known set, and disables valid names.
+func ValidateNamesAndDisable(names []string) error {
+	// This list is not de-deduplicated, so in someone could specify valid names multiple times.
+	for _, n := range names {
+		// Make sure we're doing a case-insensitive comaparison
+		name := strings.ToLower(n)
+		if _, ok := disabledControllers[name]; !ok {
+			return fmt.Errorf(notValidErr, name)
+		}
+		disabledControllers[name] = true
+	}
+	return nil
+}

--- a/controllers/disabled_controllers_unit_test.go
+++ b/controllers/disabled_controllers_unit_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"slices"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestIsDisabled(t *testing.T) {
+	g := NewWithT(t)
+	defer resetDefaults()
+
+	// Valid names default to false
+	g.Expect(IsDisabled(Unmanaged)).To(BeFalse(), "unmanaged should default to false")
+
+	// Invalid names are also false
+	g.Expect(IsDisabled("eks")).To(BeFalse(), "invalid controller name eks should report disabled")
+	g.Expect(IsDisabled("rosa")).To(BeFalse(), "invalid controller name rosa should report disabled")
+
+	// Disable the known names
+	disabledControllers = map[string]bool{
+		Unmanaged: true,
+	}
+
+	// Valid names
+	g.Expect(IsDisabled(Unmanaged)).To(BeTrue(), "unmanaged should have been disabled")
+
+	// Invalid names are still false
+	g.Expect(IsDisabled("eks")).To(BeFalse(), "invalid controller name eks should report disabled")
+	g.Expect(IsDisabled("rosa")).To(BeFalse(), "invalid controller name rosa should report disabled")
+}
+
+func TestGetValidNames(t *testing.T) {
+	g := NewWithT(t)
+	defer resetDefaults()
+
+	actual := GetValidNames()
+	// Make sure we have a stable order for testing
+	slices.Sort(actual)
+
+	g.Expect(actual).To(Equal([]string{
+		Unmanaged,
+	}), "should only have 1 name")
+}
+
+func TestValidateNames(t *testing.T) {
+	g := NewWithT(t)
+	defer resetDefaults()
+
+	// Valid set of names. Will mutate the map.
+	err := ValidateNamesAndDisable([]string{Unmanaged})
+	g.Expect(err).To(BeNil())
+	g.Expect(disabledControllers[Unmanaged]).To(BeTrue(), "should disable valid name unmanaged")
+
+	// TODO: This test should fail and require updating when EKS and ROSA controllers graduate.
+	err = ValidateNamesAndDisable([]string{"eks", "rosa"})
+	g.Expect(err.Error()).To(ContainSubstring("eks"), "should error on first invalid entry")
+	g.Expect(disabledControllers[Unmanaged]).To(BeTrue(), "should not change existing key unmanaged")
+	g.Expect(disabledControllers["eks"]).To(BeFalse(), "eks should not be in the default map")
+}
+
+// resetDefaults returns the disabledControllers map to expected default state.
+func resetDefaults() {
+	disabledControllers = map[string]bool{
+		Unmanaged: false,
+	}
+}

--- a/docs/proposal/20250314-optional-controllers.md
+++ b/docs/proposal/20250314-optional-controllers.md
@@ -1,0 +1,75 @@
+# Problem
+
+EKS and ROSA are implemented in (relatively) standalone sets of controllers. These are currently grouped with the associated feature gates.
+
+However, the feature gate mechanism has no specifier for GA, meaning that both implementations have stayed in beta.
+
+This proposal supercedes `docs/proposal/20250314-optional-controllers.md`.
+
+# Background
+
+Cluster API Provider for AWS offers a `--feature-flags` argument to manage introduction of new features.
+
+This allows features to move through `alpha` and `beta` phases, but there is not currently a defined path to general availability.
+
+Specifically of interest is controllers for the `EKS` and ROSA`, which offer optional features to the program.
+
+This proposal focuses on how these controllers could be grouped in order to remain optional, while also giving a path to GA.
+
+## Goals
+
+ - Allow features spanning groups of controllers to graduate, while also remaining optional
+
+## Non-goals
+
+ - Provide a generalized path to general availbility
+
+
+## Proposed solution
+
+Introduce a new argument, `--disable-controllers`, which allows controllers to be logically grouped as feature sets and turned on and off independently.
+
+The groups and their disabled status will be tracked in a map within a private module, and can be queried via exposed functions.
+
+The map's structure and functions would be as follows.
+
+```go
+var disabledControllers = map[string]bool{
+    ControllerGroupName: false,
+}
+
+// IsDisabled checks if a controller is disabled.
+// If the name provided is not in the map, this will return 'false'.
+func IsDisabled(name string) bool
+
+// GetValidNames returns a list of controller names that are valid to disable.
+// Note: these are the entries in the `disabledControllers` variable.
+// Used for error and help messages 
+func GetValidNames() []string
+
+// ValidateNamesAndDisable validates a list of controller names against the known set, and disables valid names.
+func ValidateNamesAndDisable(names []string) error
+```
+
+Within `main.go`, `ValidateNamesAndDisable` will check against the contents of the `--disable-controllers` slice.
+Valid entires will then be marked as `true`, indicating they are disabled.
+
+Before initializing a controller or group of controllers, `IsDisabled` can be checked to determine whether or not they should register with the manager and start.
+
+If a controller is disabled, a log message indicating it is disabled should be emitted.
+This will aid users in troubleshooting, should the deployment behave unexpectedly.
+
+## Logical groups
+
+EKS and ROSA are currently behind feature gate checks.
+These checks can be updated to instead use `IsDisabled` and entries within the `disabledControllers` map can be made.
+
+## Core controllers and alternatives
+
+The proposal `2025-01-07-aws-self-managed-feature-gates.md` was merged and planned to add `AWSMachine` and `AWSCluster` feature gates.
+This merged with lazy concensus and the implementation was proposed in [PR #5284](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5284).
+
+However, maintainers were opposed to moving these core controllers into feature gates, which would have put them into a permanent pre-GA phase.
+This leads to a conflict between the implementation and the proposal, which was indeed accepted.
+
+This current proposal includes the ability to disable `AWSMachine` and `AWSCluster` as a compromise, using the `unmanaged` set; it achieves the goals of the original proposal, while addressing the objections to the proposed implementation.

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -109,6 +110,7 @@ var (
 	webhookCertDir              string
 	healthAddr                  string
 	serviceEndpoints            string
+	disabledControllers         []string
 
 	// maxEKSSyncPeriod is the maximum allowed duration for the sync-period flag when using EKS. It is set to 10 minutes
 	// because during resync it will create a new AWS auth token which can a maximum life of 15 minutes and this ensures
@@ -129,6 +131,11 @@ func main() {
 	initFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+
+	if err := controllers.ValidateNamesAndDisable(disabledControllers); err != nil {
+		setupLog.Error(err, "unable to validate disabled controller names")
+		os.Exit(1)
+	}
 
 	if err := v1.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "unable to validate and apply log options")
@@ -298,29 +305,36 @@ func main() {
 func setupReconcilersAndWebhooks(ctx context.Context, mgr ctrl.Manager, awsServiceEndpoints []scope.ServiceEndpoint,
 	externalResourceGC, alternativeGCStrategy bool,
 ) {
-	if err := (&controllers.AWSMachineReconciler{
-		Client:                       mgr.GetClient(),
-		Log:                          ctrl.Log.WithName("controllers").WithName("AWSMachine"),
-		Recorder:                     mgr.GetEventRecorderFor("awsmachine-controller"),
-		Endpoints:                    awsServiceEndpoints,
-		WatchFilterValue:             watchFilterValue,
-		TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
-	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsMachineConcurrency, RecoverPanic: ptr.To[bool](true)}); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "AWSMachine")
-		os.Exit(1)
-	}
+	// Default case - unmanaged controllers are enabled.
+	if !controllers.IsDisabled(controllers.Unmanaged) {
+		if err := (&controllers.AWSMachineReconciler{
+			Client:                       mgr.GetClient(),
+			Log:                          ctrl.Log.WithName("controllers").WithName("AWSMachine"),
+			Recorder:                     mgr.GetEventRecorderFor("awsmachine-controller"),
+			Endpoints:                    awsServiceEndpoints,
+			WatchFilterValue:             watchFilterValue,
+			TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsMachineConcurrency, RecoverPanic: ptr.To[bool](true)}); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "AWSMachine")
+			os.Exit(1)
+		}
+		setupLog.Info("controller disabled", "controller", "AWSMachine", "congrollerGroup", controllers.Unmanaged)
 
-	if err := (&controllers.AWSClusterReconciler{
-		Client:                       mgr.GetClient(),
-		Recorder:                     mgr.GetEventRecorderFor("awscluster-controller"),
-		Endpoints:                    awsServiceEndpoints,
-		WatchFilterValue:             watchFilterValue,
-		ExternalResourceGC:           externalResourceGC,
-		AlternativeGCStrategy:        alternativeGCStrategy,
-		TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
-	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsClusterConcurrency, RecoverPanic: ptr.To[bool](true)}); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "AWSCluster")
-		os.Exit(1)
+		if err := (&controllers.AWSClusterReconciler{
+			Client:                       mgr.GetClient(),
+			Recorder:                     mgr.GetEventRecorderFor("awscluster-controller"),
+			Endpoints:                    awsServiceEndpoints,
+			WatchFilterValue:             watchFilterValue,
+			ExternalResourceGC:           externalResourceGC,
+			AlternativeGCStrategy:        alternativeGCStrategy,
+			TagUnmanagedNetworkResources: feature.Gates.Enabled(feature.TagUnmanagedNetworkResources),
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: awsClusterConcurrency, RecoverPanic: ptr.To[bool](true)}); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "AWSCluster")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("controller disabled", "controller", "AWSMachine", "congrollerGroup", controllers.Unmanaged)
+		setupLog.Info("controller disabled", "controller", "AWSCluster", "controller-group", controllers.Unmanaged)
 	}
 
 	if feature.Gates.Enabled(feature.MachinePool) {
@@ -594,7 +608,7 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&serviceEndpoints,
 		"service-endpoints",
 		"",
-		"Set custom AWS service endpoins in semi-colon separated format: ${SigningRegion1}:${ServiceID1}=${URL},${ServiceID2}=${URL};${SigningRegion2}...",
+		"Set custom AWS service endpoints in semi-colon separated format: ${SigningRegion1}:${ServiceID1}=${URL},${ServiceID2}=${URL};${SigningRegion2}...",
 	)
 
 	fs.StringVar(
@@ -602,6 +616,13 @@ func initFlags(fs *pflag.FlagSet) {
 		"watch-filter",
 		"",
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel),
+	)
+
+	fs.StringSliceVar(
+		&disabledControllers,
+		"disable-controllers",
+		nil,
+		fmt.Sprintf("Sets of controllers that should be disabled for this instance of the controller manager in a comma-separated list. Options are: %q", strings.Join(controllers.GetValidNames(), ",")),
 	)
 
 	logs.AddFlags(fs, logs.SkipLoggingConfigurationFlags())


### PR DESCRIPTION

/kind feature


**What this PR does / why we need it**:

This PR introduces the ability to disable controllers within the controller manager binary. It is an alternative to #5284 using a dedicated argument instead of the existing feature gates.

It starts with AWSMachine and AWSCluster as `unmanaged`, since those are the two we're interested in at the moment.

Other controllers that can be optional, such as the EKS, ROSA, and MachinePool ones, are currently managed with feature flags. When they graduate, they should be controlled by the disabled controllers flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Locally, this prints the options that can be passed in. Other output is omitted in this example.

```shell
❯ ./bin/manager --help
 Usage of ./bin/manager:
 ...
      --disable-controllers strings            Sets of controllers that should be disabled for this instance of the controller manager in a comma-separated list. Options are: "unmanaged"
...
```

And when enabled, the following log message appears:

```shell
❯ go run main.go --disable-controllers=awsmachine,awscluster -v 4 --logtostderr --stderrthreshold 0
❮ ./bin/manager --disable-controllers=unmanaged -v 4 --logtostderr
I0317 11:49:25.286786   74733 logger.go:75] "feature gates: \n" logger="setup"
I0317 11:49:25.286901   74733 logger.go:75] "controller disabled" logger="setup" controller="AWSMachine" congrollerGroup="unmanaged"
I0317 11:49:25.286905   74733 logger.go:75] "controller disabled" logger="setup" controller="AWSCluster" controller-group="unmanaged"
....
```

Note also that this is an alternative to #5284, with apologies to @mzazrivec and @serngawy. The original proposal did follow our established process and was accepted through lazy consensus. However, the maintainers would like to avoid using feature flags for GA functionality, even if it is code that is rapidly removed. Such addition and removal is a form of interface stability, and doing so would cause unnecessary churn, while leaving it as a feature flag indefinitely communicates the wrong status.


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [x] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests

**Release note**:

```release-note
Introduce the `--disable-controllers` argument to the controller manager binary.
```
