### PR TITLE
🐛 Fix lifecycle hooks being updated constantly, consider changes to `RoleARN` field as well

### DIFF
--- a/pkg/cloud/services/autoscaling/lifecyclehook.go
+++ b/pkg/cloud/services/autoscaling/lifecyclehook.go
@@ -204,8 +204,9 @@ func lifecycleHookNeedsUpdate(existing *expinfrav1.AWSLifecycleHook, expected *e
 	return ptr.Deref(existing.DefaultResult, expinfrav1.LifecycleHookDefaultResultAbandon) != ptr.Deref(expected.DefaultResult, expinfrav1.LifecycleHookDefaultResultAbandon) ||
 		ptr.Deref(existing.HeartbeatTimeout, metav1.Duration{Duration: 3600 * time.Second}) != ptr.Deref(expected.HeartbeatTimeout, metav1.Duration{Duration: 3600 * time.Second}) ||
 		existing.LifecycleTransition != expected.LifecycleTransition ||
-		existing.NotificationTargetARN != expected.NotificationTargetARN ||
-		existing.NotificationMetadata != expected.NotificationMetadata
+		ptr.Deref(existing.NotificationTargetARN, "") != ptr.Deref(expected.NotificationTargetARN, "") ||
+		ptr.Deref(existing.RoleARN, "") != ptr.Deref(expected.RoleARN, "") ||
+		ptr.Deref(existing.NotificationMetadata, "") != ptr.Deref(expected.NotificationMetadata, "")
 }
 
 func reconcileLifecycleHook(ctx context.Context, asgService services.ASGInterface, asgName string, wantedHook *expinfrav1.AWSLifecycleHook, existingHooks []*expinfrav1.AWSLifecycleHook, storeConditionsOnObject deprecatedv1beta1conditions.Setter, log logger.Wrapper) error {

--- a/pkg/cloud/services/autoscaling/lifecyclehook_test.go
+++ b/pkg/cloud/services/autoscaling/lifecyclehook_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 )
@@ -49,6 +50,29 @@ func TestLifecycleHookNeedsUpdate(t *testing.T) {
 				LifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING",
 				HeartbeatTimeout:    &metav1.Duration{Duration: 3600 * time.Second},
 				DefaultResult:       &defaultResultAbandon,
+			},
+			wantUpdate: false,
+		},
+
+		{
+			name: "exactly equal (all fields filled)",
+			existing: expinfrav1.AWSLifecycleHook{
+				Name:                  "test",
+				NotificationTargetARN: ptr.To("arn:aws:sqs:eu-west-1:123456789012:mycluster-nth"),
+				RoleARN:               ptr.To("arn:aws:iam::123456789012:role/mycluster-nth-notification"),
+				LifecycleTransition:   "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:      &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:         &defaultResultAbandon,
+				NotificationMetadata:  nil,
+			},
+			expected: expinfrav1.AWSLifecycleHook{
+				Name:                  "test",
+				NotificationTargetARN: ptr.To("arn:aws:sqs:eu-west-1:123456789012:mycluster-nth"),
+				RoleARN:               ptr.To("arn:aws:iam::123456789012:role/mycluster-nth-notification"),
+				LifecycleTransition:   "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:      &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:         &defaultResultAbandon,
+				NotificationMetadata:  nil,
 			},
 			wantUpdate: false,
 		},
@@ -116,6 +140,90 @@ func TestLifecycleHookNeedsUpdate(t *testing.T) {
 				LifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING",
 				HeartbeatTimeout:    &metav1.Duration{Duration: 3600 * time.Second},
 				DefaultResult:       &defaultResultContinue,
+			},
+			wantUpdate: true,
+		},
+
+		{
+			name: "role ARN differs",
+			existing: expinfrav1.AWSLifecycleHook{
+				Name:                  "test",
+				NotificationTargetARN: ptr.To("arn:aws:sqs:eu-west-1:123456789012:mycluster-nth"),
+				RoleARN:               ptr.To("arn:aws:iam::123456789012:role/mycluster-nth-notification"),
+				LifecycleTransition:   "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:      &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:         &defaultResultAbandon,
+				NotificationMetadata:  nil,
+			},
+			expected: expinfrav1.AWSLifecycleHook{
+				Name:                  "test",
+				NotificationTargetARN: ptr.To("arn:aws:sqs:eu-west-1:123456789012:mycluster-nth"),
+				RoleARN:               ptr.To("arn:aws:iam::123456789012:role/mycluster-nth-notification2"),
+				LifecycleTransition:   "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:      &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:         &defaultResultAbandon,
+				NotificationMetadata:  nil,
+			},
+			wantUpdate: true,
+		},
+
+		{
+			name: "notification target ARN differs",
+			existing: expinfrav1.AWSLifecycleHook{
+				Name:                  "test",
+				NotificationTargetARN: ptr.To("arn:aws:sqs:eu-west-1:123456789012:mycluster-nth"),
+				RoleARN:               ptr.To("arn:aws:iam::123456789012:role/mycluster-nth-notification"),
+				LifecycleTransition:   "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:      &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:         &defaultResultAbandon,
+				NotificationMetadata:  nil,
+			},
+			expected: expinfrav1.AWSLifecycleHook{
+				Name:                  "test",
+				NotificationTargetARN: ptr.To("arn:aws:sqs:eu-west-1:123456789012:mycluster-nth2"),
+				RoleARN:               ptr.To("arn:aws:iam::123456789012:role/mycluster-nth-notification"),
+				LifecycleTransition:   "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:      &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:         &defaultResultAbandon,
+				NotificationMetadata:  nil,
+			},
+			wantUpdate: true,
+		},
+
+		{
+			name: "notification metadata both empty",
+			existing: expinfrav1.AWSLifecycleHook{
+				Name:                 "test",
+				LifecycleTransition:  "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:     &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:        &defaultResultAbandon,
+				NotificationMetadata: nil,
+			},
+			expected: expinfrav1.AWSLifecycleHook{
+				Name:                 "test",
+				LifecycleTransition:  "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:     &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:        &defaultResultAbandon,
+				NotificationMetadata: ptr.To(""),
+			},
+			wantUpdate: false,
+		},
+
+		{
+			name: "notification metadata differs",
+			existing: expinfrav1.AWSLifecycleHook{
+				Name:                 "test",
+				LifecycleTransition:  "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:     &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:        &defaultResultAbandon,
+				NotificationMetadata: ptr.To("abc"),
+			},
+			expected: expinfrav1.AWSLifecycleHook{
+				Name:                 "test",
+				LifecycleTransition:  "autoscaling:EC2_INSTANCE_TERMINATING",
+				HeartbeatTimeout:     &metav1.Duration{Duration: 3600 * time.Second},
+				DefaultResult:        &defaultResultAbandon,
+				NotificationMetadata: ptr.To("xyz"),
 			},
 			wantUpdate: true,
 		},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug
/area machinepool

**What this PR does / why we need it**:

CAPA kept logging `Updating lifecycle hook` and thereby calling the `PutLifecycleHook` API.

This fix ports our fork PR (https://github.com/giantswarm/cluster-api-provider-aws/pull/639) to upstream. It solves the high rate of AWS API requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix lifecycle hooks being updated constantly, consider changes to `RoleARN` field as well
```
