### PR TITLE
:bug: Fix nil dereference when DescribeDhcpOptions call returns an error

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -1165,7 +1165,7 @@ func (s *Service) GetDHCPOptionSetDomainName(ec2client common.EC2API, vpcID *str
 
 	dhcpResult, err := ec2client.DescribeDhcpOptions(context.TODO(), dhcpInput)
 	if err != nil {
-		log.Error(err, "failed to describe DHCP Options Set", "DhcpOptionsSet", *dhcpResult)
+		log.Error(err, "failed to describe DHCP Options Set", "input", *dhcpInput)
 		return nil
 	}
 

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -6359,6 +6359,19 @@ func TestGetDHCPOptionSetDomainName(t *testing.T) {
 			expectedPrivateDNSName: nil,
 			mockCalls:              mockedGetPrivateDNSDomainNameFromDHCPOptionsEmptyCalls,
 		},
+		{
+			name:  "DescribeDhcpOptions call returns error, e.g. because it is denied by IAM policy",
+			vpcID: "vpc-exists",
+			dhcpOpt: &types.DhcpOptions{
+				DhcpConfigurations: []types.DhcpConfiguration{
+					{
+						Key: aws.String("domain-name"),
+					},
+				},
+			},
+			expectedPrivateDNSName: nil,
+			mockCalls:              mockedGetPrivateDNSDomainNameFromDHCPOptionsErrorCalls,
+		},
 	}
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -6462,6 +6475,25 @@ func mockedGetPrivateDNSDomainNameFromDHCPOptionsEmptyCalls(m *mocks.MockEC2APIM
 			},
 		},
 	}, nil)
+}
+
+func mockedGetPrivateDNSDomainNameFromDHCPOptionsErrorCalls(m *mocks.MockEC2APIMockRecorder) {
+	m.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{
+		VpcIds: []string{"vpc-exists"},
+	}).Return(&ec2.DescribeVpcsOutput{
+		Vpcs: []types.Vpc{
+			{
+				VpcId:         aws.String("vpc-exists"),
+				CidrBlock:     aws.String("10.0.0.0/16"),
+				IsDefault:     aws.Bool(false),
+				State:         types.VpcStateAvailable,
+				DhcpOptionsId: aws.String("dopt-12345678"),
+			},
+		},
+	}, nil)
+	m.DescribeDhcpOptions(context.TODO(), &ec2.DescribeDhcpOptionsInput{
+		DhcpOptionsIds: []string{"dopt-12345678"},
+	}).Return(nil, errors.New("some error"))
 }
 
 func TestGetCapacityReservationSpecification(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This fixes a nil dereference that causes the controller to panic.

The PR has two commits. The first commit adds a (failing) test that reproduces the issue. The second commit fixes the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
