### PR TITLE
:book: Fixes 5544: update link to point to new e2e documentation location

### DIFF
--- a/docs/book/src/development/e2e.md
+++ b/docs/book/src/development/e2e.md
@@ -2,7 +2,7 @@
 
 Visit the [Cluster API documentation on E2E][cluster_api_e2e] for information on how to develop and run e2e tests. 
 
-[cluster_api_e2e]: https://cluster-api.sigs.k8s.io/developer/e2e.html
+[cluster_api_e2e]: https://cluster-api.sigs.k8s.io/developer/core/e2e
 
 ## Set up
 


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:

Fixes a broken link in the developer documentation.

**Which issue(s) this PR fixes** 
Fixes # 5544

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] includes emoji in title 

**Release note**:
```release-note
Update documentation to refer to new e2e documentation link.
```
