### PR TITLE
🌱 Upgrade Go version to 1.24

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v5

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 10m
-  go: "1.22"
+  go: "1.24"
   allow-parallel-runners: true
 
 linters:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 # https://suva.sh/posts/well-documented-makefiles
 
 # Go
-GO_VERSION ?=1.23.9
+GO_VERSION ?=1.24.7
 GO_CONTAINER_IMAGE ?= golang:$(GO_VERSION)
 
 # Directories.

--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:4e830b673791d5595719bc6c4ca62dce3746b4e20d749e45004254bc6ef0a140' # v20250116-2a05ea7e3d go 1.23.4
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:63840f133e0dfeea0af9ef391210da7fab9d2676172e2967fccab0cd6110c4e7' # v20250513-9264efb079 go 1.24.3
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:4e830b673791d5595719bc6c4ca62dce3746b4e20d749e45004254bc6ef0a140' # v20250116-2a05ea7e3d go 1.23.4
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:63840f133e0dfeea0af9ef391210da7fab9d2676172e2967fccab0cd6110c4e7' # v20250513-9264efb079 go 1.24.3
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/v2
 
-go 1.23.1
+go 1.24.0
 
 require (
 	github.com/alessio/shellescape v1.4.2

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -45,7 +45,8 @@ ifeq ($(OS), windows)
 	MDBOOK_EXTRACT_COMMAND := unzip -d /tmp
 endif
 
-GOLANGCI_LINT_VERSION := v1.55.2
+# Use a golangci-lint built with Go >= 1.24 to match repo go.mod
+GOLANGCI_LINT_VERSION := v1.60.3
 ## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------


### PR DESCRIPTION
**What type of PR is this?**
/kind support

**What this PR does / why we need it**:
- Update go.mod and hack/tools/go.mod to Go 1.24.7
- Update Makefile GO_VERSION to 1.24.7
- Update GitHub Actions workflow to use Go 1.24
- Update golangci-kal.yml to use Go 1.24
- Upgrade golangci-lint to v1.60.3 for Go 1.24 compatibility

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Go to v1.24
```
