### PR TITLE
🐛 Skip adding reserved aws internal tags to resources as they are invalid

### DIFF
--- a/pkg/cloud/converters/tags.go
+++ b/pkg/cloud/converters/tags.go
@@ -18,6 +18,7 @@ package converters
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -58,12 +59,14 @@ func MapToTags(src infrav1.Tags) []*ec2.Tag {
 	tags := make([]*ec2.Tag, 0, len(src))
 
 	for k, v := range src {
-		tag := &ec2.Tag{
-			Key:   aws.String(k),
-			Value: aws.String(v),
-		}
+		if !strings.HasPrefix(k, "aws:") {
+			tag := &ec2.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			}
 
-		tags = append(tags, tag)
+			tags = append(tags, tag)
+		}
 	}
 
 	// Sort so that unit tests can expect a stable order


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Skip adding reserved aws internal tags (that start with `aws:`) to resources as they are invalid and will cause instance creation errors:

```
I0409 03:42:59.545979       1 awsmachine_controller.go:732] "Creating EC2 instance"
E0409 03:43:01.676476       1 awsmachine_controller.go:535] "unable to create instance" err=<
failed to create AWSMachine instance: failed to create tags for resource "eni-05807e398e7f79df3": : failed to create tags for resource "eni-05807e398e7f79df3": map[MachineName:openshift-cluster-api/capimachineset-ct2tn Name:capimachineset-ct2tn aws:ec2:capacity-reservation-type:capacity-block kubernetes.io/cluster/huliu-aws49a-bwrxg:owned sigs.k8s.io/cluster-api-provider-aws/cluster/huliu-aws49a-bwrxg:owned sigs.k8s.io/cluster-api-provider-aws/role:node]: InvalidParameterValue: Value ( aws:ec2:capacity-reservation-type ) for parameter key is invalid. Tag keys starting with 'aws:' are reserved for internal use
status code: 400, request id: fe84aa27-7975-48c0-946a-e10ab25d7c16
```

External BUG reference:
[OCPBUGS-54757](https://issues.redhat.com/browse/OCPBUGS-54757)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip adding reserved aws internal tags to resources as they are invalid
```
