### PR TITLE
:seedling: Add kind: Metadata to metadata manifests

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 4

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 1
     minor: 10

--- a/test/e2e/data/shared/v1beta1_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1_provider/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 4

--- a/test/e2e/data/shared/v1beta2_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta2_provider/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 4

--- a/test/e2e/data/shared/v1beta2_provider/v2.7/metadata.yaml
+++ b/test/e2e/data/shared/v1beta2_provider/v2.7/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 4


### PR DESCRIPTION
**What type of PR is this?**
/kind support

**What this PR does / why we need it**:
Requirement introduced by https://github.com/kubernetes-sigs/cluster-api/pull/12242 and required by CAPI v1.11 (and thus its clusterctl)

**Release note**:

```release-note
add Metadata kind to metadata
```
