### PR TITLE
🌱 fix: e2e test: validate inputData during log postprocessing to avoid panic

### DIFF
--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -312,7 +312,11 @@ func postProcessBase64LogData(dir, src, dst string) error {
 	}
 
 	// Extract second line which contains the data (first line contains the command)
-	inputStringData := strings.Split(string(inputData), "\n")[1]
+	inputDataLines := strings.Split(string(inputData), "\n")
+	if len(inputDataLines) < 2 {
+		return errors.Errorf("source file %q does not contain expected data (need at least 2 lines, got %d), input data content: %q", sourceFile, len(inputDataLines), string(inputData))
+	}
+	inputStringData := inputDataLines[1]
 
 	// Trim spaces and the $ suffix.
 	inputStringData = strings.TrimSpace(inputStringData)


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

validate inputData during log postprocessing to avoid panic.
Occurrence https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-aws-e2e/1995405094014685184#1:build-log.txt%3A1594

```
[PANICKED] in [It] - /usr/local/go/src/runtime/panic.go:792 @ 12/01/25 08:47:22.599
  << Timeline
push_pin
  [PANICKED] Test Panicked
  In [It] at: /usr/local/go/src/runtime/panic.go:792 @ 12/01/25 08:47:22.599
  runtime error: index out of range [1] with length 1
  Full Stack Trace
    panic({0x48b5c60?, 0xc0019e2000?})
    	/usr/local/go/src/runtime/panic.go:792 +0x132
    sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared.postProcessBase64LogData({0xc003156580, 0x6a}, {0x4d195ef?, 0xc000ab8558?}, {0x4d2319d, 0xf})
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/common.go:315 +0x3b7
    sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared.DumpMachine({_, _}, _, {{{0xc001fcee90, 0xa}, {0xc00293a840, 0x27}}, {{0xc002b167e0, 0x1f}, {0x0, ...}, ...}, ...}, ...)
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/common.go:218 +0x5ac
    sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared.DumpMachines({0x5416508, 0xc0013a2370}, 0xc0004a72c0, 0x0?)
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/common.go:127 +0x119
    sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared.AllNodesBeforeSuite.func2()
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/suite.go:276 +0x127
    created by sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared.AllNodesBeforeSuite in goroutine 103
    	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/shared/suite.go:267 +0x70c
```

<!-- Enter a description of the change and why this change is needed -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
