### PR TITLE
🐛 fix: change HostAffinity default 'host'->'default' improved API doc and tests

### DIFF
--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -251,18 +251,22 @@ type AWSMachineSpec struct {
 	HostID *string `json:"hostID,omitempty"`
 
 	// HostAffinity specifies the dedicated host affinity setting for the instance.
-	// When HostAffinity is set to host, an instance started onto a specific host always restarts on the same host if stopped.
-	// When HostAffinity is set to default, and you stop and restart the instance, it can be restarted on any available host.
-	// When HostAffinity is defined, HostID is required.
+	// When HostAffinity is set to "host", an instance started onto a specific host always restarts on the same host if stopped:
+	// - If HostID is set, the instance launches on the specific host and must return to that same host after any stop/start (Targeted & Pinned).
+	// - If HostID is not set, the instance gets launched on any available and must returns to the same host after any stop/start (Auto-placed & Pinned).
+	// When HostAffinity is set to "default" (the default value), the instance (when restarted) can return on any available host:
+	// - If HostID is set, the instance launches on the specified host now, but (when restarted) can return to any available hosts (Targeted & Flexible).
+	// - If HostID is not set, the instance launches on any available host now, and (when restarted) can return to any available hosts (Auto-placed & Flexible).
+	// If HostAffinity is not specified, it defaults to "default".
 	// +optional
 	// +kubebuilder:validation:Enum:=default;host
-	// +kubebuilder:default=host
+	// +kubebuilder:default=default
 	HostAffinity *string `json:"hostAffinity,omitempty"`
 
 	// DynamicHostAllocation enables automatic allocation of a single dedicated host.
-	// This field is mutually exclusive with HostID and always allocates exactly one host.
 	// Cost effectiveness of allocating a single instance on a dedicated host may vary
 	// depending on the instance type and the region.
+	// This field is mutually exclusive with HostID and always allocates exactly one host.
 	// +optional
 	DynamicHostAllocation *DynamicHostAllocationSpec `json:"dynamicHostAllocation,omitempty"`
 

--- a/api/v1beta2/awsmachine_webhook.go
+++ b/api/v1beta2/awsmachine_webhook.go
@@ -481,6 +481,7 @@ func (r *AWSMachine) validateHostAllocation() field.ErrorList {
 	hasHostID := r.Spec.HostID != nil && len(*r.Spec.HostID) > 0
 	hasDynamicHostAllocation := r.Spec.DynamicHostAllocation != nil
 
+	// If both hostID and dynamicHostAllocation are specified, return an error
 	if hasHostID && hasDynamicHostAllocation {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.hostID"), "hostID and dynamicHostAllocation are mutually exclusive"), field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "hostID and dynamicHostAllocation are mutually exclusive"))
 	}

--- a/api/v1beta2/awsmachinetemplate_webhook.go
+++ b/api/v1beta2/awsmachinetemplate_webhook.go
@@ -186,6 +186,11 @@ func (r *AWSMachineTemplate) validateHostAllocation() field.ErrorList {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.hostID"), "hostID and dynamicHostAllocation are mutually exclusive"), field.Forbidden(field.NewPath("spec.template.spec.dynamicHostAllocation"), "hostID and dynamicHostAllocation are mutually exclusive"))
 	}
 
+	// When hostAffinity is "host", either hostID or dynamicHostAllocation must be specified
+	if spec.HostAffinity != nil && *spec.HostAffinity == "host" && !hasHostID && !hasDynamicHostAllocation {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec.template.spec.hostID"), "hostID or dynamicHostAllocation must be set when hostAffinity is 'host'"))
+	}
+
 	return allErrs
 }
 

--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -100,6 +100,70 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			name: "hostAffinity=host requires hostID or dynamicHostAllocation",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test",
+							HostAffinity: ptr.To("host"),
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "hostAffinity=host with hostID is valid",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test",
+							HostAffinity: ptr.To("host"),
+							HostID:       ptr.To("h-09dcf61cb388b0149"),
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "hostAffinity=host with dynamicHostAllocation is valid",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test",
+							HostAffinity: ptr.To("host"),
+							DynamicHostAllocation: &DynamicHostAllocationSpec{
+								Tags: map[string]string{"env": "test"},
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "hostAffinity=default without hostID is valid",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test",
+							HostAffinity: ptr.To("default"),
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -275,9 +275,12 @@ type Instance struct {
 	MarketType MarketType `json:"marketType,omitempty"`
 
 	// HostAffinity specifies the dedicated host affinity setting for the instance.
-	// When hostAffinity is set to host, an instance started onto a specific host always restarts on the same host if stopped.
-	// When hostAffinity is set to default, and you stop and restart the instance, it can be restarted on any available host.
-	// When HostAffinity is defined, HostID is required.
+	// When HostAffinity is set to "host", an instance started onto a specific host always restarts on the same host if stopped:
+	// - If HostID is set, the instance launches on the specific host and must return to that same host after any stop/start (Targeted & Pinned).
+	// - If HostID is not set, the instance gets launched on any available and must returns to the same host after any stop/start (Auto-placed & Pinned).
+	// When HostAffinity is set to "default" (the default value), the instance (when restarted) can return on any available host:
+	// - If HostID is set, the instance launches on the specified host now, but (when restarted) can return to any available hosts (Targeted & Flexible).
+	// - If HostID is not set, the instance launches on any available host now, and (when restarted) can return to any available hosts (Auto-placed & Flexible).
 	// +optional
 	// +kubebuilder:validation:Enum:=default;host
 	HostAffinity *string `json:"hostAffinity,omitempty"`

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1284,9 +1284,12 @@ spec:
                   hostAffinity:
                     description: |-
                       HostAffinity specifies the dedicated host affinity setting for the instance.
-                      When hostAffinity is set to host, an instance started onto a specific host always restarts on the same host if stopped.
-                      When hostAffinity is set to default, and you stop and restart the instance, it can be restarted on any available host.
-                      When HostAffinity is defined, HostID is required.
+                      When HostAffinity is set to "host", an instance started onto a specific host always restarts on the same host if stopped:
+                      - If HostID is set, the instance launches on the specific host and must return to that same host after any stop/start (Targeted & Pinned).
+                      - If HostID is not set, the instance gets launched on any available and must returns to the same host after any stop/start (Auto-placed & Pinned).
+                      When HostAffinity is set to "default" (the default value), the instance (when restarted) can return on any available host:
+                      - If HostID is set, the instance launches on the specified host now, but (when restarted) can return to any available hosts (Targeted & Flexible).
+                      - If HostID is not set, the instance launches on any available host now, and (when restarted) can return to any available hosts (Auto-placed & Flexible).
                     enum:
                     - default
                     - host
@@ -3572,9 +3575,12 @@ spec:
                   hostAffinity:
                     description: |-
                       HostAffinity specifies the dedicated host affinity setting for the instance.
-                      When hostAffinity is set to host, an instance started onto a specific host always restarts on the same host if stopped.
-                      When hostAffinity is set to default, and you stop and restart the instance, it can be restarted on any available host.
-                      When HostAffinity is defined, HostID is required.
+                      When HostAffinity is set to "host", an instance started onto a specific host always restarts on the same host if stopped:
+                      - If HostID is set, the instance launches on the specific host and must return to that same host after any stop/start (Targeted & Pinned).
+                      - If HostID is not set, the instance gets launched on any available and must returns to the same host after any stop/start (Auto-placed & Pinned).
+                      When HostAffinity is set to "default" (the default value), the instance (when restarted) can return on any available host:
+                      - If HostID is set, the instance launches on the specified host now, but (when restarted) can return to any available hosts (Targeted & Flexible).
+                      - If HostID is not set, the instance launches on any available host now, and (when restarted) can return to any available hosts (Auto-placed & Flexible).
                     enum:
                     - default
                     - host

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -2262,9 +2262,12 @@ spec:
                   hostAffinity:
                     description: |-
                       HostAffinity specifies the dedicated host affinity setting for the instance.
-                      When hostAffinity is set to host, an instance started onto a specific host always restarts on the same host if stopped.
-                      When hostAffinity is set to default, and you stop and restart the instance, it can be restarted on any available host.
-                      When HostAffinity is defined, HostID is required.
+                      When HostAffinity is set to "host", an instance started onto a specific host always restarts on the same host if stopped:
+                      - If HostID is set, the instance launches on the specific host and must return to that same host after any stop/start (Targeted & Pinned).
+                      - If HostID is not set, the instance gets launched on any available and must returns to the same host after any stop/start (Auto-placed & Pinned).
+                      When HostAffinity is set to "default" (the default value), the instance (when restarted) can return on any available host:
+                      - If HostID is set, the instance launches on the specified host now, but (when restarted) can return to any available hosts (Targeted & Flexible).
+                      - If HostID is not set, the instance launches on any available host now, and (when restarted) can return to any available hosts (Auto-placed & Flexible).
                     enum:
                     - default
                     - host

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -720,9 +720,9 @@ spec:
               dynamicHostAllocation:
                 description: |-
                   DynamicHostAllocation enables automatic allocation of a single dedicated host.
-                  This field is mutually exclusive with HostID and always allocates exactly one host.
                   Cost effectiveness of allocating a single instance on a dedicated host may vary
                   depending on the instance type and the region.
+                  This field is mutually exclusive with HostID and always allocates exactly one host.
                 properties:
                   tags:
                     additionalProperties:
@@ -760,12 +760,16 @@ spec:
                       rule: self in ['none','amazon-pool']
                 type: object
               hostAffinity:
-                default: host
+                default: default
                 description: |-
                   HostAffinity specifies the dedicated host affinity setting for the instance.
-                  When HostAffinity is set to host, an instance started onto a specific host always restarts on the same host if stopped.
-                  When HostAffinity is set to default, and you stop and restart the instance, it can be restarted on any available host.
-                  When HostAffinity is defined, HostID is required.
+                  When HostAffinity is set to "host", an instance started onto a specific host always restarts on the same host if stopped:
+                  - If HostID is set, the instance launches on the specific host and must return to that same host after any stop/start (Targeted & Pinned).
+                  - If HostID is not set, the instance gets launched on any available and must returns to the same host after any stop/start (Auto-placed & Pinned).
+                  When HostAffinity is set to "default" (the default value), the instance (when restarted) can return on any available host:
+                  - If HostID is set, the instance launches on the specified host now, but (when restarted) can return to any available hosts (Targeted & Flexible).
+                  - If HostID is not set, the instance launches on any available host now, and (when restarted) can return to any available hosts (Auto-placed & Flexible).
+                  If HostAffinity is not specified, it defaults to "default".
                 enum:
                 - default
                 - host

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -639,9 +639,9 @@ spec:
                       dynamicHostAllocation:
                         description: |-
                           DynamicHostAllocation enables automatic allocation of a single dedicated host.
-                          This field is mutually exclusive with HostID and always allocates exactly one host.
                           Cost effectiveness of allocating a single instance on a dedicated host may vary
                           depending on the instance type and the region.
+                          This field is mutually exclusive with HostID and always allocates exactly one host.
                         properties:
                           tags:
                             additionalProperties:
@@ -680,12 +680,16 @@ spec:
                               rule: self in ['none','amazon-pool']
                         type: object
                       hostAffinity:
-                        default: host
+                        default: default
                         description: |-
                           HostAffinity specifies the dedicated host affinity setting for the instance.
-                          When HostAffinity is set to host, an instance started onto a specific host always restarts on the same host if stopped.
-                          When HostAffinity is set to default, and you stop and restart the instance, it can be restarted on any available host.
-                          When HostAffinity is defined, HostID is required.
+                          When HostAffinity is set to "host", an instance started onto a specific host always restarts on the same host if stopped:
+                          - If HostID is set, the instance launches on the specific host and must return to that same host after any stop/start (Targeted & Pinned).
+                          - If HostID is not set, the instance gets launched on any available and must returns to the same host after any stop/start (Auto-placed & Pinned).
+                          When HostAffinity is set to "default" (the default value), the instance (when restarted) can return on any available host:
+                          - If HostID is set, the instance launches on the specified host now, but (when restarted) can return to any available hosts (Targeted & Flexible).
+                          - If HostID is not set, the instance launches on any available host now, and (when restarted) can return to any available hosts (Auto-placed & Flexible).
+                          If HostAffinity is not specified, it defaults to "default".
                         enum:
                         - default
                         - host

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -709,11 +709,14 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 
 	if i.HostID != nil {
 		if i.HostAffinity == nil {
+			// If HostAffinity is not specified, default to "default" Affinity (flexible affinity).
 			i.HostAffinity = aws.String("default")
 		}
 		if len(i.Tenancy) == 0 {
+			// If Tenancy is not specified with HostID set, default to "host" Tenancy.
 			i.Tenancy = "host"
 		}
+
 		s.scope.Debug("Running instance with dedicated host placement",
 			"hostId", i.HostID,
 			"affinity", i.HostAffinity)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

fix: change HostAffinity default 'host'->'default', improve API doc and tests

This PR updates the default value for HostAffinity from `host` to `default` as that's also the AWS platform default,
and potentially a more sensible value to set if the user does not have a preference.

It also improves the API's go doc comments to further explain the
effects of the settings and adds a bunch more units to pinpoint the
exact behaviour described in the updated doc.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: change HostAffinity default 'host'->'default', improve API doc and tests
```
