### PR TITLE
[WIP] 🌱 e2e: fix debian_injection_script for kubernetes v1.35 which removed kubelet's pod-infra-container-image flag

### DIFF
--- a/docs/book/src/topics/external-cloud-provider-with-ebs-csi-driver.md
+++ b/docs/book/src/topics/external-cloud-provider-with-ebs-csi-driver.md
@@ -10,9 +10,6 @@ This document explains how to create a CAPA cluster with external CSI/CCM plugin
 For clusters that will use external CCM, `cloud-provider: external` flag needs to be set in KubeadmConfig resources in both `KubeadmControlPlane` and `MachineDeployment` resources.
 
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external
@@ -213,9 +210,6 @@ When `CSIMigrationAWS=true`, installed external CSI driver will be used while re
 
 
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-flatcar-machinepool.yaml
+++ b/templates/cluster-template-flatcar-machinepool.yaml
@@ -42,9 +42,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -42,9 +42,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -37,9 +37,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -37,9 +37,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-efs-support.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-efs-support.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-external-cloud-provider.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-gpu.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-gpu.yaml
@@ -36,9 +36,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ignition.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ignition.yaml
@@ -40,9 +40,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-internal-elb.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-internal-elb.yaml
@@ -57,9 +57,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-remediation.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-scale-in.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-limit-az.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-limit-az.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-machine-pool.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-md-remediation.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-multi-az.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-multi-az.yaml
@@ -51,9 +51,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
@@ -43,9 +43,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-peered-remote.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-peered-remote.yaml
@@ -48,9 +48,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
@@ -38,9 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
@@ -41,9 +41,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-spot-instances.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-spot-instances.yaml
@@ -35,9 +35,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ssm.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ssm.yaml
@@ -37,9 +37,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-external-cloud-provider.yaml
@@ -35,9 +35,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-main.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-main.yaml
@@ -35,9 +35,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrades.yaml
@@ -35,9 +35,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template.yaml
@@ -35,9 +35,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/addons/ccm/patches/external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/addons/ccm/patches/external-cloud-provider.yaml
@@ -13,9 +13,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/machine-pool/patches/external-csi-provider-controlplane.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/machine-pool/patches/external-csi-provider-controlplane.yaml
@@ -13,9 +13,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/test/helpers/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
+++ b/test/helpers/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
@@ -116,6 +116,12 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
     $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
     $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
   done
+
+  # TODO: remove once we use k8s v1.35 image-builder templates.
+  # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.        
+  echo "Clearing --pod-infra-container-image in /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+  sed -i -E 's/--pod-infra-container-image[= ][a-zA-Z0-9._/-]+(:[a-zA-Z0-9._-]+ *)?//' /etc/sysconfig/kubelet || true
+  sed -i -E 's/--pod-infra-container-image[= ][a-zA-Z0-9._/-]+(:[a-zA-Z0-9._-]+ *)?//' /etc/default/kubelet || true
 fi
 echo "* checking binary versions"
 echo "ctr version: " "$(ctr version)"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Does fix e2e which use latest-ci artifacts for kubernetes for kubernetes >= v1.35.

xref:
* Similar fix in CAPV: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3661
* Fix in image-builder: https://github.com/kubernetes-sigs/image-builder/pull/1876

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
