### PR TITLE
 🐛 Fix missing CRD validation for Amazon Linux 2023 eksLookupType

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -51,7 +51,7 @@ type AMIReference struct {
 	ID *string `json:"id,omitempty"`
 
 	// EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store
-	// +kubebuilder:validation:Enum:=AmazonLinux;AmazonLinuxGPU;AmazonLinux2023;AmazonLinux2023GPU
+	// +kubebuilder:validation:Enum:=AmazonLinux;AmazonLinuxGPU
 	// +optional
 	EKSOptimizedLookupType *EKSAMILookupType `json:"eksLookupType,omitempty"`
 }

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -51,7 +51,7 @@ type AMIReference struct {
 	ID *string `json:"id,omitempty"`
 
 	// EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store
-	// +kubebuilder:validation:Enum:=AmazonLinux;AmazonLinuxGPU
+	// +kubebuilder:validation:Enum:=AmazonLinux;AmazonLinuxGPU;AmazonLinux2023;AmazonLinux2023GPU
 	// +optional
 	EKSOptimizedLookupType *EKSAMILookupType `json:"eksLookupType,omitempty"`
 }

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -54,7 +54,7 @@ type AMIReference struct {
 	ID *string `json:"id,omitempty"`
 
 	// EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store
-	// +kubebuilder:validation:Enum:=AmazonLinux;AmazonLinuxGPU
+	// +kubebuilder:validation:Enum:=AmazonLinux;AmazonLinuxGPU;AmazonLinux2023;AmazonLinux2023GPU
 	// +optional
 	EKSOptimizedLookupType *EKSAMILookupType `json:"eksLookupType,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -131,6 +131,8 @@ spec:
                         enum:
                         - AmazonLinux
                         - AmazonLinuxGPU
+                        - AmazonLinux2023
+                        - AmazonLinux2023GPU
                         type: string
                       id:
                         description: ID of resource
@@ -624,6 +626,8 @@ spec:
                         enum:
                         - AmazonLinux
                         - AmazonLinuxGPU
+                        - AmazonLinux2023
+                        - AmazonLinux2023GPU
                         type: string
                       id:
                         description: ID of resource

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -127,8 +127,6 @@ spec:
                     enum:
                     - AmazonLinux
                     - AmazonLinuxGPU
-                    - AmazonLinux2023
-                    - AmazonLinux2023GPU
                     type: string
                   id:
                     description: ID of resource

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -127,6 +127,8 @@ spec:
                     enum:
                     - AmazonLinux
                     - AmazonLinuxGPU
+                    - AmazonLinux2023
+                    - AmazonLinux2023GPU
                     type: string
                   id:
                     description: ID of resource
@@ -615,6 +617,8 @@ spec:
                     enum:
                     - AmazonLinux
                     - AmazonLinuxGPU
+                    - AmazonLinux2023
+                    - AmazonLinux2023GPU
                     type: string
                   id:
                     description: ID of resource

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -140,8 +140,6 @@ spec:
                             enum:
                             - AmazonLinux
                             - AmazonLinuxGPU
-                            - AmazonLinux2023
-                            - AmazonLinux2023GPU
                             type: string
                           id:
                             description: ID of resource

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -140,6 +140,8 @@ spec:
                             enum:
                             - AmazonLinux
                             - AmazonLinuxGPU
+                            - AmazonLinux2023
+                            - AmazonLinux2023GPU
                             type: string
                           id:
                             description: ID of resource
@@ -549,6 +551,8 @@ spec:
                             enum:
                             - AmazonLinux
                             - AmazonLinuxGPU
+                            - AmazonLinux2023
+                            - AmazonLinux2023GPU
                             type: string
                           id:
                             description: ID of resource

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -140,6 +140,8 @@ spec:
                         enum:
                         - AmazonLinux
                         - AmazonLinuxGPU
+                        - AmazonLinux2023
+                        - AmazonLinux2023GPU
                         type: string
                       id:
                         description: ID of resource
@@ -620,6 +622,8 @@ spec:
                         enum:
                         - AmazonLinux
                         - AmazonLinuxGPU
+                        - AmazonLinux2023
+                        - AmazonLinux2023GPU
                         type: string
                       id:
                         description: ID of resource


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

With recent changes introduced to support AL2023 EKS lookup https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5517.

This PR fixes the missing CRD changes that prevent users from using the AL2023 feature. While PR #5517 added the AMI lookup logic for Amazon Linux 2023, it missed updating the CRD validation enums, causing validation errors when users try to specify `eksLookupType: "AmazonLinux2023"`.

**What this PR does / why we need it**:

This PR completes the AL2023 support by adding the missing CRD enum values. The original PR #5517 added the backend logic for AL2023 AMI lookup but forgot to update the CRD validation, making the feature unusable. This fix enables users to actually use the AL2023 feature that was intended to be supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Fixes the validation error when users try to use `eksLookupType: "AmazonLinux2023"` in their AWSManagedMachinePool specifications.

**Special notes for your reviewer**:

- This change is backward compatible - existing configurations using `AmazonLinux` and `AmazonLinuxGPU` will continue to work
- The CRDs have been regenerated to include the new enum values
- Both v1beta1 and v1beta2 API versions are updated
- This completes the AL2023 support that was partially implemented in PR #5517

**Changes made**:

- **API Types**: Updated the `EKSOptimizedLookupType` enum in both `api/v1beta1/types.go` and `api/v1beta2/types.go` to include:
  - `AmazonLinux2023`
  - `AmazonLinux2023GPU`
- **CRD Generation**: Regenerated all relevant CRDs to include the new enum values:
  - `infrastructure.cluster.x-k8s.io_awsmachinepools.yaml`
  - `infrastructure.cluster.x-k8s.io_awsmachines.yaml`
  - `infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml`
  - `infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml`

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
🐛 Fix missing CRD validation for Amazon Linux 2023 eksLookupType enum values, completing the AL2023 support introduced in v2.8.
```