### PR TITLE
🌱 Allow ROSA NodePool autoscaling MinReplicas to be 0

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
@@ -233,7 +233,7 @@ spec:
                         minimum: 1
                         type: integer
                       minReplicas:
-                        minimum: 1
+                        minimum: 0
                         type: integer
                     type: object
                   instanceType:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
@@ -80,7 +80,7 @@ spec:
                     minimum: 1
                     type: integer
                   minReplicas:
-                    minimum: 1
+                    minimum: 0
                     type: integer
                 type: object
               availabilityZone:

--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -397,7 +397,7 @@ type DefaultMachinePoolSpec struct {
 
 // AutoScaling specifies scaling options.
 type AutoScaling struct {
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	MinReplicas int `json:"minReplicas,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	MaxReplicas int `json:"maxReplicas,omitempty"`


### PR DESCRIPTION
Relaxes the validation for ROSA NodePool autoscaling to allow users to specify a minimum of 0 replicas, enabling scale-to-zero scenarios. MaxReplicas remains with a minimum of 1.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

Rosa is gaining the ability to accept autoscaling nodepools with a minimum size of 0.  This change enables setting min=0 in rosa for autoscaling nodepools.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ x ] squashed commits
- [ ] includes documentation
- [ x ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ROSA: Enable setting min=0 for autoscaling nodepools.
```
