### PR TITLE
🐛  Validate region when reconciling cluster

### DIFF
--- a/api/v1beta2/awscluster_webhook_test.go
+++ b/api/v1beta2/awscluster_webhook_test.go
@@ -37,7 +37,12 @@ import (
 )
 
 func TestAWSClusterDefault(t *testing.T) {
-	cluster := &AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	cluster := &AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: AWSClusterSpec{
+			Region: "us-west-2",
+		},
+	}
 	t.Run("for AWSCluster", defaultValidateTest(context.Background(), cluster, &awsClusterWebhook{}, true))
 	cluster.Default()
 	g := NewWithT(t)
@@ -61,6 +66,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						LoadBalancerType: LoadBalancerTypeDisabled,
 						Name:             ptr.To("name"),
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -73,6 +79,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						CrossZoneLoadBalancing: true,
 						LoadBalancerType:       LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -85,6 +92,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						Subnets:          []string{"foo", "bar"},
 						LoadBalancerType: LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -97,6 +105,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						HealthCheckProtocol: &ELBProtocolTCP,
 						LoadBalancerType:    LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -109,6 +118,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						AdditionalSecurityGroups: []string{"foo", "bar"},
 						LoadBalancerType:         LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -126,6 +136,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						},
 						LoadBalancerType: LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -145,6 +156,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						},
 						LoadBalancerType: LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -157,6 +169,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						DisableHostsRewrite: true,
 						LoadBalancerType:    LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -169,6 +182,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						PreserveClientIP: true,
 						LoadBalancerType: LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -179,6 +193,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{Scheme: &unsupportedIncorrectScheme},
+					Region:                   "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -193,6 +208,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 						strings.Repeat("CAPI", 33): "value-3",
 						"key-4":                    strings.Repeat("CAPI", 65),
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -201,6 +217,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "accepts bucket name with acceptable characters",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name:                           "abcdefghijklmnoprstuwxyz-0123456789",
 						ControlPlaneIAMInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io",
@@ -213,6 +230,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "rejects empty bucket name",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region:   "us-west-2",
 					S3Bucket: &S3Bucket{},
 				},
 			},
@@ -222,6 +240,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "rejects bucket name shorter than 3 characters",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name: "fo",
 					},
@@ -233,6 +252,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "rejects bucket name longer than 63 characters",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name: strings.Repeat("a", 64),
 					},
@@ -244,6 +264,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "rejects bucket name starting with not letter or number",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name: "-foo",
 					},
@@ -255,6 +276,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "rejects bucket name ending with not letter or number",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name: "foo-",
 					},
@@ -266,6 +288,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "rejects bucket name formatted as IP address",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name: "8.8.8.8",
 					},
@@ -277,6 +300,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "requires bucket control plane IAM instance profile to be not empty",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name:                           "foo",
 						ControlPlaneIAMInstanceProfile: "",
@@ -289,6 +313,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "requires at least one bucket node IAM instance profile",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name:                           "foo",
 						ControlPlaneIAMInstanceProfile: "foo",
@@ -301,6 +326,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "requires all bucket node IAM instance profiles to be not empty",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name:                           "foo",
 						ControlPlaneIAMInstanceProfile: "foo",
@@ -314,6 +340,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 			name: "does not return error when all IAM instance profiles are populated",
 			cluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					S3Bucket: &S3Bucket{
 						Name:                           "foo",
 						ControlPlaneIAMInstanceProfile: "foo",
@@ -335,6 +362,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -354,6 +382,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -370,6 +399,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -387,6 +417,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -405,6 +436,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -424,6 +456,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -441,6 +474,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -458,6 +492,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -474,6 +509,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -490,6 +526,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -506,6 +543,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -523,6 +561,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -536,6 +575,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							IPAMPool: &IPAMPool{},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -550,6 +590,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							IPAMPool:  &IPAMPool{},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -567,6 +608,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -584,6 +626,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -602,6 +645,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -618,6 +662,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -635,6 +680,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -652,6 +698,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -669,6 +716,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -687,6 +735,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -703,6 +752,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -720,6 +770,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -731,6 +782,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 					NetworkSpec: NetworkSpec{
 						NodePortIngressRuleCidrBlocks: []string{"10.0.0.0/16"},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -742,6 +794,7 @@ func TestAWSClusterValidateCreate(t *testing.T) {
 					NetworkSpec: NetworkSpec{
 						NodePortIngressRuleCidrBlocks: []string{"10.0.0.0"},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -798,6 +851,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						LoadBalancerType: LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -805,6 +859,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						LoadBalancerType: LoadBalancerTypeClassic,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -816,6 +871,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						LoadBalancerType: LoadBalancerTypeClassic,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -823,6 +879,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						LoadBalancerType: LoadBalancerTypeDisabled,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -848,6 +905,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Name: aws.String("old-apiserver"),
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -855,6 +913,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Name: aws.String("new-apiserver"),
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -866,6 +925,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Name: nil,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -873,6 +933,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Name: aws.String("example-apiserver"),
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -884,6 +945,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Scheme: &ELBSchemeInternal,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -891,6 +953,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Scheme: &ELBSchemeInternetFacing,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -898,13 +961,16 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 		{
 			name: "controlPlaneLoadBalancer scheme is immutable when left empty",
 			oldCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			newCluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Scheme: &ELBSchemeInternal,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -912,13 +978,16 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 		{
 			name: "controlPlaneLoadBalancer scheme can be set to default when left empty",
 			oldCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			newCluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Scheme: &ELBSchemeInternetFacing,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -930,6 +999,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						CrossZoneLoadBalancing: false,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -937,6 +1007,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						CrossZoneLoadBalancing: true,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -949,6 +1020,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						Host: "example.com",
 						Port: int32(8000),
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -957,6 +1029,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						Host: "foo.example.com",
 						Port: int32(9000),
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -966,6 +1039,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 			oldCluster: &AWSCluster{
 				Spec: AWSClusterSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{},
+					Region:               "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -974,6 +1048,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						Host: "example.com",
 						Port: int32(8000),
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -984,16 +1059,30 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{clusterv1beta1.ManagedByAnnotation: ""},
 				},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
-			newCluster: &AWSCluster{},
-			wantErr:    true,
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
+			},
+			wantErr: true,
 		},
 		{
-			name:       "adding externally managed annotation is allowed",
-			oldCluster: &AWSCluster{},
+			name: "adding externally managed annotation is allowed",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
+			},
 			newCluster: &AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{clusterv1beta1.ManagedByAnnotation: ""},
+				},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -1005,10 +1094,13 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					NetworkSpec: NetworkSpec{
 						VPC: VPCSpec{ID: "managed-or-unmanaged-vpc"},
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			wantErr: true,
 		},
@@ -1019,6 +1111,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					NetworkSpec: NetworkSpec{
 						VPC: VPCSpec{ID: "managed-or-unmanaged-vpc"},
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -1026,6 +1119,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					NetworkSpec: NetworkSpec{
 						VPC: VPCSpec{ID: "a-new-vpc"},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1038,6 +1132,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						"key-1": "value-1",
 						"key-2": "value-2",
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -1048,6 +1143,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						strings.Repeat("CAPI", 33): "value-3",
 						"key-4":                    strings.Repeat("CAPI", 65),
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1060,6 +1156,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						LoadBalancerType:    LoadBalancerTypeNLB,
 						HealthCheckProtocol: &ELBProtocolTCP,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -1068,6 +1165,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						LoadBalancerType:    LoadBalancerTypeNLB,
 						HealthCheckProtocol: &ELBProtocolSSL,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1080,6 +1178,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						LoadBalancerType:    LoadBalancerTypeClassic,
 						HealthCheckProtocol: &ELBProtocolSSL,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -1088,6 +1187,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						LoadBalancerType:    LoadBalancerTypeClassic,
 						HealthCheckProtocol: &ELBProtocolTCP,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -1095,10 +1195,13 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 		{
 			name: "Should pass if old secondary lb is absent",
 			oldCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			newCluster: &AWSCluster{
 				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 					SecondaryControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						Name: ptr.To("test-lb"),
 					},
@@ -1113,6 +1216,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						HealthCheckProtocol: &ELBProtocolTCP,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -1120,6 +1224,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						HealthCheckProtocol: &ELBProtocolTCP,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -1131,6 +1236,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						LoadBalancerType: LoadBalancerTypeNLB,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -1139,6 +1245,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						LoadBalancerType:    LoadBalancerTypeNLB,
 						HealthCheckProtocol: &ELBProtocolTCP,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1150,6 +1257,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 					ControlPlaneLoadBalancer: &AWSLoadBalancerSpec{
 						LoadBalancerType: LoadBalancerTypeClassic,
 					},
+					Region: "us-west-2",
 				},
 			},
 			newCluster: &AWSCluster{
@@ -1158,6 +1266,7 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						LoadBalancerType:    LoadBalancerTypeNLB,
 						HealthCheckProtocol: &ELBProtocolTCP,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -1165,7 +1274,9 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 		{
 			name: "correct GC tasks annotation",
 			oldCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			newCluster: &AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1173,13 +1284,18 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						ExternalResourceGCTasksAnnotation: "load-balancer,target-group,security-group",
 					},
 				},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "empty GC tasks annotation",
 			oldCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			newCluster: &AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1187,19 +1303,27 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 						ExternalResourceGCTasksAnnotation: "",
 					},
 				},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "incorrect GC tasks annotation",
 			oldCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			newCluster: &AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						ExternalResourceGCTasksAnnotation: "load-balancer,INVALID,security-group",
 					},
+				},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1241,7 +1365,9 @@ func TestAWSClusterDefaultCNIIngressRules(t *testing.T) {
 		{
 			name: "CNI ingressRules are updated cni spec undefined",
 			beforeCluster: &AWSCluster{
-				Spec: AWSClusterSpec{},
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			afterCluster: &AWSCluster{
 				Spec: AWSClusterSpec{
@@ -1264,6 +1390,7 @@ func TestAWSClusterDefaultCNIIngressRules(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 		},
@@ -1275,6 +1402,7 @@ func TestAWSClusterDefaultCNIIngressRules(t *testing.T) {
 						VPC: defaultVPCSpec,
 						CNI: &CNISpec{},
 					},
+					Region: "us-west-2",
 				},
 			},
 			afterCluster: &AWSCluster{
@@ -1283,6 +1411,7 @@ func TestAWSClusterDefaultCNIIngressRules(t *testing.T) {
 						VPC: defaultVPCSpec,
 						CNI: &CNISpec{},
 					},
+					Region: "us-west-2",
 				},
 			},
 		},
@@ -1303,6 +1432,7 @@ func TestAWSClusterDefaultCNIIngressRules(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			afterCluster: &AWSCluster{
@@ -1320,6 +1450,7 @@ func TestAWSClusterDefaultCNIIngressRules(t *testing.T) {
 							},
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 		},
@@ -1355,6 +1486,7 @@ func TestAWSClusterValidateAllowedCIDRBlocks(t *testing.T) {
 							"192.168.0.1/32",
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -1367,6 +1499,7 @@ func TestAWSClusterValidateAllowedCIDRBlocks(t *testing.T) {
 						AllowedCIDRBlocks:   []string{},
 						DisableIngressRules: true,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: false,
@@ -1382,6 +1515,7 @@ func TestAWSClusterValidateAllowedCIDRBlocks(t *testing.T) {
 						},
 						DisableIngressRules: true,
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1395,6 +1529,7 @@ func TestAWSClusterValidateAllowedCIDRBlocks(t *testing.T) {
 							"100.200.300.400/99",
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1408,6 +1543,7 @@ func TestAWSClusterValidateAllowedCIDRBlocks(t *testing.T) {
 							"abcdefg",
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 			wantErr: true,
@@ -1447,6 +1583,7 @@ func TestAWSClusterDefaultAllowedCIDRBlocks(t *testing.T) {
 							"0.0.0.0/0",
 						},
 					},
+					Region: "us-west-2",
 				},
 			},
 		},
@@ -1459,6 +1596,7 @@ func TestAWSClusterDefaultAllowedCIDRBlocks(t *testing.T) {
 						DisableIngressRules: true,
 						Enabled:             true,
 					},
+					Region: "us-west-2",
 				},
 			},
 			afterCluster: &AWSCluster{
@@ -1467,6 +1605,7 @@ func TestAWSClusterDefaultAllowedCIDRBlocks(t *testing.T) {
 						DisableIngressRules: true,
 						Enabled:             true,
 					},
+					Region: "us-west-2",
 				},
 			},
 		},
@@ -1485,6 +1624,197 @@ func TestAWSClusterDefaultAllowedCIDRBlocks(t *testing.T) {
 				g.Expect(err).To(HaveOccurred())
 			} else {
 				g.Expect(cluster.Spec.Bastion).To(Equal(tt.afterCluster.Spec.Bastion))
+			}
+		})
+	}
+}
+
+func TestAWSClusterValidateRegion(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *AWSCluster
+		wantErr bool
+	}{
+		{
+			name: "valid us-east-1 region",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-east-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid us-west-2 region",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid eu-west-1 region",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "eu-west-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid ap-northeast-1 region",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "ap-northeast-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid cn-north-1 region (China partition)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "cn-north-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid us-gov-west-1 region (GovCloud partition)",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-gov-west-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid region - nonexistent",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "invalid-region-xyz",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid region - empty string",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid region - malformed",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-12345",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid region - random string",
+			cluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "notaregion",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			cluster := tt.cluster.DeepCopy()
+			cluster.ObjectMeta = metav1.ObjectMeta{
+				GenerateName: "cluster-",
+				Namespace:    "default",
+			}
+			if cluster.Spec.Region == "" && !tt.wantErr {
+				cluster.Spec.Region = "us-west-2"
+			}
+			if err := testEnv.Create(ctx, cluster); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCreate() with region validation error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAWSClusterValidateRegionUpdate(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldCluster *AWSCluster
+		newCluster *AWSCluster
+		wantErr    bool
+	}{
+		{
+			name: "region change should fail - immutable field",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-east-1",
+				},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-west-2",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "region stays same - should pass",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-east-1",
+				},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-east-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "update with invalid region should fail",
+			oldCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "us-east-1",
+				},
+			},
+			newCluster: &AWSCluster{
+				Spec: AWSClusterSpec{
+					Region: "invalid-region",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			cluster := tt.oldCluster.DeepCopy()
+			cluster.ObjectMeta = metav1.ObjectMeta{
+				GenerateName: "cluster-",
+				Namespace:    "default",
+			}
+			if cluster.Spec.Region == "" {
+				cluster.Spec.Region = "us-west-2"
+			}
+
+			if err := testEnv.Create(ctx, cluster); err != nil {
+				t.Errorf("failed to create cluster: %v", err)
+			}
+
+			cluster.Spec.Region = tt.newCluster.Spec.Region
+			if err := testEnv.Update(ctx, cluster); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() with region validation error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/api/v1beta2/sshkeyname_test.go
+++ b/api/v1beta2/sshkeyname_test.go
@@ -71,6 +71,7 @@ func TestSSHKeyName(t *testing.T) {
 				},
 				Spec: AWSClusterSpec{
 					SSHKeyName: tt.sshKeyName,
+					Region:     "us-west-2",
 				},
 			}
 			machine := &AWSMachine{

--- a/controllers/awscluster_controller_unit_test.go
+++ b/controllers/awscluster_controller_unit_test.go
@@ -59,17 +59,21 @@ func TestAWSClusterReconcilerReconcile(t *testing.T) {
 					Name:       "capi-fail-test",
 					UID:        "1",
 				},
-			}}},
+			}},
+				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
+				},
+			},
 			expectError: true,
 		},
 		{
 			name:        "Should not reconcile if owner reference is not set",
-			awsCluster:  &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{GenerateName: "aws-test-"}},
+			awsCluster:  &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{GenerateName: "aws-test-"}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}},
 			expectError: false,
 		},
 		{
 			name:       "Should not Reconcile if cluster is paused",
-			awsCluster: &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{GenerateName: "aws-test-", Annotations: map[string]string{clusterv1.PausedAnnotation: ""}}},
+			awsCluster: &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{GenerateName: "aws-test-", Annotations: map[string]string{clusterv1.PausedAnnotation: ""}}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}},
 			ownerCluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "capi-test-"},
 				Spec: clusterv1.ClusterSpec{

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -109,14 +109,16 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, awsMachine, ns, secret)).To(Succeed())
 		})
 
-		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{NetworkSpec: infrav1.NetworkSpec{
-			Subnets: []infrav1.SubnetSpec{
-				{
-					ID:               "subnet-1",
-					AvailabilityZone: "us-east-1a",
+		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
+			NetworkSpec: infrav1.NetworkSpec{
+				Subnets: []infrav1.SubnetSpec{
+					{
+						ID:               "subnet-1",
+						AvailabilityZone: "us-east-1a",
+					},
 				},
-			},
-		}}})
+			}}})
 		g.Expect(err).To(BeNil())
 		cs.Cluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
 		cs.AWSCluster.Spec.NetworkSpec.VPC = infrav1.VPCSpec{
@@ -213,7 +215,7 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, awsMachine, ns)).To(Succeed())
 		})
 
-		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
+		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}})
 		g.Expect(err).To(BeNil())
 		cs.Cluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
 		cs.AWSCluster.Spec.ControlPlaneLoadBalancer = &infrav1.AWSLoadBalancerSpec{
@@ -289,14 +291,16 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, awsMachine, ns, secret)).To(Succeed())
 		})
 
-		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{NetworkSpec: infrav1.NetworkSpec{
-			Subnets: []infrav1.SubnetSpec{
-				{
-					ID:               "subnet-1",
-					AvailabilityZone: "us-east-1a",
+		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
+			NetworkSpec: infrav1.NetworkSpec{
+				Subnets: []infrav1.SubnetSpec{
+					{
+						ID:               "subnet-1",
+						AvailabilityZone: "us-east-1a",
+					},
 				},
-			},
-		}}})
+			}}})
 		g.Expect(err).To(BeNil())
 		cs.Cluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
 		cs.AWSCluster.Status.Network.APIServerELB.DNSName = DNSName
@@ -394,7 +398,7 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, awsMachine, ns)).To(Succeed())
 		})
 
-		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
+		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}})
 		g.Expect(err).To(BeNil())
 		cs.Cluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
 		cs.AWSCluster.Spec.ControlPlaneLoadBalancer = &infrav1.AWSLoadBalancerSpec{
@@ -496,7 +500,7 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			g.Expect(testEnv.Cleanup(ctx, awsMachine, ns)).To(Succeed())
 		})
 
-		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
+		cs, err := getClusterScope(infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}})
 		g.Expect(err).To(BeNil())
 		cs.Cluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
 		ms, err := getMachineScope(cs, awsMachine)

--- a/controllers/awsmachine_controller_unit_test.go
+++ b/controllers/awsmachine_controller_unit_test.go
@@ -147,12 +147,13 @@ func TestAWSMachineReconciler(t *testing.T) {
 			scope.ClusterScopeParams{
 				Client:     fake.NewClientBuilder().WithObjects(awsMachine, secret).WithStatusSubresource(awsMachine).Build(),
 				Cluster:    &clusterv1.Cluster{},
-				AWSCluster: &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}},
+				AWSCluster: &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}},
 			},
 		)
 		g.Expect(err).To(BeNil())
 		cs.AWSCluster = &infrav1.AWSCluster{
 			Spec: infrav1.AWSClusterSpec{
+				Region: "us-west-2",
 				ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 					LoadBalancerType: infrav1.LoadBalancerTypeClassic,
 				},
@@ -2669,7 +2670,7 @@ func TestAWSMachineReconcilerReconcile(t *testing.T) {
 					},
 				},
 			},
-			awsCluster:  &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "aws-test-5"}},
+			awsCluster:  &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "aws-test-5"}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}},
 			expectError: true,
 		},
 	}
@@ -2784,6 +2785,7 @@ func TestAWSMachineReconcilerReconcileDefaultsToLoadBalancerTypeClassic(t *testi
 			},
 		},
 		Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
 			ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 				Scheme: &infrav1.ELBSchemeInternetFacing,
 				// `LoadBalancerType` not set (i.e. empty string; must default to attaching instance to classic LB)

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook_test.go
@@ -85,52 +85,56 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			spec:         AWSManagedControlPlaneSpec{Region: "us-west-2"},
+			expectSpec:   AWSManagedControlPlaneSpec{Region: "us-west-2", EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
 		},
 		{
 			name:         "less than 100 chars, dot in name",
 			resourceName: "team1.cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_team1_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			spec:         AWSManagedControlPlaneSpec{Region: "us-west-2"},
+			expectSpec:   AWSManagedControlPlaneSpec{Region: "us-west-2", EKSClusterName: "default_team1_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
 		},
 		{
 			name:         "more than 100 chars",
 			resourceName: "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde",
 			resourceNS:   "default",
 			expectHash:   true,
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "capi_", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			spec:         AWSManagedControlPlaneSpec{Region: "us-west-2"},
+			expectSpec:   AWSManagedControlPlaneSpec{Region: "us-west-2", EKSClusterName: "capi_", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
 		},
 		{
 			name:         "with patch",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			spec:         AWSManagedControlPlaneSpec{Version: &vV1_17_1},
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Version: &vV1_17_1, IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			spec:         AWSManagedControlPlaneSpec{Region: "us-west-2", Version: &vV1_17_1},
+			expectSpec:   AWSManagedControlPlaneSpec{Region: "us-west-2", EKSClusterName: "default_cluster1", Version: &vV1_17_1, IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
 		},
 		{
 			name:         "with allowed ip on bastion",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			spec:         AWSManagedControlPlaneSpec{Bastion: infrav1.Bastion{AllowedCIDRBlocks: []string{"100.100.100.100/0"}}},
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: infrav1.Bastion{AllowedCIDRBlocks: []string{"100.100.100.100/0"}}, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			spec:         AWSManagedControlPlaneSpec{Region: "us-west-2", Bastion: infrav1.Bastion{AllowedCIDRBlocks: []string{"100.100.100.100/0"}}},
+			expectSpec:   AWSManagedControlPlaneSpec{Region: "us-west-2", EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: infrav1.Bastion{AllowedCIDRBlocks: []string{"100.100.100.100/0"}}, NetworkSpec: defaultNetworkSpec, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
 		},
 		{
 			name:         "with CNI on network",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			spec:         AWSManagedControlPlaneSpec{NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}}},
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}, VPC: defaultVPCSpec}, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			spec:         AWSManagedControlPlaneSpec{Region: "us-west-2", NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}}},
+			expectSpec:   AWSManagedControlPlaneSpec{Region: "us-west-2", EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}, VPC: defaultVPCSpec}, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
 		},
 		{
 			name:         "secondary CIDR",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, SecondaryCidrBlock: nil, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			spec:         AWSManagedControlPlaneSpec{Region: "us-west-2"},
+			expectSpec:   AWSManagedControlPlaneSpec{Region: "us-west-2", EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, SecondaryCidrBlock: nil, TokenMethod: &EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
 		},
 	}
 
@@ -144,9 +148,9 @@ func TestDefaultingWebhook(t *testing.T) {
 					Name:      tc.resourceName,
 					Namespace: tc.resourceNS,
 				},
+				Spec: tc.spec,
 			}
 			t.Run("for AWSManagedMachinePool", utildefaulting.DefaultValidateTest(context.Background(), mcp, &awsManagedControlPlaneWebhook{}))
-			mcp.Spec = tc.spec
 
 			g.Expect(testEnv.Create(ctx, mcp)).To(Succeed())
 
@@ -377,6 +381,7 @@ func TestWebhookCreate(t *testing.T) {
 					Namespace:    "default",
 				},
 				Spec: AWSManagedControlPlaneSpec{
+					Region:         "us-west-2",
 					EKSClusterName: tc.eksClusterName,
 					KubeProxy:      tc.kubeProxy,
 					AdditionalTags: tc.additionalTags,
@@ -554,6 +559,7 @@ func TestWebhookCreateIPv6Details(t *testing.T) {
 					Namespace:    "default",
 				},
 				Spec: AWSManagedControlPlaneSpec{
+					Region:         "us-west-2",
 					EKSClusterName: "test-cluster",
 					Addons:         tc.addons,
 					NetworkSpec:    tc.networkSpec,
@@ -585,9 +591,11 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "ekscluster specified, same cluster names",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			expectError: false,
@@ -595,9 +603,11 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "ekscluster specified, different cluster names",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster2",
 			},
 			expectError: true,
@@ -605,9 +615,11 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "old ekscluster specified, no new cluster name",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "",
 			},
 			expectError: true,
@@ -615,10 +627,12 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "older version",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				Version:        &vV1_17,
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				Version:        &vV1_16,
 			},
@@ -627,10 +641,12 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "same version",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				Version:        &vV1_17,
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				Version:        &vV1_17,
 			},
@@ -639,10 +655,12 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "newer version",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				Version:        &vV1_16,
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				Version:        &vV1_17,
 			},
@@ -651,12 +669,14 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "no change in access config",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeConfigMap,
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeConfigMap,
@@ -667,12 +687,14 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in access config to nil",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeConfigMap,
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			expectError: true,
@@ -680,9 +702,11 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in access config from nil to valid",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeConfigMap,
@@ -693,12 +717,14 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in access config auth mode from ApiAndConfigMap to API is allowed",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeAPIAndConfigMap,
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeAPI,
@@ -709,12 +735,14 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in access config auth mode from API to Config Map is denied",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeAPI,
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeConfigMap,
@@ -725,12 +753,14 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in access config auth mode from APIAndConfigMap to Config Map is denied",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeAPIAndConfigMap,
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					AuthenticationMode: EKSAuthenticationModeConfigMap,
@@ -741,12 +771,14 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in access config bootstrap admin permissions is ignored",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					BootstrapClusterCreatorAdminPermissions: ptr.To(true),
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AccessConfig: &AccessConfig{
 					BootstrapClusterCreatorAdminPermissions: ptr.To(false),
@@ -757,6 +789,7 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in encryption config to nil",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				EncryptionConfig: &EncryptionConfig{
 					Provider:  ptr.To[string]("provider"),
@@ -764,6 +797,7 @@ func TestWebhookUpdate(t *testing.T) {
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			expectError: true,
@@ -771,9 +805,11 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in encryption config from nil to valid encryption-config",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				EncryptionConfig: &EncryptionConfig{
 					Provider:  ptr.To[string]("provider"),
@@ -785,6 +821,7 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "change in provider of encryption config",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				EncryptionConfig: &EncryptionConfig{
 					Provider:  ptr.To[string]("provider"),
@@ -792,6 +829,7 @@ func TestWebhookUpdate(t *testing.T) {
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				EncryptionConfig: &EncryptionConfig{
 					Provider:  ptr.To[string]("new-provider"),
@@ -803,12 +841,14 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "no change in provider of encryption config",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				EncryptionConfig: &EncryptionConfig{
 					Provider: ptr.To[string]("provider"),
 				},
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				EncryptionConfig: &EncryptionConfig{
 					Provider: ptr.To[string]("provider"),
@@ -819,9 +859,11 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "ekscluster specified, same name, invalid tags",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				AdditionalTags: infrav1.Tags{
 					"key-1":                    "value-1",
@@ -835,6 +877,7 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "changing ipv6 enabled is not allowed after it has been set - false, true",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				NetworkSpec: infrav1.NetworkSpec{
 					VPC: infrav1.VPCSpec{},
@@ -842,6 +885,7 @@ func TestWebhookUpdate(t *testing.T) {
 				Version: ptr.To[string]("1.22"),
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				NetworkSpec: infrav1.NetworkSpec{
 					VPC: infrav1.VPCSpec{
@@ -854,6 +898,7 @@ func TestWebhookUpdate(t *testing.T) {
 		{
 			name: "changing ipv6 enabled is not allowed after it has been set - true, false",
 			oldClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				NetworkSpec: infrav1.NetworkSpec{
 					VPC: infrav1.VPCSpec{
@@ -869,6 +914,7 @@ func TestWebhookUpdate(t *testing.T) {
 				Version: ptr.To[string]("v1.22.0"),
 			},
 			newClusterSpec: AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: "default_cluster1",
 				NetworkSpec: infrav1.NetworkSpec{
 					VPC: infrav1.VPCSpec{},
@@ -952,6 +998,7 @@ func TestValidatingWebhookCreateSecondaryCidr(t *testing.T) {
 
 			mcp := &AWSManagedControlPlane{
 				Spec: AWSManagedControlPlaneSpec{
+					Region:         "us-west-2",
 					EKSClusterName: "default_cluster1",
 				},
 			}
@@ -1021,12 +1068,14 @@ func TestValidatingWebhookUpdateSecondaryCidr(t *testing.T) {
 
 			newMCP := &AWSManagedControlPlane{
 				Spec: AWSManagedControlPlaneSpec{
+					Region:             "us-west-2",
 					EKSClusterName:     "default_cluster1",
 					SecondaryCidrBlock: aws.String(tc.cidrRange),
 				},
 			}
 			oldMCP := &AWSManagedControlPlane{
 				Spec: AWSManagedControlPlaneSpec{
+					Region:             "us-west-2",
 					EKSClusterName:     "default_cluster1",
 					SecondaryCidrBlock: nil,
 				},
@@ -1185,6 +1234,7 @@ func TestWebhookValidateAccessEntries(t *testing.T) {
 
 			mcp := &AWSManagedControlPlane{
 				Spec: AWSManagedControlPlaneSpec{
+					Region:         "us-west-2",
 					EKSClusterName: "default_cluster1",
 					AccessConfig:   tc.accessConfig,
 					AccessEntries:  tc.accessEntries,
@@ -1203,6 +1253,97 @@ func TestWebhookValidateAccessEntries(t *testing.T) {
 			}
 			// Nothing emits warnings yet
 			g.Expect(warn).To(BeEmpty())
+		})
+	}
+}
+
+func TestAWSManagedControlPlaneValidateRegion(t *testing.T) {
+	tests := []struct {
+		name    string
+		mcp     *AWSManagedControlPlane
+		wantErr bool
+	}{
+		{
+			name: "valid us-east-1 region",
+			mcp: &AWSManagedControlPlane{
+				Spec: AWSManagedControlPlaneSpec{
+					EKSClusterName: "test-cluster",
+					Region:         "us-east-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid eu-west-1 region",
+			mcp: &AWSManagedControlPlane{
+				Spec: AWSManagedControlPlaneSpec{
+					EKSClusterName: "test-cluster",
+					Region:         "eu-west-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid cn-north-1 region (China partition)",
+			mcp: &AWSManagedControlPlane{
+				Spec: AWSManagedControlPlaneSpec{
+					EKSClusterName: "test-cluster",
+					Region:         "cn-north-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid us-gov-west-1 region (GovCloud)",
+			mcp: &AWSManagedControlPlane{
+				Spec: AWSManagedControlPlaneSpec{
+					EKSClusterName: "test-cluster",
+					Region:         "us-gov-west-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid region - nonexistent",
+			mcp: &AWSManagedControlPlane{
+				Spec: AWSManagedControlPlaneSpec{
+					EKSClusterName: "test-cluster",
+					Region:         "invalid-region-xyz",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid region - empty string",
+			mcp: &AWSManagedControlPlane{
+				Spec: AWSManagedControlPlaneSpec{
+					EKSClusterName: "test-cluster",
+					Region:         "",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid region - malformed",
+			mcp: &AWSManagedControlPlane{
+				Spec: AWSManagedControlPlaneSpec{
+					EKSClusterName: "test-cluster",
+					Region:         "us-12345",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			_, err := (&awsManagedControlPlaneWebhook{}).ValidateCreate(context.Background(), tt.mcp)
+			if tt.wantErr {
+				g.Expect(err).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+			}
 		})
 	}
 }

--- a/exp/controlleridentitycreator/awscontrolleridentity_controller_test.go
+++ b/exp/controlleridentitycreator/awscontrolleridentity_controller_test.go
@@ -34,7 +34,7 @@ func TestAWSControllerIdentityController(t *testing.T) {
 		g := NewWithT(t)
 		ctx := context.Background()
 
-		instance := &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+		instance := &infrav1.AWSCluster{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}, Spec: infrav1.AWSClusterSpec{Region: "us-west-2"}}
 		instance.Default()
 
 		// Create the AWSCluster object and expect the Reconcile and Deployment to be created

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -1433,7 +1433,9 @@ func setupCluster(clusterName string) (*scope.ClusterScope, error) {
 	_ = infrav1.AddToScheme(scheme)
 	awsCluster := &infrav1.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
-		Spec:       infrav1.AWSClusterSpec{},
+		Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
+		},
 	}
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(awsCluster).Build()
 	return scope.NewClusterScope(scope.ClusterScopeParams{

--- a/exp/controllers/rosanetwork_controller_test.go
+++ b/exp/controllers/rosanetwork_controller_test.go
@@ -72,7 +72,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 			StackName:             name,
 			CIDRBlock:             "10.0.0.0/8",
 			AvailabilityZoneCount: 1,
-			Region:                "test-region",
+			Region:                "us-west-2",
 			IdentityRef: &infrav1.AWSIdentityReference{
 				Name: identity.Name,
 				Kind: infrav1.ControllerIdentityKind,
@@ -93,7 +93,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 			StackName:             nameDeleted,
 			CIDRBlock:             "10.0.0.0/8",
 			AvailabilityZoneCount: 1,
-			Region:                "test-region",
+			Region:                "us-west-2",
 			IdentityRef: &infrav1.AWSIdentityReference{
 				Name: identity.Name,
 				Kind: infrav1.ControllerIdentityKind,

--- a/exp/instancestate/helpers_test.go
+++ b/exp/instancestate/helpers_test.go
@@ -38,6 +38,9 @@ func createAWSCluster(name string) *infrav1.AWSCluster {
 			Name:      name,
 			Namespace: "default",
 		},
+		Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
+		},
 	}
 }
 

--- a/pkg/cloud/endpoints/partition.go
+++ b/pkg/cloud/endpoints/partition.go
@@ -101,3 +101,14 @@ func mergeOverrides(into PartitionConfig, from RegionOverrides) PartitionConfig 
 	}
 	return into
 }
+
+// IsValidRegion checks if the given region string is a valid AWS region
+// by checking if it exists in any partition's region map.
+func IsValidRegion(region string) bool {
+	for _, partition := range partitions {
+		if _, ok := partition.Regions[region]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cloud/scope/rosanetwork_test.go
+++ b/pkg/cloud/scope/rosanetwork_test.go
@@ -89,6 +89,7 @@ func TestNewROSANetworkScope(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Spec: expinfrav1.ROSANetworkSpec{
+			Region: "us-west-2",
 			IdentityRef: &infrav1.AWSIdentityReference{
 				Name: "default",
 				Kind: "AWSClusterControllerIdentity",

--- a/pkg/cloud/scope/rosaroleconfig.go
+++ b/pkg/cloud/scope/rosaroleconfig.go
@@ -70,7 +70,9 @@ func NewRosaRoleConfigScope(params RosaRoleConfigScopeParams) (*RosaRoleConfigSc
 		RosaRoleConfig: params.RosaRoleConfig,
 	}
 
-	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, RosaRoleConfigScope, "", params.Logger)
+	// IAM is a global service, but AWS SDK still requires a region.
+	// Use us-east-1 as the default region for IAM operations.
+	session, serviceLimiters, err := sessionForClusterWithRegion(params.Client, RosaRoleConfigScope, "us-east-1", params.Logger)
 	if err != nil {
 		return nil, errors.Errorf("failed to create aws V2 session: %v", err)
 	}

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -1300,6 +1300,7 @@ func getClusterScope(client client.Client) (*scope.ClusterScope, error) {
 		Cluster: cluster,
 		AWSCluster: &infrav1.AWSCluster{
 			Spec: infrav1.AWSClusterSpec{
+				Region: "us-west-2",
 				NetworkSpec: infrav1.NetworkSpec{
 					Subnets: []infrav1.SubnetSpec{
 						{

--- a/pkg/cloud/services/ec2/bastion_test.go
+++ b/pkg/cloud/services/ec2/bastion_test.go
@@ -224,7 +224,7 @@ func TestServiceDeleteBastion(t *testing.T) {
 				awsCluster := &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
-						NetworkSpec: infrav1.NetworkSpec{
+						Region: "us-west-2", NetworkSpec: infrav1.NetworkSpec{
 							VPC: infrav1.VPCSpec{
 								ID: "vpcID",
 							},
@@ -446,7 +446,7 @@ func TestServiceReconcileBastion(t *testing.T) {
 				awsCluster := &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
-						NetworkSpec: infrav1.NetworkSpec{
+						Region: "us-west-2", NetworkSpec: infrav1.NetworkSpec{
 							VPC: infrav1.VPCSpec{
 								ID: "vpcID",
 							},

--- a/pkg/cloud/services/ec2/dedicatedhosts_test.go
+++ b/pkg/cloud/services/ec2/dedicatedhosts_test.go
@@ -47,6 +47,7 @@ func createTestClusterScope(t *testing.T) *scope.ClusterScope {
 		AWSCluster: &infrav1.AWSCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			Spec: infrav1.AWSClusterSpec{
+				Region: "us-west-2",
 				NetworkSpec: infrav1.NetworkSpec{
 					VPC: infrav1.VPCSpec{
 						ID: "test-vpc",

--- a/pkg/cloud/services/ec2/helper_test.go
+++ b/pkg/cloud/services/ec2/helper_test.go
@@ -133,6 +133,7 @@ func newAWSCluster() *infrav1.AWSCluster {
 			Namespace: "aws-cluster-ns",
 		},
 		Spec: infrav1.AWSClusterSpec{
+			Region:            "us-west-2",
 			ImageLookupFormat: "img-lookup-format",
 			ImageLookupBaseOS: "img-lookup-os",
 			ImageLookupOrg:    "img-lookup-org",
@@ -158,6 +159,9 @@ func newAWSManagedControlPlane() *ekscontrolplanev1.AWSManagedControlPlane {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "aws-cluster-name",
 			Namespace: "aws-cluster-ns",
+		},
+		Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+			Region: "us-west-2",
 		},
 	}
 }

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -185,6 +185,7 @@ func TestInstanceIfExists(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region: "us-west-2",
 						NetworkSpec: infrav1.NetworkSpec{
 							VPC: infrav1.VPCSpec{
 								ID: "test-vpc",
@@ -260,9 +261,13 @@ func TestTerminateInstance(t *testing.T) {
 			_ = infrav1.AddToScheme(scheme)
 			client := fake.NewClientBuilder().WithScheme(scheme).Build()
 			scope, err := scope.NewClusterScope(scope.ClusterScopeParams{
-				Client:     client,
-				Cluster:    &clusterv1.Cluster{},
-				AWSCluster: &infrav1.AWSCluster{},
+				Client:  client,
+				Cluster: &clusterv1.Cluster{},
+				AWSCluster: &infrav1.AWSCluster{
+					Spec: infrav1.AWSClusterSpec{
+						Region: "us-west-2",
+					},
+				},
 			})
 			if err != nil {
 				t.Fatalf("Failed to create test context: %v", err)
@@ -331,6 +336,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -448,6 +454,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -591,6 +598,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-foo",
@@ -859,6 +867,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-foo",
@@ -1095,6 +1104,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -1247,6 +1257,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -1401,6 +1412,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -1563,6 +1575,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -1686,6 +1699,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -1812,6 +1826,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -1904,6 +1919,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2030,6 +2046,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2125,6 +2142,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2210,6 +2228,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2339,6 +2358,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2479,6 +2499,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -2610,6 +2631,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2711,6 +2733,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2848,6 +2871,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -2993,6 +3017,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -3111,6 +3136,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -3243,6 +3269,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "vpc-id",
@@ -3329,6 +3356,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -3454,6 +3482,7 @@ func TestCreateInstance(t *testing.T) {
 			},
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -3668,6 +3697,7 @@ func TestCreateInstance(t *testing.T) {
 			},
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -3885,6 +3915,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -4101,6 +4132,7 @@ func TestCreateInstance(t *testing.T) {
 			},
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -4314,6 +4346,7 @@ func TestCreateInstance(t *testing.T) {
 			},
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -4393,6 +4426,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -4525,6 +4559,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -4659,6 +4694,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -4793,6 +4829,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -4924,6 +4961,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -5055,6 +5093,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -5187,6 +5226,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -5355,6 +5395,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -5477,6 +5518,7 @@ func TestCreateInstance(t *testing.T) {
 			},
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -5559,6 +5601,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -5679,6 +5722,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -5803,6 +5847,7 @@ func TestCreateInstance(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							infrav1.SubnetSpec{
@@ -6395,6 +6440,7 @@ func TestGetDHCPOptionSetDomainName(t *testing.T) {
 					AWSCluster: &infrav1.AWSCluster{
 						ObjectMeta: metav1.ObjectMeta{Name: "test"},
 						Spec: infrav1.AWSClusterSpec{
+							Region: "us-west-2",
 							NetworkSpec: infrav1.NetworkSpec{
 								VPC: infrav1.VPCSpec{
 									ID: tc.vpcID,

--- a/pkg/cloud/services/eks/accessentry_test.go
+++ b/pkg/cloud/services/eks/accessentry_test.go
@@ -381,6 +381,7 @@ func TestReconcileAccessEntries(t *testing.T) {
 					Name:      clusterName,
 				},
 				Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+					Region:         "us-west-2",
 					EKSClusterName: clusterName,
 					AccessConfig: &ekscontrolplanev1.AccessConfig{
 						AuthenticationMode: ekscontrolplanev1.EKSAuthenticationModeAPIAndConfigMap,
@@ -559,6 +560,7 @@ func TestReconcileAccessPolicies(t *testing.T) {
 						Name:      clusterName,
 					},
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:         "us-west-2",
 						EKSClusterName: clusterName,
 					},
 				},
@@ -681,6 +683,7 @@ func TestCreateAccessEntry(t *testing.T) {
 						Name:      clusterName,
 					},
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:         "us-west-2",
 						EKSClusterName: clusterName,
 					},
 				},
@@ -934,6 +937,7 @@ func TestUpdateAccessEntry(t *testing.T) {
 						Name:      clusterName,
 					},
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:         "us-west-2",
 						EKSClusterName: clusterName,
 					},
 				},
@@ -1009,6 +1013,7 @@ func TestDeleteAccessEntry(t *testing.T) {
 						Name:      clusterName,
 					},
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:         "us-west-2",
 						EKSClusterName: clusterName,
 					},
 				},

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -451,6 +451,7 @@ func TestReconcileClusterVersion(t *testing.T) {
 				},
 				ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:  "us-west-2",
 						Version: aws.String("1.16"),
 					},
 				},
@@ -565,6 +566,7 @@ func TestReconcileAccessConfig(t *testing.T) {
 				},
 				ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:         "us-west-2",
 						EKSClusterName: clusterName,
 						AccessConfig: &ekscontrolplanev1.AccessConfig{
 							AuthenticationMode: ekscontrolplanev1.EKSAuthenticationModeAPIAndConfigMap,
@@ -647,6 +649,7 @@ func TestCreateCluster(t *testing.T) {
 				},
 				ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:                     "us-west-2",
 						EKSClusterName:             clusterName,
 						Version:                    version,
 						RoleName:                   tc.role,
@@ -788,6 +791,7 @@ func TestReconcileEKSEncryptionConfig(t *testing.T) {
 				},
 				ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:           "us-west-2",
 						Version:          aws.String("1.16"),
 						EncryptionConfig: tc.newEncryptionConfig,
 					},
@@ -875,6 +879,7 @@ func TestReconcileUpgradePolicy(t *testing.T) {
 				},
 				ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:        "us-west-2",
 						Version:       aws.String("1.16"),
 						UpgradePolicy: tc.newUpgradePolicy,
 					},
@@ -926,6 +931,7 @@ func TestCreateIPv6Cluster(t *testing.T) {
 		},
 		ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 			Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				Region:   "us-west-2",
 				RoleName: ptr.To[string]("arn-role"),
 				Version:  aws.String("1.22"),
 				NetworkSpec: infrav1.NetworkSpec{
@@ -1019,6 +1025,7 @@ func TestCreateClusterWithBootstrapClusterCreatorAdminPermissions(t *testing.T) 
 		},
 		ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 			Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				Region:         "us-west-2",
 				EKSClusterName: clusterName,
 				Version:        aws.String("1.24"),
 				RoleName:       aws.String("arn:role"),

--- a/pkg/cloud/services/eks/config_test.go
+++ b/pkg/cloud/services/eks/config_test.go
@@ -69,6 +69,7 @@ func Test_createCAPIKubeconfigSecret(t *testing.T) {
 							UID:       types.UID("1"),
 						},
 						Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+							Region:         "us-west-2",
 							EKSClusterName: "cluster-foo",
 						},
 					},
@@ -170,6 +171,7 @@ func Test_updateCAPIKubeconfigSecret(t *testing.T) {
 							UID:       "1",
 						},
 						Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+							Region:         "us-west-2",
 							EKSClusterName: "cluster-foo",
 						},
 					},
@@ -216,6 +218,7 @@ func Test_updateCAPIKubeconfigSecret(t *testing.T) {
 							UID:       "1",
 						},
 						Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+							Region:         "us-west-2",
 							EKSClusterName: "cluster-foo",
 						},
 					},

--- a/pkg/cloud/services/eks/oidc_test.go
+++ b/pkg/cloud/services/eks/oidc_test.go
@@ -144,6 +144,7 @@ func TestOIDCReconcile(t *testing.T) {
 					Namespace: "ns",
 				},
 				Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+					Region:                "us-west-2",
 					Version:               aws.String("1.25"),
 					AssociateOIDCProvider: true,
 				},

--- a/pkg/cloud/services/elb/loadbalancer_test.go
+++ b/pkg/cloud/services/elb/loadbalancer_test.go
@@ -78,6 +78,9 @@ func TestELBName(t *testing.T) {
 					Name:      "example",
 					Namespace: metav1.NamespaceDefault,
 				},
+				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			},
 			expected: "example-apiserver",
 		},
@@ -89,7 +92,7 @@ func TestELBName(t *testing.T) {
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name: ptr.To[string]("myapiserver"),
 					},
 				},
@@ -298,7 +301,7 @@ func TestGetAPIServerClassicELBSpecControlPlaneLoadBalancer(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
-						ControlPlaneLoadBalancer: tc.lb,
+						Region: "us-west-2", ControlPlaneLoadBalancer: tc.lb,
 					},
 				},
 			})
@@ -460,7 +463,7 @@ func TestGetAPIServerV2ELBSpecControlPlaneLoadBalancer(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
-						ControlPlaneLoadBalancer: tc.lb,
+						Region: "us-west-2", ControlPlaneLoadBalancer: tc.lb,
 					},
 				},
 			})
@@ -509,7 +512,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name: aws.String(elbName),
 					},
 					NetworkSpec: infrav1.NetworkSpec{
@@ -577,7 +580,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					NetworkSpec: infrav1.NetworkSpec{
+					Region: "us-west-2", NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{infrav1.SubnetSpec{
 							ID:               clusterSubnetID,
 							AvailabilityZone: az,
@@ -660,7 +663,7 @@ func TestRegisterInstanceWithAPIServerELB(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					NetworkSpec: infrav1.NetworkSpec{
+					Region: "us-west-2", NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{infrav1.SubnetSpec{
 							ID:               clusterSubnetID,
 							AvailabilityZone: az,
@@ -812,7 +815,7 @@ func TestRegisterInstanceWithAPIServerNLB(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name:             aws.String(elbName),
 						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 					},
@@ -905,7 +908,7 @@ func TestRegisterInstanceWithAPIServerNLB(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name:             aws.String(elbName),
 						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 						AdditionalListeners: []infrav1.AdditionalListenerSpec{
@@ -1048,7 +1051,7 @@ func TestRegisterInstanceWithAPIServerNLB(t *testing.T) {
 			awsCluster: &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					NetworkSpec: infrav1.NetworkSpec{
+					Region: "us-west-2", NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{infrav1.SubnetSpec{
 							ID:               clusterSubnetID,
 							AvailabilityZone: az,
@@ -1410,7 +1413,7 @@ func TestCreateNLB(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name:             aws.String(elbName),
 						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 					},
@@ -2206,7 +2209,7 @@ func TestReconcileTargetGroupsAndListeners(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name:             aws.String(elbName),
 						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 					},
@@ -2590,7 +2593,7 @@ func TestReconcileV2LB(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name:             aws.String(elbName),
 						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 					},
@@ -2907,7 +2910,7 @@ func TestReconcileLoadbalancers(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name:             aws.String(elbName),
 						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 					},
@@ -3105,7 +3108,7 @@ func TestDeleteAPIServerELB(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name: aws.String(elbName),
 					},
 				},
@@ -3296,7 +3299,7 @@ func TestDeleteNLB(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Name:             aws.String(elbName),
 						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 					},
@@ -3456,7 +3459,9 @@ func TestDeleteAWSCloudProviderELBs(t *testing.T) {
 
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec:       infrav1.AWSClusterSpec{},
+				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
+				},
 			}
 
 			client := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -3535,7 +3540,7 @@ func TestDescribeLoadbalancers(t *testing.T) {
 			}
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec: infrav1.AWSClusterSpec{ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+				Spec: infrav1.AWSClusterSpec{Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 					Scheme: &infrav1.ELBSchemeInternetFacing,
 				}},
 			}
@@ -3610,7 +3615,7 @@ func TestDescribeV2Loadbalancers(t *testing.T) {
 			}
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec: infrav1.AWSClusterSpec{ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+				Spec: infrav1.AWSClusterSpec{Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 					Scheme:           &infrav1.ELBSchemeInternetFacing,
 					LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 				}},
@@ -3735,6 +3740,7 @@ func TestGetHealthCheckProtocol(t *testing.T) {
 				},
 				AWSCluster: &infrav1.AWSCluster{
 					Spec: infrav1.AWSClusterSpec{
+						Region:                   "us-west-2",
 						ControlPlaneLoadBalancer: tc.lbSpec,
 					},
 				},
@@ -3778,7 +3784,7 @@ func stubGetBaseService(t *testing.T, clusterName string) *Service {
 	}
 	awsCluster := &infrav1.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: clusterName},
-		Spec: infrav1.AWSClusterSpec{ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+		Spec: infrav1.AWSClusterSpec{Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 			Scheme:           &infrav1.ELBSchemeInternetFacing,
 			LoadBalancerType: infrav1.LoadBalancerTypeNLB,
 		}},

--- a/pkg/cloud/services/gc/cleanup_test.go
+++ b/pkg/cloud/services/gc/cleanup_test.go
@@ -958,6 +958,7 @@ func createManagedControlPlane(gcAnnotationValue, gcTasksAnnotationValue string)
 			Namespace: "default",
 		},
 		Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+			Region:         "us-west-2",
 			EKSClusterName: "eks-test-cluster",
 		},
 	}
@@ -991,7 +992,9 @@ func createAWSCluser(gcAnnotationValue, gcTasksAnnotationValue string) *infrav1.
 			Name:      "cluster1",
 			Namespace: "default",
 		},
-		Spec: infrav1.AWSClusterSpec{},
+		Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
+		},
 	}
 
 	if gcAnnotationValue != "" {

--- a/pkg/cloud/services/iamauth/reconcile_test.go
+++ b/pkg/cloud/services/iamauth/reconcile_test.go
@@ -125,7 +125,9 @@ func createEKSCluster(name, namespace string) *ekscontrolplanev1.AWSManagedContr
 				clusterv1.ClusterNameLabel: name,
 			},
 		},
-		Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{},
+		Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+			Region: "us-west-2",
+		},
 	}
 	return eksCluster
 }

--- a/pkg/cloud/services/instancestate/helpers_test.go
+++ b/pkg/cloud/services/instancestate/helpers_test.go
@@ -31,7 +31,9 @@ func setupCluster(clusterName string) (*scope.ClusterScope, error) {
 	_ = infrav1.AddToScheme(scheme)
 	awsCluster := &infrav1.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
-		Spec:       infrav1.AWSClusterSpec{},
+		Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
+		},
 	}
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(awsCluster).Build()
 	return scope.NewClusterScope(scope.ClusterScopeParams{

--- a/pkg/cloud/services/network/carriergateways_test.go
+++ b/pkg/cloud/services/network/carriergateways_test.go
@@ -130,6 +130,7 @@ func TestReconcileCarrierGateway(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},
@@ -236,6 +237,7 @@ func TestDeleteCarrierGateway(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},

--- a/pkg/cloud/services/network/egress_only_gateways_test.go
+++ b/pkg/cloud/services/network/egress_only_gateways_test.go
@@ -177,6 +177,7 @@ func TestReconcileEgressOnlyInternetGateways(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},
@@ -300,6 +301,7 @@ func TestDeleteEgressOnlyInternetGateways(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},

--- a/pkg/cloud/services/network/eips_test.go
+++ b/pkg/cloud/services/network/eips_test.go
@@ -154,9 +154,13 @@ func TestServiceReleaseAddresses(t *testing.T) {
 			ec2Mock := mocks.NewMockEC2API(mockCtrl)
 
 			cs, err := scope.NewClusterScope(scope.ClusterScopeParams{
-				Client:     client,
-				Cluster:    &clusterv1.Cluster{},
-				AWSCluster: &infrav1.AWSCluster{},
+				Client:  client,
+				Cluster: &clusterv1.Cluster{},
+				AWSCluster: &infrav1.AWSCluster{
+					Spec: infrav1.AWSClusterSpec{
+						Region: "us-west-2",
+					},
+				},
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/cloud/services/network/gateways_test.go
+++ b/pkg/cloud/services/network/gateways_test.go
@@ -133,6 +133,7 @@ func TestReconcileInternetGateways(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},
@@ -246,6 +247,7 @@ func TestDeleteInternetGateways(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},

--- a/pkg/cloud/services/network/natgateways_test.go
+++ b/pkg/cloud/services/network/natgateways_test.go
@@ -449,6 +449,7 @@ func TestReconcileNatGateways(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: subnetsVPCID,
@@ -791,6 +792,7 @@ func TestDeleteNatGateways(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: "managed-vpc",
@@ -1053,6 +1055,7 @@ func TestGetdNatGatewayForEdgeSubnet(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region: "us-west-2",
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							ID: subnetsVPCID,

--- a/pkg/cloud/services/network/routetables_test.go
+++ b/pkg/cloud/services/network/routetables_test.go
@@ -577,6 +577,7 @@ func TestReconcileRouteTables(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},
@@ -755,6 +756,7 @@ func TestDeleteRouteTables(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: *tc.input,
 					},
 				},
@@ -831,7 +833,9 @@ func TestDeleteRouteTable(t *testing.T) {
 				},
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
-					Spec:       infrav1.AWSClusterSpec{},
+					Spec: infrav1.AWSClusterSpec{
+						Region: "us-west-2",
+					},
 				},
 			})
 			g.Expect(err).NotTo(HaveOccurred())
@@ -1316,7 +1320,9 @@ func TestService_getRoutesForSubnet(t *testing.T) {
 				},
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
-					Spec:       infrav1.AWSClusterSpec{},
+					Spec: infrav1.AWSClusterSpec{
+						Region: "us-west-2",
+					},
 				},
 			}
 			cluster.AWSCluster.Spec.NetworkSpec = defaultNetwork

--- a/pkg/cloud/services/network/secondarycidr_test.go
+++ b/pkg/cloud/services/network/secondarycidr_test.go
@@ -44,6 +44,7 @@ func setupNewManagedControlPlaneScope(cl client.Client) (*scope.ManagedControlPl
 		Cluster: &clusterv1.Cluster{},
 		ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 			Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				Region:             "us-west-2",
 				SecondaryCidrBlock: ptr.To[string]("secondary-cidr"),
 				NetworkSpec: infrav1.NetworkSpec{
 					VPC: infrav1.VPCSpec{ID: "vpc-id"},

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -4383,7 +4383,7 @@ func TestDiscoverSubnets(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
-						NetworkSpec: *tc.input,
+						Region: "us-west-2", NetworkSpec: *tc.input,
 					},
 				},
 			})
@@ -4522,7 +4522,7 @@ func TestDeleteSubnets(t *testing.T) {
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 					Spec: infrav1.AWSClusterSpec{
-						NetworkSpec: *tc.input,
+						Region: "us-west-2", NetworkSpec: *tc.input,
 					},
 				},
 			})
@@ -4590,7 +4590,9 @@ func (b *ClusterScopeBuilder) Build() (scope.NetworkScope, error) {
 		},
 		AWSCluster: &infrav1.AWSCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
-			Spec:       infrav1.AWSClusterSpec{},
+			Spec: infrav1.AWSClusterSpec{
+				Region: "us-west-2",
+			},
 		},
 	}
 
@@ -4640,7 +4642,9 @@ func (b *ManagedControlPlaneScopeBuilder) Build() (scope.NetworkScope, error) {
 		},
 		ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
-			Spec:       ekscontrolplanev1.AWSManagedControlPlaneSpec{},
+			Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				Region: "us-west-2",
+			},
 		},
 	}
 
@@ -4857,7 +4861,9 @@ func TestService_retrieveZoneInfo(t *testing.T) {
 				},
 				AWSCluster: &infrav1.AWSCluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
-					Spec:       infrav1.AWSClusterSpec{},
+					Spec: infrav1.AWSClusterSpec{
+						Region: "us-west-2",
+					},
 				},
 			})
 			g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/cloud/services/network/vpc_test.go
+++ b/pkg/cloud/services/network/vpc_test.go
@@ -667,6 +667,7 @@ func getClusterScope(vpcSpec *infrav1.VPCSpec, additionalTags map[string]string)
 	awsCluster := &infrav1.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
 		Spec: infrav1.AWSClusterSpec{
+			Region: "us-west-2",
 			NetworkSpec: infrav1.NetworkSpec{
 				VPC: *vpcSpec,
 			},

--- a/pkg/cloud/services/s3/s3_test.go
+++ b/pkg/cloud/services/s3/s3_test.go
@@ -137,7 +137,7 @@ func TestReconcileBucket(t *testing.T) {
 			},
 			AWSCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					S3Bucket: &infrav1.S3Bucket{},
+					Region: "us-west-2", S3Bucket: &infrav1.S3Bucket{},
 				},
 			},
 		})

--- a/pkg/cloud/services/secretsmanager/secret_test.go
+++ b/pkg/cloud/services/secretsmanager/secret_test.go
@@ -272,9 +272,13 @@ func getClusterScope(client client.Client) (*scope.ClusterScope, error) {
 		},
 	}
 	return scope.NewClusterScope(scope.ClusterScopeParams{
-		Client:     client,
-		Cluster:    cluster,
-		AWSCluster: &infrav1.AWSCluster{},
+		Client:  client,
+		Cluster: cluster,
+		AWSCluster: &infrav1.AWSCluster{
+			Spec: infrav1.AWSClusterSpec{
+				Region: "us-west-2",
+			},
+		},
 	})
 }
 

--- a/pkg/cloud/services/securitygroup/securitygroups_test.go
+++ b/pkg/cloud/services/securitygroup/securitygroups_test.go
@@ -1136,7 +1136,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 			cluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
-					NetworkSpec: *tc.input,
+					Region: "us-west-2", NetworkSpec: *tc.input,
 				},
 			}
 			awsCluster := tc.awsCluster(*cluster)
@@ -1176,7 +1176,11 @@ func TestControlPlaneSecurityGroupNotOpenToAnyCIDR(t *testing.T) {
 		Cluster: &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 		},
-		AWSCluster: &infrav1.AWSCluster{},
+		AWSCluster: &infrav1.AWSCluster{
+			Spec: infrav1.AWSClusterSpec{
+				Region: "us-west-2",
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Failed to create test context: %v", err)
@@ -1418,6 +1422,7 @@ func TestAdditionalControlPlaneSecurityGroup(t *testing.T) {
 				},
 				AWSCluster: &infrav1.AWSCluster{
 					Spec: infrav1.AWSClusterSpec{
+						Region:      "us-west-2",
 						NetworkSpec: tc.networkSpec,
 					},
 					Status: infrav1.AWSClusterStatus{
@@ -1530,6 +1535,7 @@ func TestAdditionalManagedControlPlaneSecurityGroup(t *testing.T) {
 				},
 				ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
 					Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+						Region:      "us-west-2",
 						NetworkSpec: tc.networkSpec,
 					},
 					Status: ekscontrolplanev1.AWSManagedControlPlaneStatus{
@@ -1587,7 +1593,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "when no ingress rules are passed and nat gateway IPs are not available, the default is set",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{},
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{},
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							CidrBlock: "10.0.0.0/16",
@@ -1610,7 +1616,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "when no ingress rules are passed and nat gateway IPs are not available, the default for IPv6 is set",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{},
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{},
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							CidrBlock: "10.0.0.0/16",
@@ -1634,7 +1640,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "when no ingress rules are passed, allow the Nat Gateway IPs and default to allow all",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{},
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{},
 					NetworkSpec: infrav1.NetworkSpec{
 						VPC: infrav1.VPCSpec{
 							CidrBlock: "10.0.0.0/16",
@@ -1668,7 +1674,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "defined rules are used",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						IngressRules: infrav1.IngressRules{
 							{
 								Description: "My custom ingress rule",
@@ -1712,7 +1718,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "when no ingress rules are passed while using internal LB",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Scheme: &infrav1.ELBSchemeInternal,
 					},
 					NetworkSpec: infrav1.NetworkSpec{
@@ -1743,7 +1749,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "when no ingress rules are passed while using internal LB and IPv6",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						Scheme: &infrav1.ELBSchemeInternal,
 					},
 					NetworkSpec: infrav1.NetworkSpec{
@@ -1776,7 +1782,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "defined rules are used while using internal LB",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						IngressRules: infrav1.IngressRules{
 							{
 								Description: "My custom ingress rule",
@@ -1816,7 +1822,7 @@ func TestControlPlaneLoadBalancerIngressRules(t *testing.T) {
 			name: "defined rules are used when using internal and external LB",
 			awsCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
-					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+					Region: "us-west-2", ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
 						IngressRules: []infrav1.IngressRule{
 							{
 								Description: "My custom ingress rule",
@@ -2047,6 +2053,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 			awsCluster := &infrav1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: infrav1.AWSClusterSpec{
+					Region:      "us-west-2",
 					NetworkSpec: *tc.input,
 				},
 			}
@@ -2398,6 +2405,7 @@ func TestNodePortServicesIngressRules(t *testing.T) {
 				},
 				AWSCluster: &infrav1.AWSCluster{
 					Spec: infrav1.AWSClusterSpec{
+						Region:                   "us-west-2",
 						ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{},
 						NetworkSpec: infrav1.NetworkSpec{
 							VPC: infrav1.VPCSpec{

--- a/pkg/cloud/services/ssm/secret_test.go
+++ b/pkg/cloud/services/ssm/secret_test.go
@@ -334,9 +334,13 @@ func getClusterScope(client client.Client) (*scope.ClusterScope, error) {
 		},
 	}
 	return scope.NewClusterScope(scope.ClusterScopeParams{
-		Client:     client,
-		Cluster:    cluster,
-		AWSCluster: &infrav1.AWSCluster{},
+		Client:  client,
+		Cluster: cluster,
+		AWSCluster: &infrav1.AWSCluster{
+			Spec: infrav1.AWSClusterSpec{
+				Region: "us-west-2",
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When reconciling clusters using `AWSClusterRoleIdentity` with an **invalid or empty region name**, the wrong region credentials could be cached and reused for **ALL clusters** using the same identity, causing subsequent clusters to fail or use the wrong region.

The codebase had three critical issues:

1. **No validation of region names** - Any string was accepted as a region
2. **Global mutable caches** - Provider and session objects were cached globally using sync.Map
3. **Cache keys included region** - But invalid regions weren't rejected, so they poisoned the cache
4. **Subsequent clusters got poisoned sessions** - Next cluster with the same identity would get the wrong cached session

We implemented two layers of validation:

- Reject invalid regions at admission time before they reach the controller.
- Add defensive checks in session creation to prevent cache poisoning if an invalid region somehow gets through.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The high number of files changed in the PR are due to making the `spec.region` field to be required. It was optional before. So tests that did not specify any region or that used an invalid region name needed to be updated.

When a cluster with an empty region was created before, here's the sequence of events:

  1. No Webhook Validation: The resource was accepted without any validation
  2. Controller Reconciliation: At pkg/cloud/scope/cluster.go:79, the code would call:
  session, serviceLimiters, err := sessionForClusterWithRegion(
      params.Client,
      clusterScope,
      params.AWSCluster.Spec.Region,  // This would be ""
      params.Logger
  )
  3. Session Creation: The empty region "" was passed to AWS SDK:
  config.LoadDefaultConfig(context.Background(), config.WithRegion(""))
  4. AWS SDK Behavior:
    - When config.WithRegion("") is used, the SDK ignores that parameter
    - The SDK then falls back to checking:
        - AWS_REGION environment variable
      - AWS_DEFAULT_REGION environment variable
      - AWS config files
      - EC2 instance metadata (if running on EC2)
  5. Controller Environment: Looking at config/manager/manager.yaml, no AWS region environment variables are set in the controller pod

  Outcome: the AWS SDK would return 

```
  operation error <SERVICE>: <OPERATION>, failed to resolve service endpoint,
  an AWS region is required, but was not found
```

Taking all of this into consideration, I believe it makes sense to make the field required, as it was actually required in the first place.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Validate region when reconciling cluster
```
