### PR TITLE
fix: 🐛do not set tags on existing network interfaces when creating ec2 instances

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -623,7 +623,12 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 	}
 
 	if len(i.Tags) > 0 {
-		resources := []string{ec2.ResourceTypeInstance, ec2.ResourceTypeVolume, ec2.ResourceTypeNetworkInterface}
+		resources := []string{ec2.ResourceTypeInstance, ec2.ResourceTypeVolume}
+
+		if len(i.NetworkInterfaces) == 0 {
+			resources = append(resources, ec2.ResourceTypeNetworkInterface)
+		}
+
 		for _, r := range resources {
 			spec := &ec2.TagSpecification{ResourceType: aws.String(r)}
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
When creating an ec2 instance the awsmachine_controller tags existing network interfaces which leads to the creation of ec2 instances failing with the error :  `InvalidParameterValue: You cannot specify tags for network interfaces if there are no network interfaces being created by the request.`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5594

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x ] squashed commits
- [ ] includes documentation
- [x ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue with creation of ec2 instances when specifying an existing network interface
```
