### PR TITLE
🌱 Fix envsubstr installation in Devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -15,6 +15,7 @@
   ],
   "shell": {
     "init_hook": [
+      "export PATH=$PWD/bin:$PATH",
       "./scripts/devbox-init-hook.sh"
     ],
     "scripts": {

--- a/scripts/devbox-init-hook.sh
+++ b/scripts/devbox-init-hook.sh
@@ -2,29 +2,16 @@
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="$(dirname $DIR)"
 
-# Set install path
-INSTALL_DIR="$HOME/.local/bin"
-mkdir -p "$INSTALL_DIR"
+# Set install path to devbox packages directory
+INSTALL_DIR="$DEVBOX_PACKAGES_DIR/bin"
 
-# Check if envsubst.old exists
-if [[ ! -f "/usr/bin/envsubst.old" ]]; then
-    echo "envsubst.old does not exist. Proceeding with installation..."
-
+if [[ ! -f "$INSTALL_DIR/envsubst" ]]; then
     ENVSUBST_VERSION="v1.4.3"
     URL="https://github.com/a8m/envsubst/releases/download/$ENVSUBST_VERSION/envsubst-$(uname -s)-$(uname -m)"
     echo "Downloading: $URL"
-
-    curl -sL $URL -o $INSTALL_DIR/envsubst
-    chmod +x "$INSTALL_DIR/envsubst"
-
-    # Replace existing envsubst if present
-    if [[ -f "/usr/bin/envsubst" ]]; then
-        sudo mv /usr/bin/envsubst /usr/bin/envsubst.old
-        sudo ln -s "$INSTALL_DIR/envsubst" /usr/bin/envsubst
-        echo "Replaced existing envsubst with the new one at /usr/bin/envsubst"
-    else
-        touch /usr/bin/envsubst.old
-    fi
+    echo "Installing github.com/a8m/envsubst into Devbox shell"
+    sudo curl -sL $URL -o $INSTALL_DIR/envsubst
+    sudo chmod +x "$INSTALL_DIR/envsubst"
 
     # Verify installation
     if ! command -v envsubst &>/dev/null; then
@@ -34,8 +21,7 @@ if [[ ! -f "/usr/bin/envsubst.old" ]]; then
 fi
 
 # Use build location by default
-if [[ ! -e "$INSTALL_DIR/clusterawsadm" ]]; then
+if [[ ! -L "$INSTALL_DIR/clusterawsadm" ]]; then
     echo "Linking [$SRC_DIR/bin/clusterawsadm] [$INSTALL_DIR/clusterawsadm]"
-    mkdir -p "$INSTALL_DIR"
-    ln -s "$SRC_DIR/bin/clusterawsadm" $INSTALL_DIR/clusterawsadm
+    sudo ln -s "$SRC_DIR/bin/clusterawsadm" $INSTALL_DIR/clusterawsadm
 fi

--- a/scripts/devbox-init-hook.sh
+++ b/scripts/devbox-init-hook.sh
@@ -2,16 +2,14 @@
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="$(dirname $DIR)"
 
-# Set install path to devbox packages directory
-INSTALL_DIR="$DEVBOX_PACKAGES_DIR/bin"
+# Set install path
+INSTALL_DIR="$SRC_DIR/bin"
+mkdir -p "$INSTALL_DIR"
 
 if [[ ! -f "$INSTALL_DIR/envsubst" ]]; then
-    ENVSUBST_VERSION="v1.4.3"
-    URL="https://github.com/a8m/envsubst/releases/download/$ENVSUBST_VERSION/envsubst-$(uname -s)-$(uname -m)"
-    echo "Downloading: $URL"
-    echo "Installing github.com/a8m/envsubst into Devbox shell"
-    sudo curl -sL $URL -o $INSTALL_DIR/envsubst
-    sudo chmod +x "$INSTALL_DIR/envsubst"
+    echo "Installing github.com/a8m/envsubst into bin"
+    make -C "$SRC_DIR/hack/tools" bin/envsubst
+    ln -s "$SRC_DIR/hack/tools/bin/envsubst" "$INSTALL_DIR/envsubst"
 
     # Verify installation
     if ! command -v envsubst &>/dev/null; then
@@ -21,7 +19,7 @@ if [[ ! -f "$INSTALL_DIR/envsubst" ]]; then
 fi
 
 # Use build location by default
-if [[ ! -L "$INSTALL_DIR/clusterawsadm" ]]; then
-    echo "Linking [$SRC_DIR/bin/clusterawsadm] [$INSTALL_DIR/clusterawsadm]"
-    sudo ln -s "$SRC_DIR/bin/clusterawsadm" $INSTALL_DIR/clusterawsadm
+if [[ ! -f "$INSTALL_DIR/clusterawsadm" ]]; then
+    echo "Installing clusterawsadm into bin"
+	make -C "$SRC_DIR" clusterawsadm
 fi


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
For users using devbox directly on their machines, envsubstr is now installed in the isolated devbox environment. Thus not conflicting with the GNU system installation.

Fix the below clusterawsadm installation error when re-entering the devbox environment "ln: failed to create symbolic link '$INSTALL_DIR/clusterawsadm': File exists"


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5423

**Special notes for your reviewer**:
`-L` checks if symlink exists, `-e or -f` errors out because `clusterawsadm` does not exist initially when the devbox session is created.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
