### PR TITLE
✨ Skip AWSCluster reconciliation when owner Cluster is being deleted

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -312,6 +312,11 @@ func (r *AWSClusterReconciler) reconcileLoadBalancer(ctx context.Context, cluste
 }
 
 func (r *AWSClusterReconciler) reconcileNormal(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
+	if !clusterScope.Cluster.DeletionTimestamp.IsZero() {
+		clusterScope.Info("Cluster owning the AWSCluster is being deleted, skipping reconciliation")
+		return reconcile.Result{}, nil
+	}
+
 	clusterScope.Info("Reconciling AWSCluster")
 
 	awsCluster := clusterScope.AWSCluster

--- a/controllers/awscluster_controller_unit_test.go
+++ b/controllers/awscluster_controller_unit_test.go
@@ -73,6 +73,12 @@ func TestAWSClusterReconcilerReconcile(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name:         "Should not Reconcile if owner cluster is deleted",
+			awsCluster:   &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{GenerateName: "aws-test-"}},
+			ownerCluster: &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{GenerateName: "capi-test-", DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+			expectError:  false,
+		},
+		{
 			name:        "Should Reconcile successfully if no AWSCluster found",
 			expectError: false,
 		},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When a `Cluster` CR is deleted, CAPA takes care of deleting the dependant CRs in an specific order, i.e. first the worker nodes, then the control plane, and finally the infra cluster CR `AWSCluster`. Removing everything can take a little while, depending on the size of the cluster. While things are getting removed, the `awscluster_controllerl` keeps reconciling the `AWSCluster`, trying to keep the AWS resources such as the VPC or subnets up to date. But these resources will be removed shortly. 
With the changes on this PR, we are skipping the reconciliation of the `AWSCluster` when the owner `Cluster` has been set for deletion. That way we skip reconciliation loops done on resources that are about to be removed, saving CAPA resources and AWS API calls.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip AWSCluster reconciliation when owner Cluster is being deleted
```
