### PR TITLE
✨ feat: Eks pod identity for controller role

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -51,8 +51,8 @@ func (t Template) controllersPolicyRoleAttachments() []string {
 	return attachments
 }
 
-func (t Template) controllersTrustPolicy() *iamv1.PolicyDocument {
-	policyDocument := ec2AssumeRolePolicy()
+func (t Template) controllersTrustPolicy(eksEnabled bool) *iamv1.PolicyDocument {
+	policyDocument := ec2AssumeRolePolicy(eksEnabled)
 	policyDocument.Statement = append(policyDocument.Statement, t.Spec.ClusterAPIControllers.TrustStatements...)
 	return policyDocument
 }

--- a/cmd/clusterawsadm/cloudformation/bootstrap/control_plane.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/control_plane.go
@@ -40,7 +40,7 @@ func (t Template) controlPlanePolicies() []cfn_iam.Role_Policy {
 }
 
 func (t Template) controlPlaneTrustPolicy() *iamv1.PolicyDocument {
-	policyDocument := ec2AssumeRolePolicy()
+	policyDocument := ec2AssumeRolePolicy(false)
 	policyDocument.Statement = append(policyDocument.Statement, t.Spec.ControlPlane.TrustStatements...)
 	return policyDocument
 }

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -427,6 +427,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -472,6 +473,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -427,7 +427,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -441,10 +440,12 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.custom-suffix.com
     Type: AWS::IAM::Role
@@ -473,7 +474,6 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
-            - pods.eks.amazonaws.com
         Version: 2012-10-17
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -427,7 +427,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -441,6 +440,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -427,6 +427,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -444,6 +445,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -440,7 +440,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -454,6 +453,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -440,6 +440,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -457,6 +458,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -432,6 +432,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -449,6 +450,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -432,7 +432,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -446,6 +445,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -435,7 +435,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -449,6 +448,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -435,6 +435,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -452,6 +453,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -435,7 +435,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -449,6 +448,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -435,6 +435,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -452,6 +453,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -427,7 +427,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -441,6 +440,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -427,6 +427,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -444,6 +445,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -447,7 +447,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -461,6 +460,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -447,6 +447,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -464,6 +465,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -427,7 +427,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -441,6 +440,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -427,6 +427,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -443,7 +444,8 @@ Resources:
           Effect: Allow
           Principal:
             Service:
-            - ec2.amazonaws.com
+            - ec2.amazonaws.com 
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -444,7 +444,7 @@ Resources:
           Effect: Allow
           Principal:
             Service:
-            - ec2.amazonaws.com 
+            - ec2.amazonaws.com
             - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -426,7 +426,8 @@ Resources:
       AssumeRolePolicyDocument:
         Statement:
         - Action:
-          - sts:AssumeRole
+          - sts:AssumeRole  
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -444,6 +445,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -426,8 +426,7 @@ Resources:
       AssumeRolePolicyDocument:
         Statement:
         - Action:
-          - sts:AssumeRole  
-          - sts:TagSession
+          - sts:AssumeRole
           Effect: Allow
           Principal:
             Service:
@@ -441,6 +440,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -435,6 +435,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -462,6 +463,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       Policies:
       - PolicyDocument:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -435,7 +435,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -459,6 +458,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -440,7 +440,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -454,6 +453,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -440,6 +440,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -457,6 +458,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -427,7 +427,6 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
-          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -441,6 +440,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -427,6 +427,7 @@ Resources:
         Statement:
         - Action:
           - sts:AssumeRole
+          - sts:TagSession
           Effect: Allow
           Principal:
             Service:
@@ -444,6 +445,7 @@ Resources:
           Principal:
             Service:
             - ec2.amazonaws.com
+            - pods.eks.amazonaws.com
         Version: 2012-10-17
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role

--- a/cmd/clusterawsadm/cloudformation/bootstrap/node.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/node.go
@@ -39,7 +39,7 @@ func (t Template) nodePolicies() []cfn_iam.Role_Policy {
 }
 
 func (t Template) nodeTrustPolicy() *iamv1.PolicyDocument {
-	policyDocument := ec2AssumeRolePolicy()
+	policyDocument := ec2AssumeRolePolicy(false)
 	policyDocument.Statement = append(policyDocument.Statement, t.Spec.Nodes.TrustStatements...)
 	return policyDocument
 }

--- a/cmd/clusterawsadm/cloudformation/bootstrap/template.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/template.go
@@ -244,13 +244,22 @@ func AWSServiceAssumeRolePolicy(identityID string) *iamv1.PolicyDocument {
 
 // AssumeRolePolicy will create a role session and pass session policies programmatically.
 func AssumeRolePolicy(identityType iamv1.PrincipalType, principalIDs []string) *iamv1.PolicyDocument {
+	actions := iamv1.Actions{"sts:AssumeRole"}
+
+	for _, principal := range principalIDs {
+		if principal == "pods.eks.amazonaws.com" {
+			actions = append(actions, "sts:TagSession")
+			break
+		}
+	}
+
 	return &iamv1.PolicyDocument{
 		Version: iamv1.CurrentVersion,
 		Statement: []iamv1.StatementEntry{
 			{
 				Effect:    iamv1.EffectAllow,
 				Principal: iamv1.Principals{identityType: principalIDs},
-				Action:    iamv1.Actions{"sts:AssumeRole"},
+				Action:    actions,
 			},
 		},
 	}

--- a/cmd/clusterawsadm/cmd/controller/controller.go
+++ b/cmd/clusterawsadm/cmd/controller/controller.go
@@ -44,6 +44,7 @@ func RootCmd() *cobra.Command {
 	newCmd.AddCommand(credentials.UpdateCredentialsCmd())
 	newCmd.AddCommand(credentials.PrintCredentialsCmd())
 	newCmd.AddCommand(rollout.RolloutControllersCmd())
+	newCmd.AddCommand(credentials.UseEKSPodIdentityCmd())
 
 	return newCmd
 }

--- a/cmd/clusterawsadm/cmd/controller/credentials/use_pod_identity.go
+++ b/cmd/clusterawsadm/cmd/controller/credentials/use_pod_identity.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// UseEKSPodIdentityCmd is a CLI command that will enable using EKS pod identity for CAPA.
+func UseEKSPodIdentityCmd() *cobra.Command {
+	clusterName := ""
+	region := ""
+	namespace := ""
+	serviceAccount := ""
+	roleName := ""
+
+	newCmd := &cobra.Command{
+		Use:   "use-pod-identity",
+		Short: "Enable EKS pod identity with CAPA",
+		Long: templates.LongDesc(`
+			Updates CAPA running in an EKS cluster to use EKS pod identity
+		`),
+		Example: templates.Examples(`
+		clusterawsadm controller use-pod-identity --cluster-name cluster1
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return usePodIdentity(cmd.Context(), region, clusterName, namespace, serviceAccount, roleName)
+		},
+	}
+
+	newCmd.Flags().StringVarP(&region, "region", "r", "", "The AWS region containing the EKS cluster")
+	newCmd.Flags().StringVarP(&clusterName, "cluster-name", "n", "", "The name of the EKS management cluster")
+	newCmd.Flags().StringVar(&namespace, "namespace", "capa-system", "The namespace of CAPA controller")
+	newCmd.Flags().StringVar(&serviceAccount, "service-account", "capa-controller-manager", "The service account for the CAPA controller")
+	newCmd.Flags().StringVar(&roleName, "role-name", "controllers.cluster-api-provider-aws.sigs.k8s.io", "The name of the CAPA controller role. If you have used a prefix or suffix this will need to be changed.")
+
+	newCmd.MarkFlagRequired("cluster-name") //nolint: errcheck
+
+	return newCmd
+}
+
+func usePodIdentity(ctx context.Context, region, clusterName, namespace, serviceAccount, roleName string) error {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to load SDK config: %w", err)
+	}
+	if region != "" {
+		cfg.Region = region
+	}
+
+	roleArn, err := getRoleArn(ctx, &cfg, roleName)
+	if err != nil {
+		return err
+	}
+
+	eksClient := eks.NewFromConfig(cfg)
+
+	listInput := &eks.ListPodIdentityAssociationsInput{
+		ClusterName: aws.String(clusterName),
+		Namespace:   aws.String(namespace),
+	}
+
+	listOutput, err := eksClient.ListPodIdentityAssociations(ctx, listInput)
+	if err != nil {
+		return fmt.Errorf("listing existing pod identity associations for cluster %s in namespace %s: %w", clusterName, namespace, err)
+	}
+
+	for _, association := range listOutput.Associations {
+		if *association.ServiceAccount == serviceAccount {
+			needsUpdate, err := podIdentityNeedsUpdate(ctx, eksClient, &association, roleName)
+			if err != nil {
+				return err
+			}
+			if !needsUpdate {
+				fmt.Printf("EKS pod association for service account %s already exists, no action taken\n", serviceAccount)
+			}
+
+			return updatePodIdentity(ctx, eksClient, &association, roleName)
+		}
+	}
+
+	fmt.Printf("Creating pod association for service account %s.....\n", serviceAccount)
+
+	createInput := &eks.CreatePodIdentityAssociationInput{
+		ClusterName:    &clusterName,
+		Namespace:      &namespace,
+		RoleArn:        &roleArn,
+		ServiceAccount: &serviceAccount,
+	}
+
+	output, err := eksClient.CreatePodIdentityAssociation(ctx, createInput)
+	if err != nil {
+		return fmt.Errorf("failed to create pod identity association: %w", err)
+	}
+
+	fmt.Printf("Created pod identity association (%s)\n", *output.Association.AssociationId)
+
+	return nil
+}
+
+func podIdentityNeedsUpdate(ctx context.Context, client *eks.Client, association *types.PodIdentityAssociationSummary, roleArn string) (bool, error) {
+	input := &eks.DescribePodIdentityAssociationInput{
+		AssociationId: association.AssociationId,
+		ClusterName:   association.ClusterName,
+	}
+
+	output, err := client.DescribePodIdentityAssociation(ctx, input)
+	if err != nil {
+		return false, fmt.Errorf("failed describing pod identity association: %w", err)
+	}
+
+	return *output.Association.RoleArn != roleArn, nil
+}
+
+func updatePodIdentity(ctx context.Context, client *eks.Client, association *types.PodIdentityAssociationSummary, roleArn string) error {
+	input := &eks.UpdatePodIdentityAssociationInput{
+		AssociationId: association.AssociationId,
+		ClusterName:   association.ClusterName,
+		RoleArn:       &roleArn,
+	}
+
+	_, err := client.UpdatePodIdentityAssociation(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed updating pod identity association: %w", err)
+	}
+
+	fmt.Printf("Updated pod identity to use role %s\n", roleArn)
+
+	return nil
+}
+
+func getRoleArn(ctx context.Context, cfg *aws.Config, roleName string) (string, error) {
+	client := iam.NewFromConfig(*cfg)
+
+	input := &iam.GetRoleInput{
+		RoleName: &roleName,
+	}
+
+	output, err := client.GetRole(ctx, input)
+	if err != nil {
+		return "", fmt.Errorf("failed looking up role %s: %w", roleName, err)
+	}
+
+	return *output.Role.Arn, nil
+}

--- a/docs/book/src/topics/eks/eks-pod-identity.md
+++ b/docs/book/src/topics/eks/eks-pod-identity.md
@@ -1,0 +1,32 @@
+# Using EKS Pod Identity for CAPA Controller
+
+You can use [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to supply the credentials for the CAPA controller when the management is in EKS. This is an alternative to using the static boostrap credentials or IRSA.
+
+## Pre-requisites
+
+- Management cluster must be an EKS cluster
+- AWS environment variables set for your account
+
+## Steps
+
+1. Install the **Amazon EKS Pod Identity Agent** EKS addon into the cluster. This can be done using the AWS console or using the AWS cli.
+
+> NOTE: If your management cluster is a "self-managed" CAPI cluster then its possible to install the addon via the **EKSManagedControlPlane**.
+
+2. Create an EKS pod identity association for CAPA by running the following (replacing **<clustername>** with the name of your EKS cluster):
+
+```bash
+clusterawsadm controller use-pod-identity --cluster-name <clustername>
+```
+
+3. Ensure any credentials set for the controller are removed (a.k.a zeroed out):
+
+```bash
+clusterawsadm controller zero-credentials --namespace=capa-system
+```
+
+4. Force CAPA to restart so that the AWS credentials are injected:
+
+```bash
+clusterawsadm controller rollout-controller --kubeconfig=kubeconfig --namespace=capa-system
+```

--- a/docs/book/src/topics/eks/eks-pod-identity.md
+++ b/docs/book/src/topics/eks/eks-pod-identity.md
@@ -1,25 +1,25 @@
 # Using EKS Pod Identity for CAPA Controller
 
-You can use [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to supply the credentials for the CAPA controller when the management is in EKS. This is an alternative to using the static boostrap credentials or IRSA.
+You can use [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to supply the credentials for the CAPA controller when the management cluster is in EKS. This is an alternative to using static bootstrap credentials or IRSA.
 
 ## Pre-requisites
 
 - Management cluster must be an EKS cluster
-- AWS environment variables set for your account
+- If using aws-cli, AWS [environment variables set](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html) to target your account
 
 ## Steps
 
 1. Install the **Amazon EKS Pod Identity Agent** EKS addon into the cluster. This can be done using the AWS console or using the AWS cli.
 
-> NOTE: If your management cluster is a "self-managed" CAPI cluster then its possible to install the addon via the **EKSManagedControlPlane**.
+> NOTE: If your management cluster is managed by CAPI, it's possible to install the addon via the **EKSManagedControlPlane**.
 
-2. Create an EKS pod identity association for CAPA by running the following (replacing **<clustername>** with the name of your EKS cluster):
+2. Create an EKS pod identity association for CAPA by running the following (replacing `mycluster` with the name of your EKS cluster):
 
 ```bash
-clusterawsadm controller use-pod-identity --cluster-name <clustername>
+clusterawsadm controller use-pod-identity --cluster-name mycluster
 ```
 
-3. Ensure any credentials set for the controller are removed (a.k.a zeroed out):
+3. Ensure any credentials set for the controller are removed (zeroed out):
 
 ```bash
 clusterawsadm controller zero-credentials --namespace=capa-system

--- a/docs/book/src/topics/eks/index.md
+++ b/docs/book/src/topics/eks/index.md
@@ -29,11 +29,12 @@ And a number of new templates are available in the templates folder for creating
 
 ## SEE ALSO
 
-* [Prerequisites](prerequisites.md)
-* [Enabling EKS Support](enabling.md)
-* [Disabling EKS Support](disabling.md)
-* [Creating a cluster](creating-a-cluster.md)
-* [Using EKS Console](eks-console.md)
-* [Using EKS Addons](addons.md)
-* [Enabling Encryption](encryption.md)
-* [Cluster Upgrades](cluster-upgrades.md)
+- [Prerequisites](prerequisites.md)
+- [Enabling EKS Support](enabling.md)
+- [Disabling EKS Support](disabling.md)
+- [Creating a cluster](creating-a-cluster.md)
+- [Using EKS Console](eks-console.md)
+- [Using EKS Addons](addons.md)
+- [Enabling Encryption](encryption.md)
+- [Cluster Upgrades](cluster-upgrades.md)
+- [Using EKS Pod Identity for controller credentials](eks-pod-identity.md)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Addresses feedback in the original PR #5713, which is a soft blocker to #5808.

**Which issue(s) this PR fixes**
Related to #4906

**Special notes for your reviewer**:
This mainly addresses the feedback in #5713. Most of the comments were stylistic/grammatical, but there was a question as to whether the `clusterawsadm controller zero-credentials --namespace=capa-system` step is required both for new clusters and when migrating existing clusters.

`clusterctl init` will always create the k8s secret, even if the AWS credentials were empty from the start. Therefore  even if `zero-credentials` is redundant, it should be safe to run for both new and existing clusters.

There's also one functional change: this only adds the `sts:TagSession` action to the trust policy when the principals include `pods.eks.amazonaws.com`. Pod identity associations require this, but it's superfluous otherwise.

**Checklist**:
- [ ] squashed commits
- [x] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Add support for using EKS pod identity for the controller credentials.
```
