### PR TITLE
🌱 e2e: adjust templates to use AWSClusterRoleIdentities per Cluster

### DIFF
--- a/templates/cluster-template-multitenancy-clusterclass.yaml
+++ b/templates/cluster-template-multitenancy-clusterclass.yaml
@@ -247,7 +247,7 @@ spec:
     - name: identityRef
       value:
         kind: AWSClusterRoleIdentity
-        name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}
+        name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
     version: ${KUBERNETES_VERSION}
     workers:
       machineDeployments:
@@ -277,12 +277,12 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}
+  name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
   durationSeconds: 900
   roleARN: ${MULTI_TENANCY_JUMP_ROLE_ARN}
-  sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-session
+  sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity
     name: default
@@ -290,11 +290,11 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}
+  name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
   roleARN: ${MULTI_TENANCY_NESTED_ROLE_ARN}
-  sessionName: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-session
+  sessionName: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:
     kind: AWSClusterRoleIdentity
-    name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}
+    name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}

--- a/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-nested-multitenancy-clusterclass.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-nested-multitenancy-clusterclass.yaml
@@ -31,7 +31,7 @@ spec:
     - name: identityRef
       value:
         kind: AWSClusterRoleIdentity
-        name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}
+        name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
     version: ${KUBERNETES_VERSION}
     workers:
       machineDeployments:
@@ -87,12 +87,12 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}
+  name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
   durationSeconds: 900
   roleARN: ${MULTI_TENANCY_JUMP_ROLE_ARN}
-  sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-session
+  sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity
     name: default
@@ -100,14 +100,14 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}
+  name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
   roleARN: ${MULTI_TENANCY_NESTED_ROLE_ARN}
-  sessionName: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-session
+  sessionName: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:
     kind: AWSClusterRoleIdentity
-    name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}
+    name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
 ---
 apiVersion: v1
 data:

--- a/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/cluster-template.yaml
@@ -37,7 +37,7 @@ spec:
     - name: identityRef
       value:
         kind: AWSClusterRoleIdentity
-        name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}"
+        name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}"
 ---
 apiVersion: v1
 data: ${CNI_RESOURCES}

--- a/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/role.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/role.yaml
@@ -2,11 +2,11 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}"
+  name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
 spec:
   roleARN: "${MULTI_TENANCY_JUMP_ROLE_ARN}"
   durationSeconds: 900
-  sessionName: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-session"
+  sessionName: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity
     name: "default"
@@ -15,11 +15,11 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}"
+  name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}"
 spec:
   roleARN: "${MULTI_TENANCY_NESTED_ROLE_ARN}"
-  sessionName: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-session"
+  sessionName: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}"
   sourceIdentityRef:
     kind: AWSClusterRoleIdentity
-    name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}"
+    name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
   allowedNamespaces: {}

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
@@ -29,7 +29,7 @@ spec:
     enabled: true
   identityRef:
     kind: AWSClusterRoleIdentity
-    name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}
+    name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
   network:
     vpc:
       availabilityZoneUsageLimit: 1
@@ -1165,12 +1165,12 @@ metadata:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}
+  name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
   durationSeconds: 900
   roleARN: ${MULTI_TENANCY_JUMP_ROLE_ARN}
-  sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-session
+  sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity
     name: default
@@ -1178,11 +1178,11 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}
+  name: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
   roleARN: ${MULTI_TENANCY_NESTED_ROLE_ARN}
-  sessionName: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-session
+  sessionName: ${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:
     kind: AWSClusterRoleIdentity
-    name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}
+    name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
@@ -1160,7 +1160,7 @@ spec:
   allowedNamespaces: {}
   durationSeconds: 900
   roleARN: ${MULTI_TENANCY_SIMPLE_ROLE_ARN}
-  sessionName: ${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}-session
+  sessionName: ${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity
     name: default

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/nested-multitenancy/patches/role-identity.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/nested-multitenancy/patches/role-identity.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   identityRef:
     kind: AWSClusterRoleIdentity
-    name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}"
+    name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/nested-multitenancy/role.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/nested-multitenancy/role.yaml
@@ -2,11 +2,11 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}"
+  name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
 spec:
   roleARN: "${MULTI_TENANCY_JUMP_ROLE_ARN}"
   durationSeconds: 900
-  sessionName: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-session"
+  sessionName: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity
     name: "default"
@@ -15,11 +15,11 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterRoleIdentity
 metadata:
-  name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}"
+  name: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}"
 spec:
   roleARN: "${MULTI_TENANCY_NESTED_ROLE_ARN}"
-  sessionName: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-session"
+  sessionName: "${MULTI_TENANCY_NESTED_IDENTITY_NAME}-${CLUSTER_NAME}"
   sourceIdentityRef:
     kind: AWSClusterRoleIdentity
-    name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}"
+    name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
   allowedNamespaces: {}

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/simple-multitenancy/role.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/simple-multitenancy/role.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   roleARN: "${MULTI_TENANCY_SIMPLE_ROLE_ARN}"
   durationSeconds: 900
-  sessionName: "${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}-session"
+  sessionName: "${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}"
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity
     name: "default"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Fixes the perma-failing / flaking test: `capa-e2e.[It] [unmanaged] [functional] Multitenancy test should create cluster with nested assumed role`

This happens because we have multiple tests using the same AWSClusterRoleIdentity, and if it got created 15 mins before the test started the credentials are not valid anymore.

Testgrid: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-aws#periodic-e2e-main

k8s-triage to see this is resolved after merging: https://storage.googleapis.com/k8s-triage/index.html?job=periodic-cluster-api-provider-aws-e2e&test=Multitenancy%20test%20should%20create%20cluster%20with%20nested%20assumed%20role


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix e2e templates to create an `AWSClusterRoleIdentity` per Cluster
```
