### PR TITLE
:bug: Fix: Changed dedicated host validation logic to require tenancy=host

### DIFF
--- a/api/v1beta2/awsmachine_webhook_test.go
+++ b/api/v1beta2/awsmachine_webhook_test.go
@@ -483,6 +483,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 				},
 			},
@@ -493,6 +494,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 					HostID:       ptr.To("h-09dcf61cb388b0149"),
 				},
@@ -504,6 +506,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 					DynamicHostAllocation: &DynamicHostAllocationSpec{
 						Tags: map[string]string{"env": "test"},
@@ -527,6 +530,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostAffinity: ptr.To("default"),
 					HostID:       ptr.To("h-09dcf61cb388b0149"),
 				},
@@ -538,6 +542,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostAffinity: ptr.To("default"),
 					DynamicHostAllocation: &DynamicHostAllocationSpec{
 						Tags: map[string]string{"env": "test"},
@@ -560,6 +565,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostID:       ptr.To("h-09dcf61cb388b0149"),
 				},
 			},
@@ -570,6 +576,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					DynamicHostAllocation: &DynamicHostAllocationSpec{
 						Tags: map[string]string{"env": "test"},
 					},
@@ -582,6 +589,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostAffinity: ptr.To("host"),
 					HostID:       aws.String("h-1234567890abcdef0"),
 					DynamicHostAllocation: &DynamicHostAllocationSpec{
@@ -598,12 +606,48 @@ func TestAWSMachineCreate(t *testing.T) {
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					InstanceType: "test",
+					Tenancy:      "host",
 					HostAffinity: ptr.To("default"),
 					HostID:       aws.String("h-1234567890abcdef0"),
 					DynamicHostAllocation: &DynamicHostAllocationSpec{
 						Tags: map[string]string{
 							"Environment": "test",
 						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "hostID without tenancy=host is invalid",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					InstanceType: "test",
+					Tenancy:      "default",
+					HostID:       ptr.To("h-09dcf61cb388b0149"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "hostAffinity=host without tenancy=host is invalid",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					InstanceType: "test",
+					Tenancy:      "default",
+					HostAffinity: ptr.To("host"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dynamicHostAllocation without tenancy=host is invalid",
+			machine: &AWSMachine{
+				Spec: AWSMachineSpec{
+					InstanceType: "test",
+					Tenancy:      "dedicated",
+					DynamicHostAllocation: &DynamicHostAllocationSpec{
+						Tags: map[string]string{"env": "test"},
 					},
 				},
 			},

--- a/api/v1beta2/awsmachinetemplate_webhook.go
+++ b/api/v1beta2/awsmachinetemplate_webhook.go
@@ -186,8 +186,21 @@ func (r *AWSMachineTemplate) validateHostAllocation() field.ErrorList {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.hostID"), "hostID and dynamicHostAllocation are mutually exclusive"), field.Forbidden(field.NewPath("spec.template.spec.dynamicHostAllocation"), "hostID and dynamicHostAllocation are mutually exclusive"))
 	}
 
+	// HostID, HostAffinity, and DynamicHostAllocation can only be set when Tenancy is "host"
+	if hasHostID && spec.Tenancy != hostTenancy {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.hostID"), "hostID can only be set when tenancy is 'host'"))
+	}
+
+	if spec.HostAffinity != nil && *spec.HostAffinity == hostAffinity && spec.Tenancy != hostTenancy {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.hostAffinity"), "hostAffinity can only be set to 'host' when tenancy is 'host'"))
+	}
+
+	if hasDynamicHostAllocation && spec.Tenancy != hostTenancy {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when tenancy is 'host'"))
+	}
+
 	// When hostAffinity is "host", either hostID or dynamicHostAllocation must be specified
-	if spec.HostAffinity != nil && *spec.HostAffinity == "host" && !hasHostID && !hasDynamicHostAllocation {
+	if spec.HostAffinity != nil && *spec.HostAffinity == hostAffinity && !hasHostID && !hasDynamicHostAllocation {
 		allErrs = append(allErrs, field.Required(field.NewPath("spec.template.spec.hostID"), "hostID or dynamicHostAllocation must be set when hostAffinity is 'host'"))
 	}
 

--- a/api/v1beta2/awsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/awsmachinetemplate_webhook_test.go
@@ -88,6 +88,7 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: AWSMachineTemplateResource{
 						Spec: AWSMachineSpec{
 							InstanceType: "test",
+							Tenancy:      "host",
 							HostID:       aws.String("h-1234567890abcdef0"),
 							DynamicHostAllocation: &DynamicHostAllocationSpec{
 								Tags: map[string]string{
@@ -108,6 +109,7 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: AWSMachineTemplateResource{
 						Spec: AWSMachineSpec{
 							InstanceType: "test",
+							Tenancy:      "host",
 							HostAffinity: ptr.To("host"),
 						},
 					},
@@ -123,6 +125,7 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: AWSMachineTemplateResource{
 						Spec: AWSMachineSpec{
 							InstanceType: "test",
+							Tenancy:      "host",
 							HostAffinity: ptr.To("host"),
 							HostID:       ptr.To("h-09dcf61cb388b0149"),
 						},
@@ -139,6 +142,7 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 					Template: AWSMachineTemplateResource{
 						Spec: AWSMachineSpec{
 							InstanceType: "test",
+							Tenancy:      "host",
 							HostAffinity: ptr.To("host"),
 							DynamicHostAllocation: &DynamicHostAllocationSpec{
 								Tags: map[string]string{"env": "test"},
@@ -163,6 +167,57 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 				},
 			},
 			wantError: false,
+		},
+		{
+			name: "hostID without tenancy=host is invalid",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test",
+							Tenancy:      "default",
+							HostID:       ptr.To("h-09dcf61cb388b0149"),
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "hostAffinity=host without tenancy=host is invalid",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test",
+							Tenancy:      "default",
+							HostAffinity: ptr.To("host"),
+							HostID:       ptr.To("h-09dcf61cb388b0149"),
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "dynamicHostAllocation without tenancy=host is invalid",
+			inputTemplate: &AWSMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: AWSMachineTemplateSpec{
+					Template: AWSMachineTemplateResource{
+						Spec: AWSMachineSpec{
+							InstanceType: "test",
+							Tenancy:      "dedicated",
+							DynamicHostAllocation: &DynamicHostAllocationSpec{
+								Tags: map[string]string{"env": "test"},
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR enhances the dedicated host logic to verify that the tenancy is `host` if any of the dedicated host fields (hostAffinity, hostID, dynamic hosts) are set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

In testing this feature in OCP, we came across configuration combinations that were working with AWS with CAPA but not as expected with CLI.  If we test this directly with AWS cli, and setting only `Affinity=default`, we see it is not allowed:

```
prompt > AWS_PROFILE=saml aws ec2 run-instances --region us-east-2 \
    --image-id ami-0bc8dda494f111572 --count 1 \
    --instance-type m6i.xlarge --key-name huliu-testdns \
    --security-group-ids <value> \
    --subnet-id <value> \
    --placement Affinity=default

An error occurred (InvalidParameterCombination) when calling the RunInstances operation: The parameter affinity cannot be used without specifying a tenancy of 'host'
```
This confirms that Affinity requires Tenancy=host to be set as well. We should align with AWS's behavior, shouldn't we?

**Special notes for your reviewer**:

**Checklist**:

- [X ] squashed commits
- [ ] includes documentation
- [X ] includes emoji in title 
- [X ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Enhanced dedicated host logic to require tenancy=host when attempting to use dedicated hosts for instances.
```
