### PR TITLE
🐛 Print reason for launch template needing update, fix constant instance refreshes for AWSMachinePool by considering SSHKeyName nil and empty string the same

### DIFF
--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -773,7 +773,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 					nil,
 					nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any(), gomock.Any()).Return(ptr.To[string]("ami-existing"), nil) // no change
-				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, services.LaunchTemplateNeedsUpdateReasonNone, nil)
 
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).DoAndReturn(func(scope *scope.MachinePoolScope) (*expinfrav1.AutoScalingGroup, error) {
 					g.Expect(scope.Name()).To(Equal("test"))
@@ -822,7 +822,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 					nil,
 					nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any(), gomock.Any()).Return(ptr.To[string]("ami-different"), nil)
-				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, services.LaunchTemplateNeedsUpdateReasonNone, nil)
 				asgSvc.EXPECT().CanStartASGInstanceRefresh(gomock.Any()).Return(true, nil, nil)
 				ec2Svc.EXPECT().PruneLaunchTemplateVersions(gomock.Any()).Return(nil, nil)
 				ec2Svc.EXPECT().CreateLaunchTemplateVersion(gomock.Any(), gomock.Any(), gomock.Eq(ptr.To[string]("ami-different")), gomock.Eq(apimachinerytypes.NamespacedName{Namespace: "default", Name: "bootstrap-data"}), gomock.Any(), gomock.Any()).Return(nil)
@@ -878,7 +878,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 					nil,
 					nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any(), gomock.Any()).Return(ptr.To[string]("ami-existing"), nil)
-				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, services.LaunchTemplateNeedsUpdateReasonNone, nil)
 				asgSvc.EXPECT().CanStartASGInstanceRefresh(gomock.Any()).Return(true, nil, nil)
 				ec2Svc.EXPECT().PruneLaunchTemplateVersions(gomock.Any()).Return(nil, nil)
 				ec2Svc.EXPECT().CreateLaunchTemplateVersion(gomock.Any(), gomock.Any(), gomock.Eq(ptr.To[string]("ami-existing")), gomock.Eq(apimachinerytypes.NamespacedName{Namespace: "default", Name: "bootstrap-data"}), gomock.Any(), gomock.Any()).Return(nil)
@@ -970,7 +970,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 					nil,
 					nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any(), gomock.Any()).Return(ptr.To[string]("ami-existing"), nil)
-				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, services.LaunchTemplateNeedsUpdateReasonNone, nil)
 				asgSvc.EXPECT().CanStartASGInstanceRefresh(gomock.Any()).Return(true, nil, nil)
 				ec2Svc.EXPECT().PruneLaunchTemplateVersions(gomock.Any()).Return(nil, nil)
 				ec2Svc.EXPECT().CreateLaunchTemplateVersion(gomock.Any(), gomock.Any(), gomock.Eq(ptr.To[string]("ami-existing")), gomock.Eq(apimachinerytypes.NamespacedName{Namespace: "default", Name: "bootstrap-data-new"}), gomock.Any(), gomock.Any()).Return(nil)
@@ -1056,7 +1056,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 					nil,
 					nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any(), gomock.Any()).Return(ptr.To[string]("ami-existing"), nil)
-				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, services.LaunchTemplateNeedsUpdateReasonNone, nil)
 
 				s3Mock.EXPECT().PutObject(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, input *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 					g.Expect(*input.Key).To(Equal(fmt.Sprintf("machine-pool/test/%s", userdata.ComputeHash([]byte("shell-script")))))
@@ -1106,7 +1106,7 @@ func TestAWSMachinePoolReconciler(t *testing.T) {
 					nil,
 					nil)
 				ec2Svc.EXPECT().DiscoverLaunchTemplateAMI(gomock.Any(), gomock.Any()).Return(ptr.To[string]("ami-existing"), nil)
-				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+				ec2Svc.EXPECT().LaunchTemplateNeedsUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, services.LaunchTemplateNeedsUpdateReasonNone, nil)
 
 				s3Mock.EXPECT().PutObject(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, input *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 					g.Expect(*input.Key).To(Equal(fmt.Sprintf("machine-pool/test/%s", userdata.ComputeHash([]byte("shell-script")))))

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -233,7 +233,7 @@ func (s *Service) ReconcileLaunchTemplate(
 	// Check if the instance tags were changed. If they were, create a new LaunchTemplate.
 	tagsChanged, _, _, _ := tagsChanged(annotation, scope.AdditionalTags()) //nolint:dogsled
 
-	needsUpdate, err := ec2svc.LaunchTemplateNeedsUpdate(scope, scope.GetLaunchTemplate(), launchTemplate)
+	needsUpdate, needsUpdateReason, err := ec2svc.LaunchTemplateNeedsUpdate(scope, scope.GetLaunchTemplate(), launchTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (s *Service) ReconcileLaunchTemplate(
 	// Create a new launch template version if there's a difference in configuration, tags,
 	// userdata, OR we've discovered a new AMI ID.
 	if needsUpdate || tagsChanged || amiChanged || userDataHashChanged || userDataSecretKeyChanged || launchTemplateNeedsUserDataSecretKeyTag {
-		scope.Info("creating new version for launch template", "existing", launchTemplate, "incoming", scope.GetLaunchTemplate(), "needsUpdate", needsUpdate, "tagsChanged", tagsChanged, "amiChanged", amiChanged, "userDataHashChanged", userDataHashChanged, "userDataSecretKeyChanged", userDataSecretKeyChanged)
+		scope.Info("creating new version for launch template", "existing", launchTemplate, "incoming", scope.GetLaunchTemplate(), "needsUpdate", needsUpdate, "needsUpdateReason", needsUpdateReason, "tagsChanged", tagsChanged, "amiChanged", amiChanged, "userDataHashChanged", userDataHashChanged, "userDataSecretKeyChanged", userDataSecretKeyChanged)
 
 		// There is a limit to the number of Launch Template Versions.
 		// We ensure that the number of versions does not grow without bound by following a simple rule: Before we create a new version, we delete one old version, if there is at least one old version that is not in use.
@@ -1003,58 +1003,59 @@ func (s *Service) SDKToLaunchTemplate(d types.LaunchTemplateVersion) (*expinfrav
 //
 // FIXME(dlipovetsky): This check should account for changed userdata, but does not yet do so.
 // Although userdata is stored in an EC2 Launch Template, it is not a field of AWSLaunchTemplate.
-func (s *Service) LaunchTemplateNeedsUpdate(scope scope.LaunchTemplateScope, incoming *expinfrav1.AWSLaunchTemplate, existing *expinfrav1.AWSLaunchTemplate) (bool, error) {
+func (s *Service) LaunchTemplateNeedsUpdate(scope scope.LaunchTemplateScope, incoming *expinfrav1.AWSLaunchTemplate, existing *expinfrav1.AWSLaunchTemplate) (bool, services.LaunchTemplateNeedsUpdateReason, error) {
 	if incoming.IamInstanceProfile != existing.IamInstanceProfile {
-		return true, nil
+		return true, services.LaunchTemplateNeedsUpdateReasonIamInstanceProfile, nil
 	}
 
 	if incoming.InstanceType != existing.InstanceType {
-		return true, nil
+		return true, services.LaunchTemplateNeedsUpdateReasonInstanceType, nil
 	}
 
 	if !cmp.Equal(incoming.InstanceMetadataOptions, existing.InstanceMetadataOptions) {
-		return true, nil
+		return true, services.LaunchTemplateNeedsUpdateReasonInstanceMetadataOptions, nil
 	}
 
 	if !cmp.Equal(incoming.SpotMarketOptions, existing.SpotMarketOptions) {
-		return true, nil
+		return true, services.LaunchTemplateNeedsUpdateReasonSpotMarketOptions, nil
 	}
 
 	if !cmp.Equal(incoming.CapacityReservationID, existing.CapacityReservationID) {
-		return true, nil
+		return true, services.LaunchTemplateNeedsUpdateReasonCapacityReservationID, nil
 	}
 
 	if !cmp.Equal(incoming.PrivateDNSName, existing.PrivateDNSName) {
-		return true, nil
+		return true, services.LaunchTemplateNeedsUpdateReasonPrivateDNSName, nil
 	}
 
-	if !cmp.Equal(incoming.SSHKeyName, existing.SSHKeyName) {
-		return true, nil
+	// We treat nil and empty string the same (see `createLaunchTemplateData`)
+	if !cmp.Equal(ptr.Deref(incoming.SSHKeyName, ""), ptr.Deref(existing.SSHKeyName, "")) {
+		return true, services.LaunchTemplateNeedsUpdateReasonSSHKeyName, nil
 	}
 
 	incomingIDs, err := s.GetAdditionalSecurityGroupsIDs(incoming.AdditionalSecurityGroups)
 	if err != nil {
-		return false, err
+		return false, services.LaunchTemplateNeedsUpdateReasonNone, err
 	}
 
 	coreIDs, err := s.GetCoreNodeSecurityGroups(scope)
 	if err != nil {
-		return false, err
+		return false, services.LaunchTemplateNeedsUpdateReasonNone, err
 	}
 
 	incomingIDs = append(incomingIDs, coreIDs...)
 	existingIDs, err := s.GetAdditionalSecurityGroupsIDs(existing.AdditionalSecurityGroups)
 	if err != nil {
-		return false, err
+		return false, services.LaunchTemplateNeedsUpdateReasonNone, err
 	}
 	sort.Strings(incomingIDs)
 	sort.Strings(existingIDs)
 
 	if !cmp.Equal(incomingIDs, existingIDs) {
-		return true, nil
+		return true, services.LaunchTemplateNeedsUpdateReasonAdditionalSecurityGroupIDs, nil
 	}
 
-	return false, nil
+	return false, services.LaunchTemplateNeedsUpdateReasonNone, nil
 }
 
 // DiscoverLaunchTemplateAMI will discover the AMI launch template.

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -40,6 +40,7 @@ import (
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/ssm/mock_ssmiface"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/userdata"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
@@ -588,12 +589,13 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	tests := []struct {
-		name     string
-		incoming *expinfrav1.AWSLaunchTemplate
-		existing *expinfrav1.AWSLaunchTemplate
-		expect   func(m *mocks.MockEC2APIMockRecorder)
-		want     bool
-		wantErr  bool
+		name                  string
+		incoming              *expinfrav1.AWSLaunchTemplate
+		existing              *expinfrav1.AWSLaunchTemplate
+		expect                func(m *mocks.MockEC2APIMockRecorder)
+		want                  bool
+		wantNeedsUpdateReason services.LaunchTemplateNeedsUpdateReason
+		wantErr               bool
 	}{
 		{
 			name: "only core security groups, order shouldn't matter",
@@ -639,8 +641,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					{ID: aws.String("sg-999")},
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonAdditionalSecurityGroupIDs,
+			wantErr:               false,
 		},
 		{
 			name: "new additional security group",
@@ -657,8 +660,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					{ID: aws.String("sg-999")},
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonAdditionalSecurityGroupIDs,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if incoming IamInstanceProfile is not same as existing IamInstanceProfile",
@@ -672,7 +676,8 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				IamInstanceProfile: "some-other-profile",
 			},
-			want: true,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonIamInstanceProfile,
 		},
 		{
 			name: "Should return true if incoming InstanceType is not same as existing InstanceType",
@@ -686,7 +691,8 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				InstanceType: "t3.large",
 			},
-			want: true,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonInstanceType,
 		},
 		{
 			name: "new additional security group with filters",
@@ -706,8 +712,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				m.DescribeSecurityGroups(context.TODO(), gomock.Eq(&ec2.DescribeSecurityGroupsInput{Filters: []ec2types.Filter{{Name: aws.String("sg-2"), Values: []string{"test-2"}}}})).
 					Return(&ec2.DescribeSecurityGroupsOutput{SecurityGroups: []ec2types.SecurityGroup{{GroupId: aws.String("sg-2")}}}, nil)
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonAdditionalSecurityGroupIDs,
+			wantErr:               false,
 		},
 		{
 			name: "new launch template instance metadata options, requiring IMDSv2",
@@ -723,8 +730,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					{ID: aws.String("sg-222")},
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonInstanceMetadataOptions,
+			wantErr:               false,
 		},
 		{
 			name:     "new launch template instance metadata options, removing IMDSv2 requirement",
@@ -735,8 +743,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					HTTPTokens:              infrav1.HTTPTokensStateRequired,
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonInstanceMetadataOptions,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if incoming SpotMarketOptions is different from existing SpotMarketOptions",
@@ -754,8 +763,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					MaxPrice: aws.String("0.05"),
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonSpotMarketOptions,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if incoming adds SpotMarketOptions and existing has none",
@@ -771,8 +781,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				SpotMarketOptions: nil,
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonSpotMarketOptions,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if incoming removes SpotMarketOptions and existing has some",
@@ -788,8 +799,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					MaxPrice: aws.String("0.05"),
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonSpotMarketOptions,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if SSH key names are different",
@@ -803,8 +815,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				SSHKeyName: aws.String("old-key"),
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonSSHKeyName,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if one has SSH key name and other doesn't",
@@ -818,8 +831,25 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				SSHKeyName: nil,
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonSSHKeyName,
+			wantErr:               false,
+		},
+		{
+			name: "Should return false if no SSH key is set in the spec and AWS returns no key pair as well",
+			incoming: &expinfrav1.AWSLaunchTemplate{
+				SSHKeyName: aws.String(""), // explicit empty string
+			},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				AdditionalSecurityGroups: []infrav1.AWSResourceReference{
+					{ID: aws.String("sg-111")},
+					{ID: aws.String("sg-222")},
+				},
+				SSHKeyName: nil,
+			},
+			want:                  false,
+			wantNeedsUpdateReason: "",
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if incoming PrivateDNSName is different from existing PrivateDNSName",
@@ -841,8 +871,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					HostnameType:                    aws.String("ip-name"),
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonPrivateDNSName,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if incoming adds PrivateDNSName and existing has none",
@@ -860,8 +891,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				PrivateDNSName: nil,
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonPrivateDNSName,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if incoming removes PrivateDNSName and existing has some",
@@ -879,8 +911,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 					HostnameType:                    aws.String("resource-name"),
 				},
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonPrivateDNSName,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if capacity reservation IDs are different",
@@ -894,8 +927,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				CapacityReservationID: aws.String("old-reservation"),
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonCapacityReservationID,
+			wantErr:               false,
 		},
 		{
 			name: "Should return true if one has capacity reservation ID and other doesn't",
@@ -909,8 +943,9 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				},
 				CapacityReservationID: nil,
 			},
-			want:    true,
-			wantErr: false,
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonCapacityReservationID,
+			wantErr:               false,
 		},
 	}
 	for _, tt := range tests {
@@ -948,12 +983,13 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 				tt.expect(mockEC2Client.EXPECT())
 			}
 
-			got, err := s.LaunchTemplateNeedsUpdate(machinePoolScope, tt.incoming, tt.existing)
+			got, gotNeedsUpdateReason, err := s.LaunchTemplateNeedsUpdate(machinePoolScope, tt.incoming, tt.existing)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return
 			}
 			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(gotNeedsUpdateReason).Should(Equal(tt.wantNeedsUpdateReason))
 			g.Expect(got).Should(Equal(tt.want))
 		})
 	}

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -41,6 +41,31 @@ const (
 	NAT64CidrBlock = "64:ff9b::/96"
 )
 
+// LaunchTemplateNeedsUpdateReason describes why a launch template needs to be updated. Only the first found difference
+// is shown, not all reasons.
+type LaunchTemplateNeedsUpdateReason string
+
+const (
+	// LaunchTemplateNeedsUpdateReasonNone means no update reason was found (no relevant differences).
+	LaunchTemplateNeedsUpdateReasonNone LaunchTemplateNeedsUpdateReason = ""
+	// LaunchTemplateNeedsUpdateReasonIamInstanceProfile means a difference in the IAM instance profile was found.
+	LaunchTemplateNeedsUpdateReasonIamInstanceProfile LaunchTemplateNeedsUpdateReason = "IamInstanceProfile"
+	// LaunchTemplateNeedsUpdateReasonInstanceType means a difference in the instance type was found.
+	LaunchTemplateNeedsUpdateReasonInstanceType LaunchTemplateNeedsUpdateReason = "InstanceType"
+	// LaunchTemplateNeedsUpdateReasonInstanceMetadataOptions means a difference in the instance metadata options was found.
+	LaunchTemplateNeedsUpdateReasonInstanceMetadataOptions LaunchTemplateNeedsUpdateReason = "InstanceMetadataOptions"
+	// LaunchTemplateNeedsUpdateReasonSpotMarketOptions means a difference in the spot market options was found.
+	LaunchTemplateNeedsUpdateReasonSpotMarketOptions LaunchTemplateNeedsUpdateReason = "SpotMarketOptions"
+	// LaunchTemplateNeedsUpdateReasonCapacityReservationID means a difference in the capacity reservation ID was found.
+	LaunchTemplateNeedsUpdateReasonCapacityReservationID LaunchTemplateNeedsUpdateReason = "CapacityReservationID"
+	// LaunchTemplateNeedsUpdateReasonPrivateDNSName means a difference in the private DNS name was found.
+	LaunchTemplateNeedsUpdateReasonPrivateDNSName LaunchTemplateNeedsUpdateReason = "PrivateDNSName"
+	// LaunchTemplateNeedsUpdateReasonSSHKeyName means a difference in the SSH key name was found.
+	LaunchTemplateNeedsUpdateReasonSSHKeyName LaunchTemplateNeedsUpdateReason = "SSHKeyName"
+	// LaunchTemplateNeedsUpdateReasonAdditionalSecurityGroupIDs means a difference in the additional security group IDs was found.
+	LaunchTemplateNeedsUpdateReasonAdditionalSecurityGroupIDs LaunchTemplateNeedsUpdateReason = "AdditionalSecurityGroupIDs"
+)
+
 // ASGInterface encapsulates the methods exposed to the machinepool
 // actuator.
 type ASGInterface interface {
@@ -88,7 +113,7 @@ type EC2Interface interface {
 	CreateLaunchTemplateVersion(id string, scope scope.LaunchTemplateScope, imageID *string, userDataSecretKey apimachinerytypes.NamespacedName, userData []byte, bootstrapDataHash string) error
 	PruneLaunchTemplateVersions(id string) (*ec2types.LaunchTemplateVersion, error)
 	DeleteLaunchTemplate(id string) error
-	LaunchTemplateNeedsUpdate(scope scope.LaunchTemplateScope, incoming *expinfrav1.AWSLaunchTemplate, existing *expinfrav1.AWSLaunchTemplate) (bool, error)
+	LaunchTemplateNeedsUpdate(scope scope.LaunchTemplateScope, incoming *expinfrav1.AWSLaunchTemplate, existing *expinfrav1.AWSLaunchTemplate) (bool, LaunchTemplateNeedsUpdateReason, error)
 	DeleteBastion() error
 	ReconcileBastion() error
 	// ReconcileElasticIPFromPublicPool reconciles the elastic IP from a custom Public IPv4 Pool.

--- a/pkg/cloud/services/mock_services/ec2_interface_mock.go
+++ b/pkg/cloud/services/mock_services/ec2_interface_mock.go
@@ -30,6 +30,7 @@ import (
 	v1beta2 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	v1beta20 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	scope "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	services "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services"
 )
 
 // MockEC2Interface is a mock of EC2Interface interface.
@@ -310,12 +311,13 @@ func (mr *MockEC2InterfaceMockRecorder) InstanceIfExists(arg0 interface{}) *gomo
 }
 
 // LaunchTemplateNeedsUpdate mocks base method.
-func (m *MockEC2Interface) LaunchTemplateNeedsUpdate(arg0 scope.LaunchTemplateScope, arg1, arg2 *v1beta20.AWSLaunchTemplate) (bool, error) {
+func (m *MockEC2Interface) LaunchTemplateNeedsUpdate(arg0 scope.LaunchTemplateScope, arg1, arg2 *v1beta20.AWSLaunchTemplate) (bool, services.LaunchTemplateNeedsUpdateReason, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LaunchTemplateNeedsUpdate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(services.LaunchTemplateNeedsUpdateReason)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // LaunchTemplateNeedsUpdate indicates an expected call of LaunchTemplateNeedsUpdate.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The type spec in CAPA says

```
// SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string
// (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
// +optional
SSHKeyName *string `json:"sshKeyName,omitempty"`
```

but in launch template creation, CAPA treats `""` and `nil` the same and there's no fallback to a default value. The two must compare equal or else we keep refreshing instances by mistake.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Print reason for launch template needing update, fix constant instance refreshes for AWSMachinePool
```
