### PR TITLE
🌱 Try to fix test flake in which secret is not yet available

### DIFF
--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -913,6 +913,12 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 					},
 				}
 				g.Expect(testEnv.Create(ctx, newBootstrapSecret)).To(Succeed())
+				g.Eventually(func(gomega Gomega) {
+					gomega.Expect(testEnv.Client.Get(ctx, client.ObjectKey{
+						Name:      newBootstrapSecret.Name,
+						Namespace: newBootstrapSecret.Namespace,
+					}, newBootstrapSecret)).To(Succeed())
+				}).Should(Succeed())
 				ms.MachinePool.Spec.Template.Spec.Bootstrap.DataSecretName = ptr.To[string](newBootstrapSecret.Name)
 
 				// Since `AWSMachinePool.status.launchTemplateVersion` isn't set yet,


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

There seems to be one flake that keeps reappearing:

```
=== RUN   TestAWSMachinePoolReconciler/Reconciling_an_AWSMachinePool/ReconcileLaunchTemplate_not_mocked/launch_template_and_ASG_created_from_zero,_then_bootstrap_config_reference_changes
E0624 07:12:01.962501   46441 awsmachinepool_controller.go:341] "failed to reconcile launch template" err="failed to retrieve bootstrap data secret bootstrap-data-new for AWSMachinePool default/test: Secret \"bootstrap-data-new\" not found"
    awsmachinepool_controller_test.go:966: 
        Expected success, but got an error:
            <*errors.withStack | 0xc002129788>: 
            failed to retrieve bootstrap data secret bootstrap-data-new for AWSMachinePool default/test: Secret "bootstrap-data-new" not found
            {
                error: <*errors.withMessage | 0xc0025847c0>{
                    cause: <*errors.StatusError | 0xc0021214a0>{
                        ErrStatus: {
                            TypeMeta: {Kind: "", APIVersion: ""},
                            ListMeta: {
                                SelfLink: "",
                                ResourceVersion: "",
                                Continue: "",
                                RemainingItemCount: nil,
                            },
                            Status: "Failure",
                            Message: "Secret \"bootstrap-data-new\" not found",
                            Reason: "NotFound",
                            Details: {
                                Name: "bootstrap-data-new",
                                Group: "",
                                Kind: "Secret",
                                UID: "",
                                Causes: nil,
                                RetryAfterSeconds: 0,
                            },
                            Code: 404,
                        },
                    },
                    msg: "failed to retrieve bootstrap data secret bootstrap-data-new for AWSMachinePool default/test",
                },
                stack: [0x24c366e, 0x2547151, 0x26e6bbe, 0x26fb374, 0x556854, 0x480101],
            }
```

This change tries to work around by waiting for the `Secret` to be available.

<!-- Enter a description of the change and why this change is needed -->

**Special notes for your reviewer**:

I couldn't reproduce the flake locally, so this is a guess.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
