### PR TITLE
:bug: Default AWSMachine in admission controller instead of during reconciliation as it's not allowed to update the `awsmachine.spec` field after the initial creation

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -190,7 +190,6 @@ func (t Template) ControllersPolicy() *iamv1.PolicyDocument {
 				"ec2:DeleteLaunchTemplate",
 				"ec2:DeleteLaunchTemplateVersions",
 				"ec2:DescribeKeyPairs",
-				"ec2:ModifyInstanceMetadataOptions",
 				"eks:CreateAccessEntry",
 				"eks:DeleteAccessEntry",
 				"eks:DescribeAccessEntry",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -256,7 +256,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -256,7 +256,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -256,7 +256,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -256,7 +256,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -250,7 +250,6 @@ Resources:
           - ec2:DeleteLaunchTemplate
           - ec2:DeleteLaunchTemplateVersions
           - ec2:DescribeKeyPairs
-          - ec2:ModifyInstanceMetadataOptions
           - eks:CreateAccessEntry
           - eks:DeleteAccessEntry
           - eks:DescribeAccessEntry

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -213,8 +213,6 @@ func (r *AWSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	infrav1.SetDefaults_AWSMachineSpec(&awsMachine.Spec)
-
 	if isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, awsMachine); err != nil || isPaused || conditionChanged {
 		return ctrl.Result{}, err
 	}
@@ -758,12 +756,6 @@ func (r *AWSMachineReconciler) reconcileOperationalState(ec2svc services.EC2Inte
 		return err
 	}
 	v1beta1conditions.MarkTrue(machineScope.AWSMachine, infrav1.SecurityGroupsReadyCondition)
-
-	err = r.ensureInstanceMetadataOptions(ec2svc, instance, machineScope.AWSMachine)
-	if err != nil {
-		machineScope.Error(err, "failed to ensure instance metadata options")
-		return err
-	}
 
 	return nil
 }
@@ -1357,12 +1349,4 @@ func (r *AWSMachineReconciler) ensureStorageTags(ec2svc services.EC2Interface, i
 			r.Log.Error(err, "Failed to fetch the changed volume tags in EC2 instance")
 		}
 	}
-}
-
-func (r *AWSMachineReconciler) ensureInstanceMetadataOptions(ec2svc services.EC2Interface, instance *infrav1.Instance, machine *infrav1.AWSMachine) error {
-	if cmp.Equal(machine.Spec.InstanceMetadataOptions, instance.InstanceMetadataOptions) {
-		return nil
-	}
-
-	return ec2svc.ModifyInstanceMetadataOptions(instance.ID, machine.Spec.InstanceMetadataOptions)
 }

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -590,6 +590,12 @@ func getAWSMachine() *infrav1.AWSMachine {
 			},
 			InstanceType: "test",
 			Subnet:       &infrav1.AWSResourceReference{ID: aws.String("subnet-1")},
+			InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+				HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+				HTTPPutResponseHopLimit: 1,
+				HTTPTokens:              infrav1.HTTPTokensStateOptional,
+				InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+			},
 		},
 	}
 }

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -88,6 +88,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 		}
 		klog.SetOutput(GinkgoWriter)
 
+		// Ensure InstanceMetadataOptions defaults are set (webhook sets these normally, but not in unit tests)
+		if awsMachine.Spec.InstanceMetadataOptions == nil {
+			awsMachine.Spec.InstanceMetadataOptions = &infrav1.InstanceMetadataOptions{}
+			awsMachine.Spec.InstanceMetadataOptions.SetDefaults()
+		}
+
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "bootstrap-data",
@@ -361,6 +367,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 				instance = &infrav1.Instance{
 					ID:        "myMachine",
 					VolumeIDs: []string{"volume-1", "volume-2"},
+					InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+						HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+						HTTPPutResponseHopLimit: 1,
+						HTTPTokens:              infrav1.HTTPTokensStateOptional,
+						InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+					},
 				}
 				instance.State = infrav1.InstanceStatePending
 
@@ -766,6 +778,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 					ID:               "myMachine",
 					VolumeIDs:        []string{"volume-1", "volume-2"},
 					AvailabilityZone: "us-east-1",
+					InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+						HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+						HTTPPutResponseHopLimit: 1,
+						HTTPTokens:              infrav1.HTTPTokensStateOptional,
+						InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+					},
 				}
 				instance.State = infrav1.InstanceStatePending
 			}
@@ -1022,6 +1040,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 				instance = &infrav1.Instance{
 					ID:    "myMachine",
 					State: infrav1.InstanceStatePending,
+					InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+						HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+						HTTPPutResponseHopLimit: 1,
+						HTTPTokens:              infrav1.HTTPTokensStateOptional,
+						InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+					},
 				}
 
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -1059,6 +1083,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 				instance = &infrav1.Instance{
 					ID:    "myMachine",
 					State: infrav1.InstanceStatePending,
+					InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+						HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+						HTTPPutResponseHopLimit: 1,
+						HTTPTokens:              infrav1.HTTPTokensStateOptional,
+						InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+					},
 				}
 
 				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -1083,6 +1113,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				instance = &infrav1.Instance{
 					ID: "myMachine",
+					InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+						HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+						HTTPPutResponseHopLimit: 1,
+						HTTPTokens:              infrav1.HTTPTokensStateOptional,
+						InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+					},
 				}
 
 				ms.Machine.Status.NodeRef = clusterv1.MachineNodeReference{
@@ -1217,6 +1253,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				instance = &infrav1.Instance{
 					ID: "myMachine",
+					InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+						HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+						HTTPPutResponseHopLimit: 1,
+						HTTPTokens:              infrav1.HTTPTokensStateOptional,
+						InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+					},
 				}
 
 				ms.AWSMachine.Spec.CloudInit = infrav1.CloudInit{
@@ -1314,6 +1356,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 				instance = &infrav1.Instance{
 					ID: "myMachine",
+					InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+						HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+						HTTPPutResponseHopLimit: 1,
+						HTTPTokens:              infrav1.HTTPTokensStateOptional,
+						InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+					},
 				}
 				instance.State = infrav1.InstanceStatePending
 				secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(1), nil).Times(1)
@@ -1366,6 +1414,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 					instance = &infrav1.Instance{
 						ID:    "myMachine",
 						State: infrav1.InstanceStatePending,
+						InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+							HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+							HTTPPutResponseHopLimit: 1,
+							HTTPTokens:              infrav1.HTTPTokensStateOptional,
+							InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+						},
 					}
 					fakeS3URL := "s3://foo"
 
@@ -1399,6 +1453,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 					instance = &infrav1.Instance{
 						ID:    "myMachine",
 						State: infrav1.InstanceStatePending,
+						InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+							HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+							HTTPPutResponseHopLimit: 1,
+							HTTPTokens:              infrav1.HTTPTokensStateOptional,
+							InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+						},
 					}
 
 					//nolint:gosec
@@ -1426,6 +1486,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 					instance = &infrav1.Instance{
 						ID: "myMachine",
+						InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+							HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+							HTTPPutResponseHopLimit: 1,
+							HTTPTokens:              infrav1.HTTPTokensStateOptional,
+							InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+						},
 					}
 
 					ms.Machine.Status.NodeRef = clusterv1.MachineNodeReference{
@@ -1507,6 +1573,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 
 					instance = &infrav1.Instance{
 						ID: "myMachine",
+						InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+							HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+							HTTPPutResponseHopLimit: 1,
+							HTTPTokens:              infrav1.HTTPTokensStateOptional,
+							InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+						},
 					}
 					ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
 				}
@@ -1616,6 +1688,12 @@ func TestAWSMachineReconciler(t *testing.T) {
 					instance = &infrav1.Instance{
 						ID:    "myMachine",
 						State: infrav1.InstanceStatePending,
+						InstanceMetadataOptions: &infrav1.InstanceMetadataOptions{
+							HTTPEndpoint:            infrav1.InstanceMetadataEndpointStateEnabled,
+							HTTPPutResponseHopLimit: 1,
+							HTTPTokens:              infrav1.HTTPTokensStateOptional,
+							InstanceMetadataTags:    infrav1.InstanceMetadataEndpointStateDisabled,
+						},
 					}
 					fakeS3URL := "s3://foo"
 

--- a/pkg/cloud/services/common/common.go
+++ b/pkg/cloud/services/common/common.go
@@ -84,7 +84,6 @@ type EC2API interface {
 	DisassociateAddress(ctx context.Context, params *ec2.DisassociateAddressInput, optFns ...func(*ec2.Options)) (*ec2.DisassociateAddressOutput, error)
 	DisassociateRouteTable(ctx context.Context, params *ec2.DisassociateRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DisassociateRouteTableOutput, error)
 	DisassociateVpcCidrBlock(ctx context.Context, params *ec2.DisassociateVpcCidrBlockInput, optFns ...func(*ec2.Options)) (*ec2.DisassociateVpcCidrBlockOutput, error)
-	ModifyInstanceMetadataOptions(ctx context.Context, params *ec2.ModifyInstanceMetadataOptionsInput, optFns ...func(*ec2.Options)) (*ec2.ModifyInstanceMetadataOptionsOutput, error)
 	ModifyNetworkInterfaceAttribute(ctx context.Context, params *ec2.ModifyNetworkInterfaceAttributeInput, optFns ...func(*ec2.Options)) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
 	ModifySubnetAttribute(ctx context.Context, params *ec2.ModifySubnetAttributeInput, optFns ...func(*ec2.Options)) (*ec2.ModifySubnetAttributeOutput, error)
 	ModifyVpcAttribute(ctx context.Context, params *ec2.ModifyVpcAttributeInput, optFns ...func(*ec2.Options)) (*ec2.ModifyVpcAttributeOutput, error)

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -1178,25 +1178,6 @@ func (s *Service) checkRootVolume(rootVolume *infrav1.Volume, imageID string) (*
 	return rootDeviceName, nil
 }
 
-// ModifyInstanceMetadataOptions modifies the metadata options of the given EC2 instance.
-func (s *Service) ModifyInstanceMetadataOptions(instanceID string, options *infrav1.InstanceMetadataOptions) error {
-	input := &ec2.ModifyInstanceMetadataOptionsInput{
-		HttpEndpoint:            types.InstanceMetadataEndpointState(string(options.HTTPEndpoint)),
-		HttpPutResponseHopLimit: utils.ToInt32Pointer(&options.HTTPPutResponseHopLimit),
-		HttpTokens:              types.HttpTokensState(string(options.HTTPTokens)),
-		InstanceMetadataTags:    types.InstanceMetadataTagsState(string(options.InstanceMetadataTags)),
-		HttpProtocolIpv6:        types.InstanceMetadataProtocolState(string(options.HTTPProtocolIPv6)),
-		InstanceId:              aws.String(instanceID),
-	}
-
-	s.scope.Info("Updating instance metadata options", "instance id", instanceID, "options", input)
-	if _, err := s.EC2Client.ModifyInstanceMetadataOptions(context.TODO(), input); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // GetDHCPOptionSetDomainName returns the domain DNS name for the VPC from the DHCP Options.
 func (s *Service) GetDHCPOptionSetDomainName(ec2client common.EC2API, vpcID *string) *string {
 	log := s.scope.GetLogger()

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -102,7 +102,6 @@ type EC2Interface interface {
 	GetInstanceSecurityGroups(instanceID string) (map[string][]string, error)
 	UpdateInstanceSecurityGroups(id string, securityGroups []string) error
 	UpdateResourceTags(resourceID *string, create, remove map[string]string) error
-	ModifyInstanceMetadataOptions(instanceID string, options *infrav1.InstanceMetadataOptions) error
 
 	TerminateInstanceAndWait(instanceID string) error
 	DetachSecurityGroupsFromNetworkInterface(groups []string, interfaceID string) error

--- a/pkg/cloud/services/mock_services/ec2_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_interface_mock.go
@@ -326,20 +326,6 @@ func (mr *MockEC2InterfaceMockRecorder) LaunchTemplateNeedsUpdate(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LaunchTemplateNeedsUpdate", reflect.TypeOf((*MockEC2Interface)(nil).LaunchTemplateNeedsUpdate), arg0, arg1, arg2)
 }
 
-// ModifyInstanceMetadataOptions mocks base method.
-func (m *MockEC2Interface) ModifyInstanceMetadataOptions(arg0 string, arg1 *v1beta2.InstanceMetadataOptions) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModifyInstanceMetadataOptions", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ModifyInstanceMetadataOptions indicates an expected call of ModifyInstanceMetadataOptions.
-func (mr *MockEC2InterfaceMockRecorder) ModifyInstanceMetadataOptions(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceMetadataOptions", reflect.TypeOf((*MockEC2Interface)(nil).ModifyInstanceMetadataOptions), arg0, arg1)
-}
-
 // PruneLaunchTemplateVersions mocks base method.
 func (m *MockEC2Interface) PruneLaunchTemplateVersions(arg0 string) (*types.LaunchTemplateVersion, error) {
 	m.ctrl.T.Helper()

--- a/test/mocks/aws_ec2api_mock.go
+++ b/test/mocks/aws_ec2api_mock.go
@@ -1231,26 +1231,6 @@ func (mr *MockEC2APIMockRecorder) DisassociateVpcCidrBlock(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateVpcCidrBlock", reflect.TypeOf((*MockEC2API)(nil).DisassociateVpcCidrBlock), varargs...)
 }
 
-// ModifyInstanceMetadataOptions mocks base method.
-func (m *MockEC2API) ModifyInstanceMetadataOptions(arg0 context.Context, arg1 *ec2.ModifyInstanceMetadataOptionsInput, arg2 ...func(*ec2.Options)) (*ec2.ModifyInstanceMetadataOptionsOutput, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ModifyInstanceMetadataOptions", varargs...)
-	ret0, _ := ret[0].(*ec2.ModifyInstanceMetadataOptionsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModifyInstanceMetadataOptions indicates an expected call of ModifyInstanceMetadataOptions.
-func (mr *MockEC2APIMockRecorder) ModifyInstanceMetadataOptions(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceMetadataOptions", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceMetadataOptions), varargs...)
-}
-
 // ModifyNetworkInterfaceAttribute mocks base method.
 func (m *MockEC2API) ModifyNetworkInterfaceAttribute(arg0 context.Context, arg1 *ec2.ModifyNetworkInterfaceAttributeInput, arg2 ...func(*ec2.Options)) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
 	m.ctrl.T.Helper()

--- a/webhooks/awsmachine_webhook.go
+++ b/webhooks/awsmachine_webhook.go
@@ -471,6 +471,11 @@ func (w *AWSMachine) Default(_ context.Context, obj runtime.Object) error {
 		r.Spec.Ignition.Version = infrav1.DefaultIgnitionVersion
 	}
 
+	if r.Spec.InstanceMetadataOptions == nil {
+		r.Spec.InstanceMetadataOptions = &infrav1.InstanceMetadataOptions{}
+	}
+	r.Spec.InstanceMetadataOptions.SetDefaults()
+
 	return nil
 }
 

--- a/webhooks/awsmachine_webhook_test.go
+++ b/webhooks/awsmachine_webhook_test.go
@@ -39,6 +39,12 @@ func TestMachineDefault(t *testing.T) {
 	err := (&AWSMachine{}).Default(context.Background(), machine)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(machine.Spec.CloudInit.SecureSecretsBackend).To(Equal(infrav1.SecretBackendSecretsManager))
+	g.Expect(machine.Spec.InstanceMetadataOptions).NotTo(BeNil())
+	g.Expect(machine.Spec.InstanceMetadataOptions.HTTPEndpoint).To(Equal(infrav1.InstanceMetadataEndpointStateEnabled))
+	g.Expect(machine.Spec.InstanceMetadataOptions.HTTPProtocolIPv6).To(Equal(infrav1.InstanceMetadataEndpointStateDisabled))
+	g.Expect(machine.Spec.InstanceMetadataOptions.HTTPPutResponseHopLimit).To(Equal(int64(1)))
+	g.Expect(machine.Spec.InstanceMetadataOptions.HTTPTokens).To(Equal(infrav1.HTTPTokensStateOptional))
+	g.Expect(machine.Spec.InstanceMetadataOptions.InstanceMetadataTags).To(Equal(infrav1.InstanceMetadataEndpointStateDisabled))
 }
 
 func TestAWSMachineCreate(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

While reconciling newly created `AWSMachines`, I noticed that this error usually happens

```
admission webhook \"validation.awsmachine.infrastructure.cluster.x-k8s.io\" denied the request: AWSMachine.infrastructure.cluster.x-k8s.io \"mycluster-somemachine\" is invalid: spec: Forbidden: cannot be modified" controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="default/mycluster-somemachine" namespace="default" name="mycluster-mymachine" reconcileID="92584f4e-6f44-4f12-8007-352eab8a1429"
```

The problem is that we are setting the defaults on the existing `AWSMachine` while reconciling it. I think it'd be better to use the defaulting admission controller instead, and avoid default during the reconciliation.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default AWSMachine in admission controller instead of during reconciliation as it's not allowed to update the `awsmachine.spec` field after the initial creation
```
