### PR TITLE
[release-2.9] :bug: fix: bumps golangci-lint to resolve problem caused by git

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # tag=v8.0.0
         with:
-          version: v2.1.0
+          version: v2.7.0
           working-directory: ${{matrix.working-directory}}
       - name: Lint API
         run: make lint-api

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -223,6 +223,9 @@ linters:
           - staticcheck
         text: 'QF1009: probably want to use time.Time.Equal instead'
       - linters:
+          - staticcheck
+        text: "s.scope.ControlPlaneLoadBalancer is deprecated"
+      - linters:
           - revive
         # Ignoring stylistic checks for generated code
         path: .*(api|types|test)\/.*\/.*conversion.*\.go$
@@ -293,6 +296,38 @@ linters:
         path: .*(api|types|test)\/.*\/.*conversion.*\.go$
         # This rule warns when initialism, variable or package naming conventions are not followed.
         text: 'var-naming: don''t use underscores in Go names'
+      - linters:
+          - revive
+        path: 'exp/utils/*'
+        text: 'var-naming: avoid meaningless package names'
+      - linters:
+          - revive
+        path: 'cmd/clusterawsadm/cmd/ami/common'
+        text: 'var-naming: avoid meaningless package names'
+      - linters:
+          - revive
+        path: 'cmd/clusterawsadm/cmd/util'
+        text: 'var-naming: avoid meaningless package names'
+      - linters:
+          - revive
+        path: 'pkg/utils'
+        text: 'var-naming: avoid meaningless package names'
+      - linters:
+          - revive
+        path: 'pkg/cloud/services/common/'
+        text: 'var-naming: avoid meaningless package names'
+      - linters:
+          - revive
+        path: 'test/e2e/shared/'
+        text: 'var-naming: avoid meaningless package names'
+      - linters:
+          - revive
+        text: 'avoid package names that conflict with Go standard library package names'
+        path: 'pkg/internal/bytes/'
+      - linters:
+          - revive
+        text: 'avoid package names that conflict with Go standard library package names'
+        path: 'pkg/hash/'
       - linters:
           - unparam
         text: always receives

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -32,6 +32,7 @@ type AWSResourceReference struct {
 
 	// ARN of resource.
 	// +optional
+	//
 	// Deprecated: This field has no function and is going to be removed in the next release.
 	ARN *string `json:"arn,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -80,6 +80,7 @@ spec:
                     arn:
                       description: |-
                         ARN of resource.
+
                         Deprecated: This field has no function and is going to be removed in the next release.
                       type: string
                     filters:
@@ -344,6 +345,7 @@ spec:
                   arn:
                     description: |-
                       ARN of resource.
+
                       Deprecated: This field has no function and is going to be removed in the next release.
                     type: string
                   filters:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -91,6 +91,7 @@ spec:
                             arn:
                               description: |-
                                 ARN of resource.
+
                                 Deprecated: This field has no function and is going to be removed in the next release.
                               type: string
                             filters:
@@ -360,6 +361,7 @@ spec:
                           arn:
                             description: |-
                               ARN of resource.
+
                               Deprecated: This field has no function and is going to be removed in the next release.
                             type: string
                           filters:

--- a/pkg/cloud/converters/eks.go
+++ b/pkg/cloud/converters/eks.go
@@ -189,11 +189,11 @@ func NodegroupUpdateconfigToSDK(updateConfig *expinfrav1.UpdateConfig) (*ekstype
 
 	converted := &ekstypes.NodegroupUpdateConfig{}
 	if updateConfig.MaxUnavailable != nil {
-		//nolint:gosec,G115 // Added golint exception as there is a kubebuilder validation configured
+		//nolint:G115 // Added golint exception as there is a kubebuilder validation configured
 		converted.MaxUnavailable = aws.Int32(int32(*updateConfig.MaxUnavailable))
 	}
 	if updateConfig.MaxUnavailablePercentage != nil {
-		//nolint:gosec,G115 // Added golint exception as there is a kubebuilder validation configured
+		//nolint:G115 // Added golint exception as there is a kubebuilder validation configured
 		converted.MaxUnavailablePercentage = aws.Int32(int32(*updateConfig.MaxUnavailablePercentage))
 	}
 

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -207,6 +207,7 @@ func (s *ClusterScope) ControlPlaneLoadBalancers() []*infrav1.AWSLoadBalancerSpe
 }
 
 // ControlPlaneLoadBalancerScheme returns the Classic ELB scheme (public or internal facing).
+//
 // Deprecated: This method is going to be removed in a future release. Use LoadBalancer.Scheme.
 func (s *ClusterScope) ControlPlaneLoadBalancerScheme() infrav1.ELBScheme {
 	if s.ControlPlaneLoadBalancer() != nil && s.ControlPlaneLoadBalancer().Scheme != nil {

--- a/pkg/cloud/scope/elb.go
+++ b/pkg/cloud/scope/elb.go
@@ -39,10 +39,12 @@ type ELBScope interface {
 	VPC() *infrav1.VPCSpec
 
 	// ControlPlaneLoadBalancer returns the AWSLoadBalancerSpec
+	//
 	// Deprecated: Use ControlPlaneLoadBalancers()
 	ControlPlaneLoadBalancer() *infrav1.AWSLoadBalancerSpec
 
 	// ControlPlaneLoadBalancerScheme returns the Classic ELB scheme (public or internal facing)
+	//
 	// Deprecated: This method is going to be removed in a future release. Use LoadBalancer.Scheme.
 	ControlPlaneLoadBalancerScheme() infrav1.ELBScheme
 

--- a/pkg/cloud/scope/sg.go
+++ b/pkg/cloud/scope/sg.go
@@ -44,6 +44,7 @@ type SGScope interface {
 	Bastion() *infrav1.Bastion
 
 	// ControlPlaneLoadBalancer returns the load balancer settings that are requested.
+	//
 	// Deprecated: Use ControlPlaneLoadBalancers()
 	ControlPlaneLoadBalancer() *infrav1.AWSLoadBalancerSpec
 

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -576,7 +576,7 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 		for index, id := range i.NetworkInterfaces {
 			netInterfaces = append(netInterfaces, types.InstanceNetworkInterfaceSpecification{
 				NetworkInterfaceId: aws.String(id),
-				DeviceIndex:        aws.Int32(int32(index)), //nolint:gosec // disable G115
+				DeviceIndex:        aws.Int32(int32(index)),
 			})
 		}
 		netInterfaces[0].AssociatePublicIpAddress = i.PublicIPOnLaunch

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -764,7 +764,7 @@ func ensureTestImageUploaded(ctx context.Context, e2eCtx *E2EContext) error {
 		return err
 	}
 
-	cmd := exec.Command("docker", "inspect", "--format='{{index .Id}}'", "gcr.io/k8s-staging-cluster-api/capa-manager:e2e")
+	cmd := exec.CommandContext(ctx, "docker", "inspect", "--format='{{index .Id}}'", "gcr.io/k8s-staging-cluster-api/capa-manager:e2e")
 	var stdOut bytes.Buffer
 	cmd.Stdout = &stdOut
 	err := cmd.Run()
@@ -775,7 +775,7 @@ func ensureTestImageUploaded(ctx context.Context, e2eCtx *E2EContext) error {
 	imageSha := strings.ReplaceAll(strings.TrimSuffix(stdOut.String(), "\n"), "'", "")
 
 	ecrImageName := repoName + ":e2e"
-	cmd = exec.Command("docker", "tag", imageSha, ecrImageName) //nolint:gosec
+	cmd = exec.CommandContext(ctx, "docker", "tag", imageSha, ecrImageName) //nolint:gosec
 	err = cmd.Run()
 	if err != nil {
 		return err
@@ -794,13 +794,13 @@ func ensureTestImageUploaded(ctx context.Context, e2eCtx *E2EContext) error {
 		return errors.New("failed to decode ECR authentication token")
 	}
 
-	cmd = exec.Command("docker", "login", "--username", strList[0], "--password", strList[1], "public.ecr.aws") //nolint:gosec
+	cmd = exec.CommandContext(ctx, "docker", "login", "--username", strList[0], "--password", strList[1], "public.ecr.aws") //nolint:gosec
 	err = cmd.Run()
 	if err != nil {
 		return err
 	}
 
-	cmd = exec.Command("docker", "push", ecrImageName)
+	cmd = exec.CommandContext(ctx, "docker", "push", ecrImageName)
 	err = cmd.Run()
 	if err != nil {
 		return err

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -89,7 +89,7 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 		templateDir := path.Join(e2eCtx.Settings.ArtifactFolder, "templates")
 		newTemplatePath := templateDir + "/" + ciTemplateForUpgradeName
 
-		err = exec.Command("cp", ciTemplateForUpgradePath, newTemplatePath).Run() //nolint:gosec
+		err = exec.CommandContext(context.TODO(), "cp", ciTemplateForUpgradePath, newTemplatePath).Run() //nolint:gosec
 		Expect(err).NotTo(HaveOccurred())
 
 		clusterctlCITemplateForUpgrade := clusterctl.Files{

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -271,7 +271,8 @@ func (t *TestEnvironment) WaitForWebhooks() {
 	timeout := 1 * time.Second
 	for {
 		time.Sleep(1 * time.Second)
-		conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), timeout)
+		dialer := &net.Dialer{Timeout: timeout}
+		conn, err := dialer.DialContext(context.TODO(), "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
 		if err != nil {
 			klog.V(2).Infof("Webhook port is not ready, will retry in %v: %s", timeout, err)
 			continue

--- a/test/helpers/kubernetesversions/template.go
+++ b/test/helpers/kubernetesversions/template.go
@@ -22,6 +22,7 @@ package kubernetesversions
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -128,7 +129,7 @@ func GenerateCIArtifactsInjectedTemplateForDebian(input GenerateCIArtifactsInjec
 	if err := os.WriteFile(path.Join(overlayDir, "platform-kustomization.yaml"), input.PlatformKustomization, 0o600); err != nil {
 		return "", err
 	}
-	cmd := exec.Command("kustomize", "build", overlayDir) //nolint:gosec // We don't care about command injection here.
+	cmd := exec.CommandContext(context.TODO(), "kustomize", "build", overlayDir) //nolint:gosec // We don't care about command injection here.
 	data, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind fix

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This is a backport of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5793, adapted to this branch. We need it to run builds on this branch.

The git version is determined by the GitHub Actions runners, and is now incompatible with the golangci-lint custom command, used to compile the KAL linter.

For the root cause, see https://github.com/golangci/golangci-lint/issues/6205


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
