### PR TITLE
🌱 Fix(ignition): Default version only if not storageType UnencryptedUserData

### DIFF
--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -286,9 +286,10 @@ type CloudInit struct {
 // For more information on Ignition configuration, see https://coreos.github.io/butane/specs/
 type Ignition struct {
 	// Version defines which version of Ignition will be used to generate bootstrap data.
+	// Defaults to `2.3` if storageType is set to `ClusterObjectStore`.
+	// It will be ignored if storageType is set to `UnencryptedUserData`, as the userdata defines its own version.
 	//
 	// +optional
-	// +kubebuilder:default="2.3"
 	// +kubebuilder:validation:Enum="2.3";"3.0";"3.1";"3.2";"3.3";"3.4"
 	Version string `json:"version,omitempty"`
 

--- a/api/v1beta2/awsmachine_webhook.go
+++ b/api/v1beta2/awsmachine_webhook.go
@@ -451,7 +451,9 @@ func (*awsMachineWebhook) Default(_ context.Context, obj runtime.Object) error {
 		r.Spec.CloudInit.SecureSecretsBackend = SecretBackendSecretsManager
 	}
 
-	if r.ignitionEnabled() && r.Spec.Ignition.Version == "" {
+	// Defaults the version field if StorageType is not set to `UnencryptedUserData`.
+	// When using `UnencryptedUserData` the version field is ignored because the userdata defines its version itself.
+	if r.ignitionEnabled() && r.Spec.Ignition.Version == "" && r.Spec.Ignition.StorageType != IgnitionStorageTypeOptionUnencryptedUserData {
 		r.Spec.Ignition.Version = DefaultIgnitionVersion
 	}
 	if r.ignitionEnabled() && r.Spec.Ignition.StorageType == "" {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -1001,9 +1001,10 @@ spec:
                         type: array
                     type: object
                   version:
-                    default: "2.3"
-                    description: Version defines which version of Ignition will be
-                      used to generate bootstrap data.
+                    description: |-
+                      Version defines which version of Ignition will be used to generate bootstrap data.
+                      Defaults to `2.3` if storageType is set to `ClusterObjectStore`.
+                      It will be ignored if storageType is set to `UnencryptedUserData`, as the userdata defines its own version.
                     enum:
                     - "2.3"
                     - "3.0"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -822,9 +822,10 @@ spec:
                         type: array
                     type: object
                   version:
-                    default: "2.3"
-                    description: Version defines which version of Ignition will be
-                      used to generate bootstrap data.
+                    description: |-
+                      Version defines which version of Ignition will be used to generate bootstrap data.
+                      Defaults to `2.3` if storageType is set to `ClusterObjectStore`.
+                      It will be ignored if storageType is set to `UnencryptedUserData`, as the userdata defines its own version.
                     enum:
                     - "2.3"
                     - "3.0"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -741,9 +741,10 @@ spec:
                                 type: array
                             type: object
                           version:
-                            default: "2.3"
-                            description: Version defines which version of Ignition
-                              will be used to generate bootstrap data.
+                            description: |-
+                              Version defines which version of Ignition will be used to generate bootstrap data.
+                              Defaults to `2.3` if storageType is set to `ClusterObjectStore`.
+                              It will be ignored if storageType is set to `UnencryptedUserData`, as the userdata defines its own version.
                             enum:
                             - "2.3"
                             - "3.0"

--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -314,7 +314,9 @@ func (*AWSMachinePoolWebhook) Default(ctx context.Context, obj runtime.Object) e
 		r.Spec.DefaultInstanceWarmup.Duration = 300 * time.Second
 	}
 
-	if r.ignitionEnabled() && r.Spec.Ignition.Version == "" {
+	// Defaults the version field if StorageType is not set to `UnencryptedUserData`.
+	// When using `UnencryptedUserData` the version field is ignored because the userdata defines its version itself.
+	if r.ignitionEnabled() && r.Spec.Ignition.Version == "" && r.Spec.Ignition.StorageType != infrav1.IgnitionStorageTypeOptionUnencryptedUserData {
 		r.Spec.Ignition.Version = infrav1.DefaultIgnitionVersion
 	}
 	if r.ignitionEnabled() && r.Spec.Ignition.StorageType == "" {

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -92,14 +92,17 @@ func (s *Service) ReconcileLaunchTemplate(
 	}
 
 	var ignitionStorageType = infrav1.DefaultMachinePoolIgnitionStorageType
-	var ignitionVersion = infrav1.DefaultIgnitionVersion
 	if ignition := ignitionScope.Ignition(); ignition != nil {
 		ignitionStorageType = ignition.StorageType
-		ignitionVersion = ignition.Version
 	}
 
 	var userDataForLaunchTemplate []byte
 	if bootstrapDataFormat == "ignition" && ignitionStorageType == infrav1.IgnitionStorageTypeOptionClusterObjectStore {
+		var ignitionVersion = infrav1.DefaultIgnitionVersion
+		if ignition := ignitionScope.Ignition(); ignition != nil {
+			ignitionVersion = ignition.Version
+		}
+
 		if s3Scope.Bucket() == nil {
 			return errors.New("using Ignition with `AWSMachinePool.spec.ignition.storageType=ClusterObjectStore` " +
 				"requires a cluster wide object storage configured at `AWSCluster.spec.s3Bucket`")


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

The ignition version on AWSMachine's and AWSMachinePool's is not used when having `storageType` set to `UnencryptedUserData`.

Because of that, defaulting to 2.3 could be misleading.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This PR relaxes the defaulting (which happened in openapi and in the webhook) and only defaults via the webhook if the storageType is not set to `UnencryptedUserData`.

This PR also improves the description of the field.

Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable defaulting for .spec.ignition.version when `.spec.ignition.storageType` is set to `UnencryptedUserData`
```
