### PR TITLE
🌱 Enable nofloats linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -23,7 +23,7 @@ linters:
               #- "jsontags" # Ensure every field has a json tag.
               #- "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
               #- "nobools" # Bools do not evolve over time, should use enums instead.
-              #- "nofloats" # Ensure floats are not used.
+              - "nofloats" # Ensure floats are not used.
               #- "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
               # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
               - "statussubresource" # All root objects that have a `status` field should have a status subresource.

--- a/pkg/internal/rate/rate.go
+++ b/pkg/internal/rate/rate.go
@@ -30,6 +30,8 @@ import (
 // Limit defines the maximum frequency of some events.
 // Limit is represented as number of events per second.
 // A zero Limit allows no events.
+//
+//nolint:kubeapilinter // This is an internal rate limiter implementation, not a Kubernetes API
 type Limit float64
 
 // Inf is the infinite rate limit; it allows all events (even if burst is zero).
@@ -66,6 +68,8 @@ func Every(interval time.Duration) Limit {
 // or its associated context.Context is canceled.
 //
 // The methods AllowN, ReserveN, and WaitN consume n tokens.
+//
+//nolint:kubeapilinter // This is an internal rate limiter implementation, not a Kubernetes API
 type Limiter struct {
 	mu     sync.Mutex
 	limit  Limit
@@ -117,6 +121,8 @@ func (lim *Limiter) AllowN(now time.Time, n int) bool {
 
 // A Reservation holds information about events that are permitted by a Limiter to happen after a delay.
 // A Reservation may be canceled, which may enable the Limiter to permit additional events.
+//
+//nolint:kubeapilinter // This is an internal rate limiter implementation, not a Kubernetes API
 type Reservation struct {
 	ok        bool
 	lim       *Limiter


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR enables the `nofloats` linter as part of the KAL (Kube-API-Linter) configuration to enforce Kubernetes API best practices by preventing the use of float types in API definitions.

Float types are discouraged in Kubernetes APIs due to:
- Precision issues across different platforms
- Unreliable round-tripping in serialization/deserialization
- Difficulties in comparison operations

The internal rate limiter implementation (`pkg/internal/rate/rate.go`) legitimately uses float64 for token bucket calculations and has been exempted from this linter rule using `//nolint:kubeapilinter` comments, as it is not part of the Kubernetes API surface.

**Which issue(s) this PR fixes**:
Fixes #5490

**Special notes for your reviewer**:

The `nofloats` linter only flags float usage in type definitions and struct fields, not in type conversions or temporary calculations. This is why `exp/api/v1beta2/validation.go` (which uses `float64()` conversions) doesn't trigger errors.

The existing `path-except: "api//*"` rule in `.golangci-kal.yml` doesn't effectively limit KAL linting to API folders only - KAL runs on all Go code similar to how `optionalorrequired` linter was previously enabled. Therefore, internal packages that legitimately use floats need explicit `//nolint` comments.

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
NONE