### PR TITLE
:bug: Remove deleted `--short` option for kubectl

### DIFF
--- a/test/helpers/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
+++ b/test/helpers/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
@@ -120,6 +120,6 @@ fi
 echo "* checking binary versions"
 echo "ctr version: " "$(ctr version)"
 echo "kubeadm version: " "$(kubeadm version -o=short)"
-echo "kubectl version: " "$(kubectl version --client=true --short=true)"
+echo "kubectl version: " "$(kubectl version --client=true)"
 echo "kubelet version: " "$(kubelet --version)"
 echo "$${LINE_SEPARATOR}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Per https://github.com/kubernetes/kubernetes/commit/3f07fc3acc9014f33fb9bbde12937b35e3f48c75,
the `--short` option on `kubectl version` has been removed for the 1.35 alpha,
which is being used by the conformance tests.

Calling this flag has caused nightly jobs to fail, because the nodes never proceed after getting an error about the missing argument. See this excerpt from a [failed job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts/1957415637013762048)'s [logs](https://storage.googleapis.com/kubernetes-ci-logs/logs/periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts/1957415637013762048/artifacts/clusters/bootstrap/instances/conformance-rpgbj9/conformance-dxeann-md-0-f4hdd-bpw87/cloud-final.log)

```
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] unpacking registry.k8s.io/kube-scheduler-amd64:v1.35.0-alpha.0.37_17d6c9c551f917 (sha256:8498a55462234612273fccff8289690dcc6aec66b8eda59f7a2fdb4637b6d366)...done
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] registry.k8s.io/kube-scheduler:v1.35.0-alpha.0.37_17d6c9c551f917
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] gcr.io/k8s-staging-ci-images/kube-scheduler:v1.35.0-alpha.0.37_17d6c9c551f917
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] * checking binary versions
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] ctr version:  Client:
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38]   Version:  v1.7.20
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38]   Revision: 8fc6bcff51318944179630522a095cc9dbf9f353
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38]   Go version: go1.21.12
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38]
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] Server:
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38]   Version:  v1.7.20
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38]   Revision: 8fc6bcff51318944179630522a095cc9dbf9f353
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38]   UUID: 0c426acc-2884-4940-bc19-daf65ce4caee
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] kubeadm version:  v1.35.0-alpha.0.37+17d6c9c551f917
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] error: unknown flag: --short
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] See 'kubectl version --help' for usage.
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] kubectl version:
Aug 18 12:41:38 ip-10-0-92-106 cloud-init[1178]: [2025-08-18 12:41:38] kubelet version:  Kubernetes v1.35.0-alpha.0.37+17d6c9c551f917
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
