### PR TITLE
fix: 🐛  Reconciler error when updating AWSMCP publicCIDRs to empty list with endpointPrivateAccess: true and endpointPublicAccess: false

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -353,7 +353,9 @@ func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.End
 		SubnetIds:             subnetIDs,
 	}
 
-	if len(cidrs) > 0 {
+	isPrivateOnlyEndPoint := !aws.BoolValue(vpcConfig.EndpointPublicAccess) && aws.BoolValue(vpcConfig.EndpointPrivateAccess)
+
+	if len(cidrs) > 0 || isPrivateOnlyEndPoint {
 		vpcConfig.PublicAccessCidrs = cidrs
 	}
 	sg, ok := securityGroups[infrav1.SecurityGroupEKSNodeAdditional]


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
fix

CAPA EKS reconciler errors when an EKS cluster is deployed with:
- `endpointPrivateAccess: true`
- `endpointPublicAccess: false`

...and later, the AWSManagedControlPlane (AWSMCP) resource is updated to change `publicCIDRs` from a list of IPs to an **empty list**.

This results in a `Reconciler error`:
```
271] [capa-controller-manager-694c8f6879-wxg8q] 1 controller.go:326] "msg"="Reconciler error" "error"="failed to reconcile control plane for AWSManagedControlPlane cluster-67bdf4503897e994b608c9f3/alias-eks-privatetest-cp: failed reconciling cluster config: failed to update EKS cluster: InvalidParameterException: Cluster is already at the desired configuration with endpointPrivateAccess: true , endpointPublicAccess: false, and Public Endpoint Restrictions: [42.35.163.177/32, 34.23.247.65/32, 98.11.13.11/32, 52.6.49.73/32, 94.80.29.17/32, 13.52.68.26/32, 34.158.209.13/32, 34.22.106.120/32]\n{\n RespMetadata: {\n StatusCode: 400,\n RequestID: \"10163f97-d89b-44c1-bee1-75a3c476b980\"\n },\n ClusterName: \"alias-eks-privatetest\",\n Message_: \"Cluster is already at the desired configuration with endpointPrivateAccess: true , endpointPublicAccess: false, and Public Endpoint Restrictions: [42.35.163.177/32, 34.23.247.65/32, 98.11.13.11/32, 52.6.49.73/32, 94.80.29.17/32, 13.52.68.26/32, 34.158.209.13/32, 34.22.106.120/32]\"\n}" "AWSManagedControlPlane"={"name":"alias-eks-privatetest-cp","namespace":"cluster-67bdf4503897e994b608c9f3"} "controller"="awsmanagedcontrolplane" "controllerGroup"="controlplane.cluster.x-k8s.io" "controllerKind"="AWSManagedControlPlane" "name"="alias-eks-privatetest-cp" "namespace"="cluster-67bdf4503897e994b608c9f3" "reconcileID"="81216a1c-47f8-4059-b3b4-4f9664c3806f"
```
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5441

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
