### PR TITLE
✨ Cache architecture for each instance type in memory to avoid unnecessary AWS API requests

### DIFF
--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -147,7 +147,7 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 		ms.AWSMachine.Status.InstanceState = &infrav1.InstanceStateRunning
 		ms.Machine.Labels = map[string]string{clusterv1.MachineControlPlaneLabel: ""}
 
-		ec2Svc := ec2Service.NewService(cs)
+		ec2Svc := ec2Service.NewService(cs).WithInstanceTypeArchitectureCache(nil)
 		ec2Svc.EC2Client = ec2Mock
 		reconciler.ec2ServiceFactory = func(scope scope.EC2Scope) services.EC2Interface {
 			return ec2Svc

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -5971,7 +5971,7 @@ func TestCreateInstance(t *testing.T) {
 			machineScope.AWSMachine.Spec = *tc.machineConfig
 			tc.expect(ec2Mock.EXPECT())
 
-			s := NewService(clusterScope)
+			s := NewService(clusterScope).WithInstanceTypeArchitectureCache(nil)
 			s.EC2Client = ec2Mock
 
 			instance, err := s.CreateInstance(context.TODO(), machineScope, data, "")

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -2028,7 +2028,7 @@ func TestDiscoverLaunchTemplateAMI(t *testing.T) {
 				tc.expect(ec2Mock.EXPECT())
 			}
 
-			s := NewService(cs)
+			s := NewService(cs).WithInstanceTypeArchitectureCache(nil)
 			s.EC2Client = ec2Mock
 
 			id, err := s.DiscoverLaunchTemplateAMI(context.TODO(), ms)
@@ -2104,7 +2104,7 @@ func TestDiscoverLaunchTemplateAMIForEKS(t *testing.T) {
 				tc.expectSSM(ssmMock.EXPECT())
 			}
 
-			s := NewService(mcps)
+			s := NewService(mcps).WithInstanceTypeArchitectureCache(nil)
 			s.EC2Client = ec2Mock
 			s.SSMClient = ssmMock
 

--- a/pkg/cloud/services/ec2/service.go
+++ b/pkg/cloud/services/ec2/service.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/common"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/network"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/ssm"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/util/cache"
 )
 
 // Service holds a collection of interfaces.
@@ -38,14 +39,23 @@ type Service struct {
 	// RetryEC2Client is used for dedicated host operations with enhanced retry configuration
 	// If nil, a new retry client will be created as needed
 	RetryEC2Client common.EC2API
+
+	InstanceTypeArchitectureCache cache.InstanceTypeArchitectureCache
 }
 
 // NewService returns a new service given the ec2 api client.
 func NewService(clusterScope scope.EC2Scope) *Service {
 	return &Service{
-		scope:      clusterScope,
-		EC2Client:  scope.NewEC2Client(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
-		SSMClient:  scope.NewSSMClient(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
-		netService: network.NewService(clusterScope.(scope.NetworkScope)),
+		scope:                         clusterScope,
+		EC2Client:                     scope.NewEC2Client(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
+		SSMClient:                     scope.NewSSMClient(clusterScope, clusterScope, clusterScope, clusterScope.InfraCluster()),
+		netService:                    network.NewService(clusterScope.(scope.NetworkScope)),
+		InstanceTypeArchitectureCache: cache.InstanceTypeArchitectureCacheSingleton,
 	}
+}
+
+// WithInstanceTypeArchitectureCache overrides the cache for InstanceTypeArchitectureCacheEntry items (nil disables caching).
+func (s *Service) WithInstanceTypeArchitectureCache(instanceTypeArchitectureCache cache.InstanceTypeArchitectureCache) *Service {
+	s.InstanceTypeArchitectureCache = instanceTypeArchitectureCache
+	return s
 }

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cache implements caching helper functions.
+package cache
+
+import (
+	"time"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	capicache "sigs.k8s.io/cluster-api/util/cache"
+)
+
+// InstanceTypeArchitectureCacheEntry caches DescribeInstanceTypes results since they are not expected to change.
+type InstanceTypeArchitectureCacheEntry struct {
+	InstanceType ec2types.InstanceType
+	Architecture string
+}
+
+// Key returns the cache key of a InstanceTypeArchitectureCacheEntry.
+func (e InstanceTypeArchitectureCacheEntry) Key() string {
+	return string(e.InstanceType)
+}
+
+// InstanceTypeArchitectureCache stores InstanceTypeArchitectureCacheEntry items.
+type InstanceTypeArchitectureCache = capicache.Cache[InstanceTypeArchitectureCacheEntry]
+
+var (
+	// InstanceTypeArchitectureCacheSingleton is the singleton cache for InstanceTypeArchitectureCacheEntry items.
+	// It should be used in all relevant controllers (and possibly disabled for unit tests).
+	InstanceTypeArchitectureCacheSingleton InstanceTypeArchitectureCache = capicache.New[InstanceTypeArchitectureCacheEntry](2 * time.Hour)
+)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

With the MachinePool Machines feature gate turned on, we now see a lot more reconciliation queueing on large MCs due to reconciling a lot of `AWSMachine` objects. This PR was a low-hanging fruit: the `DescribeInstanceTypes` AWS request is 100% cacheable.

This uses CAPI's caching helper and uses a very long caching duration as I don't expect the instance type to architecture mapping to change within AWS.

Confirmed working in our fork already (https://github.com/giantswarm/cluster-api-provider-aws/pull/638).

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cache architecture for each instance type in memory to avoid repeated AWS API requests
```
