### PR TITLE
🐛 fix(addons): avoid infinite reconciliation loop

### DIFF
--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -197,7 +197,7 @@ func (s *Service) translateAPIToAddon(addons []ekscontrolplanev1.Addon) []*eksad
 		convertedAddon := &eksaddons.EKSAddon{
 			Name:                  &addon.Name,
 			Version:               &addon.Version,
-			Configuration:         &addon.Configuration,
+			Configuration:         convertConfiguration(addon.Configuration),
 			Tags:                  ngTags(s.scope.Cluster.Name, s.scope.AdditionalTags()),
 			ResolveConflict:       convertConflictResolution(*addon.ConflictResolution),
 			ServiceAccountRoleARN: addon.ServiceAccountRoleArn,
@@ -214,4 +214,11 @@ func convertConflictResolution(conflict ekscontrolplanev1.AddonResolution) *stri
 		return aws.String(eks.ResolveConflictsNone)
 	}
 	return aws.String(eks.ResolveConflictsOverwrite)
+}
+
+func convertConfiguration(configuration string) *string {
+	if configuration == "" {
+		return nil
+	}
+	return &configuration
 }

--- a/pkg/eks/addons/types.go
+++ b/pkg/eks/addons/types.go
@@ -36,7 +36,7 @@ type EKSAddon struct {
 
 // IsEqual determines if 2 EKSAddon are equal.
 func (e *EKSAddon) IsEqual(other *EKSAddon, includeTags bool) bool {
-	//NOTE: we do not compare the ARN as that is only for existing addons
+	// NOTE: we do not compare the ARN as that is only for existing addons
 	if e == other {
 		return true
 	}
@@ -47,9 +47,6 @@ func (e *EKSAddon) IsEqual(other *EKSAddon, includeTags bool) bool {
 		return false
 	}
 	if !cmp.Equal(e.Configuration, other.Configuration) {
-		return false
-	}
-	if !cmp.Equal(e.ResolveConflict, other.ResolveConflict) {
 		return false
 	}
 

--- a/pkg/eks/addons/types_test.go
+++ b/pkg/eks/addons/types_test.go
@@ -58,6 +58,32 @@ func TestAddOnEqual(t *testing.T) {
 			orig: &EKSAddon{
 				Version:               ptr("a"),
 				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         nil,
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				Configuration:         nil,
+			},
+			result: gomega.BeTrueBecause("addon values are equal with optional nil configuration"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				ResolveConflict:       ptr("OVERWRITE"),
+			},
+			other: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
+				ResolveConflict:       nil,
+			},
+			result: gomega.BeTrueBecause("addon values are equal with expected diff on resolve conflict"),
+		},
+		{
+			orig: &EKSAddon{
+				Version:               ptr("a"),
+				ServiceAccountRoleARN: ptr("b"),
 				Configuration:         ptr("c"),
 			},
 			other: &EKSAddon{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind regression

**What this PR does / why we need it**:

With latest v2.7.2 and [this PR](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5202), there is an infinite reconciliation loop for eks addons.

We have seen two problems:

1. It tries to compare _resolveConflicts_ despite the fact that it's not part of _describe-addon_ output
2. It fails to compare emptyString ("") (_desired_ when not set) with nil pointer (_describe-addon output_) on optional `Configuration` field


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Fix: Ignore conflict resolution and correctly compare configuration for AddOn reconciliation
```
