### PR TITLE
🐛 fix: backwards compatibility for AWS service endpoint resolution

### DIFF
--- a/pkg/cloud/endpoints/endpoints_test.go
+++ b/pkg/cloud/endpoints/endpoints_test.go
@@ -19,28 +19,60 @@ package endpoints
 import (
 	"errors"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseFlags(t *testing.T) {
 	testCases := []struct {
-		name          string
-		flagToParse   string
-		expectedError error
+		name                        string
+		flagToParse                 string
+		expectedError               error
+		expectedServiceEndpointsMap map[string]serviceEndpoint
 	}{
 		{
-			name:          "no configuration",
-			flagToParse:   "",
-			expectedError: nil,
+			name:                        "no configuration",
+			flagToParse:                 "",
+			expectedServiceEndpointsMap: make(map[string]serviceEndpoint),
 		},
 		{
-			name:          "single region, single service",
-			flagToParse:   "us-iso:ec2=https://localhost:8080",
-			expectedError: nil,
+			name:                        "single region, single service",
+			flagToParse:                 "us-iso:ec2=https://localhost:8080",
+			expectedServiceEndpointsMap: map[string]serviceEndpoint{"EC2": {ServiceID: "EC2", URL: "https://localhost:8080", SigningRegion: "us-iso"}},
 		},
 		{
-			name:          "single region, multiple services",
-			flagToParse:   "us-iso:ec2=https://localhost:8080,sts=https://elbhost:8080",
-			expectedError: nil,
+			name:        "single region, multiple services with v1 service IDs",
+			flagToParse: "us-iso:s3=https://s3.com,elasticloadbalancing=https://elb.com,ec2=https://ec2.com,tagging=https://tagging.com,sqs=https://sqs.com,events=https://events.com,eks=https://eks.com,ssm=https://ssm.com,sts=https://sts.com,secretsmanager=https://secretmanager.com",
+			expectedServiceEndpointsMap: map[string]serviceEndpoint{
+				"EC2":                         {ServiceID: "EC2", URL: "https://ec2.com", SigningRegion: "us-iso"},
+				"EKS":                         {ServiceID: "EKS", URL: "https://eks.com", SigningRegion: "us-iso"},
+				"Elastic Load Balancing":      {ServiceID: "Elastic Load Balancing", URL: "https://elb.com", SigningRegion: "us-iso"},
+				"Elastic Load Balancing v2":   {ServiceID: "Elastic Load Balancing v2", URL: "https://elb.com", SigningRegion: "us-iso"},
+				"EventBridge":                 {ServiceID: "EventBridge", URL: "https://events.com", SigningRegion: "us-iso"},
+				"Resource Groups Tagging API": {ServiceID: "Resource Groups Tagging API", URL: "https://tagging.com", SigningRegion: "us-iso"},
+				"S3":                          {ServiceID: "S3", URL: "https://s3.com", SigningRegion: "us-iso"},
+				"SQS":                         {ServiceID: "SQS", URL: "https://sqs.com", SigningRegion: "us-iso"},
+				"SSM":                         {ServiceID: "SSM", URL: "https://ssm.com", SigningRegion: "us-iso"},
+				"STS":                         {ServiceID: "STS", URL: "https://sts.com", SigningRegion: "us-iso"},
+				"Secrets Manager":             {ServiceID: "Secrets Manager", URL: "https://secretmanager.com", SigningRegion: "us-iso"},
+			},
+		},
+		{
+			name:        "single region, multiple services with v2 service IDs",
+			flagToParse: "us-iso:S3=https://s3.com,Elastic Load Balancing=https://elb.com,Elastic Load Balancing v2=https://elbv2.com,EC2=https://ec2.com,Resource Groups Tagging API=https://tagging.com,SQS=https://sqs.com,EventBridge=https://events.com,EKS=https://eks.com,SSM=https://ssm.com,STS=https://sts.com,Secrets Manager=https://secretmanager.com",
+			expectedServiceEndpointsMap: map[string]serviceEndpoint{
+				"EC2":                         {ServiceID: "EC2", URL: "https://ec2.com", SigningRegion: "us-iso"},
+				"EKS":                         {ServiceID: "EKS", URL: "https://eks.com", SigningRegion: "us-iso"},
+				"Elastic Load Balancing":      {ServiceID: "Elastic Load Balancing", URL: "https://elb.com", SigningRegion: "us-iso"},
+				"Elastic Load Balancing v2":   {ServiceID: "Elastic Load Balancing v2", URL: "https://elbv2.com", SigningRegion: "us-iso"},
+				"EventBridge":                 {ServiceID: "EventBridge", URL: "https://events.com", SigningRegion: "us-iso"},
+				"Resource Groups Tagging API": {ServiceID: "Resource Groups Tagging API", URL: "https://tagging.com", SigningRegion: "us-iso"},
+				"S3":                          {ServiceID: "S3", URL: "https://s3.com", SigningRegion: "us-iso"},
+				"SQS":                         {ServiceID: "SQS", URL: "https://sqs.com", SigningRegion: "us-iso"},
+				"SSM":                         {ServiceID: "SSM", URL: "https://ssm.com", SigningRegion: "us-iso"},
+				"STS":                         {ServiceID: "STS", URL: "https://sts.com", SigningRegion: "us-iso"},
+				"Secrets Manager":             {ServiceID: "Secrets Manager", URL: "https://secretmanager.com", SigningRegion: "us-iso"},
+			},
 		},
 		{
 			name:          "single region, duplicate service",
@@ -56,6 +88,10 @@ func TestParseFlags(t *testing.T) {
 			name:          "multiples regions",
 			flagToParse:   "us-iso:ec2=https://localhost:8080,sts=https://elbhost:8080;gb-iso:ec2=https://localhost:8080,sts=https://elbhost:8080",
 			expectedError: nil,
+			expectedServiceEndpointsMap: map[string]serviceEndpoint{
+				"EC2": {ServiceID: "EC2", URL: "https://localhost:8080", SigningRegion: "gb-iso"},
+				"STS": {ServiceID: "STS", URL: "https://elbhost:8080", SigningRegion: "gb-iso"},
+			},
 		},
 		{
 			name:          "invalid config",
@@ -66,10 +102,20 @@ func TestParseFlags(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			defer t.Cleanup(func() {
+				serviceEndpointsMap = make(map[string]serviceEndpoint)
+			})
+
 			err := ParseFlag(tc.flagToParse)
 
 			if !errors.Is(err, tc.expectedError) {
 				t.Fatalf("did not expect correct error: got %v, expected %v", err, tc.expectedError)
+			}
+
+			if err == nil {
+				if !cmp.Equal(serviceEndpointsMap, tc.expectedServiceEndpointsMap) {
+					t.Fatalf("expected serviceEndpointsMap: %#v, but got: %#v", tc.expectedServiceEndpointsMap, serviceEndpointsMap)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

In AWS SDKv1, each service exports a constant `EndpointsID` to look up the custom service endpoint, for example, see ref [[0]](https://github.com/aws/aws-sdk-go/blob/070853e88d22854d2355c2543d0958a5f76ad407/service/resourcegroupstaggingapi/service.go#L33-L34). In AWS SDKv2, these contants are no longer available. Thus, for backwards compatibility, we copy those constants from the SDKv1 and map them to the corresponding `ServiceID` in SDK v2.

Additionally, in AWS SDKv1, `elb` and `elbv2` uses the same identifier (i.e. same EndpointsID), thus the same custom endpoint [[1]](https://github.com/aws/aws-sdk-go/blob/070853e88d22854d2355c2543d0958a5f76ad407/service/elbv2/service.go#L32-L33) [[2]](https://github.com/aws/aws-sdk-go/blob/070853e88d22854d2355c2543d0958a5f76ad407/service/elb/service.go#L32-L33). For backwards compatibility, if `elbv2` endpoint is undefined, `elbv2` endpoint resolver should fall back to `elb` endpoint if any.

This also fixes the bug where CAPA does not recognize services that define its `serviceID` with more than 1 word due to the incorrect assumption [endpoints.go#L90-L94](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/88cb4b92b1a76591623e9d5ef347bfdc22010622/pkg/cloud/endpoints/endpoints.go#L90-L94)). The services are:

- Elastic Load Balancing
- Elastic Load Balancing v2
- Resource Groups Tagging API
- EventBridge
- Secrets Manager


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5670 

**Special notes for your reviewer**:


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ensure custom service endpoints for supported AWS services are properly selected by
both AWS SDKv2 and SDKv1 service ID (for backwards compatibility) 
```
