### PR TITLE
🐛 Fix invalid cloud-config when write_files is nil

### DIFF
--- a/bootstrap/eks/internal/userdata/node.go
+++ b/bootstrap/eks/internal/userdata/node.go
@@ -30,7 +30,9 @@ const (
 	defaultBootstrapCommand = "/etc/eks/bootstrap.sh"
 
 	nodeUserData = `#cloud-config
+{{- if .Files }}
 {{template "files" .Files}}
+{{- end }}
 runcmd:
 {{- template "commands" .PreBootstrapCommands }}
   - {{ .BootstrapCommand }} {{.ClusterName}} {{- template "args" . }}

--- a/bootstrap/eks/internal/userdata/node_test.go
+++ b/bootstrap/eks/internal/userdata/node_test.go
@@ -49,7 +49,6 @@ func TestNewNode(t *testing.T) {
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster
 `),
@@ -67,7 +66,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --kubelet-extra-args '--node-labels=node-role.undistro.io/infra=true --register-with-taints=dedicated=infra:NoSchedule'
 `),
@@ -81,7 +79,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --container-runtime containerd
 `),
@@ -99,7 +96,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --kubelet-extra-args '--node-labels=node-role.undistro.io/infra=true --register-with-taints=dedicated=infra:NoSchedule' --container-runtime containerd
 `),
@@ -114,7 +110,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --ip-family ipv6 --service-ipv6-cidr fe80:0000:0000:0000:0204:61ff:fe9d:f156/24
 `),
@@ -128,7 +123,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --use-max-pods false
 `),
@@ -142,7 +136,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --aws-api-retry-attempts 5
 `),
@@ -157,7 +150,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --pause-container-account 12345678 --pause-container-version v1
 `),
@@ -171,7 +163,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --dns-cluster-ip 192.168.0.1
 `),
@@ -185,7 +176,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster --docker-config-json '{"debug":true}'
 `),
@@ -199,7 +189,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - "date"
   - "echo \"testing\""
@@ -215,7 +204,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster
   - "date"
@@ -232,7 +220,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - "echo \"testing pre\""
   - /etc/eks/bootstrap.sh test-cluster
@@ -248,7 +235,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /custom/mybootstrap.sh test-cluster
 `),
@@ -280,7 +266,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster
 disk_setup:
@@ -326,6 +311,31 @@ runcmd:
 `),
 		},
 		{
+			name: "with empty files",
+			args: args{
+				input: &NodeInput{
+					ClusterName: "test-cluster",
+					Files:       []eksbootstrapv1.File{},
+				},
+			},
+			expectedBytes: []byte(`#cloud-config
+runcmd:
+  - /etc/eks/bootstrap.sh test-cluster
+`),
+		},
+		{
+			name: "with nil files",
+			args: args{
+				input: &NodeInput{
+					ClusterName: "test-cluster",
+				},
+			},
+			expectedBytes: []byte(`#cloud-config
+runcmd:
+  - /etc/eks/bootstrap.sh test-cluster
+`),
+		},
+		{
 			name: "with ntp",
 			args: args{
 				input: &NodeInput{
@@ -337,7 +347,6 @@ runcmd:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster
 ntp:
@@ -363,7 +372,6 @@ ntp:
 				},
 			},
 			expectedBytes: []byte(`#cloud-config
-write_files:
 runcmd:
   - /etc/eks/bootstrap.sh test-cluster
 users:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When `EKSConfigTemplate.spec.template.spec.files` is empty, the resulting cloud config is invalid:
```
#cloud-config
write_files:
runcmd:
  - /etc/eks/bootstrap.sh cluster-name
```
```
cloud-init status --long
status: error
extended_status: error - done
boot_status_code: enabled-by-generator
last_update: Thu, 01 Jan 1970 00:25:50 +0000
detail: Failed due to systemd unit failure
errors:
        - ('write_files', TypeError("'NoneType' object is not iterable"))
```
**Special notes for your reviewer**:

This may only be an issue on newer versions of cloud-init (or maybe the underlying system Python?) We've been using CAPA for years and only saw this problem after updating our AMIs to Ubuntu 24.04:
```
cloud-init --version
/usr/bin/cloud-init 25.2-0ubuntu1~24.04.1
```

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Fix invalid cloud-config when EKS config has no files
```