### PR TITLE
🐛 fix: efs & elb upgrade e2e tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ var (
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 func main() {
+	setupLog.Info("starting cluster-api-provider-aws", "version", version.Get().String())
 	initFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -241,4 +241,4 @@ intervals:
   default/wait-deployment-ready: ["5m", "10s"]
   default/wait-loadbalancer-ready: ["5m", "30s"]
   default/wait-classic-elb-health-check-short: ["1m", "10s"]
-  default/wait-classic-elb-health-check-long: ["10m", "10s"]
+  default/wait-classic-elb-health-check-long: ["15m", "30s"]

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/efs-support/patches/efs-support.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/efs-support/patches/efs-support.yaml
@@ -15,3 +15,13 @@ spec:
     spec:
       rootVolume:
         size: 16
+---
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      rootVolume:
+        size: 16

--- a/test/e2e/shared/aws_helpers.go
+++ b/test/e2e/shared/aws_helpers.go
@@ -196,7 +196,7 @@ func CheckClassicElbHealthCheck(input CheckClassicElbHealthCheckInput, intervals
 		}
 
 		if *lb.HealthCheck.Target != input.ExpectedTarget {
-			return fmt.Errorf("health check target %s does not match expected target %s", *lb.HealthCheck.Target, input.ExpectedTarget)
+			return fmt.Errorf("health check target %q does not match expected target %q", *lb.HealthCheck.Target, input.ExpectedTarget)
 		}
 
 		return nil

--- a/test/e2e/shared/aws_helpers.go
+++ b/test/e2e/shared/aws_helpers.go
@@ -196,7 +196,7 @@ func CheckClassicElbHealthCheck(input CheckClassicElbHealthCheckInput, intervals
 		}
 
 		if *lb.HealthCheck.Target != input.ExpectedTarget {
-			return fmt.Errorf("health check target does not match expected target")
+			return fmt.Errorf("health check target %s does not match expected target %s", *lb.HealthCheck.Target, input.ExpectedTarget)
 		}
 
 		return nil

--- a/test/e2e/suites/unmanaged/helpers_test.go
+++ b/test/e2e/suites/unmanaged/helpers_test.go
@@ -539,7 +539,7 @@ func createPodWithEFSMount(clusterClient crclient.Client) {
 			Containers: []corev1.Container{
 				{
 					Name:    "app",
-					Image:   "centos",
+					Image:   "ubuntu",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "while true; do echo $(date -u) >> /data/out; sleep 5; done"},
 					VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The EFS e2e test was breaking for 2 reasons:

1. Running out if disk space on the control plane nodes. It only had 8Gb so this has been increased to 16gb 
2. The workload being deployed to test EFS was using centos with has been discontinued for a long time now. So changed to use Ubuntu

The classic ELB upgrade test was failing because on upgrade of CAPA, the CAPA controller manager was restarted. From the logs i could see that the AWSCluster was no being reconciled and thats because the "old" and "new" versions were the same basic ion the predicate logic in SetupWithManager. Changed SetupWithManager to be more consistent with other CAPI infra providers. Also it was failing because of the wait introduced by the new `paused.EnsurePausedCondition` functionality but this is fixed in #5425

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Fix the EFS & classic elb e2e tests.
```
