### PR TITLE
feat: add amazon-linux-2023 ami lookup parameters for ssm ✨

### DIFF
--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -463,6 +463,10 @@ const (
 	AmazonLinux EKSAMILookupType = "AmazonLinux"
 	// AmazonLinuxGPU is the AmazonLinux GPU AMI type.
 	AmazonLinuxGPU EKSAMILookupType = "AmazonLinuxGPU"
+	// AmazonLinux2023 is the AmazonLinux 2023 AMI type.
+	AmazonLinux2023 EKSAMILookupType = "AmazonLinux2023"
+	// AmazonLinux2023 is the AmazonLinux 2023 GPU AMI type.
+	AmazonLinux2023GPU EKSAMILookupType = "AmazonLinux2023GPU"
 )
 
 // PrivateDNSName is the options for the instance hostname.

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -80,11 +80,20 @@ const (
 	// EKS AMI ID SSM Parameter name.
 	eksAmiSSMParameterFormat = "/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id"
 
+	// EKS AL2023 AMI ID SSM Parameter name.
+	eksAmiAl2023SSMParameterFormat = "/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id"
+
 	// EKS ARM64 AMI ID SSM Parameter name.
 	eksARM64AmiSSMParameterFormat = "/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id"
 
+	// EKS ARM64 AL2023 AMI ID SSM Parameter name.
+	eksARM64AmiAl2023SSMParameterFormat = "/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/nvidia/recommended/image_id"
+
 	// EKS GPU AMI ID SSM Parameter name.
 	eksGPUAmiSSMParameterFormat = "/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id"
+
+	// EKS GPU AL2023 AMI ID SSM Parameter name.
+	eksGPUAmiAl2023SSMParameterFormat = "/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/nvidia/recommended/image_id"
 )
 
 // AMILookup contains the parameters used to template AMI names used for lookup.
@@ -323,14 +332,24 @@ func (s *Service) eksAMILookup(kubernetesVersion string, architecture string, am
 	}
 
 	switch *amiType {
+	case infrav1.AmazonLinux2023GPU:
+		paramName = fmt.Sprintf(eksGPUAmiAl2023SSMParameterFormat, formattedVersion)
 	case infrav1.AmazonLinuxGPU:
 		paramName = fmt.Sprintf(eksGPUAmiSSMParameterFormat, formattedVersion)
 	default:
 		switch architecture {
 		case Arm64ArchitectureTag:
-			paramName = fmt.Sprintf(eksARM64AmiSSMParameterFormat, formattedVersion)
+			if *amiType == infrav1.AmazonLinux2023 {
+				paramName = fmt.Sprintf(eksARM64AmiAl2023SSMParameterFormat, formattedVersion)
+			} else {
+				paramName = fmt.Sprintf(eksARM64AmiSSMParameterFormat, formattedVersion)
+			}
 		case Amd64ArchitectureTag:
-			paramName = fmt.Sprintf(eksAmiSSMParameterFormat, formattedVersion)
+			if *amiType == infrav1.AmazonLinux2023 {
+				paramName = fmt.Sprintf(eksAmiAl2023SSMParameterFormat, formattedVersion)
+			} else {
+				paramName = fmt.Sprintf(eksAmiSSMParameterFormat, formattedVersion)
+			}
 		default:
 			return "", fmt.Errorf("cannot look up eks-optimized image for architecture %q", architecture)
 		}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for Amazon Linux 2023 AMI lookup in the EKS optimized AMI workflow. It ensures compatibility with the latest Amazon Linux 2023 and its GPU variant, enabling users to leverage these AMIs for their EKS clusters.

**Which issue(s) this PR fixes**:
Fixes #5516

**Special notes for your reviewer**:

- The `EKSAMILookupType` has been extended to include `AmazonLinux2023` and `AmazonLinux2023GPU`.
- Updated the SSM parameter lookup logic to handle the new AMI types.

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] includes emoji in title ✨
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
✨ Added support for Amazon Linux 2023 and Amazon Linux 2023 GPU AMI lookup in EKS optimized AMI workflow.