### PR TITLE
🌱 e2e: fix panic when dumping CloudTrail logs

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -919,6 +919,7 @@ func DumpCloudTrailEvents(e2eCtx *E2EContext) {
 		page, err := paginator.NextPage(context.TODO())
 		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "Couldn't get AWS CloudTrail events: err=%v\n", err)
+			break
 		}
 		events = append(events, page.Events...)
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Periodic e2e main shows this panic:

https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-aws#periodic-e2e-main

Example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-aws-e2e/1990331610909642752

```
------------------------------
[SynchronizedAfterSuite] PASSED [0.000 seconds]
[SynchronizedAfterSuite] 
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/suites/unmanaged/unmanaged_suite_test.go:57
------------------------------
[SynchronizedAfterSuite] [PANICKED] [1751.284 seconds]
[SynchronizedAfterSuite] 
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/suites/unmanaged/unmanaged_suite_test.go:57
  Timeline >>
  INFO: Creating log watcher for controller capa-system/capa-controller-manager, pod capa-controller-manager-6dbb98f7b5-mplkd, container manager
  Folder created for eks clusters: "/logs/artifacts/clusters/bootstrap/aws-resources"
  Couldn't get AWS CloudTrail events: err=operation error CloudTrail: LookupEvents, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: e57af8dc-1865-447d-8509-c13cc407926f, api error ThrottlingException: Rate exceeded
  [PANICKED] in [SynchronizedAfterSuite] - /usr/local/go/src/runtime/panic.go:262 @ 11/17/25 09:17:28.535
  << Timeline
  [PANICKED] Test Panicked
  In [SynchronizedAfterSuite] at: /usr/local/go/src/runtime/panic.go:262 @ 11/17/25 09:17:28.535
attachment
  runtime error: invalid memory address or nil pointer dereference
  Full Stack Trace
    sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared.DumpCloudTrailEvents(0xc001089400)
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/aws.go:923 +0x345
    sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared.Node1AfterSuite(0xc001089400)
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/suite.go:287 +0x68
    sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/suites/unmanaged.init.func12()
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/suites/unmanaged/unmanaged_suite_test.go:62 +0x1a
------------------------------
[ReportAfterSuite] PASSED [0.028 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
------------------------------
Summarizing 1 Failure:
  [PANICKED!] [SynchronizedAfterSuite] 
  /usr/local/go/src/runtime/panic.go:262
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
