### PR TITLE
🌱 Bump cloud build timeout to 2h

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 3000s
+timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 3000s
+timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Created this from: https://github.com/kubernetes/test-infra/pull/35678#issuecomment-3390523469

**What type of PR is this?**

/kind support
**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**

Currently facing timeout issues
```
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
ERROR: (gcloud.builds.submit) build ef58c2b2-9e25-4987-9c79-97e2ba87f0a3 completed with status "TIMEOUT"
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cluster-api-provider-aws-push-images/1976637049523933184#

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
