### PR TITLE
🐛 fix: eks security groups not provisioned with sourceSecurityGroupRoles

### DIFF
--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -692,7 +692,10 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 
 		return append(cniRules, rules...), nil
 	case infrav1.SecurityGroupEKSNodeAdditional:
-		ingressRules := s.scope.AdditionalControlPlaneIngressRules()
+		ingressRules, err := s.processIngressRulesSGs(s.scope.AdditionalControlPlaneIngressRules())
+		if err != nil {
+			return nil, err
+		}
 		if s.scope.Bastion().Enabled {
 			ingressRules = append(ingressRules, s.defaultSSHIngressRule(s.scope.SecurityGroups()[infrav1.SecurityGroupBastion].ID))
 		}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Related to #5806 , eks node-eks-additional security group role doesn't provisioned if IngressRules provided with `sourceSecurityGroupRoles`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5806


**Release note**:
```release-note
Fix: Ensure additionalControlPlaneIngressRules are applied for EKS when sourceSecurityGroupRoles is specified
```
