### PR TITLE
🐛 Fix determined value for `MinSize` field of ASG

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -50,7 +50,7 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscalingtypes.AutoScalingGroup) (*
 		// TODO(rudoi): this is just terrible
 		DesiredCapacity:   v.DesiredCapacity,
 		MaxSize:           aws.Int32Value(v.MaxSize), //#nosec G115
-		MinSize:           aws.Int32Value(v.MaxSize), //#nosec G115
+		MinSize:           aws.Int32Value(v.MinSize), //#nosec G115
 		CapacityRebalance: aws.BoolValue(v.CapacityRebalance),
 		// TODO: determine what additional values go here and what else should be in the struct
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5497 introduced this bug (copy-paste mistake) which leads to permanent updates of the ASG like this:

```
capa_control… │ I0604 10:14:12.938231      13 awsmachinepool_controller.go:528] "asg diff detected" controller="awsmachinepool" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachinePool" AWSMachinePool="org-myorg/andreas245-mp-0" namespace="org-myorg" name="andreas245-mp-0" reconcileID="5480a2f8-f0b3-44c5-af31-0c74cbe7bce3" machinePool="org-myorg/andreas245-mp-0" cluster="org-myorg/andreas245" asgDiff=<
capa_control… │ 	  v1beta2.AWSMachinePoolSpec{
capa_control… │ 	  	ProviderID:        "arn:aws:autoscaling:eu-west-2:242036376510:autoScalingGroup:6e23"...,
capa_control… │ 	- 	MinSize:           1,
capa_control… │ 	+ 	MinSize:           10,
capa_control… │ 	  	MaxSize:           10,
capa_control… │ 	  	AvailabilityZones: {"eu-west-2a"},
capa_control… │ 	  	... // 13 identical fields
capa_control… │ 	  }
capa_control… │  > subnetDiff=""
```

/kind bug

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix determined value for `MinSize` field of ASG, avoiding unnecessary updates to ASG
```
