### PR TITLE
🌱 Add make target to generate test-infra prowjobs via CAPI's prowjob-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ YQ := $(TOOLS_BIN_DIR)/yq
 KPROMO := $(TOOLS_BIN_DIR)/kpromo
 RELEASE_NOTES := $(TOOLS_BIN_DIR)/release-notes
 GORELEASER := $(TOOLS_BIN_DIR)/goreleaser
+PROWJOB_GEN := $(TOOLS_BIN_DIR)/prowjob-gen
 
 CLUSTERAWSADM_SRCS := $(call rwildcard,.,cmd/clusterawsadm/*.*)
 
@@ -422,6 +423,14 @@ $(ARTIFACTS):
 generate-test-flavors: $(KUSTOMIZE)  ## Generate test template flavors
 	./hack/gen-test-flavors.sh withoutclusterclass
 	./hack/gen-test-flavors.sh withclusterclass
+
+.PHONY: generate-test-infra-prowjobs
+generate-test-infra-prowjobs: $(PROWJOB_GEN) ## Generates the prowjob configurations in test-infra
+	@if [ -z "${TEST_INFRA_DIR}" ]; then echo "TEST_INFRA_DIR is not set"; exit 1; fi
+	$(PROWJOB_GEN) \
+		-config "$(TEST_INFRA_DIR)/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-prowjob-gen.yaml" \
+		-templates-dir "$(TEST_INFRA_DIR)/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates" \
+		-output-dir "$(TEST_INFRA_DIR)/config/jobs/kubernetes-sigs/cluster-api-provider-aws"
 
 .PHONY: e2e-image
 e2e-image: docker-pull-prerequisites $(TOOLS_BIN_DIR)/start.sh $(TOOLS_BIN_DIR)/restart.sh ## Build an e2e test image

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -106,6 +106,10 @@ KUSTOMIZE := $(BIN_DIR)/kustomize
 $(KUSTOMIZE): $(BIN_DIR) go.mod go.sum # Build kustomize from tools folder.
 	CGO_ENABLED=0 go build -tags=tools -o $@ sigs.k8s.io/kustomize/kustomize/v5
 
+PROWJOB_GEN := $(BIN_DIR)/prowjob-gen
+$(PROWJOB_GEN): $(BIN_DIR) go.mod go.sum
+	go build -tags=tools -o $@ sigs.k8s.io/cluster-api/hack/tools/prowjob-gen
+
 MDBOOK_SHARE := $(SHARE_DIR)/mdbook$(MDBOOK_ARCHIVE_EXT)
 $(MDBOOK_SHARE): ../../versions.mk $(SHARE_DIR)
 	curl -sL -o $(MDBOOK_SHARE) "https://github.com/rust-lang/mdBook/releases/download/$(MDBOOK_VERSION)/mdBook-$(MDBOOK_VERSION)-x86_64-$(RUST_TARGET)$(MDBOOK_ARCHIVE_EXT)"

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -36,6 +36,7 @@ import (
 	_ "sigs.k8s.io/cluster-api/hack/tools/conversion-verifier"
 	_ "sigs.k8s.io/cluster-api/hack/tools/mdbook/embed"
 	_ "sigs.k8s.io/cluster-api/hack/tools/mdbook/releaselink"
+	_ "sigs.k8s.io/cluster-api/hack/tools/prowjob-gen"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kind"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In CAPI and CAPV we added the `prowjob-gen` tool (which lives in https://github.com/kubernetes-sigs/cluster-api/tree/main/hack/tools/prowjob-gen ) which allows generating prowjob configurations in test-infra via templates to ensure consistency and easier addition of jobs for new release branches.

In addition to

- https://github.com/kubernetes/test-infra/pull/35476

* Adds the `prowjob-gen` binary from CAPI.
* Adds a make target to re-generate the prowjob configuration in test-infra
  * Note: requires changes in https://github.com/kubernetes/test-infra/pull/35476 to work

Example usage:

```
$ TEST_INFRA_DIR=../../k8s.io/test-infra make generate-test-infra-prowjobs
hack/tools/bin/prowjob-gen \
                -config "../../k8s.io/test-infra/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-prowjob-gen.yaml" \
                -templates-dir "../../k8s.io/test-infra/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates" \
                -output-dir "../../k8s.io/test-infra/config/jobs/kubernetes-sigs/cluster-api-provider-aws"
I0905 10:49:58.979161   48321 generator.go:127] Deleting file cluster-api-provider-aws-periodics-main.yaml
I0905 10:49:58.979581   48321 generator.go:127] Deleting file cluster-api-provider-aws-periodics-release-2.7.yaml
I0905 10:49:58.979987   48321 generator.go:127] Deleting file cluster-api-provider-aws-periodics-release-2.8.yaml
I0905 10:49:58.980216   48321 generator.go:127] Deleting file cluster-api-provider-aws-periodics-release-2.9.yaml
I0905 10:49:58.980655   48321 generator.go:127] Deleting file cluster-api-provider-aws-presubmits-main.yaml
I0905 10:49:58.981056   48321 generator.go:127] Deleting file cluster-api-provider-aws-presubmits-release-2.7.yaml
I0905 10:49:58.981386   48321 generator.go:127] Deleting file cluster-api-provider-aws-presubmits-release-2.8.yaml
I0905 10:49:58.981661   48321 generator.go:127] Deleting file cluster-api-provider-aws-presubmits-release-2.9.yaml
I0905 10:49:58.981717   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-periodics.yaml.tpl" for branch "main"
I0905 10:49:58.981898   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-periodics.yaml.tpl" for branch "release-2.7"
I0905 10:49:58.981981   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-periodics.yaml.tpl" for branch "release-2.8"
I0905 10:49:58.982069   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-periodics.yaml.tpl" for branch "release-2.9"
I0905 10:49:58.982148   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-presubmits.yaml.tpl" for branch "main"
I0905 10:49:58.982293   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-presubmits.yaml.tpl" for branch "release-2.7"
I0905 10:49:58.982427   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-presubmits.yaml.tpl" for branch "release-2.8"
I0905 10:49:58.982545   48321 generator.go:84] Executing and writing template "cluster-api-provider-aws-presubmits.yaml.tpl" for branch "release-2.9"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
