### PR TITLE
🐛 Fix constant re-applying of tags if `AWSMachine.metadata.annotations` is nil

### DIFF
--- a/controllers/awsmachine_annotations.go
+++ b/controllers/awsmachine_annotations.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"maps"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 )
@@ -40,12 +41,13 @@ func (r *AWSMachineReconciler) updateMachineAnnotationJSON(machine *infrav1.AWSM
 // `content`.
 func (r *AWSMachineReconciler) updateMachineAnnotation(machine *infrav1.AWSMachine, annotation, content string) {
 	// Get the annotations
-	annotations := machine.GetAnnotations()
+	annotations := maps.Clone(machine.GetAnnotations())
 
-	// Set our annotation to the given content.
-	if annotations != nil {
-		annotations[annotation] = content
+	if annotations == nil {
+		annotations = map[string]string{}
 	}
+
+	annotations[annotation] = content
 
 	// Update the machine object with these annotations
 	machine.SetAnnotations(annotations)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

CAPA would constantly call `CreateTags` on instances and volumes because it didn't actually write the "these are the tags I've set" annotation back to the `AWSMachine` object. The code didn't do anything if the annotations map is nil. This probably only applies to AWSMachinePool machines – they currently get created without any annotations. Other `AWSMachine` objects normally have annotations like `cluster.x-k8s.io/cloned-from-groupkind: AWSMachineTemplate.infrastructure.cluster.x-k8s.io` and therefore, I believe, weren't affected.

We detected this issue from very verbose logs and a high rate of AWS requests.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix constant re-applying of tags if `AWSMachine.metadata.annotations` is nil
```
