### PR TITLE
🌱 Drop unused conversion functions

### DIFF
--- a/controlplane/eks/api/v1beta1/conversion.go
+++ b/controlplane/eks/api/v1beta1/conversion.go
@@ -20,8 +20,6 @@ import (
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
-	infrav1beta1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
@@ -228,36 +226,6 @@ func (r *AWSManagedControlPlaneList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*ekscontrolplanev1.AWSManagedControlPlaneList)
 
 	return Convert_v1beta2_AWSManagedControlPlaneList_To_v1beta1_AWSManagedControlPlaneList(src, r, nil)
-}
-
-// Convert_v1beta1_NetworkSpec_To_v1beta2_NetworkSpec is a conversion function.
-func Convert_v1beta1_NetworkSpec_To_v1beta2_NetworkSpec(in *infrav1beta1.NetworkSpec, out *infrav1.NetworkSpec, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta1_NetworkSpec_To_v1beta2_NetworkSpec(in, out, s)
-}
-
-// Convert_v1beta2_NetworkSpec_To_v1beta1_NetworkSpec is a generated conversion function.
-func Convert_v1beta2_NetworkSpec_To_v1beta1_NetworkSpec(in *infrav1.NetworkSpec, out *infrav1beta1.NetworkSpec, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta2_NetworkSpec_To_v1beta1_NetworkSpec(in, out, s)
-}
-
-// Convert_v1beta1_NetworkStatus_To_v1beta2_NetworkStatus is a conversion function.
-func Convert_v1beta1_NetworkStatus_To_v1beta2_NetworkStatus(in *infrav1beta1.NetworkStatus, out *infrav1.NetworkStatus, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta1_NetworkStatus_To_v1beta2_NetworkStatus(in, out, s)
-}
-
-// Convert_v1beta2_NetworkStatus_To_v1beta1_NetworkStatus is a conversion function.
-func Convert_v1beta2_NetworkStatus_To_v1beta1_NetworkStatus(in *infrav1.NetworkStatus, out *infrav1beta1.NetworkStatus, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta2_NetworkStatus_To_v1beta1_NetworkStatus(in, out, s)
-}
-
-// Convert_v1beta1_Bastion_To_v1beta2_Bastion is a generated conversion function.
-func Convert_v1beta1_Bastion_To_v1beta2_Bastion(in *infrav1beta1.Bastion, out *infrav1.Bastion, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta1_Bastion_To_v1beta2_Bastion(in, out, s)
-}
-
-// Convert_v1beta2_Bastion_To_v1beta1_Bastion is a generated conversion function.
-func Convert_v1beta2_Bastion_To_v1beta1_Bastion(in *infrav1.Bastion, out *infrav1beta1.Bastion, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta2_Bastion_To_v1beta1_Bastion(in, out, s)
 }
 
 func Convert_v1beta1_AWSManagedControlPlaneSpec_To_v1beta2_AWSManagedControlPlaneSpec(in *AWSManagedControlPlaneSpec, out *ekscontrolplanev1.AWSManagedControlPlaneSpec, s apiconversion.Scope) error {

--- a/exp/api/v1beta1/conversion.go
+++ b/exp/api/v1beta1/conversion.go
@@ -20,8 +20,6 @@ import (
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
-	infrav1beta1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
@@ -228,26 +226,6 @@ func (r *AWSFargateProfileList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*expinfrav1.AWSFargateProfileList)
 
 	return Convert_v1beta2_AWSFargateProfileList_To_v1beta1_AWSFargateProfileList(src, r, nil)
-}
-
-// Convert_v1beta1_AMIReference_To_v1beta2_AMIReference converts the v1beta1 AMIReference receiver to a v1beta2 AMIReference.
-func Convert_v1beta1_AMIReference_To_v1beta2_AMIReference(in *infrav1beta1.AMIReference, out *infrav1.AMIReference, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta1_AMIReference_To_v1beta2_AMIReference(in, out, s)
-}
-
-// Convert_v1beta2_AMIReference_To_v1beta1_AMIReference converts the v1beta2 AMIReference receiver to a v1beta1 AMIReference.
-func Convert_v1beta2_AMIReference_To_v1beta1_AMIReference(in *infrav1.AMIReference, out *infrav1beta1.AMIReference, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta2_AMIReference_To_v1beta1_AMIReference(in, out, s)
-}
-
-// Convert_v1beta2_Instance_To_v1beta1_Instance is a conversion function.
-func Convert_v1beta2_Instance_To_v1beta1_Instance(in *infrav1.Instance, out *infrav1beta1.Instance, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta2_Instance_To_v1beta1_Instance(in, out, s)
-}
-
-// Convert_v1beta1_Instance_To_v1beta2_Instance is a conversion function.
-func Convert_v1beta1_Instance_To_v1beta2_Instance(in *infrav1beta1.Instance, out *infrav1.Instance, s apiconversion.Scope) error {
-	return infrav1beta1.Convert_v1beta1_Instance_To_v1beta2_Instance(in, out, s)
 }
 
 // Convert_v1beta2_AWSLaunchTemplate_To_v1beta1_AWSLaunchTemplate converts the v1beta2 AWSLaunchTemplate receiver to a v1beta1 AWSLaunchTemplate.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes unused conversion functions in favor of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5739

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
