### PR TITLE
🐛 Fix AWSManagedClusterTemplate short name

### DIFF
--- a/api/v1beta2/awsmanagedclustertemplate_types.go
+++ b/api/v1beta2/awsmanagedclustertemplate_types.go
@@ -26,7 +26,7 @@ type AWSManagedClusterTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=awsmanagedclustertemplates,scope=Namespaced,categories=cluster-api,shortName=amct
+// +kubebuilder:resource:path=awsmanagedclustertemplates,scope=Namespaced,categories=cluster-api,shortName=awsmct
 // +kubebuilder:storageversion
 
 // AWSManagedClusterTemplate is the Schema for the AWSManagedClusterTemplates API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedclustertemplates.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: AWSManagedClusterTemplateList
     plural: awsmanagedclustertemplates
     shortNames:
-    - amct
+    - awsmct
     singular: awsmanagedclustertemplate
   scope: Namespaced
   versions:


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Fix AWSManagedClusterTemplate short name. The current short name conflicts with CAPZ, making it impossible to install the latest CAPA version on the same management cluster as CAPZ.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required
The short name for AWSManagedClusterTemplate has changed from amct to awsmct. If you have any automation that relies on the short name it will needf to be updated.
```
