### PR TITLE
🐛: Skip webhook defaulting during AWSManagedControlPlane deletion

### DIFF
--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_webhook.go
@@ -653,6 +653,9 @@ func (*awsManagedControlPlaneWebhook) Default(_ context.Context, obj runtime.Obj
 	r, ok := obj.(*AWSManagedControlPlane)
 	if !ok {
 		return fmt.Errorf("expected an AWSManagedControlPlane object but got %T", r)
+	} else if r.DeletionTimestamp != nil {
+		mcpLog.Info("AWSManagedControlPlane is being deleted, skipping defaults", "control-plane", klog.KObj(r))
+		return nil
 	}
 
 	mcpLog.Info("AWSManagedControlPlane setting defaults", "control-plane", klog.KObj(r))
@@ -679,7 +682,8 @@ func (*awsManagedControlPlaneWebhook) Default(_ context.Context, obj runtime.Obj
 	infrav1.SetDefaults_Bastion(&r.Spec.Bastion)
 	infrav1.SetDefaults_NetworkSpec(&r.Spec.NetworkSpec)
 
-	// Set default value for BootstrapSelfManagedAddons
-	r.Spec.BootstrapSelfManagedAddons = true
+	if r.ResourceVersion == "" {
+		r.Spec.BootstrapSelfManagedAddons = true
+	}
 	return nil
 }


### PR DESCRIPTION
Fixes #5660

The defaulter webhook was running on every UPDATE, including during deletion. This caused two issues:

1. Deletion blocked: Setting BootstrapSelfManagedAddons=true triggered strict addon validation for clusters with BYO IPv6 VPCs, blocking deletion of otherwise valid clusters.

2. Spec drift: Unconditionally setting BootstrapSelfManagedAddons=true on UPDATE caused spec drift for clusters created before this field existed, potentially triggering unwanted reconciliation.

Fix by:
- Skip all defaulting when DeletionTimestamp is set
- Only set BootstrapSelfManagedAddons on CREATE (ResourceVersion=="") to avoid modifying existing clusters

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix AWSManagedControlPlane webhook to skip defaulting during deletion and only set BootstrapSelfManagedAddons on CREATE to prevent spec drift on existing clusters.
```
