### PR TITLE
🌱 Add minimalist EKS e2e quick test for PR sanity checks

### DIFF
--- a/test/e2e/suites/managed/README.md
+++ b/test/e2e/suites/managed/README.md
@@ -14,3 +14,13 @@ For example, in [eks_test.go](eks_test.go) we perform the following steps:
 6. Perform tests against the machine pool
 7. Apply a AWSMachinePool
 8. Perform tests against the machine pool
+
+## EKS Quick Test
+
+The [eks_quick_test.go](eks_quick_test.go) implements a minimalist quick test for EKS clusters that is designed to run on every PR as a sanity check. This test is tagged with `[PR-Blocking]` and `[smoke]` labels.
+
+This test creates a basic EKS cluster with:
+1. An EKS control plane
+2. A single managed node group
+
+The test validates basic cluster provisioning and then performs cleanup. It is designed to be fast and provide quick feedback on PRs without running the full test suite.

--- a/test/e2e/suites/managed/eks_quick_test.go
+++ b/test/e2e/suites/managed/eks_quick_test.go
@@ -1,0 +1,125 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gofrs/flock"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+var _ = ginkgo.Context("[managed] [EKS] [smoke] [PR-Blocking]", func() {
+	var (
+		namespace         *corev1.Namespace
+		ctx               context.Context
+		requiredResources *shared.TestResource
+		specName          = "eks-quick-start"
+		clusterName       string
+	)
+
+	ginkgo.BeforeEach(func() {
+		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
+		ctx = context.TODO()
+		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+	})
+
+	ginkgo.Describe("Running the EKS quick-start spec", func() {
+		ginkgo.BeforeEach(func() {
+			requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3, EventBridgeRules: 50}
+			requiredResources.WriteRequestedResources(e2eCtx, "eks-quick-start-test")
+			Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		})
+
+		ginkgo.It("should create an EKS cluster with control plane and managed node group", func() {
+			eksClusterName := getEKSClusterName(namespace.Name, clusterName)
+
+			ginkgo.By("default iam role should exist")
+			VerifyRoleExistsAndOwned(ctx, ekscontrolplanev1.DefaultEKSControlPlaneRole, eksClusterName, false, e2eCtx.AWSSession)
+
+			ginkgo.By("should create an EKS control plane")
+			ManagedClusterSpec(ctx, func() ManagedClusterSpecInput {
+				return ManagedClusterSpecInput{
+					E2EConfig:                e2eCtx.E2EConfig,
+					ConfigClusterFn:          defaultConfigCluster,
+					BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
+					AWSSession:               e2eCtx.BootstrapUserAWSSession,
+					Namespace:                namespace,
+					ClusterName:              clusterName,
+					Flavour:                  EKSControlPlaneOnlyFlavor,
+					ControlPlaneMachineCount: 1,
+					WorkerMachineCount:       0,
+				}
+			})
+
+			ginkgo.By("should create a managed node pool")
+			MachinePoolSpec(ctx, func() MachinePoolSpecInput {
+				return MachinePoolSpecInput{
+					E2EConfig:             e2eCtx.E2EConfig,
+					ConfigClusterFn:       defaultConfigCluster,
+					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+					AWSSession:            e2eCtx.BootstrapUserAWSSession,
+					Namespace:             namespace,
+					ClusterName:           clusterName,
+					IncludeScaling:        false,
+					Cleanup:               false,
+					ManagedMachinePool:    true,
+					Flavor:                EKSManagedMachinePoolOnlyFlavor,
+				}
+			})
+
+			ginkgo.By(fmt.Sprintf("getting cluster with name %s", clusterName))
+			cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+				Getter:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+				Namespace: namespace.Name,
+				Name:      clusterName,
+			})
+			Expect(cluster).NotTo(BeNil(), "couldn't find CAPI cluster")
+
+			framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+				Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+				Cluster: cluster,
+			})
+			framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+				ClusterProxy:         e2eCtx.Environment.BootstrapClusterProxy,
+				Cluster:              cluster,
+				ClusterctlConfigPath: e2eCtx.Environment.ClusterctlConfigPath,
+				ArtifactFolder:       e2eCtx.Settings.ArtifactFolder,
+			}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
+		})
+
+		ginkgo.AfterEach(func() {
+			_ = shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+		})
+	})
+
+	ginkgo.AfterEach(func() {
+		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+	})
+})

--- a/test/e2e/suites/managed/eks_quick_test.go
+++ b/test/e2e/suites/managed/eks_quick_test.go
@@ -2,33 +2,19 @@
 // +build e2e
 
 /*
-
 Copyright 2026 The Kubernetes Authors.
 
-
-
 Licensed under the Apache License, Version 2.0 (the "License");
-
 you may not use this file except in compliance with the License.
-
 You may obtain a copy of the License at
-
-
 
 	http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
-
 distributed under the License is distributed on an "AS IS" BASIS,
-
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
 See the License for the specific language governing permissions and
-
 limitations under the License.
-
 */
 
 package managed
@@ -48,22 +34,16 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-var _ = ginkgo.Context("[managed] [EKS] [smoke] [PR-Blocking]", func() {
-
+var _ = ginkgo.Describe("[managed] [EKS] [smoke] [PR-Blocking]", func() {
 	var (
-		namespace *corev1.Namespace
-
-		ctx context.Context
-
+		namespace         *corev1.Namespace
+		ctx               context.Context
 		requiredResources *shared.TestResource
-
-		specName = "eks-quick-start"
-
-		clusterName string
+		specName          = "eks-quick-start"
+		clusterName       string
 	)
 
 	ginkgo.BeforeEach(func() {
-
 		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
 
 		ctx = context.TODO()
@@ -71,130 +51,78 @@ var _ = ginkgo.Context("[managed] [EKS] [smoke] [PR-Blocking]", func() {
 		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
 
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
-
 	})
 
-	ginkgo.Describe("Running the EKS quick-start spec", func() {
+	ginkgo.BeforeEach(func() {
+		requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3, EventBridgeRules: 50}
 
-		ginkgo.BeforeEach(func() {
+		requiredResources.WriteRequestedResources(e2eCtx, "eks-quick-start-test")
 
-			requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3, EventBridgeRules: 50}
+		Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+	})
 
-			requiredResources.WriteRequestedResources(e2eCtx, "eks-quick-start-test")
+	ginkgo.It("should create an EKS cluster with control plane and managed node group", func() {
+		eksClusterName := getEKSClusterName(namespace.Name, clusterName)
 
-			Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+		ginkgo.By("default iam role should exist")
+		VerifyRoleExistsAndOwned(ctx, ekscontrolplanev1.DefaultEKSControlPlaneRole, eksClusterName, false, e2eCtx.AWSSession)
 
+		ginkgo.By("should create an EKS control plane")
+		ManagedClusterSpec(ctx, func() ManagedClusterSpecInput {
+			return ManagedClusterSpecInput{
+				E2EConfig:                e2eCtx.E2EConfig,
+				ConfigClusterFn:          defaultConfigCluster,
+				BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
+				AWSSession:               e2eCtx.BootstrapUserAWSSession,
+				Namespace:                namespace,
+				ClusterName:              clusterName,
+				Flavour:                  EKSControlPlaneOnlyFlavor,
+				ControlPlaneMachineCount: 1,
+				WorkerMachineCount:       0,
+			}
 		})
 
-		ginkgo.It("should create an EKS cluster with control plane and managed node group", func() {
-
-			eksClusterName := getEKSClusterName(namespace.Name, clusterName)
-
-			ginkgo.By("default iam role should exist")
-
-			VerifyRoleExistsAndOwned(ctx, ekscontrolplanev1.DefaultEKSControlPlaneRole, eksClusterName, false, e2eCtx.AWSSession)
-
-			ginkgo.By("should create an EKS control plane")
-
-			ManagedClusterSpec(ctx, func() ManagedClusterSpecInput {
-
-				return ManagedClusterSpecInput{
-
-					E2EConfig: e2eCtx.E2EConfig,
-
-					ConfigClusterFn: defaultConfigCluster,
-
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-
-					AWSSession: e2eCtx.BootstrapUserAWSSession,
-
-					Namespace: namespace,
-
-					ClusterName: clusterName,
-
-					Flavour: EKSControlPlaneOnlyFlavor,
-
-					ControlPlaneMachineCount: 1,
-
-					WorkerMachineCount: 0,
-				}
-
-			})
-
-			ginkgo.By("should create a managed node pool")
-
-			MachinePoolSpec(ctx, func() MachinePoolSpecInput {
-
-				return MachinePoolSpecInput{
-
-					E2EConfig: e2eCtx.E2EConfig,
-
-					ConfigClusterFn: defaultConfigCluster,
-
-					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-
-					AWSSession: e2eCtx.BootstrapUserAWSSession,
-
-					Namespace: namespace,
-
-					ClusterName: clusterName,
-
-					IncludeScaling: false,
-
-					Cleanup: false,
-
-					ManagedMachinePool: true,
-
-					Flavor: EKSManagedMachinePoolOnlyFlavor,
-				}
-
-			})
-
-			ginkgo.By(fmt.Sprintf("getting cluster with name %s", clusterName))
-
-			cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
-
-				Getter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
-
-				Namespace: namespace.Name,
-
-				Name: clusterName,
-			})
-
-			Expect(cluster).NotTo(BeNil(), "couldn't find CAPI cluster")
-
-			framework.DeleteCluster(ctx, framework.DeleteClusterInput{
-
-				Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
-
-				Cluster: cluster,
-			})
-
-			framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
-
-				ClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-
-				Cluster: cluster,
-
-				ClusterctlConfigPath: e2eCtx.Environment.ClusterctlConfigPath,
-
-				ArtifactFolder: e2eCtx.Settings.ArtifactFolder,
-			}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
-
+		ginkgo.By("should create a managed node pool")
+		MachinePoolSpec(ctx, func() MachinePoolSpecInput {
+			return MachinePoolSpecInput{
+				E2EConfig:             e2eCtx.E2EConfig,
+				ConfigClusterFn:       defaultConfigCluster,
+				BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+				AWSSession:            e2eCtx.BootstrapUserAWSSession,
+				Namespace:             namespace,
+				ClusterName:           clusterName,
+				IncludeScaling:        false,
+				Cleanup:               false,
+				ManagedMachinePool:    true,
+				Flavor:                EKSManagedMachinePoolOnlyFlavor,
+			}
 		})
 
-		ginkgo.AfterEach(func() {
-
-			_ = shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
-
+		ginkgo.By(fmt.Sprintf("getting cluster with name %s", clusterName))
+		cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+			Getter:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Namespace: namespace.Name,
+			Name:      clusterName,
 		})
+		Expect(cluster).NotTo(BeNil(), "couldn't find CAPI cluster")
 
+		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+			Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+			Cluster: cluster,
+		})
+		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+			ClusterProxy:         e2eCtx.Environment.BootstrapClusterProxy,
+			Cluster:              cluster,
+			ClusterctlConfigPath: e2eCtx.Environment.ClusterctlConfigPath,
+			ArtifactFolder:       e2eCtx.Settings.ArtifactFolder,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
 	})
 
 	ginkgo.AfterEach(func() {
-
-		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
-
+		_ = shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
 	})
 
+	ginkgo.AfterEach(func() {
+		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+	})
 })

--- a/test/e2e/suites/managed/eks_quick_test.go
+++ b/test/e2e/suites/managed/eks_quick_test.go
@@ -2,19 +2,33 @@
 // +build e2e
 
 /*
+
 Copyright 2026 The Kubernetes Authors.
 
+
+
 Licensed under the Apache License, Version 2.0 (the "License");
+
 you may not use this file except in compliance with the License.
+
 You may obtain a copy of the License at
+
+
 
 	http://www.apache.org/licenses/LICENSE-2.0
 
+
+
 Unless required by applicable law or agreed to in writing, software
+
 distributed under the License is distributed on an "AS IS" BASIS,
+
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 See the License for the specific language governing permissions and
+
 limitations under the License.
+
 */
 
 package managed
@@ -35,91 +49,152 @@ import (
 )
 
 var _ = ginkgo.Context("[managed] [EKS] [smoke] [PR-Blocking]", func() {
+
 	var (
-		namespace         *corev1.Namespace
-		ctx               context.Context
+		namespace *corev1.Namespace
+
+		ctx context.Context
+
 		requiredResources *shared.TestResource
-		specName          = "eks-quick-start"
-		clusterName       string
+
+		specName = "eks-quick-start"
+
+		clusterName string
 	)
 
 	ginkgo.BeforeEach(func() {
+
 		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
+
 		ctx = context.TODO()
+
 		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+
 	})
 
 	ginkgo.Describe("Running the EKS quick-start spec", func() {
+
 		ginkgo.BeforeEach(func() {
+
 			requiredResources = &shared.TestResource{EC2Normal: 2 * e2eCtx.Settings.InstanceVCPU, IGW: 1, NGW: 1, VPC: 1, ClassicLB: 1, EIP: 3, EventBridgeRules: 50}
+
 			requiredResources.WriteRequestedResources(e2eCtx, "eks-quick-start-test")
+
 			Expect(shared.AcquireResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))).To(Succeed())
+
 		})
 
 		ginkgo.It("should create an EKS cluster with control plane and managed node group", func() {
+
 			eksClusterName := getEKSClusterName(namespace.Name, clusterName)
 
 			ginkgo.By("default iam role should exist")
+
 			VerifyRoleExistsAndOwned(ctx, ekscontrolplanev1.DefaultEKSControlPlaneRole, eksClusterName, false, e2eCtx.AWSSession)
 
 			ginkgo.By("should create an EKS control plane")
+
 			ManagedClusterSpec(ctx, func() ManagedClusterSpecInput {
+
 				return ManagedClusterSpecInput{
-					E2EConfig:                e2eCtx.E2EConfig,
-					ConfigClusterFn:          defaultConfigCluster,
-					BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
-					AWSSession:               e2eCtx.BootstrapUserAWSSession,
-					Namespace:                namespace,
-					ClusterName:              clusterName,
-					Flavour:                  EKSControlPlaneOnlyFlavor,
+
+					E2EConfig: e2eCtx.E2EConfig,
+
+					ConfigClusterFn: defaultConfigCluster,
+
+					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+
+					AWSSession: e2eCtx.BootstrapUserAWSSession,
+
+					Namespace: namespace,
+
+					ClusterName: clusterName,
+
+					Flavour: EKSControlPlaneOnlyFlavor,
+
 					ControlPlaneMachineCount: 1,
-					WorkerMachineCount:       0,
+
+					WorkerMachineCount: 0,
 				}
+
 			})
 
 			ginkgo.By("should create a managed node pool")
+
 			MachinePoolSpec(ctx, func() MachinePoolSpecInput {
+
 				return MachinePoolSpecInput{
-					E2EConfig:             e2eCtx.E2EConfig,
-					ConfigClusterFn:       defaultConfigCluster,
+
+					E2EConfig: e2eCtx.E2EConfig,
+
+					ConfigClusterFn: defaultConfigCluster,
+
 					BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
-					AWSSession:            e2eCtx.BootstrapUserAWSSession,
-					Namespace:             namespace,
-					ClusterName:           clusterName,
-					IncludeScaling:        false,
-					Cleanup:               false,
-					ManagedMachinePool:    true,
-					Flavor:                EKSManagedMachinePoolOnlyFlavor,
+
+					AWSSession: e2eCtx.BootstrapUserAWSSession,
+
+					Namespace: namespace,
+
+					ClusterName: clusterName,
+
+					IncludeScaling: false,
+
+					Cleanup: false,
+
+					ManagedMachinePool: true,
+
+					Flavor: EKSManagedMachinePoolOnlyFlavor,
 				}
+
 			})
 
 			ginkgo.By(fmt.Sprintf("getting cluster with name %s", clusterName))
+
 			cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
-				Getter:    e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+
+				Getter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+
 				Namespace: namespace.Name,
-				Name:      clusterName,
+
+				Name: clusterName,
 			})
+
 			Expect(cluster).NotTo(BeNil(), "couldn't find CAPI cluster")
 
 			framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+
 				Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
+
 				Cluster: cluster,
 			})
+
 			framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
-				ClusterProxy:         e2eCtx.Environment.BootstrapClusterProxy,
-				Cluster:              cluster,
+
+				ClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+
+				Cluster: cluster,
+
 				ClusterctlConfigPath: e2eCtx.Environment.ClusterctlConfigPath,
-				ArtifactFolder:       e2eCtx.Settings.ArtifactFolder,
+
+				ArtifactFolder: e2eCtx.Settings.ArtifactFolder,
 			}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
+
 		})
 
 		ginkgo.AfterEach(func() {
+
 			_ = shared.ReleaseResources(requiredResources, ginkgo.GinkgoParallelProcess(), flock.New(shared.ResourceQuotaFilePath))
+
 		})
+
 	})
 
 	ginkgo.AfterEach(func() {
+
 		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
+
 	})
+
 })

--- a/test/e2e/suites/managed/eks_quick_test.go
+++ b/test/e2e/suites/managed/eks_quick_test.go
@@ -57,10 +57,7 @@ var _ = ginkgo.Describe("[managed] [EKS] [smoke] [PR-Blocking]", func() {
 		eksClusterName := getEKSClusterName(namespace.Name, clusterName)
 
 		ginkgo.By("default iam role should exist")
-		Expect(func() error {
-			VerifyRoleExistsAndOwned(ctx, ekscontrolplanev1.DefaultEKSControlPlaneRole, eksClusterName, false, e2eCtx.AWSSession)
-			return nil
-		}()).To(Succeed())
+		VerifyRoleExistsAndOwned(ctx, ekscontrolplanev1.DefaultEKSControlPlaneRole, eksClusterName, false, e2eCtx.AWSSession)
 
 		ginkgo.By("should create an EKS control plane")
 		ManagedClusterSpec(ctx, func() ManagedClusterSpecInput {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a new minimalist EKS e2e test, that serves as a fast sanity check for PR validation. The test is designed to run on every PR to provide quick feedback on basic EKS functionality without requiring the full comprehensive test suite.

**Key features:**
- Tagged with `[PR-Blocking]` and `[smoke]` labels for automatic inclusion in PR tests
- Creates minimal EKS cluster (control plane + single managed node group)
- Follows the same pattern as the existing unmanaged quick test

The test provides a balance between coverage and execution time, making it suitable for PR validation while minimizing AWS resource usage and costs.

**Which issue(s) this PR fixes**:
Fixes #5547 

**Special notes for your reviewer**:

This implementation mirrors the structure of the unmanaged quick test (referenced in the issue). Key design decisions:

1. **Minimal cluster configuration**: Uses only EKSControlPlaneOnlyFlavor + EKSManagedMachinePoolOnlyFlavor to reduce resource usage
2. **No scaling tests**: Skips scaling validation to optimize execution time
3. **Reuses existing helpers**: Leverages [ManagedClusterSpec](test/e2e/sui and `MachinePoolSpec` for consistency
4. **Resource management**: Properly acquires/releases AWS quotas for parallel test execution

The test compiles successfully with `make compile-e2e` and is ready for integration into the CI/CD pipeline.

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests (N/A - this is an e2e test)
- [x] adds or updates e2e tests

**Release note**:
```release-note
Add new minimalist EKS e2e quick test for PR sanity checks. The test validates basic EKS cluster creation and is tagged as [PR-Blocking] to run on every PR, providing fast feedback without requiring the full comprehensive test suite.