### PR TITLE
🐛 Fix ignition version defaulting to consider if the storageType gets defaulted itself

### DIFF
--- a/api/v1beta2/awsmachine_webhook.go
+++ b/api/v1beta2/awsmachine_webhook.go
@@ -451,13 +451,13 @@ func (*awsMachineWebhook) Default(_ context.Context, obj runtime.Object) error {
 		r.Spec.CloudInit.SecureSecretsBackend = SecretBackendSecretsManager
 	}
 
+	if r.ignitionEnabled() && r.Spec.Ignition.StorageType == "" {
+		r.Spec.Ignition.StorageType = DefaultIgnitionStorageType
+	}
 	// Defaults the version field if StorageType is not set to `UnencryptedUserData`.
 	// When using `UnencryptedUserData` the version field is ignored because the userdata defines its version itself.
 	if r.ignitionEnabled() && r.Spec.Ignition.Version == "" && r.Spec.Ignition.StorageType != IgnitionStorageTypeOptionUnencryptedUserData {
 		r.Spec.Ignition.Version = DefaultIgnitionVersion
-	}
-	if r.ignitionEnabled() && r.Spec.Ignition.StorageType == "" {
-		r.Spec.Ignition.StorageType = DefaultIgnitionStorageType
 	}
 
 	return nil

--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -314,13 +314,13 @@ func (*AWSMachinePoolWebhook) Default(ctx context.Context, obj runtime.Object) e
 		r.Spec.DefaultInstanceWarmup.Duration = 300 * time.Second
 	}
 
+	if r.ignitionEnabled() && r.Spec.Ignition.StorageType == "" {
+		r.Spec.Ignition.StorageType = infrav1.DefaultMachinePoolIgnitionStorageType
+	}
 	// Defaults the version field if StorageType is not set to `UnencryptedUserData`.
 	// When using `UnencryptedUserData` the version field is ignored because the userdata defines its version itself.
 	if r.ignitionEnabled() && r.Spec.Ignition.Version == "" && r.Spec.Ignition.StorageType != infrav1.IgnitionStorageTypeOptionUnencryptedUserData {
 		r.Spec.Ignition.Version = infrav1.DefaultIgnitionVersion
-	}
-	if r.ignitionEnabled() && r.Spec.Ignition.StorageType == "" {
-		r.Spec.Ignition.StorageType = infrav1.DefaultMachinePoolIgnitionStorageType
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Follow-up fix for

- #5641

We default the version only if storage type is not "unencrypted".

But we default the storage type too if not set.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
