### PR TITLE
🐛 Remove invalid kustomizeconfig from config/webhook

### DIFF
--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,25 +1,4 @@
-# the following config is for teaching kustomize where to look at when substituting vars.
-# It requires kustomize v2.1.0 or newer to work properly.
-nameReference:
-- kind: Service
-  version: v1
-  fieldSpecs:
-  - kind: MutatingWebhookConfiguration
-    group: admissionregistration.k8s.io
-    path: webhooks/clientConfig/service/name
-  - kind: ValidatingWebhookConfiguration
-    group: admissionregistration.k8s.io
-    path: webhooks/clientConfig/service/name
-
-namespace:
-- kind: MutatingWebhookConfiguration
-  group: admissionregistration.k8s.io
-  path: webhooks/clientConfig/service/namespace
-  create: true
-- kind: ValidatingWebhookConfiguration
-  group: admissionregistration.k8s.io
-  path: webhooks/clientConfig/service/namespace
-  create: true
-
+# This directive should be removed when vars are removed from this
+# kustomization
 varReference:
 - path: metadata/annotations


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This change has no effect on the output of this kustomization because
the removed configuration was redundant. However, it fixes a bug which
can be triggered when using this kustomization as a base for another
kustomization.

kustomizeconfig contained 3 directives:

* nameReference
* namespace
* varReference

varReference remains required until vars are removed from this
kustomization.

nameReference is redundant because the specified configuration is
already in kustomize's defaults. However, nameReference is the important
transformation here.

namespace is incorrect. It directs the namespace transformer to update
webhooks/clientConfig/service/namespace. However, this is not the
intended function of the namespace transformer: it should only set the
namespace directly on objects and allow references to be updated
automatically by nameReference. Configuring it to update a reference
directly leaves kustomize with inconsistent internal state. Depending on
execution order this can cause a subsequent transformation to fail to
update the reference when it makes further changes to the Service
object.

This issue is common amongst multiple providers, likely because it was present in an early version of the kubebuilder templates.

This PR is based on https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5982

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

To confirm that the removed configuration was redundant:
* Execute `make release-manifests`
* Copy `out/infrastructure-components.yaml` to /tmp
* Apply/revert this change
* Execute `make release-manifests` again
* diff the outputs and confirm that they are identical

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] includes emoji in title 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
