### PR TITLE
🐛 return nil if instanceMarketOptions.SpotOptions == nil

### DIFF
--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -860,7 +860,7 @@ func SDKToSpotMarketOptions(instanceMarketOptions *types.LaunchTemplateInstanceM
 	}
 
 	if instanceMarketOptions.SpotOptions == nil {
-		return &infrav1.SpotMarketOptions{}
+		return nil
 	}
 
 	result := &infrav1.SpotMarketOptions{}


### PR DESCRIPTION
## Overview

This PR fixes a bug in `SDKToSpotMarketOptions` that causes continuous launch template version churn for EKS managed node groups using **on-demand** instances. For affected environments, CAPA was reconciling launch templates every few minutes and creating new versions even when there were no configuration changes.

## Root Cause

- For on-demand instances, AWS returns `MarketType = "on-demand"` and `SpotOptions = nil` in `LaunchTemplateInstanceMarketOptions`.
- `SDKToSpotMarketOptions` currently returns a non-nil empty `*SpotMarketOptions` when `SpotOptions == nil` instead of returning `nil`.
- As a result, `LaunchTemplateNeedsUpdate` compares `nil` with `&SpotMarketOptions{}` and always evaluates them as different, which triggers launch template recreation on every reconciliation.

## Changes

- Update `SDKToSpotMarketOptions` to return `nil` when `instanceMarketOptions.SpotOptions == nil`, regardless of market type.
- This aligns the internal representation with the AWS SDK semantics of "no spot options configured" and makes spot configuration comparisons stable in `LaunchTemplateNeedsUpdate`.

## Testing

- Add a unit test covering the case: on-demand instance with `SpotOptions: nil` returns `nil` from `SDKToSpotMarketOptions` (not an empty struct).
- Optionally extend or adjust tests for `MarketType == spot` with `SpotOptions == nil` to also expect `nil`, ensuring consistent handling of "no spot options".

## Impact

- Stops continuous `CreateLaunchTemplateVersion` calls in environments using on-demand instances only, stabilizing launch template versions.
- Reduces unnecessary EC2 API operations, CloudWatch log volume, and launch template storage, eliminating the observed cost increase and lowering the risk of API throttling.

## Related Issue

Fixes #5819



/kind bug


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Launch Template Reconciliation Loop when instanceMarketOptions.SpotOptions == nil
```
