### PR TITLE
✨ Add support for multiple instance types in AWSManagedMachinePool

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -940,10 +940,9 @@ spec:
                   InstanceTypes specifies a list of AWS instance types for the node group.
                   The order of instance types specified determines priority of picking that instance type.
                   This is also influenced by the CapacityType. For On-Demand capacity, the allocation strategy
-                  uses the order of instance types to determine which instance type to use first when fulfilling capacity.
+                  uses the order of instance types to determine which instance type to use first when fulfilling capacity  for ex; c5.large, c4.large, and c3.large .
                   See AWS documentation https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
                   for more information.
-                  At most one of InstanceType or InstanceTypes may be specified.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -933,7 +933,7 @@ spec:
               instanceType:
                 description: |-
                   InstanceType specifies the AWS instance type.
-                  This field is deprecated. Use InstanceTypes instead.
+                  Deprecated: Use InstanceTypes instead.
                 type: string
               instanceTypes:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -931,15 +931,19 @@ spec:
                   name of the managed machine pool.
                 type: string
               instanceType:
-                description: InstanceType specifies the AWS instance type
+                description: |-
+                  InstanceType specifies the AWS instance type.
+                  This field is deprecated. Use InstanceTypes instead.
                 type: string
               instanceTypes:
                 description: |-
                   InstanceTypes specifies a list of AWS instance types for the node group.
-                  When specified, this allows using multiple instance types which enhances
-                  the availability of Spot instances.
+                  The order of instance types specified determines priority of picking that instance type.
+                  This is also influenced by the CapacityType. For On-Demand capacity, the allocation strategy
+                  uses the order of instance types to determine which instance type to use first when fulfilling capacity.
+                  See AWS documentation https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
+                  for more information.
                   At most one of InstanceType or InstanceTypes may be specified.
-                  See https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -933,6 +933,16 @@ spec:
               instanceType:
                 description: InstanceType specifies the AWS instance type
                 type: string
+              instanceTypes:
+                description: |-
+                  InstanceTypes specifies a list of AWS instance types for the node group.
+                  When specified, this allows using multiple instance types which enhances
+                  the availability of Spot instances.
+                  At most one of InstanceType or InstanceTypes may be specified.
+                  See https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
+                items:
+                  type: string
+                type: array
               labels:
                 additionalProperties:
                   type: string

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -733,6 +733,7 @@ func autoConvert_v1beta2_AWSManagedMachinePoolSpec_To_v1beta1_AWSManagedMachineP
 	out.Taints = *(*Taints)(unsafe.Pointer(&in.Taints))
 	out.DiskSize = (*int32)(unsafe.Pointer(in.DiskSize))
 	out.InstanceType = (*string)(unsafe.Pointer(in.InstanceType))
+	// WARNING: in.InstanceTypes requires manual conversion: does not exist in peer-type
 	out.Scaling = (*ManagedMachinePoolScaling)(unsafe.Pointer(in.Scaling))
 	out.RemoteAccess = (*ManagedRemoteAccess)(unsafe.Pointer(in.RemoteAccess))
 	out.ProviderIDList = *(*[]string)(unsafe.Pointer(&in.ProviderIDList))

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -188,7 +188,6 @@ type AWSManagedMachinePoolSpec struct {
 	// uses the order of instance types to determine which instance type to use first when fulfilling capacity.
 	// See AWS documentation https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
 	// for more information.
-	// At most one of InstanceType or InstanceTypes may be specified.
 	// +optional
 	InstanceTypes []string `json:"instanceTypes,omitempty"`
 

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -180,6 +180,14 @@ type AWSManagedMachinePoolSpec struct {
 	// +optional
 	InstanceType *string `json:"instanceType,omitempty"`
 
+	// InstanceTypes specifies a list of AWS instance types for the node group.
+	// When specified, this allows using multiple instance types which enhances
+	// the availability of Spot instances.
+	// At most one of InstanceType or InstanceTypes may be specified.
+	// See https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
+	// +optional
+	InstanceTypes []string `json:"instanceTypes,omitempty"`
+
 	// Scaling specifies scaling for the ASG behind this pool
 	// +optional
 	Scaling *ManagedMachinePoolScaling `json:"scaling,omitempty"`

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -177,8 +177,9 @@ type AWSManagedMachinePoolSpec struct {
 	DiskSize *int32 `json:"diskSize,omitempty"`
 
 	// InstanceType specifies the AWS instance type.
-	// This field is deprecated. Use InstanceTypes instead.
+	// Deprecated: Use InstanceTypes instead.
 	// +optional
+	// +kubebuilder:validation:Deprecated
 	InstanceType *string `json:"instanceType,omitempty"`
 
 	// InstanceTypes specifies a list of AWS instance types for the node group.

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -176,15 +176,18 @@ type AWSManagedMachinePoolSpec struct {
 	// +optional
 	DiskSize *int32 `json:"diskSize,omitempty"`
 
-	// InstanceType specifies the AWS instance type
+	// InstanceType specifies the AWS instance type.
+	// This field is deprecated. Use InstanceTypes instead.
 	// +optional
 	InstanceType *string `json:"instanceType,omitempty"`
 
 	// InstanceTypes specifies a list of AWS instance types for the node group.
-	// When specified, this allows using multiple instance types which enhances
-	// the availability of Spot instances.
+	// The order of instance types specified determines priority of picking that instance type.
+	// This is also influenced by the CapacityType. For On-Demand capacity, the allocation strategy
+	// uses the order of instance types to determine which instance type to use first when fulfilling capacity.
+	// See AWS documentation https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
+	// for more information.
 	// At most one of InstanceType or InstanceTypes may be specified.
-	// See https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
 	// +optional
 	InstanceTypes []string `json:"instanceTypes,omitempty"`
 

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -185,7 +185,7 @@ type AWSManagedMachinePoolSpec struct {
 	// InstanceTypes specifies a list of AWS instance types for the node group.
 	// The order of instance types specified determines priority of picking that instance type.
 	// This is also influenced by the CapacityType. For On-Demand capacity, the allocation strategy
-	// uses the order of instance types to determine which instance type to use first when fulfilling capacity.
+	// uses the order of instance types to determine which instance type to use first when fulfilling capacity  for ex; c5.large, c4.large, and c3.large .
 	// See AWS documentation https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
 	// for more information.
 	// +optional

--- a/exp/api/v1beta2/awsmanagedmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_webhook.go
@@ -200,6 +200,11 @@ func (*awsManagedMachinePoolWebhook) ValidateCreate(_ context.Context, obj runti
 
 	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
 
+	// Log deprecation warning for InstanceType field
+	if r.Spec.InstanceType != nil {
+		mmpLog.Info("spec.instanceType is deprecated, use spec.instanceTypes instead", "managed-machine-pool", klog.KObj(r))
+	}
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}

--- a/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
@@ -155,6 +155,37 @@ func TestAWSManagedMachinePoolValidateCreate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "both instanceType and instanceTypes are specified",
+			pool: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-4",
+					InstanceTypes:    []string{"m5.xlarge", "m5.2xlarge"},
+					InstanceType:     ptr.To("m5.xlarge"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "only instanceTypes is accepted",
+			pool: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-5",
+					InstanceTypes:    []string{"m5.xlarge", "m5.2xlarge"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "only instanceType is accepted",
+			pool: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-6",
+					InstanceType:     ptr.To("m5.xlarge"),
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -692,6 +723,114 @@ func TestAWSManagedMachinePoolValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "adding instanceType is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceType:     ptr.To("m5.xlarge"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing instanceType is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceType:     ptr.To("m5.xlarge"),
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing instanceType is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceType:     ptr.To("m5.xlarge"),
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceType:     ptr.To("m5.2xlarge"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding instanceTypes is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceTypes:    []string{"m5.xlarge", "m5.2xlarge"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "removing instanceTypes is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceTypes:    []string{"m5.xlarge", "m5.2xlarge"},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing instanceTypes is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceTypes:    []string{"m5.xlarge", "m5.2xlarge"},
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceTypes:    []string{"m5.xlarge", "m6.xlarge"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adding both instanceType and instanceTypes is rejected",
+			old: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+				},
+			},
+			new: &AWSManagedMachinePool{
+				Spec: AWSManagedMachinePoolSpec{
+					EKSNodegroupName: "eks-node-group-1",
+					InstanceType:     ptr.To("m5.xlarge"),
+					InstanceTypes:    []string{"m5.xlarge", "m6.xlarge"},
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -532,6 +532,11 @@ func (in *AWSManagedMachinePoolSpec) DeepCopyInto(out *AWSManagedMachinePoolSpec
 		*out = new(string)
 		**out = **in
 	}
+	if in.InstanceTypes != nil {
+		in, out := &in.InstanceTypes, &out.InstanceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Scaling != nil {
 		in, out := &in.Scaling, &out.Scaling
 		*out = new(ManagedMachinePoolScaling)

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -231,7 +231,11 @@ func (s *NodegroupService) createNodegroup(ctx context.Context) (*ekstypes.Nodeg
 	if managedPool.DiskSize != nil {
 		input.DiskSize = managedPool.DiskSize
 	}
-	if managedPool.InstanceType != nil {
+	// Support both InstanceTypes (preferred for multiple types) and InstanceType (for single type)
+	// Webhook validation ensures they are mutually exclusive
+	if len(managedPool.InstanceTypes) > 0 {
+		input.InstanceTypes = managedPool.InstanceTypes
+	} else if managedPool.InstanceType != nil {
 		input.InstanceTypes = []string{aws.ToString(managedPool.InstanceType)}
 	}
 	if len(managedPool.Taints) > 0 {

--- a/test-awsmanagedmachinepool.yaml
+++ b/test-awsmanagedmachinepool.yaml
@@ -1,0 +1,39 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedMachinePool
+metadata:
+  name: test-pool-multiple-instance-types
+  namespace: default
+spec:
+  eksNodegroupName: test-nodegroup
+  # Use instanceTypes (plural) to specify multiple instance types
+  # This enhances availability when using Spot instances
+  instanceTypes:
+    - t3.medium
+    - t3a.medium
+    - t2.medium
+  capacityType: spot
+  scaling:
+    minSize: 1
+    maxSize: 10
+  updateConfig:
+    maxUnavailable: 1
+  tags:
+    usage: test
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedMachinePool
+metadata:
+  name: test-pool-single-instance-type
+  namespace: default
+spec:
+  eksNodegroupName: test-nodegroup-single
+  # Use instanceType (singular) for a single instance type (backward compatible)
+  instanceType: t3.medium
+  capacityType: on-demand
+  scaling:
+    minSize: 1
+    maxSize: 5
+  updateConfig:
+    maxUnavailable: 1
+  tags:
+    usage: test


### PR DESCRIPTION
**What type of PR is this?**
```
/kind feature
```

**What this PR does / why we need it**:

This PR adds support for specifying multiple instance types in `AWSManagedMachinePool` by introducing a new `instanceTypes` field. This enhancement improves availability, especially when using Spot instances with EKS Managed Node Groups.

Key changes:
- Added new `instanceTypes` (plural) field to specify a list of instance types
- Retained existing `instanceType` (singular) field for backward compatibility
- Implemented webhook validation to ensure mutual exclusivity between the two fields
- Added conversion logic between v1beta1 and v1beta2 API versions
- Enhanced launch template validation to reject both fields when launch template is specified

**Which issue(s) this PR fixes**:
Fixes #3585

**Special notes for your reviewer**:
- `instanceType` and `instanceTypes` are mutually exclusive, enforced by webhook validation
- When converting v1beta2 `instanceTypes` to v1beta1, the first element is used as `instanceType`
- Annotation-based conversion data is utilized to preserve state during version conversions
- When launch template is specified, both `instanceType` and `instanceTypes` are rejected, consistent with existing validation

**Release note**:
```release-note
✨ AWSManagedMachinePool now supports specifying multiple instance types via the new `instanceTypes` field, enhancing Spot instance availability. The existing `instanceType` field remains supported for backward compatibility.
```