### PR TITLE
🌱 Log desired AMI architecture and owner ID on errors

### DIFF
--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -213,10 +213,10 @@ func DefaultAMILookup(ec2Client common.EC2API, ownerID, baseOS, kubernetesVersio
 
 	out, err := ec2Client.DescribeImages(context.TODO(), describeImageInput)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to find ami: %q", amiName)
+		return nil, errors.Wrapf(err, "failed to find AMI with name %q, architecture %q, ownerID %q", amiName, architecture, ownerID)
 	}
 	if out == nil || len(out.Images) == 0 {
-		return nil, errors.Errorf("found no AMIs with the name: %q", amiName)
+		return nil, errors.Errorf("found no AMIs with name %q, architecture %q, ownerID %q", amiName, architecture, ownerID)
 	}
 	latestImage, err := GetLatestImage(out.Images)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

No `/kind` label matches.

**What this PR does / why we need it**:

Users shouldn't wonder why an AMI can't be found even though it's visible in the console. The architecture can make a difference (`x86_64` vs. `arm64`), for instance. Also, the AWS account is important information for users to check why the AMI isn't found.


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Log desired AMI architecture and owner ID on errors
```
