### PR TITLE
🌱 Enable nobools linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -22,7 +22,7 @@ linters:
               #- "integers" # Ensure only int32 and int64 are used for integers.
               #- "jsontags" # Ensure every field has a json tag.
               #- "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
-              #- "nobools" # Bools do not evolve over time, should use enums instead.
+              - "nobools" # Bools do not evolve over time, should use enums instead.
               #- "nofloats" # Ensure floats are not used.
               #- "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
               # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.

--- a/api/v1beta1/awscluster_types.go
+++ b/api/v1beta1/awscluster_types.go
@@ -131,12 +131,12 @@ type Bastion struct {
 	// Enabled allows this provider to create a bastion host instance
 	// with a public ip to access the VPC private network.
 	// +optional
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.
 	// Requires AllowedCIDRBlocks to be empty.
 	// +optional
-	DisableIngressRules bool `json:"disableIngressRules,omitempty"`
+	DisableIngressRules bool `json:"disableIngressRules,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.
 	// They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
@@ -180,7 +180,7 @@ type AWSLoadBalancerSpec struct {
 	//
 	// Defaults to false.
 	// +optional
-	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing"`
+	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)
 	// +optional
@@ -200,7 +200,7 @@ type AWSLoadBalancerSpec struct {
 // AWSClusterStatus defines the observed state of AWSCluster.
 type AWSClusterStatus struct {
 	// +kubebuilder:default=false
-	Ready          bool                          `json:"ready"`
+	Ready          bool                          `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	Network        NetworkStatus                 `json:"networkStatus,omitempty"`
 	FailureDomains clusterv1beta1.FailureDomains `json:"failureDomains,omitempty"`
 	Bastion        *Instance                     `json:"bastion,omitempty"`

--- a/api/v1beta1/awsmachine_types.go
+++ b/api/v1beta1/awsmachine_types.go
@@ -95,7 +95,7 @@ type AWSMachineSpec struct {
 	// 2. Cluster/flavor setting
 	// 3. Subnet default
 	// +optional
-	PublicIP *bool `json:"publicIP,omitempty"`
+	PublicIP *bool `json:"publicIP,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// AdditionalSecurityGroups is an array of references to security groups that should be applied to the
 	// instance. These security groups would be set in addition to any security groups defined
@@ -137,7 +137,7 @@ type AWSMachineSpec struct {
 	// user data stored in aws secret manager is always gzip-compressed.
 	//
 	// +optional
-	UncompressedUserData *bool `json:"uncompressedUserData,omitempty"`
+	UncompressedUserData *bool `json:"uncompressedUserData,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// CloudInit defines options related to the bootstrapping systems where
 	// CloudInit is used.
@@ -165,7 +165,7 @@ type CloudInit struct {
 	// or AWS Systems Manager Parameter Store to ensure privacy of userdata.
 	// By default, a cloud-init boothook shell script is prepended to download
 	// the userdata from Secrets Manager and additionally delete the secret.
-	InsecureSkipSecretsManager bool `json:"insecureSkipSecretsManager,omitempty"`
+	InsecureSkipSecretsManager bool `json:"insecureSkipSecretsManager,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// SecretCount is the number of secrets used to form the complete secret
 	// +optional
@@ -199,12 +199,12 @@ type Ignition struct {
 type AWSMachineStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS.
 	// This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).
 	// +optional
-	Interruptible bool `json:"interruptible,omitempty"`
+	Interruptible bool `json:"interruptible,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Addresses contains the AWS instance associated addresses.
 	Addresses []clusterv1beta1.MachineAddress `json:"addresses,omitempty"`

--- a/api/v1beta1/network_types.go
+++ b/api/v1beta1/network_types.go
@@ -125,7 +125,7 @@ type ClassicELBAttributes struct {
 
 	// CrossZoneLoadBalancing enables the classic load balancer load balancing.
 	// +optional
-	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing,omitempty"`
+	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // ClassicELBListener defines an AWS classic load balancer listener.
@@ -258,12 +258,12 @@ type SubnetSpec struct {
 
 	// IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.
 	// +optional
-	IsPublic bool `json:"isPublic"`
+	IsPublic bool `json:"isPublic"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
 	// IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
 	// +optional
-	IsIPv6 bool `json:"isIpv6,omitempty"`
+	IsIPv6 bool `json:"isIpv6,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// RouteTableID is the routing table id associated with the subnet.
 	// +optional

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -174,10 +174,10 @@ type Instance struct {
 	PublicIP *string `json:"publicIp,omitempty"`
 
 	// Specifies whether enhanced networking with ENA is enabled.
-	ENASupport *bool `json:"enaSupport,omitempty"`
+	ENASupport *bool `json:"enaSupport,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Indicates whether the instance is optimized for Amazon EBS I/O.
-	EBSOptimized *bool `json:"ebsOptimized,omitempty"`
+	EBSOptimized *bool `json:"ebsOptimized,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Configuration options for the root storage volume.
 	// +optional
@@ -233,7 +233,7 @@ type Volume struct {
 
 	// Encrypted is whether the volume should be encrypted or not.
 	// +optional
-	Encrypted *bool `json:"encrypted,omitempty"`
+	Encrypted *bool `json:"encrypted,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.
 	// If Encrypted is set and this is omitted, the default AWS key will be used.

--- a/api/v1beta2/awscluster_types.go
+++ b/api/v1beta2/awscluster_types.go
@@ -143,12 +143,12 @@ type Bastion struct {
 	// Enabled allows this provider to create a bastion host instance
 	// with a public ip to access the VPC private network.
 	// +optional
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.
 	// Requires AllowedCIDRBlocks to be empty.
 	// +optional
-	DisableIngressRules bool `json:"disableIngressRules,omitempty"`
+	DisableIngressRules bool `json:"disableIngressRules,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.
 	// They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
@@ -208,7 +208,7 @@ type AWSLoadBalancerSpec struct {
 	//
 	// Defaults to false.
 	// +optional
-	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing"`
+	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)
 	// +optional
@@ -247,11 +247,11 @@ type AWSLoadBalancerSpec struct {
 
 	// DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts
 	// file of each instance. This is by default, false.
-	DisableHostsRewrite bool `json:"disableHostsRewrite,omitempty"`
+	DisableHostsRewrite bool `json:"disableHostsRewrite,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// PreserveClientIP lets the user control if preservation of client ips must be retained or not.
 	// If this is enabled 6443 will be opened to 0.0.0.0/0.
-	PreserveClientIP bool `json:"preserveClientIP,omitempty"`
+	PreserveClientIP bool `json:"preserveClientIP,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AdditionalListenerSpec defines the desired state of an
@@ -276,7 +276,7 @@ type AdditionalListenerSpec struct {
 // AWSClusterStatus defines the observed state of AWSCluster.
 type AWSClusterStatus struct {
 	// +kubebuilder:default=false
-	Ready          bool                          `json:"ready"`
+	Ready          bool                          `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	Network        NetworkStatus                 `json:"networkStatus,omitempty"`
 	FailureDomains clusterv1beta1.FailureDomains `json:"failureDomains,omitempty"`
 	Bastion        *Instance                     `json:"bastion,omitempty"`
@@ -312,7 +312,7 @@ type S3Bucket struct {
 
 	// BestEffortDeleteObjects defines whether access/permission errors during object deletion should be ignored.
 	// +optional
-	BestEffortDeleteObjects *bool `json:"bestEffortDeleteObjects,omitempty"`
+	BestEffortDeleteObjects *bool `json:"bestEffortDeleteObjects,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta2/awscluster_webhook_test.go
+++ b/api/v1beta2/awscluster_webhook_test.go
@@ -50,7 +50,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 	tests := []struct {
 		name    string
 		cluster *AWSCluster
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect  func(g *WithT, res *AWSLoadBalancerSpec)
 	}{
 		{
@@ -789,7 +789,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 		name       string
 		oldCluster *AWSCluster
 		newCluster *AWSCluster
-		wantErr    bool
+		wantErr    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Control Plane LB type is immutable when switching from disabled to any",
@@ -1343,7 +1343,7 @@ func TestAWSClusterValidateAllowedCIDRBlocks(t *testing.T) {
 	tests := []struct {
 		name    string
 		awsc    *AWSCluster
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "allow valid CIDRs",

--- a/api/v1beta2/awsclustercontrolleridentity_webhook_test.go
+++ b/api/v1beta2/awsclustercontrolleridentity_webhook_test.go
@@ -30,7 +30,7 @@ func TestAWSClusterControllerIdentityCreationValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		identity  *AWSClusterControllerIdentity
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "only allow AWSClusterControllerIdentity creation with name default",
@@ -71,7 +71,7 @@ func TestAWSClusterControllerIdentityLabelSelectorAsSelectorValidation(t *testin
 	tests := []struct {
 		name      string
 		selectors map[string]string
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:      "should not return error for valid selector",
@@ -140,7 +140,7 @@ func TestAWSClusterControllerValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name      string
 		identity  *AWSClusterControllerIdentity
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "do not allow any spec changes",
@@ -211,7 +211,7 @@ func TestAWSClusterControllerIdentityUpdateValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		identity  *AWSClusterControllerIdentity
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:      "should not return error for valid selector",

--- a/api/v1beta2/awsclusterroleidentity_webhook_test.go
+++ b/api/v1beta2/awsclusterroleidentity_webhook_test.go
@@ -30,7 +30,7 @@ func TestAWSClusterRoleValidateCreate(t *testing.T) {
 	tests := []struct {
 		name      string
 		identity  *AWSClusterRoleIdentity
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "do not allow nil sourceIdentityRef",
@@ -77,7 +77,7 @@ func TestCreateAWSClusterRoleIdentityLabelSelectorAsSelectorValidation(t *testin
 	tests := []struct {
 		name      string
 		selectors map[string]string
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:      "should not return error for valid selector",
@@ -184,7 +184,7 @@ func TestAWSClusterRoleIdentityUpdateValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		identity  *AWSClusterRoleIdentity
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:      "should not return error for valid selector",

--- a/api/v1beta2/awsclusterstaticidentity_webhook_test.go
+++ b/api/v1beta2/awsclusterstaticidentity_webhook_test.go
@@ -30,7 +30,7 @@ func TestCreateAWSClusterStaticIdentityValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		selectors map[string]string
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:      "should not return error for valid selector",
@@ -98,7 +98,7 @@ func TestAWSClusterStaticValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name      string
 		identity  *AWSClusterStaticIdentity
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "do not allow any spec changes",
@@ -162,7 +162,7 @@ func TestAWSClusterStaticIdentityUpdateLabelSelectorValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		identity  *AWSClusterStaticIdentity
-		wantError bool
+		wantError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:      "should not return error for valid selector",

--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -137,7 +137,7 @@ type AWSMachineSpec struct {
 	// 2. Cluster/flavor setting
 	// 3. Subnet default
 	// +optional
-	PublicIP *bool `json:"publicIP,omitempty"`
+	PublicIP *bool `json:"publicIP,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// ElasticIPPool is the configuration to allocate Public IPv4 address (Elastic IP/EIP) from user-defined pool.
 	//
@@ -190,7 +190,7 @@ type AWSMachineSpec struct {
 	// user data stored in aws secret manager is always gzip-compressed.
 	//
 	// +optional
-	UncompressedUserData *bool `json:"uncompressedUserData,omitempty"`
+	UncompressedUserData *bool `json:"uncompressedUserData,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// CloudInit defines options related to the bootstrapping systems where
 	// CloudInit is used.
@@ -290,7 +290,7 @@ type CloudInit struct {
 	// or AWS Systems Manager Parameter Store to ensure privacy of userdata.
 	// By default, a cloud-init boothook shell script is prepended to download
 	// the userdata from Secrets Manager and additionally delete the secret.
-	InsecureSkipSecretsManager bool `json:"insecureSkipSecretsManager,omitempty"`
+	InsecureSkipSecretsManager bool `json:"insecureSkipSecretsManager,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// SecretCount is the number of secrets used to form the complete secret
 	// +optional
@@ -406,12 +406,12 @@ type IgnitionProxy struct {
 type AWSMachineStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS.
 	// This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).
 	// +optional
-	Interruptible bool `json:"interruptible,omitempty"`
+	Interruptible bool `json:"interruptible,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Addresses contains the AWS instance associated addresses.
 	Addresses []clusterv1beta1.MachineAddress `json:"addresses,omitempty"`

--- a/api/v1beta2/awsmachine_webhook_test.go
+++ b/api/v1beta2/awsmachine_webhook_test.go
@@ -44,7 +44,7 @@ func TestAWSMachineCreate(t *testing.T) {
 	tests := []struct {
 		name    string
 		machine *AWSMachine
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "ensure IOPS exists if type equal to io1",
@@ -620,7 +620,7 @@ func TestAWSMachineUpdate(t *testing.T) {
 		name       string
 		oldMachine *AWSMachine
 		newMachine *AWSMachine
-		wantErr    bool
+		wantErr    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "change in providerid, cloudinit, tags, securitygroups",

--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -29,7 +29,7 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 	tests := []struct {
 		name          string
 		inputTemplate *AWSMachineTemplate
-		wantError     bool
+		wantError     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "don't allow providerID",
@@ -120,7 +120,7 @@ func TestAWSMachineTemplateValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name             string
 		modifiedTemplate *AWSMachineTemplate
-		wantError        bool
+		wantError        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "don't allow updates",

--- a/api/v1beta2/awsmanagedcluster_types.go
+++ b/api/v1beta2/awsmanagedcluster_types.go
@@ -33,7 +33,7 @@ type AWSManagedClusterSpec struct {
 type AWSManagedClusterStatus struct {
 	// Ready is when the AWSManagedControlPlane has a API server URL.
 	// +optional
-	Ready bool `json:"ready,omitempty"`
+	Ready bool `json:"ready,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// FailureDomains specifies a list fo available availability zones that can be used
 	// +optional

--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -317,7 +317,7 @@ type ClassicELBAttributes struct {
 
 	// CrossZoneLoadBalancing enables the classic load balancer load balancing.
 	// +optional
-	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing,omitempty"`
+	CrossZoneLoadBalancing bool `json:"crossZoneLoadBalancing,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // ClassicELBListener defines an AWS classic load balancer listener.
@@ -477,7 +477,7 @@ type VPCSpec struct {
 	// NOTE: This only applies when the VPC is managed by the Cluster API AWS controller.
 	//
 	// +optional
-	EmptyRoutesDefaultVPCSecurityGroup bool `json:"emptyRoutesDefaultVPCSecurityGroup,omitempty"`
+	EmptyRoutesDefaultVPCSecurityGroup bool `json:"emptyRoutesDefaultVPCSecurityGroup,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// PrivateDNSHostnameTypeOnLaunch is the type of hostname to assign to instances in the subnet at launch.
 	// For IPv4-only and dual-stack (IPv4 and IPv6) subnets, an instance DNS name can be based on the instance IPv4 address (ip-name)
@@ -570,12 +570,12 @@ type SubnetSpec struct {
 
 	// IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.
 	// +optional
-	IsPublic bool `json:"isPublic"`
+	IsPublic bool `json:"isPublic"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
 	// IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
 	// +optional
-	IsIPv6 bool `json:"isIpv6,omitempty"`
+	IsIPv6 bool `json:"isIpv6,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// RouteTableID is the routing table id associated with the subnet.
 	// +optional
@@ -973,7 +973,7 @@ type IngressRule struct {
 
 	// NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.
 	// +optional
-	NatGatewaysIPsSource bool `json:"natGatewaysIPsSource,omitempty"`
+	NatGatewaysIPsSource bool `json:"natGatewaysIPsSource,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // String returns a string representation of the ingress rule.

--- a/api/v1beta2/network_types_test.go
+++ b/api/v1beta2/network_types_test.go
@@ -254,7 +254,7 @@ func TestSubnetSpec_IsEdge(t *testing.T) {
 	tests := []struct {
 		name string
 		spec *SubnetSpec
-		want bool
+		want bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "az without type is not edge",
@@ -296,7 +296,7 @@ func TestSubnetSpec_IsEdgeWavelength(t *testing.T) {
 	tests := []struct {
 		name string
 		spec *SubnetSpec
-		want bool
+		want bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "az without type is not edge wavelength",
@@ -805,7 +805,7 @@ func TestSubnets_HasPublicSubnetWavelength(t *testing.T) {
 	tests := []struct {
 		name    string
 		subnets Subnets
-		want    bool
+		want    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:    "no subnets",

--- a/api/v1beta2/sshkeyname_test.go
+++ b/api/v1beta2/sshkeyname_test.go
@@ -29,7 +29,7 @@ func TestSSHKeyName(t *testing.T) {
 	tests := []struct {
 		name       string
 		sshKeyName *string
-		wantErr    bool
+		wantErr    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:       "SSH key name is nil is valid",

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -201,10 +201,10 @@ type Instance struct {
 	PublicIP *string `json:"publicIp,omitempty"`
 
 	// Specifies whether enhanced networking with ENA is enabled.
-	ENASupport *bool `json:"enaSupport,omitempty"`
+	ENASupport *bool `json:"enaSupport,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Indicates whether the instance is optimized for Amazon EBS I/O.
-	EBSOptimized *bool `json:"ebsOptimized,omitempty"`
+	EBSOptimized *bool `json:"ebsOptimized,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Configuration options for the root storage volume.
 	// +optional
@@ -259,7 +259,7 @@ type Instance struct {
 
 	// PublicIPOnLaunch is the option to associate a public IP on instance launch
 	// +optional
-	PublicIPOnLaunch *bool `json:"publicIPOnLaunch,omitempty"`
+	PublicIPOnLaunch *bool `json:"publicIPOnLaunch,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.
 	// +optional
@@ -479,7 +479,7 @@ type Volume struct {
 
 	// Encrypted is whether the volume should be encrypted or not.
 	// +optional
-	Encrypted *bool `json:"encrypted,omitempty"`
+	Encrypted *bool `json:"encrypted,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.
 	// If Encrypted is set and this is omitted, the default AWS key will be used.
@@ -546,10 +546,10 @@ const (
 type PrivateDNSName struct {
 	// EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.
 	// +optional
-	EnableResourceNameDNSAAAARecord *bool `json:"enableResourceNameDnsAAAARecord,omitempty"`
+	EnableResourceNameDNSAAAARecord *bool `json:"enableResourceNameDnsAAAARecord,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.
 	// +optional
-	EnableResourceNameDNSARecord *bool `json:"enableResourceNameDnsARecord,omitempty"`
+	EnableResourceNameDNSARecord *bool `json:"enableResourceNameDnsARecord,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// The type of hostname to assign to an instance.
 	// +optional
 	// +kubebuilder:validation:Enum:=ip-name;resource-name

--- a/bootstrap/eks/api/v1beta1/eksconfig_types.go
+++ b/bootstrap/eks/api/v1beta1/eksconfig_types.go
@@ -45,7 +45,7 @@ type EKSConfigSpec struct {
 	PauseContainer *PauseContainer `json:"pauseContainer,omitempty"`
 	// UseMaxPods  sets --max-pods for the kubelet when true.
 	// +optional
-	UseMaxPods *bool `json:"useMaxPods,omitempty"`
+	UseMaxPods *bool `json:"useMaxPods,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then
 	// the ip family will be set to ipv6.
@@ -64,7 +64,7 @@ type PauseContainer struct {
 // EKSConfigStatus defines the observed state of the Amazon EKS Bootstrap Configuration.
 type EKSConfigStatus struct {
 	// Ready indicates the BootstrapData secret is ready to be consumed
-	Ready bool `json:"ready,omitempty"`
+	Ready bool `json:"ready,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// DataSecretName is the name of the secret that stores the bootstrap data script.
 	// +optional

--- a/bootstrap/eks/api/v1beta2/eksconfig_types.go
+++ b/bootstrap/eks/api/v1beta2/eksconfig_types.go
@@ -45,7 +45,7 @@ type EKSConfigSpec struct {
 	PauseContainer *PauseContainer `json:"pauseContainer,omitempty"`
 	// UseMaxPods  sets --max-pods for the kubelet when true.
 	// +optional
-	UseMaxPods *bool `json:"useMaxPods,omitempty"`
+	UseMaxPods *bool `json:"useMaxPods,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then
 	// the ip family will be set to ipv6.
 	// +optional
@@ -87,7 +87,7 @@ type PauseContainer struct {
 // EKSConfigStatus defines the observed state of the Amazon EKS Bootstrap Configuration.
 type EKSConfigStatus struct {
 	// Ready indicates the BootstrapData secret is ready to be consumed
-	Ready bool `json:"ready,omitempty"`
+	Ready bool `json:"ready,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// DataSecretName is the name of the secret that stores the bootstrap data script.
 	// +optional
@@ -142,7 +142,7 @@ type File struct {
 
 	// Append specifies whether to append Content to existing file if Path exists.
 	// +optional
-	Append bool `json:"append,omitempty"`
+	Append bool `json:"append,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Content is the actual content of the file.
 	// +optional
@@ -212,7 +212,7 @@ type User struct {
 
 	// Inactive specifies whether to mark the user as inactive
 	// +optional
-	Inactive *bool `json:"inactive,omitempty"`
+	Inactive *bool `json:"inactive,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Shell specifies the user's shell
 	// +optional
@@ -232,7 +232,7 @@ type User struct {
 
 	// LockPassword specifies if password login should be disabled
 	// +optional
-	LockPassword *bool `json:"lockPassword,omitempty"`
+	LockPassword *bool `json:"lockPassword,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Sudo specifies a sudo role for the user
 	// +optional
@@ -251,7 +251,7 @@ type NTP struct {
 
 	// Enabled specifies whether NTP should be enabled
 	// +optional
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // DiskSetup defines input for generated disk_setup and fs_setup in cloud-init.
@@ -272,11 +272,11 @@ type Partition struct {
 	// Layout specifies the device layout.
 	// If it is true, a single partition will be created for the entire device.
 	// When layout is false, it means don't partition or ignore existing partitioning.
-	Layout bool `json:"layout"`
+	Layout bool `json:"layout"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
 	// Use with caution. Default is 'false'.
 	// +optional
-	Overwrite *bool `json:"overwrite,omitempty"`
+	Overwrite *bool `json:"overwrite,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// TableType specifies the tupe of partition table. The following are supported:
 	// 'mbr': default and setups a MS-DOS partition table
 	// 'gpt': setups a GPT partition table
@@ -298,7 +298,7 @@ type Filesystem struct {
 	// Overwrite defines whether or not to overwrite any existing filesystem.
 	// If true, any pre-existing file system will be destroyed. Use with Caution.
 	// +optional
-	Overwrite *bool `json:"overwrite,omitempty"`
+	Overwrite *bool `json:"overwrite,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// ExtraOpts defined extra options to add to the command for creating the file system.
 	// +optional
 	ExtraOpts []string `json:"extraOpts,omitempty"`

--- a/bootstrap/eks/internal/userdata/node.go
+++ b/bootstrap/eks/internal/userdata/node.go
@@ -53,7 +53,7 @@ type NodeInput struct {
 	APIRetryAttempts      *int
 	PauseContainerAccount *string
 	PauseContainerVersion *string
-	UseMaxPods            *bool
+	UseMaxPods            *bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// NOTE: currently the IPFamily/ServiceIPV6Cidr isn't exposed to the user.
 	// TODO (richardcase): remove the above comment when IPV6 / dual stack is implemented.
 	IPFamily                 *string

--- a/bootstrap/eks/internal/userdata/node_test.go
+++ b/bootstrap/eks/internal/userdata/node_test.go
@@ -39,7 +39,7 @@ func TestNewNode(t *testing.T) {
 		name          string
 		args          args
 		expectedBytes []byte
-		expectErr     bool
+		expectErr     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "only cluster name",

--- a/cmd/clusterawsadm/ami/copy.go
+++ b/cmd/clusterawsadm/ami/copy.go
@@ -43,8 +43,8 @@ type CopyInput struct {
 	OperatingSystem   string
 	KubernetesVersion string
 	KmsKeyID          string
-	DryRun            bool
-	Encrypted         bool
+	DryRun            bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	Encrypted         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	Log               logr.Logger
 }
 
@@ -116,7 +116,7 @@ func Copy(input CopyInput) (*amiv1.AWSAMI, error) {
 
 type copyWithoutSnapshotInput struct {
 	sourceRegion string
-	dryRun       bool
+	dryRun       bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	log          logr.Logger
 	cfg          aws.Config
 	image        *types.Image
@@ -147,8 +147,8 @@ type copyWithSnapshotInput struct {
 	sourceRegion      string
 	destinationRegion string
 	kmsKeyID          string
-	dryRun            bool
-	encrypted         bool
+	dryRun            bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	encrypted         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	log               logr.Logger
 	image             *types.Image
 	cfg               aws.Config

--- a/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1alpha1/types.go
@@ -32,7 +32,7 @@ type BootstrapUser struct {
 	// This can be used to scope down the initial credentials used to bootstrap the
 	// cluster.
 	// Defaults to false.
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// UserName controls the username of the bootstrap user. Defaults to
 	// "bootstrapper.cluster-api-provider-aws.sigs.k8s.io"
@@ -62,19 +62,20 @@ type ControlPlane struct {
 
 	// DisableClusterAPIControllerPolicyAttachment, if set to true, will not attach the AWS IAM policy for Cluster
 	// API Provider AWS to the control plane role. Defaults to false.
-	DisableClusterAPIControllerPolicyAttachment bool `json:"disableClusterAPIControllerPolicyAttachment,omitempty"`
+	DisableClusterAPIControllerPolicyAttachment bool `json:"disableClusterAPIControllerPolicyAttachment,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// DisableCloudProviderPolicy if set to true, will not generate and attach the AWS IAM policy for the AWS Cloud Provider.
-	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"`
+	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// EnableCSIPolicy if set to true, will generate and attach the AWS IAM policy for the EBS CSI Driver.
-	EnableCSIPolicy bool `json:"enableCSIPolicy"`
+	EnableCSIPolicy bool `json:"enableCSIPolicy"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AWSIAMRoleSpec defines common configuration for AWS IAM roles created by
 // Kubernetes Cluster API Provider AWS.
 type AWSIAMRoleSpec struct {
 	// Disable if set to true will not create the AWS IAM role. Defaults to false.
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	Disable bool `json:"disable"` // default: false
 
 	// ExtraPolicyAttachments is a list of additional policies to be attached to the IAM role.
@@ -94,12 +95,12 @@ type AWSIAMRoleSpec struct {
 // EKSConfig represents the EKS related configuration config.
 type EKSConfig struct {
 	// Disable controls whether EKS-related permissions are granted
-	Disable bool `json:"disable"`
+	Disable bool `json:"disable"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// AllowIAMRoleCreation controls whether the EKS controllers have permissions for creating IAM
 	// roles per cluster
-	AllowIAMRoleCreation bool `json:"iamRoleCreation,omitempty"`
+	AllowIAMRoleCreation bool `json:"iamRoleCreation,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// EnableUserEKSConsolePolicy controls the creation of the policy to view EKS nodes and workloads.
-	EnableUserEKSConsolePolicy bool `json:"enableUserEKSConsolePolicy,omitempty"`
+	EnableUserEKSConsolePolicy bool `json:"enableUserEKSConsolePolicy,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// DefaultControlPlaneRole controls the configuration of the AWS IAM role for
 	// the EKS control plane. This is the default role that will be used if
 	// no role is included in the spec and automatic creation of the role
@@ -121,7 +122,7 @@ type EKSConfig struct {
 // EventBridge EC2 events.
 type EventBridgeConfig struct {
 	// Enable controls whether permissions are granted to consume EC2 events
-	Enable bool `json:"enable,omitempty"`
+	Enable bool `json:"enable,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // ClusterAPIControllers controls the configuration of the AWS IAM role for
@@ -141,11 +142,11 @@ type Nodes struct {
 
 	// DisableCloudProviderPolicy if set to true, will not generate and attach the policy for the AWS Cloud Provider.
 	// Defaults to false.
-	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"`
+	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// EC2ContainerRegistryReadOnly controls whether the node has read-only access to the
 	// EC2 container registry
-	EC2ContainerRegistryReadOnly bool `json:"ec2ContainerRegistryReadOnly"`
+	EC2ContainerRegistryReadOnly bool `json:"ec2ContainerRegistryReadOnly"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // +kubebuilder:object:root=true

--- a/cmd/clusterawsadm/api/bootstrap/v1beta1/types.go
+++ b/cmd/clusterawsadm/api/bootstrap/v1beta1/types.go
@@ -32,7 +32,7 @@ type BootstrapUser struct {
 	// This can be used to scope down the initial credentials used to bootstrap the
 	// cluster.
 	// Defaults to false.
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// UserName controls the username of the bootstrap user. Defaults to
 	// "bootstrapper.cluster-api-provider-aws.sigs.k8s.io"
@@ -62,19 +62,20 @@ type ControlPlane struct {
 
 	// DisableClusterAPIControllerPolicyAttachment, if set to true, will not attach the AWS IAM policy for Cluster
 	// API Provider AWS to the control plane role. Defaults to false.
-	DisableClusterAPIControllerPolicyAttachment bool `json:"disableClusterAPIControllerPolicyAttachment,omitempty"`
+	DisableClusterAPIControllerPolicyAttachment bool `json:"disableClusterAPIControllerPolicyAttachment,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// DisableCloudProviderPolicy if set to true, will not generate and attach the AWS IAM policy for the AWS Cloud Provider.
-	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"`
+	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// EnableCSIPolicy if set to true, will generate and attach the AWS IAM policy for the EBS CSI Driver.
-	EnableCSIPolicy bool `json:"enableCSIPolicy"`
+	EnableCSIPolicy bool `json:"enableCSIPolicy"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AWSIAMRoleSpec defines common configuration for AWS IAM roles created by
 // Kubernetes Cluster API Provider AWS.
 type AWSIAMRoleSpec struct {
 	// Disable if set to true will not create the AWS IAM role. Defaults to false.
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	Disable bool `json:"disable"` // default: false
 
 	// ExtraPolicyAttachments is a list of additional policies to be attached to the IAM role.
@@ -102,12 +103,12 @@ type AWSIAMRoleSpec struct {
 // EKSConfig represents the EKS related configuration config.
 type EKSConfig struct {
 	// Disable controls whether EKS-related permissions are granted
-	Disable bool `json:"disable"`
+	Disable bool `json:"disable"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// AllowIAMRoleCreation controls whether the EKS controllers have permissions for creating IAM
 	// roles per cluster
-	AllowIAMRoleCreation bool `json:"iamRoleCreation,omitempty"`
+	AllowIAMRoleCreation bool `json:"iamRoleCreation,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// EnableUserEKSConsolePolicy controls the creation of the policy to view EKS nodes and workloads.
-	EnableUserEKSConsolePolicy bool `json:"enableUserEKSConsolePolicy,omitempty"`
+	EnableUserEKSConsolePolicy bool `json:"enableUserEKSConsolePolicy,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// DefaultControlPlaneRole controls the configuration of the AWS IAM role for
 	// the EKS control plane. This is the default role that will be used if
 	// no role is included in the spec and automatic creation of the role
@@ -129,7 +130,7 @@ type EKSConfig struct {
 // EventBridge EC2 events.
 type EventBridgeConfig struct {
 	// Enable controls whether permissions are granted to consume EC2 events
-	Enable bool `json:"enable,omitempty"`
+	Enable bool `json:"enable,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // ClusterAPIControllers controls the configuration of the AWS IAM role for
@@ -149,11 +150,11 @@ type Nodes struct {
 
 	// DisableCloudProviderPolicy if set to true, will not generate and attach the policy for the AWS Cloud Provider.
 	// Defaults to false.
-	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"`
+	DisableCloudProviderPolicy bool `json:"disableCloudProviderPolicy"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// EC2ContainerRegistryReadOnly controls whether the node has read-only access to the
 	// EC2 container registry
-	EC2ContainerRegistryReadOnly bool `json:"ec2ContainerRegistryReadOnly"`
+	EC2ContainerRegistryReadOnly bool `json:"ec2ContainerRegistryReadOnly"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // +kubebuilder:object:root=true
@@ -171,7 +172,7 @@ type AWSIAMConfiguration struct {
 // which can be created for storing bootstrap data for nodes requiring it.
 type S3Buckets struct {
 	// Enable controls whether permissions are granted to manage S3 buckets.
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// NamePrefix will be prepended to every AWS IAM role bucket name. Defaults to "cluster-api-provider-aws-".
 	// AWSCluster S3 Bucket name must be prefixed with the same prefix.
@@ -234,7 +235,7 @@ type AWSIAMConfigurationSpec struct {
 	S3Buckets S3Buckets `json:"s3Buckets,omitempty"`
 
 	// AllowAssumeRole enables the sts:AssumeRole permission within the CAPA policies
-	AllowAssumeRole bool `json:"allowAssumeRole,omitempty"`
+	AllowAssumeRole bool `json:"allowAssumeRole,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // GetObjectKind returns the AAWSIAMConfiguration's TypeMeta.

--- a/cmd/clusterawsadm/cmd/eks/addons/types.go
+++ b/cmd/clusterawsadm/cmd/eks/addons/types.go
@@ -34,7 +34,7 @@ type availableAddon struct {
 
 type compatibility struct {
 	ClusterVersion   string   `json:"clusterVersion"`
-	DefaultVersion   bool     `json:"defaultVersion"`
+	DefaultVersion   bool     `json:"defaultVersion"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	PlatformVersions []string `json:"platformVersions"`
 }
 

--- a/cmd/clusterawsadm/gc/gc_test.go
+++ b/cmd/clusterawsadm/gc/gc_test.go
@@ -46,7 +46,7 @@ func TestEnableGC(t *testing.T) {
 		name         string
 		clusterName  string
 		existingObjs []client.Object
-		expectError  bool
+		expectError  bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:         "no capi cluster",
@@ -123,7 +123,7 @@ func TestDisableGC(t *testing.T) {
 		name         string
 		clusterName  string
 		existingObjs []client.Object
-		expectError  bool
+		expectError  bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:         "no capi cluster",
@@ -195,7 +195,7 @@ func TestConfigureGC(t *testing.T) {
 		clusterName  string
 		gcTasks      []string
 		existingObjs []client.Object
-		expectError  bool
+		expectError  bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:         "no capi cluster",

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -78,9 +78,9 @@ type AWSClusterReconciler struct {
 	elbServiceFactory            func(scope.ELBScope) services.ELBInterface
 	securityGroupFactory         func(scope.ClusterScope) services.SecurityGroupInterface
 	WatchFilterValue             string
-	ExternalResourceGC           bool
-	AlternativeGCStrategy        bool
-	TagUnmanagedNetworkResources bool
+	ExternalResourceGC           bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AlternativeGCStrategy        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	TagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	MaxWaitActiveUpdateDelete    time.Duration
 }
 

--- a/controllers/awscluster_controller_unit_test.go
+++ b/controllers/awscluster_controller_unit_test.go
@@ -48,7 +48,7 @@ func TestAWSClusterReconcilerReconcile(t *testing.T) {
 		name         string
 		awsCluster   *infrav1.AWSCluster
 		ownerCluster *clusterv1.Cluster
-		expectError  bool
+		expectError  bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Should fail Reconcile if owner cluster not found",
@@ -567,7 +567,7 @@ func cleanupCluster(g *WithT, awsCluster *infrav1.AWSCluster, namespace *corev1.
 func TestSecurityGroupRolesForCluster(t *testing.T) {
 	tests := []struct {
 		name           string
-		bastionEnabled bool
+		bastionEnabled bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		want           []infrav1.SecurityGroupRole
 	}{
 		{

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -86,7 +86,7 @@ type AWSMachineReconciler struct {
 	SSMServiceFactory            func(cloud.ClusterScoper) services.SecretInterface
 	objectStoreServiceFactory    func(cloud.ClusterScoper) services.ObjectStoreInterface
 	WatchFilterValue             string
-	TagUnmanagedNetworkResources bool
+	TagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	MaxWaitActiveUpdateDelete    time.Duration
 }
 

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -2393,8 +2393,8 @@ func TestAWSMachineReconcilerReconcile(t *testing.T) {
 		ownerMachine *clusterv1.Machine
 		ownerCluster *clusterv1.Cluster
 		awsCluster   *infrav1.AWSCluster
-		expectError  bool
-		requeue      bool
+		expectError  bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		requeue      bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:        "Should Reconcile successfully if no AWSMachine found",

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
@@ -154,7 +154,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// AssociateOIDCProvider can be enabled to automatically create an identity
 	// provider for the controller for use with IAM roles for service accounts
 	// +kubebuilder:default=false
-	AssociateOIDCProvider bool `json:"associateOIDCProvider,omitempty"`
+	AssociateOIDCProvider bool `json:"associateOIDCProvider,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Addons defines the EKS addons to enable with the EKS cluster.
 	// +optional
@@ -171,7 +171,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// should be deleted. You cannot set this to true if you are using the
 	// Amazon VPC CNI addon.
 	// +kubebuilder:default=false
-	DisableVPCCNI bool `json:"disableVPCCNI,omitempty"`
+	DisableVPCCNI bool `json:"disableVPCCNI,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// VpcCni is used to set configuration options for the VPC CNI plugin
 	// +optional
@@ -189,7 +189,7 @@ type KubeProxy struct {
 	// provides a way to specify that the kube-proxy daemonset should be deleted. You cannot
 	// set this to true if you are using the Amazon kube-proxy addon.
 	// +kubebuilder:default=false
-	Disable bool `json:"disable,omitempty"`
+	Disable bool `json:"disable,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // VpcCni specifies configuration related to the VPC CNI.
@@ -203,13 +203,13 @@ type VpcCni struct {
 type EndpointAccess struct {
 	// Public controls whether control plane endpoints are publicly accessible
 	// +optional
-	Public *bool `json:"public,omitempty"`
+	Public *bool `json:"public,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// PublicCIDRs specifies which blocks can access the public endpoint
 	// +optional
 	PublicCIDRs []*string `json:"publicCIDRs,omitempty"`
 	// Private points VPC-internal control plane access to the private endpoint
 	// +optional
-	Private *bool `json:"private,omitempty"`
+	Private *bool `json:"private,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // EncryptionConfig specifies the encryption configuration for the EKS clsuter.
@@ -254,15 +254,15 @@ type AWSManagedControlPlaneStatus struct {
 	// ExternalManagedControlPlane indicates to cluster-api that the control plane
 	// is managed by an external service such as AKS, EKS, GKE, etc.
 	// +kubebuilder:default=true
-	ExternalManagedControlPlane *bool `json:"externalManagedControlPlane,omitempty"`
+	ExternalManagedControlPlane *bool `json:"externalManagedControlPlane,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Initialized denotes whether or not the control plane has the
 	// uploaded kubernetes config-map.
 	// +optional
-	Initialized bool `json:"initialized"`
+	Initialized bool `json:"initialized"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Ready denotes that the AWSManagedControlPlane API Server is ready to
 	// receive requests and that the VPC infra is ready.
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// ErrorMessage indicates that there is a terminal problem reconciling the
 	// state, and will be set to a descriptive error message.
 	// +optional

--- a/controlplane/eks/api/v1beta1/types.go
+++ b/controlplane/eks/api/v1beta1/types.go
@@ -30,19 +30,19 @@ import (
 type ControlPlaneLoggingSpec struct {
 	// APIServer indicates if the Kubernetes API Server log (kube-apiserver) shoulkd be enabled
 	// +kubebuilder:default=false
-	APIServer bool `json:"apiServer"`
+	APIServer bool `json:"apiServer"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Audit indicates if the Kubernetes API audit log should be enabled
 	// +kubebuilder:default=false
-	Audit bool `json:"audit"`
+	Audit bool `json:"audit"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Authenticator indicates if the iam authenticator log should be enabled
 	// +kubebuilder:default=false
-	Authenticator bool `json:"authenticator"`
+	Authenticator bool `json:"authenticator"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// ControllerManager indicates if the controller manager (kube-controller-manager) log should be enabled
 	// +kubebuilder:default=false
-	ControllerManager bool `json:"controllerManager"`
+	ControllerManager bool `json:"controllerManager"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Scheduler indicates if the Kubernetes scheduler (kube-scheduler) log should be enabled
 	// +kubebuilder:default=false
-	Scheduler bool `json:"scheduler"`
+	Scheduler bool `json:"scheduler"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // IsLogEnabled returns true if the log is enabled.
@@ -144,7 +144,7 @@ type Addon struct {
 	// PreserveOnDelete indicates that the addon resources should be
 	// preserved in the cluster on delete.
 	// +optional
-	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"`
+	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AddonResolution defines the method for resolving parameter conflicts.

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
@@ -181,7 +181,7 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// AssociateOIDCProvider can be enabled to automatically create an identity
 	// provider for the controller for use with IAM roles for service accounts
 	// +kubebuilder:default=false
-	AssociateOIDCProvider bool `json:"associateOIDCProvider,omitempty"`
+	AssociateOIDCProvider bool `json:"associateOIDCProvider,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Addons defines the EKS addons to enable with the EKS cluster.
 	// +optional
@@ -204,11 +204,11 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// bare EKS cluster without EKS default networking addons
 	// If you set this value to false when creating a cluster, the default networking add-ons will not be installed
 	// +kubebuilder:default=true
-	BootstrapSelfManagedAddons bool `json:"bootstrapSelfManagedAddons,omitempty"`
+	BootstrapSelfManagedAddons bool `json:"bootstrapSelfManagedAddons,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// RestrictPrivateSubnets indicates that the EKS control plane should only use private subnets.
 	// +kubebuilder:default=false
-	RestrictPrivateSubnets bool `json:"restrictPrivateSubnets,omitempty"`
+	RestrictPrivateSubnets bool `json:"restrictPrivateSubnets,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// KubeProxy defines managed attributes of the kube-proxy daemonset
 	KubeProxy KubeProxy `json:"kubeProxy,omitempty"`
@@ -231,7 +231,7 @@ type KubeProxy struct {
 	// provides a way to specify that the kube-proxy daemonset should be deleted. You cannot
 	// set this to true if you are using the Amazon kube-proxy addon.
 	// +kubebuilder:default=false
-	Disable bool `json:"disable,omitempty"`
+	Disable bool `json:"disable,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // VpcCni specifies configuration related to the VPC CNI.
@@ -242,7 +242,7 @@ type VpcCni struct {
 	// should be deleted. You cannot set this to true if you are using the
 	// Amazon VPC CNI addon.
 	// +kubebuilder:default=false
-	Disable bool `json:"disable,omitempty"`
+	Disable bool `json:"disable,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Env defines a list of environment variables to apply to the `aws-node` DaemonSet
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`
@@ -252,13 +252,13 @@ type VpcCni struct {
 type EndpointAccess struct {
 	// Public controls whether control plane endpoints are publicly accessible
 	// +optional
-	Public *bool `json:"public,omitempty"`
+	Public *bool `json:"public,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// PublicCIDRs specifies which blocks can access the public endpoint
 	// +optional
 	PublicCIDRs []*string `json:"publicCIDRs,omitempty"`
 	// Private points VPC-internal control plane access to the private endpoint
 	// +optional
-	Private *bool `json:"private,omitempty"`
+	Private *bool `json:"private,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AccessConfig represents the access configuration information for the cluster
@@ -273,7 +273,7 @@ type AccessConfig struct {
 	// to the IAM identity creating the cluster. Only applied during creation,
 	// ignored when updating existing clusters. Defaults to true.
 	// +kubebuilder:default=true
-	BootstrapClusterCreatorAdminPermissions *bool `json:"bootstrapClusterCreatorAdminPermissions,omitempty"`
+	BootstrapClusterCreatorAdminPermissions *bool `json:"bootstrapClusterCreatorAdminPermissions,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // EncryptionConfig specifies the encryption configuration for the EKS clsuter.
@@ -318,15 +318,15 @@ type AWSManagedControlPlaneStatus struct {
 	// ExternalManagedControlPlane indicates to cluster-api that the control plane
 	// is managed by an external service such as AKS, EKS, GKE, etc.
 	// +kubebuilder:default=true
-	ExternalManagedControlPlane *bool `json:"externalManagedControlPlane,omitempty"`
+	ExternalManagedControlPlane *bool `json:"externalManagedControlPlane,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Initialized denotes whether or not the control plane has the
 	// uploaded kubernetes config-map.
 	// +optional
-	Initialized bool `json:"initialized"`
+	Initialized bool `json:"initialized"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Ready denotes that the AWSManagedControlPlane API Server is ready to
 	// receive requests and that the VPC infra is ready.
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// ErrorMessage indicates that there is a terminal problem reconciling the
 	// state, and will be set to a descriptive error message.
 	// +optional

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook_test.go
@@ -75,7 +75,7 @@ func TestDefaultingWebhook(t *testing.T) {
 		name         string
 		resourceName string
 		resourceNS   string
-		expectHash   bool
+		expectHash   bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect       string
 		spec         AWSManagedControlPlaneSpec
 		expectSpec   AWSManagedControlPlaneSpec
@@ -170,10 +170,10 @@ func TestWebhookCreate(t *testing.T) {
 	tests := []struct { //nolint:maligned
 		name                 string
 		eksClusterName       string
-		expectError          bool
+		expectError          bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expectErrorToContain string // if non-empty, the error message must contain this substring
 		eksVersion           string
-		hasAddons            bool
+		hasAddons            bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		vpcCNI               VpcCni
 		additionalTags       infrav1.Tags
 		secondaryCidr        *string
@@ -580,7 +580,7 @@ func TestWebhookUpdate(t *testing.T) {
 		newClusterName string
 		oldEksVersion  string
 		newEksVersion  string
-		expectError    bool
+		expectError    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "ekscluster specified, same cluster names",
@@ -906,7 +906,7 @@ func TestWebhookUpdate(t *testing.T) {
 func TestValidatingWebhookCreateSecondaryCidr(t *testing.T) {
 	tests := []struct {
 		name        string
-		expectError bool
+		expectError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		cidrRange   string
 	}{
 		{
@@ -976,7 +976,7 @@ func TestValidatingWebhookUpdateSecondaryCidr(t *testing.T) {
 	tests := []struct {
 		name        string
 		cidrRange   string
-		expectError bool
+		expectError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:        "complete range 1",

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook_test.go
@@ -168,18 +168,20 @@ func TestDefaultingWebhook(t *testing.T) {
 
 func TestWebhookCreate(t *testing.T) {
 	tests := []struct { //nolint:maligned
-		name                 string
-		eksClusterName       string
-		expectError          bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		name           string
+		eksClusterName string
+		//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		expectError          bool
 		expectErrorToContain string // if non-empty, the error message must contain this substring
 		eksVersion           string
-		hasAddons            bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-		vpcCNI               VpcCni
-		additionalTags       infrav1.Tags
-		secondaryCidr        *string
-		secondaryCidrBlocks  []infrav1.VpcCidrBlock
-		kubeProxy            KubeProxy
-		accessConfig         *AccessConfig
+		//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		hasAddons           bool
+		vpcCNI              VpcCni
+		additionalTags      infrav1.Tags
+		secondaryCidr       *string
+		secondaryCidrBlocks []infrav1.VpcCidrBlock
+		kubeProxy           KubeProxy
+		accessConfig        *AccessConfig
 	}{
 		{
 			name:           "ekscluster specified",

--- a/controlplane/eks/api/v1beta2/types.go
+++ b/controlplane/eks/api/v1beta2/types.go
@@ -31,19 +31,19 @@ import (
 type ControlPlaneLoggingSpec struct {
 	// APIServer indicates if the Kubernetes API Server log (kube-apiserver) shoulkd be enabled
 	// +kubebuilder:default=false
-	APIServer bool `json:"apiServer"`
+	APIServer bool `json:"apiServer"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Audit indicates if the Kubernetes API audit log should be enabled
 	// +kubebuilder:default=false
-	Audit bool `json:"audit"`
+	Audit bool `json:"audit"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Authenticator indicates if the iam authenticator log should be enabled
 	// +kubebuilder:default=false
-	Authenticator bool `json:"authenticator"`
+	Authenticator bool `json:"authenticator"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// ControllerManager indicates if the controller manager (kube-controller-manager) log should be enabled
 	// +kubebuilder:default=false
-	ControllerManager bool `json:"controllerManager"`
+	ControllerManager bool `json:"controllerManager"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Scheduler indicates if the Kubernetes scheduler (kube-scheduler) log should be enabled
 	// +kubebuilder:default=false
-	Scheduler bool `json:"scheduler"`
+	Scheduler bool `json:"scheduler"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // IsLogEnabled returns true if the log is enabled.
@@ -165,7 +165,7 @@ type Addon struct {
 	// PreserveOnDelete indicates that the addon resources should be
 	// preserved in the cluster on delete.
 	// +optional
-	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"`
+	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AddonResolution defines the method for resolving parameter conflicts.

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -97,14 +97,14 @@ type AWSManagedControlPlaneReconciler struct {
 	networkServiceFactory          func(scope.NetworkScope) services.NetworkInterface
 	securityGroupServiceFactory    func(*scope.ManagedControlPlaneScope) services.SecurityGroupInterface
 
-	EnableIAM                    bool
-	AllowAdditionalRoles         bool
+	EnableIAM                    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AllowAdditionalRoles         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	WatchFilterValue             string
-	ExternalResourceGC           bool
-	AlternativeGCStrategy        bool
+	ExternalResourceGC           bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AlternativeGCStrategy        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	WaitInfraPeriod              time.Duration
 	MaxWaitActiveUpdateDelete    time.Duration
-	TagUnmanagedNetworkResources bool
+	TagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // getAWSNodeService factory func is added for testing purpose so that we can inject mocked AWSNodeInterface to the AWSManagedControlPlaneReconciler.

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_unit_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_unit_test.go
@@ -27,7 +27,7 @@ import (
 func TestSecurityGroupRolesForCluster(t *testing.T) {
 	tests := []struct {
 		name           string
-		bastionEnabled bool
+		bastionEnabled bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:           "Should use bastion security group when bastion is enabled",

--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -162,7 +162,7 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	// +kubebuilder:default=false
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="enableExternalAuthProviders is immutable"
 	// +optional
-	EnableExternalAuthProviders bool `json:"enableExternalAuthProviders,omitempty"`
+	EnableExternalAuthProviders bool `json:"enableExternalAuthProviders,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// ExternalAuthProviders are external OIDC identity providers that can issue tokens for this cluster.
 	// Can only be set if "enableExternalAuthProviders" is set to "True".
@@ -318,7 +318,7 @@ type RegistryLocation struct {
 	// insecure indicates whether the registry is secure (https) or insecure (http), default is secured.
 	// +kubebuilder:default=false
 	// +optional
-	Insecure bool `json:"insecure,omitempty"`
+	Insecure bool `json:"insecure,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // RegistrySources contains registries configuration.
@@ -786,14 +786,14 @@ type RosaControlPlaneStatus struct {
 	// ExternalManagedControlPlane indicates to cluster-api that the control plane
 	// is managed by an external service such as AKS, EKS, GKE, etc.
 	// +kubebuilder:default=true
-	ExternalManagedControlPlane *bool `json:"externalManagedControlPlane,omitempty"`
+	ExternalManagedControlPlane *bool `json:"externalManagedControlPlane,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Initialized denotes whether or not the control plane has the
 	// uploaded kubernetes config-map.
 	// +optional
-	Initialized bool `json:"initialized"`
+	Initialized bool `json:"initialized"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Ready denotes that the ROSAControlPlane API Server is ready to receive requests.
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// FailureMessage will be set in the event that there is a terminal problem
 	// reconciling the state and will be set to a descriptive error message.
 	//

--- a/exp/api/v1beta1/awsfargateprofile_types.go
+++ b/exp/api/v1beta1/awsfargateprofile_types.go
@@ -74,7 +74,7 @@ type FargateSelector struct {
 type FargateProfileStatus struct {
 	// Ready denotes that the FargateProfile is available.
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// FailureReason will be set in the event that there is a terminal problem
 	// reconciling the FargateProfile and will contain a succinct value suitable

--- a/exp/api/v1beta1/awsmachinepool_types.go
+++ b/exp/api/v1beta1/awsmachinepool_types.go
@@ -81,7 +81,7 @@ type AWSMachinePoolSpec struct {
 
 	// Enable or disable the capacity rebalance autoscaling group feature
 	// +optional
-	CapacityRebalance bool `json:"capacityRebalance,omitempty"`
+	CapacityRebalance bool `json:"capacityRebalance,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // RefreshPreferences defines the specs for instance refreshing.
@@ -108,7 +108,7 @@ type RefreshPreferences struct {
 type AWSMachinePoolStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Replicas is the most recently observed number of replicas
 	// +optional

--- a/exp/api/v1beta1/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta1/awsmanagedmachinepool_types.go
@@ -169,7 +169,7 @@ type ManagedRemoteAccess struct {
 	SourceSecurityGroups []string `json:"sourceSecurityGroups,omitempty"`
 
 	// Public specifies whether to open port 22 to the public internet
-	Public bool `json:"public,omitempty"`
+	Public bool `json:"public,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AWSManagedMachinePoolStatus defines the observed state of AWSManagedMachinePool.
@@ -177,7 +177,7 @@ type AWSManagedMachinePoolStatus struct {
 	// Ready denotes that the AWSManagedMachinePool nodegroup has joined
 	// the cluster
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Replicas is the most recently observed number of replicas.
 	// +optional

--- a/exp/api/v1beta1/types.go
+++ b/exp/api/v1beta1/types.go
@@ -32,7 +32,7 @@ const (
 type EBS struct {
 	// Encrypted is whether the volume should be encrypted or not.
 	// +optional
-	Encrypted bool `json:"encrypted,omitempty"`
+	Encrypted bool `json:"encrypted,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// The size of the volume, in GiB.
 	// This can be a number from 1-1,024 for standard, 4-16,384 for io1, 1-16,384
@@ -191,7 +191,7 @@ type AutoScalingGroup struct {
 	PlacementGroup    string          `json:"placementGroup,omitempty"`
 	Subnets           []string        `json:"subnets,omitempty"`
 	DefaultCoolDown   metav1.Duration `json:"defaultCoolDown,omitempty"`
-	CapacityRebalance bool            `json:"capacityRebalance,omitempty"`
+	CapacityRebalance bool            `json:"capacityRebalance,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	MixedInstancesPolicy *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
 	Status               ASGStatus

--- a/exp/api/v1beta2/awsfargateprofile_types.go
+++ b/exp/api/v1beta2/awsfargateprofile_types.go
@@ -100,7 +100,7 @@ type FargateSelector struct {
 type FargateProfileStatus struct {
 	// Ready denotes that the FargateProfile is available.
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// FailureReason will be set in the event that there is a terminal problem
 	// reconciling the FargateProfile and will contain a succinct value suitable

--- a/exp/api/v1beta2/awsfargateprofile_webhook_test.go
+++ b/exp/api/v1beta2/awsfargateprofile_webhook_test.go
@@ -82,7 +82,7 @@ func TestAWSFargateProfileValidateRoleNameUpdate(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		expectErr      bool
+		expectErr      bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		before         *AWSFargateProfile
 		fargateProfile *AWSFargateProfile
 	}{
@@ -138,7 +138,7 @@ func TestAWSFargateProfileValidateCreate(t *testing.T) {
 	tests := []struct {
 		name    string
 		profile *AWSFargateProfile
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "profile with name is accepted",

--- a/exp/api/v1beta2/awsmachinepool_types.go
+++ b/exp/api/v1beta2/awsmachinepool_types.go
@@ -118,13 +118,17 @@ type SuspendProcessesTypes struct {
 
 // Processes defines the processes which can be enabled or disabled individually.
 type Processes struct {
-	Launch            *bool `json:"launch,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-	Terminate         *bool `json:"terminate,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-	AddToLoadBalancer *bool `json:"addToLoadBalancer,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-	AlarmNotification *bool `json:"alarmNotification,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-	AZRebalance       *bool `json:"azRebalance,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-	HealthCheck       *bool `json:"healthCheck,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-	InstanceRefresh   *bool `json:"instanceRefresh,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	Launch *bool `json:"launch,omitempty"`
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	Terminate *bool `json:"terminate,omitempty"`
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AddToLoadBalancer *bool `json:"addToLoadBalancer,omitempty"`
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AlarmNotification *bool `json:"alarmNotification,omitempty"`
+	AZRebalance       *bool `json:"azRebalance,omitempty"`      //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	HealthCheck       *bool `json:"healthCheck,omitempty"`      //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	InstanceRefresh   *bool `json:"instanceRefresh,omitempty"`  //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	ReplaceUnhealthy  *bool `json:"replaceUnhealthy,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	ScheduledActions  *bool `json:"scheduledActions,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }

--- a/exp/api/v1beta2/awsmachinepool_types.go
+++ b/exp/api/v1beta2/awsmachinepool_types.go
@@ -95,7 +95,7 @@ type AWSMachinePoolSpec struct {
 
 	// Enable or disable the capacity rebalance autoscaling group feature
 	// +optional
-	CapacityRebalance bool `json:"capacityRebalance,omitempty"`
+	CapacityRebalance bool `json:"capacityRebalance,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// SuspendProcesses defines a list of processes to suspend for the given ASG. This is constantly reconciled.
 	// If a process is removed from this list it will automatically be resumed.
@@ -112,21 +112,21 @@ type AWSMachinePoolSpec struct {
 
 // SuspendProcessesTypes contains user friendly auto-completable values for suspended process names.
 type SuspendProcessesTypes struct {
-	All       bool       `json:"all,omitempty"`
+	All       bool       `json:"all,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	Processes *Processes `json:"processes,omitempty"`
 }
 
 // Processes defines the processes which can be enabled or disabled individually.
 type Processes struct {
-	Launch            *bool `json:"launch,omitempty"`
-	Terminate         *bool `json:"terminate,omitempty"`
-	AddToLoadBalancer *bool `json:"addToLoadBalancer,omitempty"`
-	AlarmNotification *bool `json:"alarmNotification,omitempty"`
-	AZRebalance       *bool `json:"azRebalance,omitempty"`
-	HealthCheck       *bool `json:"healthCheck,omitempty"`
-	InstanceRefresh   *bool `json:"instanceRefresh,omitempty"`
-	ReplaceUnhealthy  *bool `json:"replaceUnhealthy,omitempty"`
-	ScheduledActions  *bool `json:"scheduledActions,omitempty"`
+	Launch            *bool `json:"launch,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	Terminate         *bool `json:"terminate,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AddToLoadBalancer *bool `json:"addToLoadBalancer,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AlarmNotification *bool `json:"alarmNotification,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AZRebalance       *bool `json:"azRebalance,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	HealthCheck       *bool `json:"healthCheck,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	InstanceRefresh   *bool `json:"instanceRefresh,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	ReplaceUnhealthy  *bool `json:"replaceUnhealthy,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	ScheduledActions  *bool `json:"scheduledActions,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // ConvertSetValuesToStringSlice converts all the values that are set into a string slice for further processing.
@@ -161,7 +161,7 @@ type RefreshPreferences struct {
 	// Disable, if true, disables instance refresh from triggering when new launch templates are detected.
 	// This is useful in scenarios where ASG nodes are externally managed.
 	// +optional
-	Disable bool `json:"disable,omitempty"`
+	Disable bool `json:"disable,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// The strategy to use for the instance refresh. The only valid value is Rolling.
 	// A rolling update is an update that is applied to all instances in an Auto
@@ -196,7 +196,7 @@ type RefreshPreferences struct {
 type AWSMachinePoolStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Replicas is the most recently observed number of replicas
 	// +optional

--- a/exp/api/v1beta2/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_types.go
@@ -236,7 +236,7 @@ type ManagedRemoteAccess struct {
 	SourceSecurityGroups []string `json:"sourceSecurityGroups,omitempty"`
 
 	// Public specifies whether to open port 22 to the public internet
-	Public bool `json:"public,omitempty"`
+	Public bool `json:"public,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // AWSManagedMachinePoolStatus defines the observed state of AWSManagedMachinePool.
@@ -244,7 +244,7 @@ type AWSManagedMachinePoolStatus struct {
 	// Ready denotes that the AWSManagedMachinePool nodegroup has joined
 	// the cluster
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// Replicas is the most recently observed number of replicas.
 	// +optional

--- a/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmanagedmachinepool_webhook_test.go
@@ -57,7 +57,7 @@ func TestAWSManagedMachinePoolValidateCreate(t *testing.T) {
 	tests := []struct {
 		name    string
 		pool    *AWSManagedMachinePool
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "pool requires a EKS Node group name",
@@ -177,7 +177,7 @@ func TestAWSManagedMachinePoolValidateUpdate(t *testing.T) {
 		name    string
 		new     *AWSManagedMachinePool
 		old     *AWSManagedMachinePool
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "update EKS node groups name is rejected",

--- a/exp/api/v1beta2/rosacluster_types.go
+++ b/exp/api/v1beta2/rosacluster_types.go
@@ -33,7 +33,7 @@ type ROSAClusterSpec struct {
 type ROSAClusterStatus struct {
 	// Ready is when the ROSAControlPlane has a API server URL.
 	// +optional
-	Ready bool `json:"ready,omitempty"`
+	Ready bool `json:"ready,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// FailureDomains specifies a list fo available availability zones that can be used
 	// +optional

--- a/exp/api/v1beta2/rosamachinepool_types.go
+++ b/exp/api/v1beta2/rosamachinepool_types.go
@@ -70,7 +70,7 @@ type RosaMachinePoolSpec struct {
 	// in the NodePool. The default is true.
 	// +kubebuilder:default=true
 	// +optional
-	AutoRepair bool `json:"autoRepair,omitempty"`
+	AutoRepair bool `json:"autoRepair,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// InstanceType specifies the AWS instance type
 	//
@@ -200,7 +200,7 @@ type RosaMachinePoolStatus struct {
 	// Ready denotes that the RosaMachinePool nodepool has joined
 	// the cluster
 	// +kubebuilder:default=false
-	Ready bool `json:"ready"`
+	Ready bool `json:"ready"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	// Replicas is the most recently observed number of replicas.
 	// +optional
 	Replicas int32 `json:"replicas"`

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -31,7 +31,7 @@ const (
 type EBS struct {
 	// Encrypted is whether the volume should be encrypted or not.
 	// +optional
-	Encrypted bool `json:"encrypted,omitempty"`
+	Encrypted bool `json:"encrypted,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	// The size of the volume, in GiB.
 	// This can be a number from 1-1,024 for standard, 4-16,384 for io1, 1-16,384
@@ -239,7 +239,7 @@ type AutoScalingGroup struct {
 	Subnets               []string        `json:"subnets,omitempty"`
 	DefaultCoolDown       metav1.Duration `json:"defaultCoolDown,omitempty"`
 	DefaultInstanceWarmup metav1.Duration `json:"defaultInstanceWarmup,omitempty"`
-	CapacityRebalance     bool            `json:"capacityRebalance,omitempty"`
+	CapacityRebalance     bool            `json:"capacityRebalance,omitempty"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	MixedInstancesPolicy      *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
 	Status                    ASGStatus

--- a/exp/controllers/awsfargatepool_controller.go
+++ b/exp/controllers/awsfargatepool_controller.go
@@ -45,7 +45,7 @@ import (
 type AWSFargateProfileReconciler struct {
 	client.Client
 	Recorder         record.EventRecorder
-	EnableIAM        bool
+	EnableIAM        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	WatchFilterValue string
 }
 

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -71,7 +71,7 @@ type AWSMachinePoolReconciler struct {
 	ec2ServiceFactory            func(scope.EC2Scope) services.EC2Interface
 	reconcileServiceFactory      func(scope.EC2Scope) services.MachinePoolReconcileInterface
 	objectStoreServiceFactory    func(scope.S3Scope) services.ObjectStoreInterface
-	TagUnmanagedNetworkResources bool
+	TagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 func (r *AWSMachinePoolReconciler) getASGService(scope cloud.ClusterScoper) services.ASGInterface {

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -1453,7 +1453,7 @@ func TestDiffASG(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           args
-		wantDifference bool
+		wantDifference bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "replicas != asg.desiredCapacity",

--- a/exp/controllers/awsmanagedmachinepool_controller.go
+++ b/exp/controllers/awsmanagedmachinepool_controller.go
@@ -55,10 +55,10 @@ import (
 type AWSManagedMachinePoolReconciler struct {
 	client.Client
 	Recorder                     record.EventRecorder
-	EnableIAM                    bool
-	AllowAdditionalRoles         bool
+	EnableIAM                    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AllowAdditionalRoles         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	WatchFilterValue             string
-	TagUnmanagedNetworkResources bool
+	TagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	MaxWaitActiveUpdateDelete    time.Duration
 }
 

--- a/pkg/cloud/endpoints/partition.go
+++ b/pkg/cloud/endpoints/partition.go
@@ -36,11 +36,13 @@ type Partition struct {
 //
 //nolint:revive
 type PartitionConfig struct {
-	Name                 string `json:"name"`
-	DnsSuffix            string `json:"dnsSuffix"`
-	DualStackDnsSuffix   string `json:"dualStackDnsSuffix"`
-	SupportsFIPS         bool   `json:"supportsFIPS"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
-	SupportsDualStack    bool   `json:"supportsDualStack"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	Name               string `json:"name"`
+	DnsSuffix          string `json:"dnsSuffix"`
+	DualStackDnsSuffix string `json:"dualStackDnsSuffix"`
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	SupportsFIPS bool `json:"supportsFIPS"`
+	//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	SupportsDualStack    bool   `json:"supportsDualStack"`
 	ImplicitGlobalRegion string `json:"implicitGlobalRegion"`
 }
 
@@ -51,7 +53,7 @@ type RegionOverrides struct {
 	Name               *string `json:"name"`
 	DnsSuffix          *string `json:"dnsSuffix"`
 	DualStackDnsSuffix *string `json:"dualStackDnsSuffix"`
-	SupportsFIPS       *bool   `json:"supportsFIPS"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	SupportsFIPS       *bool   `json:"supportsFIPS"`      //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	SupportsDualStack  *bool   `json:"supportsDualStack"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 

--- a/pkg/cloud/endpoints/partition.go
+++ b/pkg/cloud/endpoints/partition.go
@@ -39,8 +39,8 @@ type PartitionConfig struct {
 	Name                 string `json:"name"`
 	DnsSuffix            string `json:"dnsSuffix"`
 	DualStackDnsSuffix   string `json:"dualStackDnsSuffix"`
-	SupportsFIPS         bool   `json:"supportsFIPS"`
-	SupportsDualStack    bool   `json:"supportsDualStack"`
+	SupportsFIPS         bool   `json:"supportsFIPS"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	SupportsDualStack    bool   `json:"supportsDualStack"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	ImplicitGlobalRegion string `json:"implicitGlobalRegion"`
 }
 
@@ -51,8 +51,8 @@ type RegionOverrides struct {
 	Name               *string `json:"name"`
 	DnsSuffix          *string `json:"dnsSuffix"`
 	DualStackDnsSuffix *string `json:"dualStackDnsSuffix"`
-	SupportsFIPS       *bool   `json:"supportsFIPS"`
-	SupportsDualStack  *bool   `json:"supportsDualStack"`
+	SupportsFIPS       *bool   `json:"supportsFIPS"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	SupportsDualStack  *bool   `json:"supportsDualStack"` //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 const defaultPartition = "aws"

--- a/pkg/cloud/identity/identity_test.go
+++ b/pkg/cloud/identity/identity_test.go
@@ -89,7 +89,7 @@ func TestAWSStaticPrincipalTypeProvider(t *testing.T) {
 		name      string
 		provider  AWSPrincipalTypeProvider
 		expect    func(m *mock_stsiface.MockSTSClientMockRecorder)
-		expectErr bool
+		expectErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		value     aws.Credentials
 	}{
 		{

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -47,7 +47,7 @@ type ClusterScopeParams struct {
 	AWSCluster                   *infrav1.AWSCluster
 	ControllerName               string
 	Session                      aws.Config
-	TagUnmanagedNetworkResources bool
+	TagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	MaxWaitActiveUpdateDelete    time.Duration
 }
 
@@ -106,7 +106,7 @@ type ClusterScope struct {
 	serviceLimiters throttle.ServiceLimiters
 	controllerName  string
 
-	tagUnmanagedNetworkResources bool
+	tagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	maxWaitActiveUpdateDelete    time.Duration
 }
 

--- a/pkg/cloud/scope/fargate.go
+++ b/pkg/cloud/scope/fargate.go
@@ -47,7 +47,7 @@ type FargateProfileScopeParams struct {
 	ControllerName string
 	Session        aws.Config
 
-	EnableIAM bool
+	EnableIAM bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // NewFargateProfileScope creates a new Scope from the supplied parameters.
@@ -107,7 +107,7 @@ type FargateProfileScope struct {
 	serviceLimiters throttle.ServiceLimiters
 	controllerName  string
 
-	enableIAM bool
+	enableIAM bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // ManagedPoolName returns the managed machine pool name.

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -294,7 +294,7 @@ func (m *MachinePoolScope) SubnetIDs(subnetIDs []string) ([]string, error) {
 
 // NodeStatus represents the status of a Kubernetes node.
 type NodeStatus struct {
-	Ready   bool
+	Ready   bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	Version string
 }
 

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -64,9 +64,9 @@ type ManagedControlPlaneScopeParams struct {
 	Session                   aws.Config
 	MaxWaitActiveUpdateDelete time.Duration
 
-	EnableIAM                    bool
-	AllowAdditionalRoles         bool
-	TagUnmanagedNetworkResources bool
+	EnableIAM                    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AllowAdditionalRoles         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	TagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // NewManagedControlPlaneScope creates a new Scope from the supplied parameters.
@@ -127,9 +127,9 @@ type ManagedControlPlaneScope struct {
 	serviceLimiters throttle.ServiceLimiters
 	controllerName  string
 
-	enableIAM                    bool
-	allowAdditionalRoles         bool
-	tagUnmanagedNetworkResources bool
+	enableIAM                    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	allowAdditionalRoles         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	tagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // RemoteClient returns the Kubernetes client for connecting to the workload cluster.

--- a/pkg/cloud/scope/managednodegroup.go
+++ b/pkg/cloud/scope/managednodegroup.go
@@ -56,8 +56,8 @@ type ManagedMachinePoolScopeParams struct {
 	Session                   awsv2.Config
 	MaxWaitActiveUpdateDelete time.Duration
 
-	EnableIAM            bool
-	AllowAdditionalRoles bool
+	EnableIAM            bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	AllowAdditionalRoles bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 
 	InfraCluster EC2Scope
 }
@@ -140,8 +140,8 @@ type ManagedMachinePoolScope struct {
 	serviceLimiters throttle.ServiceLimiters
 	controllerName  string
 
-	enableIAM            bool
-	allowAdditionalRoles bool
+	enableIAM            bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+	allowAdditionalRoles bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // ManagedPoolName returns the managed machine pool name.

--- a/pkg/cloud/scope/session_test.go
+++ b/pkg/cloud/scope/session_test.go
@@ -43,8 +43,8 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 		clusterNamespace string
 		allowedNs        *infrav1.AllowedNamespaces
 		setup            func(*testing.T, client.Client)
-		expectedResult   bool
-		expectErr        bool
+		expectedResult   bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		expectErr        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:             "All clusters are permitted to use identity if allowedNamespaces is empty",
@@ -239,7 +239,7 @@ func TestPrincipalParsing(t *testing.T) {
 		identity    runtime.Object
 		setup       func(*testing.T, client.Client)
 		expect      func([]identity.AWSPrincipalTypeProvider)
-		expectError bool
+		expectError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Default case - no Principal specified",

--- a/pkg/cloud/scope/shared_test.go
+++ b/pkg/cloud/scope/shared_test.go
@@ -37,7 +37,7 @@ func TestSubnetPlacement(t *testing.T) {
 		controlPlaneSubnets infrav1.Subnets
 		logger              *logger.Logger
 		expectedSubnetIDs   []string
-		expectError         bool
+		expectError         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:                "spec subnets expected",

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -51,8 +51,8 @@ func TestServiceGetASGByName(t *testing.T) {
 	tests := []struct {
 		name            string
 		machinePoolName string
-		wantErr         bool
-		wantASG         bool
+		wantErr         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		wantASG         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect          func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -138,7 +138,7 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 		name    string
 		input   *autoscalingtypes.AutoScalingGroup
 		want    *expinfrav1.AutoScalingGroup
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "valid input - all required fields filled",
@@ -385,8 +385,8 @@ func TestServiceASGIfExists(t *testing.T) {
 	tests := []struct {
 		name    string
 		asgName *string
-		wantErr bool
-		wantASG bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		wantASG bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect  func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -477,8 +477,8 @@ func TestServiceCreateASG(t *testing.T) {
 		name                  string
 		machinePoolName       string
 		setupMachinePoolScope func(*scope.MachinePoolScope)
-		wantErr               bool
-		wantASG               bool
+		wantErr               bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		wantASG               bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect                func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -709,7 +709,7 @@ func TestServiceUpdateASG(t *testing.T) {
 		name                  string
 		machinePoolName       string
 		setupMachinePoolScope func(*scope.MachinePoolScope)
-		wantErr               bool
+		wantErr               bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect                func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder, g *WithT)
 	}{
 		{
@@ -797,7 +797,7 @@ func TestServiceUpdateASGWithSubnetFilters(t *testing.T) {
 		name                 string
 		machinePoolName      string
 		awsResourceReference []infrav1.AWSResourceReference
-		wantErr              bool
+		wantErr              bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect               func(e *mocks.MockEC2APIMockRecorder, m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -891,7 +891,7 @@ func TestServiceUpdateResourceTags(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect  func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -1000,7 +1000,7 @@ func TestServiceDeleteASG(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect  func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -1051,7 +1051,7 @@ func TestServiceDeleteASGAndWait(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect  func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -1125,9 +1125,9 @@ func TestServiceCanStartASGInstanceRefresh(t *testing.T) {
 
 	tests := []struct {
 		name                        string
-		wantErr                     bool
+		wantErr                     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		wantUnfinishedRefreshStatus *string
-		canStart                    bool
+		canStart                    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect                      func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{
@@ -1206,7 +1206,7 @@ func TestServiceStartASGInstanceRefresh(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect  func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder)
 	}{
 		{

--- a/pkg/cloud/services/autoscaling/lifecyclehook_test.go
+++ b/pkg/cloud/services/autoscaling/lifecyclehook_test.go
@@ -35,7 +35,7 @@ func TestLifecycleHookNeedsUpdate(t *testing.T) {
 		name       string
 		existing   expinfrav1.AWSLifecycleHook
 		expected   expinfrav1.AWSLifecycleHook
-		wantUpdate bool
+		wantUpdate bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "exactly equal",

--- a/pkg/cloud/services/ec2/ami_test.go
+++ b/pkg/cloud/services/ec2/ami_test.go
@@ -301,7 +301,7 @@ func TestFormatVersionForEKS(t *testing.T) {
 		name    string
 		version string
 		want    string
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:    "Should remove non zero patch from version",
@@ -402,7 +402,7 @@ func TestGetLatestImage(t *testing.T) {
 		name    string
 		imgs    []ec2types.Image
 		want    *ec2types.Image
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Should return image with latest creation date",
@@ -489,7 +489,7 @@ func TestEKSAMILookUp(t *testing.T) {
 		amiType    *infrav1.EKSAMILookupType
 		expect     func(m *mock_ssmiface.MockSSMAPIMockRecorder)
 		want       string
-		wantErr    bool
+		wantErr    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:       "Should return an id corresponding to GPU if GPU based AMI type passed",

--- a/pkg/cloud/services/ec2/bastion_test.go
+++ b/pkg/cloud/services/ec2/bastion_test.go
@@ -75,7 +75,7 @@ func TestServiceDeleteBastion(t *testing.T) {
 	tests := []struct {
 		name          string
 		expect        func(m *mocks.MockEC2APIMockRecorder)
-		expectError   bool
+		expectError   bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		bastionStatus *infrav1.Instance
 	}{
 		{
@@ -306,9 +306,9 @@ func TestServiceReconcileBastion(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		bastionEnabled bool
+		bastionEnabled bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect         func(m *mocks.MockEC2APIMockRecorder)
-		expectError    bool
+		expectError    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		bastionStatus  *infrav1.Instance
 	}{
 		{
@@ -538,9 +538,9 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		bastionEnabled bool
+		bastionEnabled bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect         func(m *mocks.MockEC2APIMockRecorder)
-		expectError    bool
+		expectError    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		bastionStatus  *infrav1.Instance
 	}{
 		{

--- a/pkg/cloud/services/ec2/dedicatedhosts_test.go
+++ b/pkg/cloud/services/ec2/dedicatedhosts_test.go
@@ -110,7 +110,7 @@ func TestAllocateDedicatedHost(t *testing.T) {
 		name                  string
 		dynamicAllocationSpec *infrav1.DynamicHostAllocationSpec
 		availabilityZone      string
-		expectError           bool
+		expectError           bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		instanceType          string
 		setupMocks            func(m *mocks.MockEC2API)
 	}{

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -322,7 +322,7 @@ func TestServiceSDKToLaunchTemplate(t *testing.T) {
 		wantUserDataHash      string
 		wantDataSecretKey     *types.NamespacedName
 		wantBootstrapDataHash *string
-		wantErr               bool
+		wantErr               bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "lots of input",
@@ -592,8 +592,8 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 		incoming *expinfrav1.AWSLaunchTemplate
 		existing *expinfrav1.AWSLaunchTemplate
 		expect   func(m *mocks.MockEC2APIMockRecorder)
-		want     bool
-		wantErr  bool
+		want     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		wantErr  bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "only core security groups, order shouldn't matter",
@@ -1102,7 +1102,7 @@ func TestDeleteLaunchTemplate(t *testing.T) {
 		name      string
 		versionID string
 		expect    func(m *mocks.MockEC2APIMockRecorder)
-		wantErr   bool
+		wantErr   bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:      "Should not return error if successfully deletes given launch template ID",
@@ -1469,7 +1469,7 @@ func TestCreateLaunchTemplateVersion(t *testing.T) {
 		imageID              *string
 		awsResourceReference []infrav1.AWSResourceReference
 		expect               func(m *mocks.MockEC2APIMockRecorder)
-		wantErr              bool
+		wantErr              bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		mpScopeUpdater       func(*scope.MachinePoolScope)
 		marketType           ec2types.MarketType
 	}{
@@ -2126,7 +2126,7 @@ func TestDeleteLaunchTemplateVersion(t *testing.T) {
 		name    string
 		args    args
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:    "Should return error if version is nil",

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -150,7 +150,7 @@ func TestMakeVPCConfig(t *testing.T) {
 	testCases := []struct {
 		name   string
 		input  input
-		err    bool
+		err    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect *ekstypes.VpcConfigRequest
 	}{
 		{
@@ -286,7 +286,7 @@ func TestPublicAccessCIDRsEqual(t *testing.T) {
 		name   string
 		a      []string
 		b      []string
-		expect bool
+		expect bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:   "no CIDRs",
@@ -371,7 +371,7 @@ func TestReconcileClusterVersion(t *testing.T) {
 	tests := []struct {
 		name        string
 		expect      func(m *mock_eksiface.MockEKSAPIMockRecorder)
-		expectError bool
+		expectError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no upgrade necessary",
@@ -479,7 +479,7 @@ func TestReconcileAccessConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		expect      func(m *mock_eksiface.MockEKSAPIMockRecorder)
-		expectError bool
+		expectError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no upgrade necessary",
@@ -597,7 +597,7 @@ func TestCreateCluster(t *testing.T) {
 	tests := []struct {
 		name        string
 		expectEKS   func(m *mock_eksiface.MockEKSAPIMockRecorder)
-		expectError bool
+		expectError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		role        *string
 		tags        map[string]string
 		subnets     []infrav1.SubnetSpec
@@ -701,7 +701,7 @@ func TestReconcileEKSEncryptionConfig(t *testing.T) {
 		oldEncryptionConfig *ekscontrolplanev1.EncryptionConfig
 		newEncryptionConfig *ekscontrolplanev1.EncryptionConfig
 		expect              func(m *mock_eksiface.MockEKSAPIMockRecorder)
-		expectError         bool
+		expectError         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:                "no upgrade necessary - encryption disabled",
@@ -816,7 +816,7 @@ func TestReconcileUpgradePolicy(t *testing.T) {
 		oldUpgradePolicy *ekstypes.UpgradePolicyResponse
 		newUpgradePolicy ekscontrolplanev1.UpgradePolicy
 		expect           *ekstypes.UpgradePolicyRequest
-		expectError      bool
+		expectError      bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no update necessary - upgrade policy omitted",

--- a/pkg/cloud/services/eks/config_test.go
+++ b/pkg/cloud/services/eks/config_test.go
@@ -29,7 +29,7 @@ func Test_createCAPIKubeconfigSecret(t *testing.T) {
 		name        string
 		input       *ekstypes.Cluster
 		serviceFunc func() *Service
-		wantErr     bool
+		wantErr     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "create kubeconfig secret",
@@ -113,7 +113,7 @@ func Test_updateCAPIKubeconfigSecret(t *testing.T) {
 		input       *ekstypes.Cluster
 		secret      *corev1.Secret
 		serviceFunc func(tc testCase) *Service
-		wantErr     bool
+		wantErr     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}
 	testCases := []testCase{
 		{

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -3886,7 +3886,7 @@ func TestService_getAdditionalTargetGroupHealthCheck(t *testing.T) {
 		name     string
 		listener infrav1.AdditionalListenerSpec
 		want     *infrav1.TargetGroupHealthCheck
-		wantErr  bool
+		wantErr  bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "TCP defaults",

--- a/pkg/cloud/services/gc/cleanup_test.go
+++ b/pkg/cloud/services/gc/cleanup_test.go
@@ -50,7 +50,7 @@ func TestReconcileDelete(t *testing.T) {
 		elbv2Mocks   func(m *mocks.MockELBV2APIMockRecorder)
 		rgAPIMocks   func(m *mocks.MockResourceGroupsTaggingAPIAPIMockRecorder)
 		ec2Mocks     func(m *mocks.MockEC2APIMockRecorder)
-		expectErr    bool
+		expectErr    bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:         "eks with cluster opt-out",

--- a/pkg/cloud/services/iamauth/configmap_test.go
+++ b/pkg/cloud/services/iamauth/configmap_test.go
@@ -55,7 +55,7 @@ func TestAddRoleMappingCM(t *testing.T) {
 		existingAuthConfigMap *corev1.ConfigMap
 		roleToMap             ekscontrolplanev1.RoleMapping
 		expectedRoleMaps      []ekscontrolplanev1.RoleMapping
-		expectError           bool
+		expectError           bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no existing mappings, add role mapping",
@@ -188,7 +188,7 @@ func TestAddUserMappingCM(t *testing.T) {
 		existingAuthConfigMap *corev1.ConfigMap
 		userToMap             ekscontrolplanev1.UserMapping
 		expectedUsersMap      []ekscontrolplanev1.UserMapping
-		expectError           bool
+		expectError           bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no existing user mappings, add user mapping",

--- a/pkg/cloud/services/iamauth/crd_test.go
+++ b/pkg/cloud/services/iamauth/crd_test.go
@@ -38,7 +38,7 @@ func TestAddRoleMappingCRD(t *testing.T) {
 		existingRoleMapping  *iamauthv1.IAMIdentityMapping
 		roleToMap            ekscontrolplanev1.RoleMapping
 		expectedRoleMapSpecs []iamauthv1.IAMIdentityMappingSpec
-		expectError          bool
+		expectError          bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no existing mappings, add role mapping",
@@ -166,7 +166,7 @@ func TestAddUserMappingCRD(t *testing.T) {
 		existingUserMapping  *iamauthv1.IAMIdentityMapping
 		userToMap            ekscontrolplanev1.UserMapping
 		expectedUserMapSpecs []iamauthv1.IAMIdentityMappingSpec
-		expectError          bool
+		expectError          bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no existing mappings, add user mapping",

--- a/pkg/cloud/services/instancestate/queue_test.go
+++ b/pkg/cloud/services/instancestate/queue_test.go
@@ -41,7 +41,7 @@ func TestReconcileSQSQueue(t *testing.T) {
 	testCases := []struct {
 		name      string
 		expect    func(m *mock_sqsiface.MockSQSAPIMockRecorder)
-		expectErr bool
+		expectErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "successfully creates an SQS queue",
@@ -112,7 +112,7 @@ func TestDeleteSQSQueue(t *testing.T) {
 	testCases := []struct {
 		name      string
 		expect    func(m *mock_sqsiface.MockSQSAPIMockRecorder)
-		expectErr bool
+		expectErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "deletes queue successfully",
@@ -202,7 +202,7 @@ func TestCreatePolicyForRule(t *testing.T) {
 		name      string
 		input     *createPolicyForRuleInput
 		expect    func(m *mock_sqsiface.MockSQSAPIMockRecorder)
-		expectErr bool
+		expectErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "creates a policy for a given rule",

--- a/pkg/cloud/services/instancestate/rule_test.go
+++ b/pkg/cloud/services/instancestate/rule_test.go
@@ -46,7 +46,7 @@ func TestReconcileRules(t *testing.T) {
 		eventBridgeExpect           func(m *mock_eventbridgeiface.MockEventBridgeAPIMockRecorder)
 		postCreateEventBridgeExpect func(m *mock_eventbridgeiface.MockEventBridgeAPIMockRecorder)
 		sqsExpect                   func(m *mock_sqsiface.MockSQSAPIMockRecorder)
-		expectErr                   bool
+		expectErr                   bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "successfully creates missing rule and target",
@@ -189,7 +189,7 @@ func TestDeleteRules(t *testing.T) {
 	testCases := []struct {
 		name              string
 		eventBridgeExpect func(m *mock_eventbridgeiface.MockEventBridgeAPIMockRecorder)
-		expectErr         bool
+		expectErr         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "removes target and ec2 rule successfully when they both exist",
@@ -274,7 +274,7 @@ func TestAddInstanceToRule(t *testing.T) {
 		name              string
 		eventBridgeExpect func(m *mock_eventbridgeiface.MockEventBridgeAPIMockRecorder)
 		newInstanceID     string
-		expectErr         bool
+		expectErr         bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "adds instance to event pattern when it doesn't exist",

--- a/pkg/cloud/services/network/carriergateways_test.go
+++ b/pkg/cloud/services/network/carriergateways_test.go
@@ -159,7 +159,7 @@ func TestDeleteCarrierGateway(t *testing.T) {
 		name    string
 		input   *infrav1.NetworkSpec
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Should ignore deletion if vpc is unmanaged",

--- a/pkg/cloud/services/network/egress_only_gateways_test.go
+++ b/pkg/cloud/services/network/egress_only_gateways_test.go
@@ -207,7 +207,7 @@ func TestDeleteEgressOnlyInternetGateways(t *testing.T) {
 		name    string
 		input   *infrav1.NetworkSpec
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Should ignore deletion if vpc is not ipv6",

--- a/pkg/cloud/services/network/eips_test.go
+++ b/pkg/cloud/services/network/eips_test.go
@@ -43,7 +43,7 @@ func TestServiceReleaseAddresses(t *testing.T) {
 	tests := []struct {
 		name    string
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Should return error if failed to describe IP addresses",

--- a/pkg/cloud/services/network/gateways_test.go
+++ b/pkg/cloud/services/network/gateways_test.go
@@ -161,7 +161,7 @@ func TestDeleteInternetGateways(t *testing.T) {
 		name    string
 		input   *infrav1.NetworkSpec
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Should ignore deletion if vpc is unmanaged",

--- a/pkg/cloud/services/network/natgateways_test.go
+++ b/pkg/cloud/services/network/natgateways_test.go
@@ -492,9 +492,9 @@ func TestDeleteNatGateways(t *testing.T) {
 	testCases := []struct {
 		name           string
 		input          []infrav1.SubnetSpec
-		isUnmanagedVPC bool
+		isUnmanagedVPC bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect         func(m *mocks.MockEC2APIMockRecorder)
-		wantErr        bool
+		wantErr        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:           "Should skip deletion if vpc is unmanaged",
@@ -881,7 +881,7 @@ func TestGetdNatGatewayForEdgeSubnet(t *testing.T) {
 		spec             infrav1.Subnets
 		input            infrav1.SubnetSpec
 		expect           string
-		expectErr        bool
+		expectErr        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expectErrMessage string
 	}{
 		{

--- a/pkg/cloud/services/network/routetables_test.go
+++ b/pkg/cloud/services/network/routetables_test.go
@@ -667,7 +667,7 @@ func TestDeleteRouteTables(t *testing.T) {
 		name    string
 		input   *infrav1.NetworkSpec
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "Should skip deletion if vpc is unmanaged",
@@ -785,7 +785,7 @@ func TestDeleteRouteTable(t *testing.T) {
 		name    string
 		input   types.RouteTable
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:  "Should delete route table successfully",
@@ -982,7 +982,7 @@ func TestService_getRoutesForSubnet(t *testing.T) {
 		specOverrideSubnets *infrav1.Subnets
 		inputSubnet         *infrav1.SubnetSpec
 		want                []*ec2.CreateRouteInput
-		wantErr             bool
+		wantErr             bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		wantErrMessage      string
 	}{
 		{

--- a/pkg/cloud/services/network/secondarycidr_test.go
+++ b/pkg/cloud/services/network/secondarycidr_test.go
@@ -67,10 +67,10 @@ func TestServiceAssociateSecondaryCidr(t *testing.T) {
 
 	tests := []struct {
 		name                                    string
-		fillAWSManagedControlPlaneSecondaryCIDR bool
+		fillAWSManagedControlPlaneSecondaryCIDR bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		networkSecondaryCIDRBlocks              []infrav1.VpcCidrBlock
 		expect                                  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr                                 bool
+		wantErr                                 bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:                                    "Should not associate secondary CIDR if no secondary cidr block info present in control plane",
@@ -247,11 +247,11 @@ func TestServiceDiassociateSecondaryCidr(t *testing.T) {
 
 	tests := []struct {
 		name                                    string
-		fillAWSManagedControlPlaneSecondaryCIDR bool
-		unmanagedVPC                            bool
+		fillAWSManagedControlPlaneSecondaryCIDR bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		unmanagedVPC                            bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		networkSecondaryCIDRBlocks              []infrav1.VpcCidrBlock
 		expect                                  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr                                 bool
+		wantErr                                 bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:                                    "Should not disassociate secondary CIDR if no secondary cidr block info present in control plane",

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -85,9 +85,9 @@ func TestReconcileSubnets(t *testing.T) {
 		name                         string
 		input                        ScopeBuilder
 		expect                       func(m *mocks.MockEC2APIMockRecorder)
-		errorExpected                bool
+		errorExpected                bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		errorMessageExpected         string
-		tagUnmanagedNetworkResources bool
+		tagUnmanagedNetworkResources bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		optionalExpectSubnets        infrav1.Subnets
 	}{
 		{
@@ -4437,7 +4437,7 @@ func TestDeleteSubnets(t *testing.T) {
 		name          string
 		input         *infrav1.NetworkSpec
 		expect        func(m *mocks.MockEC2APIMockRecorder)
-		errorExpected bool
+		errorExpected bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "managed vpc - success",

--- a/pkg/cloud/services/network/vpc_test.go
+++ b/pkg/cloud/services/network/vpc_test.go
@@ -591,7 +591,7 @@ func TestDeleteVPC(t *testing.T) {
 		name           string
 		input          *infrav1.VPCSpec
 		additionalTags map[string]string
-		wantErr        bool
+		wantErr        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect         func(m *mocks.MockEC2APIMockRecorder)
 	}{
 		{

--- a/pkg/cloud/services/secretsmanager/secret_test.go
+++ b/pkg/cloud/services/secretsmanager/secret_test.go
@@ -88,7 +88,7 @@ func TestServiceCreate(t *testing.T) {
 		bytesCount     int64
 		secretPrefix   string
 		expectedPrefix string
-		wantErr        bool
+		wantErr        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect         func(g *WithT, m *mocks.MockSecretsManagerAPIMockRecorder)
 	}{
 		{

--- a/pkg/cloud/services/securitygroup/securitygroups_test.go
+++ b/pkg/cloud/services/securitygroup/securitygroups_test.go
@@ -1204,7 +1204,7 @@ func TestAdditionalControlPlaneSecurityGroup(t *testing.T) {
 		networkSpec                   infrav1.NetworkSpec
 		networkStatus                 infrav1.NetworkStatus
 		expectedAdditionalIngressRule infrav1.IngressRule
-		wantErr                       bool
+		wantErr                       bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "default control plane security group is used",
@@ -1905,7 +1905,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 		name    string
 		input   *infrav1.NetworkSpec
 		expect  func(m *mocks.MockEC2APIMockRecorder)
-		wantErr bool
+		wantErr bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "do not delete security groups provided as overrides",

--- a/pkg/cloud/services/ssm/secret_test.go
+++ b/pkg/cloud/services/ssm/secret_test.go
@@ -128,7 +128,7 @@ func TestServiceCreate(t *testing.T) {
 		bytesCount     int64
 		secretPrefix   string
 		expectedPrefix string
-		wantErr        bool
+		wantErr        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		expect         func(m *mock_ssmiface.MockSSMAPIMockRecorder)
 	}{
 		{
@@ -252,7 +252,7 @@ func TestServiceDelete(t *testing.T) {
 		name        string
 		secretCount int32
 		expect      func(m *mock_ssmiface.MockSSMAPIMockRecorder)
-		wantErr     bool
+		wantErr     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 		check       func(error)
 	}{
 		{

--- a/pkg/eks/addons/plan_test.go
+++ b/pkg/eks/addons/plan_test.go
@@ -50,8 +50,8 @@ func TestEKSAddonPlan(t *testing.T) {
 		desiredAddons     []*EKSAddon
 		installedAddons   []*EKSAddon
 		expect            func(m *mock_eksiface.MockEKSAPIMockRecorder)
-		expectCreateError bool
-		expectDoError     bool
+		expectCreateError bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		expectDoError     bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no desired and no installed",

--- a/pkg/eks/addons/procedures.go
+++ b/pkg/eks/addons/procedures.go
@@ -42,7 +42,7 @@ var (
 type DeleteAddonProcedure struct {
 	plan     *plan
 	name     string
-	preserve bool
+	preserve bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // Do implements the logic for the procedure.
@@ -181,7 +181,7 @@ func (p *CreateAddonProcedure) Name() string {
 type WaitAddonActiveProcedure struct {
 	plan            *plan
 	name            string
-	includeDegraded bool
+	includeDegraded bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 }
 
 // Do implements the logic for the procedure.

--- a/pkg/eks/addons/types.go
+++ b/pkg/eks/addons/types.go
@@ -30,7 +30,7 @@ type EKSAddon struct {
 	Configuration         *string
 	Tags                  infrav1.Tags
 	ResolveConflict       *string
-	Preserve              bool
+	Preserve              bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	ARN                   *string
 	Status                *string
 }

--- a/pkg/eks/addons/types_test.go
+++ b/pkg/eks/addons/types_test.go
@@ -34,7 +34,7 @@ func TestAddOnEqual(t *testing.T) {
 		orig        *EKSAddon
 		other       *EKSAddon
 		result      gomega.OmegaMatcher
-		includeTags bool
+		includeTags bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			orig: &EKSAddon{

--- a/pkg/eks/identityprovider/plan_test.go
+++ b/pkg/eks/identityprovider/plan_test.go
@@ -43,8 +43,8 @@ func TestEKSAddonPlan(t *testing.T) {
 		currentIdentityProvider *OidcIdentityProviderConfig
 		desiredIdentityProvider *OidcIdentityProviderConfig
 		expect                  func(m *mock_eksiface.MockEKSAPIMockRecorder)
-		expectCreateError       bool
-		expectDoError           bool
+		expectCreateError       bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
+		expectDoError           bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name: "no desired and no installed",

--- a/pkg/internal/rate/rate.go
+++ b/pkg/internal/rate/rate.go
@@ -118,7 +118,7 @@ func (lim *Limiter) AllowN(now time.Time, n int) bool {
 // A Reservation holds information about events that are permitted by a Limiter to happen after a delay.
 // A Reservation may be canceled, which may enable the Limiter to permit additional events.
 type Reservation struct {
-	ok        bool
+	ok        bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	lim       *Limiter
 	tokens    int
 	timeToAct time.Time

--- a/util/paused/paused_test.go
+++ b/util/paused/paused_test.go
@@ -65,7 +65,7 @@ func TestEnsurePausedCondition(t *testing.T) {
 		name         string
 		cluster      *clusterv1.Cluster
 		object       ConditionSetter
-		wantIsPaused bool
+		wantIsPaused bool //nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.
 	}{
 		{
 			name:         "unpaused cluster and unpaused object",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup  
/kind support  

**What this PR does / why we need it**:

Enables the `nobools` linter in `golangci-kal` and adds targeted `//nolint:kubeapilinter` exemptions for existing boolean API fields and test struct fields.  
This keeps the API surface and behavior fully backward compatible while allowing the stricter linter to be enforced for newly added fields going forward.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5489 

**Special notes for your reviewer**:

- The linter is enabled globally, but all changes to code are limited to adding `//nolint:kubeapilinter // nobools: Existing API field, not changing to preserve backwards compatibility.` comments on existing fields.
- No API types or JSON schemas are changed; this should be a no-op for generated CRDs and existing clusters.
- Please double-check that all boolean API fields that would violate `nobools` are either:
  - existing and explicitly annotated with `//nolint`, or  
  - newly added and intentionally left as-is (in which case they should be reconsidered as enums).

**Checklist**:

- [ ] squashed commits  
- [ ] includes documentation  
- [x] includes emoji in title  
- [ ] adds unit tests  
- [ ] adds or updates e2e tests  

**Release note**:
```release-note
Enable the `nobools` kubeapilinter rule and add explicit exemptions for existing boolean API fields to preserve backward compatibility.
```