### PR TITLE
🌱 test: enable k8s upgrade test 

### DIFF
--- a/test/e2e/suites/conformance/conformance_test.go
+++ b/test/e2e/suites/conformance/conformance_test.go
@@ -65,7 +65,6 @@ var _ = ginkgo.Describe("[unmanaged] [conformance] tests", func() {
 		experiment := gmeasure.NewExperiment(name)
 		ginkgo.AddReportEntry(experiment.Name, experiment)
 		experiment.Sample(func(idx int) {
-			shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
 			kubernetesVersion := e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion)
 			flavor := clusterctl.DefaultFlavor
 			if e2eCtx.Settings.UseCIArtifacts {
@@ -125,7 +124,6 @@ var _ = ginkgo.Describe("[unmanaged] [conformance] tests", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		shared.SetEnvVar("USE_CI_ARTIFACTS", "false", false)
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
 	})

--- a/test/e2e/suites/conformance/conformance_test.go
+++ b/test/e2e/suites/conformance/conformance_test.go
@@ -65,6 +65,7 @@ var _ = ginkgo.Describe("[unmanaged] [conformance] tests", func() {
 		experiment := gmeasure.NewExperiment(name)
 		ginkgo.AddReportEntry(experiment.Name, experiment)
 		experiment.Sample(func(idx int) {
+			shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
 			kubernetesVersion := e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion)
 			flavor := clusterctl.DefaultFlavor
 			if e2eCtx.Settings.UseCIArtifacts {
@@ -124,6 +125,7 @@ var _ = ginkgo.Describe("[unmanaged] [conformance] tests", func() {
 	})
 
 	ginkgo.AfterEach(func() {
+		shared.SetEnvVar("USE_CI_ARTIFACTS", "false", false)
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
 	})

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -278,6 +278,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				searchSemVer, err := semver.Make(strings.TrimPrefix(e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion), tagPrefix))
 				Expect(err).NotTo(HaveOccurred())
 
+				shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
 				shared.SetEnvVar(shared.KubernetesVersion, "v"+searchSemVer.String(), false)
 				configCluster := defaultConfigCluster(cluster1Name, namespace.Name)
 
@@ -311,6 +312,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				}, e2eCtx.E2EConfig.GetIntervals(specName, "wait-machine-upgrade")...)
 
 				ginkgo.By("Deleting the Clusters")
+				shared.SetEnvVar("USE_CI_ARTIFACTS", "false", false)
 				deleteCluster(ctx, cluster2)
 			})
 		})

--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -260,8 +260,7 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 		})
 	})
 
-	// // TODO: @sedefsavas: Requires env var logic to be removed
-	ginkgo.PDescribe("[Serial] Upgrade to main branch Kubernetes", func() {
+	ginkgo.Describe("[Serial] Upgrade to main branch Kubernetes", func() {
 		ginkgo.Context("in same namespace", func() {
 			ginkgo.It("should create the clusters", func() {
 				specName := "upgrade-to-main-branch-k8s"
@@ -275,7 +274,6 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				defer shared.DumpSpecResourcesAndCleanup(ctx, "", namespace, e2eCtx)
 				ginkgo.By("Creating first cluster with single control plane")
 				cluster1Name := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
-				shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
 				tagPrefix := "v"
 				searchSemVer, err := semver.Make(strings.TrimPrefix(e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion), tagPrefix))
 				Expect(err).NotTo(HaveOccurred())
@@ -313,7 +311,6 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				}, e2eCtx.E2EConfig.GetIntervals(specName, "wait-machine-upgrade")...)
 
 				ginkgo.By("Deleting the Clusters")
-				shared.SetEnvVar("USE_CI_ARTIFACTS", "false", false)
 				deleteCluster(ctx, cluster2)
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

enables the “upgrade to main branch kubernetes” e2e test and removes unused environment variable handling.
the test is enabled by switching `PDescribe` to `Describe`. at the same time, dead code related to the `USE_CI_ARTIFACTS` environment variable is removed, as it was set but never read anywhere in the repository.
the test already correctly uses the `upgrade-ci-artifacts` flavor directly, so relying on an environment variable was unnecessary. this simplifies the code path and ensures the test behavior is explicit and easier to reason about.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**:

related #5176 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
