### PR TITLE
[release-2.7] :bug: fix: efs e2e test breaking

### DIFF
--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/efs-support/patches/efs-support.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/efs-support/patches/efs-support.yaml
@@ -15,3 +15,13 @@ spec:
     spec:
       rootVolume:
         size: 16
+---
+kind: AWSMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      rootVolume:
+        size: 16

--- a/test/e2e/suites/unmanaged/helpers_test.go
+++ b/test/e2e/suites/unmanaged/helpers_test.go
@@ -539,7 +539,7 @@ func createPodWithEFSMount(clusterClient crclient.Client) {
 			Containers: []corev1.Container{
 				{
 					Name:    "app",
-					Image:   "centos",
+					Image:   "ubuntu",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "while true; do echo $(date -u) >> /data/out; sleep 5; done"},
 					VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The EFS e2e test was breaking for 2 reasons:

1. Running out if disk space on the control plane nodes. It only had 8Gb so this has been increased to 16gb 2.The workload being deployed to test EFS was using centos with has been discontinued for a long time now. So changed to use Ubuntu

Note: This is a backport from main (#5418 specifically), but omits the ELB healthcheck test updates, as those are for v2.8+

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
