### PR TITLE
✨ Add PlacementGroupName and PlacementGroupPartition to AWSLaunchTemplate 

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -817,6 +817,19 @@ spec:
                       - size
                       type: object
                     type: array
+                  placementGroupName:
+                    description: PlacementGroupName specifies the name of the placement
+                      group in which to launch the instance.
+                    type: string
+                  placementGroupPartition:
+                    description: |-
+                      PlacementGroupPartition is the partition number within the placement group in which to launch the instance.
+                      This value is only valid if the placement group, referred in `PlacementGroupName`, was created with
+                      strategy set to partition.
+                    format: int64
+                    maximum: 7
+                    minimum: 1
+                    type: integer
                   privateDnsName:
                     description: PrivateDNSName is the options for the instance hostname.
                     properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -826,6 +826,19 @@ spec:
                       - size
                       type: object
                     type: array
+                  placementGroupName:
+                    description: PlacementGroupName specifies the name of the placement
+                      group in which to launch the instance.
+                    type: string
+                  placementGroupPartition:
+                    description: |-
+                      PlacementGroupPartition is the partition number within the placement group in which to launch the instance.
+                      This value is only valid if the placement group, referred in `PlacementGroupName`, was created with
+                      strategy set to partition.
+                    format: int64
+                    maximum: 7
+                    minimum: 1
+                    type: integer
                   privateDnsName:
                     description: PrivateDNSName is the options for the instance hostname.
                     properties:

--- a/exp/api/v1beta1/conversion.go
+++ b/exp/api/v1beta1/conversion.go
@@ -74,6 +74,14 @@ func (src *AWSMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.AWSLaunchTemplate.CapacityReservationPreference = preference
 	}
 
+	if restored.Spec.AWSLaunchTemplate.PlacementGroupName != "" {
+		dst.Spec.AWSLaunchTemplate.PlacementGroupName = restored.Spec.AWSLaunchTemplate.PlacementGroupName
+	}
+
+	if restored.Spec.AWSLaunchTemplate.PlacementGroupPartition != 0 {
+		dst.Spec.AWSLaunchTemplate.PlacementGroupPartition = restored.Spec.AWSLaunchTemplate.PlacementGroupPartition
+	}
+
 	dst.Spec.DefaultInstanceWarmup = restored.Spec.DefaultInstanceWarmup
 	dst.Spec.AWSLaunchTemplate.NonRootVolumes = restored.Spec.AWSLaunchTemplate.NonRootVolumes
 	return nil
@@ -135,6 +143,14 @@ func (src *AWSManagedMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 
 		if preference := restored.Spec.AWSLaunchTemplate.CapacityReservationPreference; preference != "" {
 			dst.Spec.AWSLaunchTemplate.CapacityReservationPreference = preference
+		}
+
+		if restored.Spec.AWSLaunchTemplate.PlacementGroupName != "" {
+			dst.Spec.AWSLaunchTemplate.PlacementGroupName = restored.Spec.AWSLaunchTemplate.PlacementGroupName
+		}
+
+		if restored.Spec.AWSLaunchTemplate.PlacementGroupPartition != 0 {
+			dst.Spec.AWSLaunchTemplate.PlacementGroupPartition = restored.Spec.AWSLaunchTemplate.PlacementGroupPartition
 		}
 	}
 	if restored.Spec.AvailabilityZoneSubnetType != nil {

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -412,6 +412,8 @@ func autoConvert_v1beta2_AWSLaunchTemplate_To_v1beta1_AWSLaunchTemplate(in *v1be
 	out.SpotMarketOptions = (*apiv1beta2.SpotMarketOptions)(unsafe.Pointer(in.SpotMarketOptions))
 	// WARNING: in.InstanceMetadataOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.PrivateDNSName requires manual conversion: does not exist in peer-type
+	// WARNING: in.PlacementGroupName requires manual conversion: does not exist in peer-type
+	// WARNING: in.PlacementGroupPartition requires manual conversion: does not exist in peer-type
 	// WARNING: in.CapacityReservationID requires manual conversion: does not exist in peer-type
 	// WARNING: in.MarketType requires manual conversion: does not exist in peer-type
 	// WARNING: in.CapacityReservationPreference requires manual conversion: does not exist in peer-type

--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -175,6 +175,14 @@ func (r *AWSMachinePool) validateLifecycleHooks() field.ErrorList {
 	return validateLifecycleHooks(r.Spec.AWSLifecycleHooks)
 }
 
+func (r *AWSMachinePool) validatePlacementGroupConfig() field.ErrorList {
+	var allErrs field.ErrorList
+	if r.Spec.AWSLaunchTemplate.PlacementGroupPartition != 0 && r.Spec.AWSLaunchTemplate.PlacementGroupName == "" {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "awsLaunchTemplate", "placementGroupPartition"), "placementGroupPartition requires placementGroupName to be set"))
+	}
+	return allErrs
+}
+
 func (r *AWSMachinePool) ignitionEnabled() bool {
 	return r.Spec.Ignition != nil
 }
@@ -214,6 +222,7 @@ func (*AWSMachinePoolWebhook) ValidateCreate(_ context.Context, obj runtime.Obje
 	allErrs = append(allErrs, r.validateCapacityReservation()...)
 	allErrs = append(allErrs, r.validateLifecycleHooks()...)
 	allErrs = append(allErrs, r.validateIgnition()...)
+	allErrs = append(allErrs, r.validatePlacementGroupConfig()...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
@@ -280,6 +289,7 @@ func (*AWSMachinePoolWebhook) ValidateUpdate(_ context.Context, oldObj, newObj r
 	allErrs = append(allErrs, r.validateSpotInstances()...)
 	allErrs = append(allErrs, r.validateRefreshPreferences()...)
 	allErrs = append(allErrs, r.validateLifecycleHooks()...)
+	allErrs = append(allErrs, r.validatePlacementGroupConfig()...)
 
 	if len(allErrs) == 0 {
 		return nil, nil

--- a/exp/api/v1beta2/awsmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook_test.go
@@ -362,6 +362,40 @@ func TestAWSMachinePoolValidateCreate(t *testing.T) {
 			},
 			wantErrToContain: nil,
 		},
+		{
+			name: "Should fail if PlacementGroupPartition is set without PlacementGroupName",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						PlacementGroupPartition: 2,
+					},
+				},
+			},
+			wantErrToContain: ptr.To[string]("placementGroupPartition"),
+		},
+		{
+			name: "Should pass if PlacementGroupName is set without PlacementGroupPartition",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						PlacementGroupName: "my-placement-group",
+					},
+				},
+			},
+			wantErrToContain: nil,
+		},
+		{
+			name: "Should pass if both PlacementGroupName and PlacementGroupPartition are set",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						PlacementGroupName:      "my-partition-pg",
+						PlacementGroupPartition: 3,
+					},
+				},
+			},
+			wantErrToContain: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -519,6 +553,18 @@ func TestAWSMachinePoolValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErrToContain: ptr.To[string]("minHealthyPercentage"),
+		},
+		{
+			name: "Should fail update if PlacementGroupPartition is set without PlacementGroupName",
+			old:  &AWSMachinePool{},
+			new: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						PlacementGroupPartition: 2,
+					},
+				},
+			},
+			wantErrToContain: ptr.To[string]("placementGroupPartition"),
 		},
 	}
 	for _, tt := range tests {

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -134,6 +134,18 @@ type AWSLaunchTemplate struct {
 	// +optional
 	PrivateDNSName *infrav1.PrivateDNSName `json:"privateDnsName,omitempty"`
 
+	// PlacementGroupName specifies the name of the placement group in which to launch the instance.
+	// +optional
+	PlacementGroupName string `json:"placementGroupName,omitempty"`
+
+	// PlacementGroupPartition is the partition number within the placement group in which to launch the instance.
+	// This value is only valid if the placement group, referred in `PlacementGroupName`, was created with
+	// strategy set to partition.
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=7
+	// +optional
+	PlacementGroupPartition int64 `json:"placementGroupPartition,omitempty"`
+
 	// CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.
 	// +optional
 	CapacityReservationID *string `json:"capacityReservationId,omitempty"`

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -1049,6 +1049,14 @@ func (s *Service) LaunchTemplateNeedsUpdate(scope scope.LaunchTemplateScope, inc
 		return true, nil
 	}
 
+	if incoming.PlacementGroupName != existing.PlacementGroupName {
+		return true, nil
+	}
+
+	if incoming.PlacementGroupPartition != existing.PlacementGroupPartition {
+		return true, nil
+	}
+
 	if !cmp.Equal(incoming.SSHKeyName, existing.SSHKeyName) {
 		return true, nil
 	}

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -674,6 +674,7 @@ func (s *Service) createLaunchTemplateData(scope scope.LaunchTemplateScope, imag
 	data.InstanceMarketOptions = instanceMarketOptions
 	data.PrivateDnsNameOptions = getLaunchTemplatePrivateDNSNameOptionsRequest(scope.GetLaunchTemplate().PrivateDNSName)
 	data.CapacityReservationSpecification = getLaunchTemplateCapacityReservationSpecification(scope.GetLaunchTemplate())
+	data.Placement = getLaunchTemplatePlacementRequest(scope.GetLaunchTemplate())
 
 	blockDeviceMappings := []types.LaunchTemplateBlockDeviceMappingRequest{}
 
@@ -722,6 +723,30 @@ func getLaunchTemplateCapacityReservationSpecification(awsLaunchTemplate *expinf
 		}
 	}
 	return spec
+}
+
+func getLaunchTemplatePlacementRequest(awsLaunchTemplate *expinfrav1.AWSLaunchTemplate) *types.LaunchTemplatePlacementRequest {
+	if awsLaunchTemplate == nil {
+		return nil
+	}
+	if awsLaunchTemplate.PlacementGroupName == "" && awsLaunchTemplate.PlacementGroupPartition == 0 {
+		return nil
+	}
+
+	// PlacementGroupPartition without PlacementGroupName is invalid
+	if awsLaunchTemplate.PlacementGroupName == "" && awsLaunchTemplate.PlacementGroupPartition != 0 {
+		return nil
+	}
+
+	placement := &types.LaunchTemplatePlacementRequest{
+		GroupName: aws.String(awsLaunchTemplate.PlacementGroupName),
+	}
+
+	if awsLaunchTemplate.PlacementGroupPartition != 0 {
+		placement.PartitionNumber = utils.ToInt32Pointer(&awsLaunchTemplate.PlacementGroupPartition)
+	}
+
+	return placement
 }
 
 func volumeToLaunchTemplateBlockDeviceMappingRequest(v *infrav1.Volume) *types.LaunchTemplateBlockDeviceMappingRequest {

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -912,6 +912,82 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name: "Should return true if PlacementGroupName changes",
+			incoming: &expinfrav1.AWSLaunchTemplate{
+				PlacementGroupName: "new-placement-group",
+			},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				AdditionalSecurityGroups: []infrav1.AWSResourceReference{
+					{ID: aws.String("sg-111")},
+					{ID: aws.String("sg-222")},
+				},
+				PlacementGroupName: "old-placement-group",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Should return true if PlacementGroupName is added",
+			incoming: &expinfrav1.AWSLaunchTemplate{
+				PlacementGroupName: "my-placement-group",
+			},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				AdditionalSecurityGroups: []infrav1.AWSResourceReference{
+					{ID: aws.String("sg-111")},
+					{ID: aws.String("sg-222")},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:     "Should return true if PlacementGroupName is removed",
+			incoming: &expinfrav1.AWSLaunchTemplate{},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				AdditionalSecurityGroups: []infrav1.AWSResourceReference{
+					{ID: aws.String("sg-111")},
+					{ID: aws.String("sg-222")},
+				},
+				PlacementGroupName: "my-placement-group",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Should return true if PlacementGroupPartition changes",
+			incoming: &expinfrav1.AWSLaunchTemplate{
+				PlacementGroupName:      "my-placement-group",
+				PlacementGroupPartition: 2,
+			},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				AdditionalSecurityGroups: []infrav1.AWSResourceReference{
+					{ID: aws.String("sg-111")},
+					{ID: aws.String("sg-222")},
+				},
+				PlacementGroupName:      "my-placement-group",
+				PlacementGroupPartition: 3,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Should return false if PlacementGroupName and PlacementGroupPartition are unchanged",
+			incoming: &expinfrav1.AWSLaunchTemplate{
+				PlacementGroupName:      "my-placement-group",
+				PlacementGroupPartition: 2,
+			},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				AdditionalSecurityGroups: []infrav1.AWSResourceReference{
+					{ID: aws.String("sg-111")},
+					{ID: aws.String("sg-222")},
+				},
+				PlacementGroupName:      "my-placement-group",
+				PlacementGroupPartition: 2,
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

This change adds support for specifying placement group configuration in AWSMachinePool launch templates.

New fields added to AWSLaunchTemplate:
- PlacementGroupName: specifies the name of the placement group in which to launch instances
- PlacementGroupPartition: specifies the partition number within a partition placement group (valid values: 1-7)

This enables users to target specific partitions when using partition placement groups with MachinePool resources, providing higher levels of availability by ensuring instances in different partitions do not share underlying hardware.

**Which issue(s) this PR fixes**
Relates-to: #4870

**Special notes for your reviewer**:
This change mirrors https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4870 but for launch templates. This allows us to create ASGs that target a specific placement group partition.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Placement.html

**Checklist**:
- [x] squashed commits
- [x] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
Adds support for specifying placement group configuration for AWSMachinePool launch templates.
```
