### PR TITLE
✨ feat: Allow EKS addons to use latest tag

### DIFF
--- a/controlplane/eks/api/v1beta2/types.go
+++ b/controlplane/eks/api/v1beta2/types.go
@@ -183,8 +183,21 @@ type Addon struct {
 	// +kubebuilder:validation:MinLength:=2
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
-	// Version is the version of the addon to use
+	// Version is the version of the addon to use.
+	// Use `default` to use the current default version for the
+	// cluster's Kubernetes version.
+	// Use `latest` to use the latest version for the cluster's
+	// Kubernetes version (which may be newer than the default.)
 	Version string `json:"version"`
+	// UpdatePolicy determines the behavior on subsequent reconcilies when
+	// the addon version is `default` or `latest`.
+	// `ifAvailable` will update the addon to the newest default or latest
+	// version, if it has changed since the last reconciliation.
+	// `never` will not update the addon version after the initial
+	// installation, even if the default or latest version changes.
+	// +kubebuilder:validation:Enum=ifAvailable;never
+	// +kubebuilder:default=never
+	UpdatePolicy string `json:"updatePolicy,omitempty"`
 	// Configuration of the EKS addon
 	// +optional
 	Configuration string `json:"configuration,omitempty"`

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
@@ -980,6 +980,8 @@ func mockedEKSCluster(ctx context.Context, g *WithT, eksRec *mock_eksiface.MockE
 
 	eksRec.UpdateClusterConfig(ctx, gomock.AssignableToTypeOf(&eks.UpdateClusterConfigInput{})).After(waitUntilClusterActiveCall).Return(&eks.UpdateClusterConfigOutput{}, nil)
 
+	eksRec.DescribeAddonVersions(ctx, &eks.DescribeAddonVersionsInput{}).Return(&eks.DescribeAddonVersionsOutput{}, nil)
+
 	awsNodeRec.ReconcileCNI(gomock.Any()).Return(nil)
 	kubeProxyRec.ReconcileKubeProxy(gomock.Any()).Return(nil)
 	iamAuthenticatorRec.ReconcileIAMAuthenticator(gomock.Any()).Return(nil)

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/zgalor/weberr v0.8.2
 	go.uber.org/mock v0.5.2
 	golang.org/x/crypto v0.46.0
+	golang.org/x/mod v0.30.0
 	golang.org/x/text v0.32.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.33.4

--- a/go.sum
+++ b/go.sum
@@ -579,6 +579,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.30.0 h1:fDEXFVZ/fmCKProc/yAXXUijritrDzahmwwefnjoPFk=
+golang.org/x/mod v0.30.0/go.mod h1:lAsf5O2EvJeSFMiBxXDki7sCgAxEUcZHXoXMKT4GJKc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -54,6 +54,11 @@ func (s *Service) reconcileAddons(ctx context.Context) error {
 	// Get the addons from the spec we want for the cluster
 	desiredAddons := s.translateAPIToAddon(s.scope.Addons())
 
+	// Update the tags with the latest version if available
+	if desiredAddons, err = s.updateAddonTagsWithLatestVersion(ctx, desiredAddons); err != nil {
+		return fmt.Errorf("updating addon tags with latest version: %w", err)
+	}
+
 	// If there are no addons desired or installed then do nothing
 	if len(installed) == 0 && len(desiredAddons) == 0 {
 		s.scope.Info("no addons installed and no addons to install, no action needed")
@@ -247,4 +252,43 @@ func convertConfiguration(configuration string) *string {
 		return nil
 	}
 	return &configuration
+}
+
+func (s *Service) updateAddonTagsWithLatestVersion(ctx context.Context, addons []*eksaddons.EKSAddon) ([]*eksaddons.EKSAddon, error) {
+	s.Debug("Updating addon tags with the latest available version")
+
+	input := &eks.DescribeAddonVersionsInput{
+		KubernetesVersion: s.scope.ControlPlane.Spec.Version,
+	}
+
+	output, err := s.EKSClient.DescribeAddonVersions(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("error describing addon versions: %w", err)
+	}
+	if len(output.Addons) == 0 {
+		s.Debug("No addons found for the specified Kubernetes version")
+		return addons, nil
+	}
+
+	latestVersions := make(map[string]string)
+	for _, addon := range output.Addons {
+		if len(addon.AddonVersions) > 0 {
+			latestVersions[*addon.AddonName] = *addon.AddonVersions[0].AddonVersion
+			for _, version := range addon.AddonVersions[1:] {
+				if *version.AddonVersion > latestVersions[*addon.AddonName] {
+					latestVersions[*addon.AddonName] = *version.AddonVersion
+				}
+			}
+		}
+	}
+
+	for _, addon := range addons {
+		if addon.Version != nil && *addon.Version == "latest" {
+			if latestVersion, ok := latestVersions[*addon.Name]; ok {
+				addon.Version = &latestVersion
+			}
+		}
+	}
+
+	return addons, nil
 }

--- a/pkg/cloud/services/eks/addons_test.go
+++ b/pkg/cloud/services/eks/addons_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/eks/mock_eksiface"
+	eksaddons "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/eks/addons"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+)
+
+func TestUpdateAddonTagsWithLatestVersion(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputAddons  []*eksaddons.EKSAddon
+		mockResponse *eks.DescribeAddonVersionsOutput
+		mockError    error
+		expected     []*eksaddons.EKSAddon
+		expectError  bool
+	}{
+		{
+			name: "replaces latest tag with highest semver",
+			inputAddons: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("latest")},
+			},
+			mockResponse: &eks.DescribeAddonVersionsOutput{
+				Addons: []ekstypes.AddonInfo{
+					{
+						AddonName: aws.String("vpc-cni"),
+						AddonVersions: []ekstypes.AddonVersionInfo{
+							{AddonVersion: aws.String("v1.12.0-eksbuild.1")},
+							{AddonVersion: aws.String("v1.11.4-eksbuild.1")},
+							{AddonVersion: aws.String("v1.12.5-eksbuild.2")},
+							{AddonVersion: aws.String("v1.12.1-eksbuild.1")},
+						},
+					},
+				},
+			},
+			expected: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("v1.12.5-eksbuild.2")},
+			},
+		},
+		{
+			name: "preserves specific version",
+			inputAddons: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("v1.11.4-eksbuild.1")},
+			},
+			mockResponse: &eks.DescribeAddonVersionsOutput{
+				Addons: []ekstypes.AddonInfo{
+					{
+						AddonName: aws.String("vpc-cni"),
+						AddonVersions: []ekstypes.AddonVersionInfo{
+							{AddonVersion: aws.String("v1.12.5-eksbuild.2")},
+							{AddonVersion: aws.String("v1.11.4-eksbuild.1")},
+						},
+					},
+				},
+			},
+			expected: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("v1.11.4-eksbuild.1")},
+			},
+		},
+		{
+			name: "handles multiple addons with latest",
+			inputAddons: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("latest")},
+				{Name: aws.String("coredns"), Version: aws.String("latest")},
+				{Name: aws.String("kube-proxy"), Version: aws.String("v1.28.1-eksbuild.1")},
+			},
+			mockResponse: &eks.DescribeAddonVersionsOutput{
+				Addons: []ekstypes.AddonInfo{
+					{
+						AddonName: aws.String("vpc-cni"),
+						AddonVersions: []ekstypes.AddonVersionInfo{
+							{AddonVersion: aws.String("v1.12.5-eksbuild.2")},
+							{AddonVersion: aws.String("v1.12.0-eksbuild.1")},
+						},
+					},
+					{
+						AddonName: aws.String("coredns"),
+						AddonVersions: []ekstypes.AddonVersionInfo{
+							{AddonVersion: aws.String("v1.10.1-eksbuild.2")},
+							{AddonVersion: aws.String("v1.10.1-eksbuild.1")},
+							{AddonVersion: aws.String("v1.9.3-eksbuild.5")},
+						},
+					},
+					{
+						AddonName: aws.String("kube-proxy"),
+						AddonVersions: []ekstypes.AddonVersionInfo{
+							{AddonVersion: aws.String("v1.28.2-eksbuild.2")},
+							{AddonVersion: aws.String("v1.28.1-eksbuild.1")},
+						},
+					},
+				},
+			},
+			expected: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("v1.12.5-eksbuild.2")},
+				{Name: aws.String("coredns"), Version: aws.String("v1.10.1-eksbuild.2")},
+				{Name: aws.String("kube-proxy"), Version: aws.String("v1.28.1-eksbuild.1")},
+			},
+		},
+		{
+			name: "handles addon not in versions list",
+			inputAddons: []*eksaddons.EKSAddon{
+				{Name: aws.String("unknown-addon"), Version: aws.String("latest")},
+			},
+			mockResponse: &eks.DescribeAddonVersionsOutput{
+				Addons: []ekstypes.AddonInfo{
+					{
+						AddonName: aws.String("vpc-cni"),
+						AddonVersions: []ekstypes.AddonVersionInfo{
+							{AddonVersion: aws.String("v1.12.5-eksbuild.2")},
+						},
+					},
+				},
+			},
+			expected: []*eksaddons.EKSAddon{
+				{Name: aws.String("unknown-addon"), Version: aws.String("latest")},
+			},
+		},
+		{
+			name: "correctly compares build numbers",
+			inputAddons: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("latest")},
+			},
+			mockResponse: &eks.DescribeAddonVersionsOutput{
+				Addons: []ekstypes.AddonInfo{
+					{
+						AddonName: aws.String("vpc-cni"),
+						AddonVersions: []ekstypes.AddonVersionInfo{
+							{AddonVersion: aws.String("v1.12.5-eksbuild.1")},
+							{AddonVersion: aws.String("v1.12.5-eksbuild.10")},
+							{AddonVersion: aws.String("v1.12.5-eksbuild.2")},
+						},
+					},
+				},
+			},
+			expected: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("v1.12.5-eksbuild.10")},
+			},
+		},
+		{
+			name: "returns error when DescribeAddonVersions fails",
+			inputAddons: []*eksaddons.EKSAddon{
+				{Name: aws.String("vpc-cni"), Version: aws.String("latest")},
+			},
+			mockError:   errors.New("API error"),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mockControl := gomock.NewController(t)
+			defer mockControl.Finish()
+
+			eksMock := mock_eksiface.NewMockEKSAPI(mockControl)
+
+			scheme := runtime.NewScheme()
+			_ = infrav1.AddToScheme(scheme)
+			_ = ekscontrolplanev1.AddToScheme(scheme)
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			scope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
+				Client: client,
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-cluster",
+					},
+				},
+				ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
+					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Version: aws.String("1.34"),
+					},
+				},
+			})
+			g.Expect(err).To(BeNil())
+
+			eksMock.EXPECT().
+				DescribeAddonVersions(gomock.Any(), gomock.Any()).
+				Return(tc.mockResponse, tc.mockError)
+
+			s := NewService(scope)
+			s.EKSClient = eksMock
+
+			result, err := s.updateAddonTagsWithLatestVersion(context.TODO(), tc.inputAddons)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).To(BeNil())
+			g.Expect(result).To(HaveLen(len(tc.expected)))
+
+			for i := range result {
+				g.Expect(*result[i].Name).To(Equal(*tc.expected[i].Name))
+				g.Expect(*result[i].Version).To(Equal(*tc.expected[i].Version))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- Feature enhancement: Adds support for specifying the latest version of EKS addons in AWSManagedControlPlane.
- Improves user experience: Automatically resolves the versioning of addons by fetching the latest supported versions.

**Which issue(s) this PR fixes**:
Fixes #5184

**Special notes for your reviewer**:
This PR is a continuation of #5210:
- Rebased to the latest `main`
- Uses the `semver` package to compare tags instead of simple lexicographic sort
- Adds basic tests

**Checklist**:
- [ ] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Support installing the latest supported version of EKS addons by specifying `version: latest` in AWSManagedControlPlane.
```
