### PR TITLE
🌱 [KAL] Enable jsontags linter and scope it to API directories and fix …

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -20,7 +20,7 @@ linters:
               #- "commentstart" # Ensure comments start with the serialized version of the field name.
               #- "conditions" # Ensure conditions have the correct json tags and markers.
               #- "integers" # Ensure only int32 and int64 are used for integers.
-              #- "jsontags" # Ensure every field has a json tag.
+              - "jsontags" # Ensure every field has a json tag.
               #- "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
               #- "nobools" # Bools do not evolve over time, should use enums instead.
               #- "nofloats" # Ensure floats are not used.
@@ -46,14 +46,9 @@ linters:
 
 exclusions:
     generated: strict
-    paths:
-      - zz_generated.*\.go$
-      - ".*_test.go"  # Exclude test files.
+    # NOTE: Path-based exclusions via config don't work reliably in this golangci-lint version.
+    # Instead, we use command-line path arguments in the Makefile to limit linting to API directories only.
     rules:
-    # KAL should only run on API folders.
-    - path-except: "api//*"
-      linters:
-        - kubeapilinter
     - path: "api/v1beta1/*|api/v1alpha1/*"
       text: "Conditions field must be a slice of metav1.Condition"
       linters:

--- a/Makefile
+++ b/Makefile
@@ -318,8 +318,16 @@ lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported
 	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
 
 .PHONY: lint-api
-lint-api: $(GOLANGCI_LINT_KAL)
-	$(GOLANGCI_LINT_KAL) run -v --config $(REPO_ROOT)/.golangci-kal.yml $(GOLANGCI_LINT_EXTRA_ARGS)
+lint-api: $(GOLANGCI_LINT_KAL) ## Lint Kubernetes API types in api/ directories
+	$(GOLANGCI_LINT_KAL) run -v --config $(REPO_ROOT)/.golangci-kal.yml \
+		./api/... \
+		./bootstrap/eks/api/... \
+		./controlplane/eks/api/... \
+		./controlplane/rosa/api/... \
+		./exp/api/... \
+		./iam/api/... \
+		./cmd/clusterawsadm/api/... \
+		$(GOLANGCI_LINT_EXTRA_ARGS)
 
 .PHONY: lint-api-fix
 lint-api-fix: $(GOLANGCI_LINT_KAL)

--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -212,25 +212,25 @@ func ClusterAWSCloudProviderTagKey(name string) string {
 // BuildParams is used to build tags around an aws resource.
 type BuildParams struct {
 	// Lifecycle determines the resource lifecycle.
-	Lifecycle ResourceLifecycle
+	Lifecycle ResourceLifecycle `json:"lifecycle,omitempty"`
 
 	// ClusterName is the cluster associated with the resource.
-	ClusterName string
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// ResourceID is the unique identifier of the resource to be tagged.
-	ResourceID string
+	ResourceID string `json:"resourceID,omitempty"`
 
 	// Name is the name of the resource, it's applied as the tag "Name" on AWS.
 	// +optional
-	Name *string
+	Name *string `json:"name,omitempty"`
 
 	// Role is the role associated to the resource.
 	// +optional
-	Role *string
+	Role *string `json:"role,omitempty"`
 
 	// Any additional tags to be added to the resource.
 	// +optional
-	Additional Tags
+	Additional Tags `json:"additional,omitempty"`
 }
 
 // WithMachineName tags the namespaced machine name

--- a/api/v1beta2/tags.go
+++ b/api/v1beta2/tags.go
@@ -216,25 +216,25 @@ func ClusterAWSCloudProviderTagKey(name string) string {
 // BuildParams is used to build tags around an aws resource.
 type BuildParams struct {
 	// Lifecycle determines the resource lifecycle.
-	Lifecycle ResourceLifecycle
+	Lifecycle ResourceLifecycle `json:"lifecycle,omitempty"`
 
 	// ClusterName is the cluster associated with the resource.
-	ClusterName string
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// ResourceID is the unique identifier of the resource to be tagged.
-	ResourceID string
+	ResourceID string `json:"resourceID,omitempty"`
 
 	// Name is the name of the resource, it's applied as the tag "Name" on AWS.
 	// +optional
-	Name *string
+	Name *string `json:"name,omitempty"`
 
 	// Role is the role associated to the resource.
 	// +optional
-	Role *string
+	Role *string `json:"role,omitempty"`
 
 	// Any additional tags to be added to the resource.
 	// +optional
-	Additional Tags
+	Additional Tags `json:"additional,omitempty"`
 }
 
 // WithMachineName tags the namespaced machine name

--- a/exp/api/v1beta1/types.go
+++ b/exp/api/v1beta1/types.go
@@ -194,7 +194,7 @@ type AutoScalingGroup struct {
 	CapacityRebalance bool            `json:"capacityRebalance,omitempty"`
 
 	MixedInstancesPolicy *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
-	Status               ASGStatus
+	Status               ASGStatus          `json:"status,omitempty"`
 	Instances            []infrav1.Instance `json:"instances,omitempty"`
 }
 

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -242,7 +242,7 @@ type AutoScalingGroup struct {
 	CapacityRebalance     bool            `json:"capacityRebalance,omitempty"`
 
 	MixedInstancesPolicy      *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
-	Status                    ASGStatus
+	Status                    ASGStatus          `json:"status,omitempty"`
 	Instances                 []infrav1.Instance `json:"instances,omitempty"`
 	CurrentlySuspendProcesses []string           `json:"currentlySuspendProcesses,omitempty"`
 }

--- a/iam/api/v1beta1/types.go
+++ b/iam/api/v1beta1/types.go
@@ -83,20 +83,20 @@ const (
 // PolicyDocument represents an AWS IAM policy document, and can be
 // converted into JSON using "sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/converters".
 type PolicyDocument struct {
-	Version   string     `json:"Version,omitempty"`
-	Statement Statements `json:"Statement,omitempty"`
-	ID        string     `json:"Id,omitempty"`
+	Version   string     `json:"version,omitempty"`
+	Statement Statements `json:"statement,omitempty"`
+	ID        string     `json:"id,omitempty"`
 }
 
 // StatementEntry represents each "statement" block in an AWS IAM policy document.
 type StatementEntry struct {
-	Sid          string     `json:",omitempty"`
-	Principal    Principals `json:",omitempty"`
-	NotPrincipal Principals `json:",omitempty"`
-	Effect       Effect     `json:"Effect"`
-	Action       Actions    `json:"Action"`
-	Resource     Resources  `json:",omitempty"`
-	Condition    Conditions `json:"Condition,omitempty"`
+	Sid          string     `json:"sid,omitempty"`
+	Principal    Principals `json:"principal,omitempty"`
+	NotPrincipal Principals `json:"notPrincipal,omitempty"`
+	Effect       Effect     `json:"effect"`
+	Action       Actions    `json:"action"`
+	Resource     Resources  `json:"resource,omitempty"`
+	Condition    Conditions `json:"condition,omitempty"`
 }
 
 // Statements is the list of StatementEntries.

--- a/iam/api/v1beta1/types.go
+++ b/iam/api/v1beta1/types.go
@@ -82,21 +82,23 @@ const (
 
 // PolicyDocument represents an AWS IAM policy document, and can be
 // converted into JSON using "sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/converters".
+// Note: JSON field names must be capitalized to match AWS IAM policy format.
 type PolicyDocument struct {
-	Version   string     `json:"version,omitempty"`
-	Statement Statements `json:"statement,omitempty"`
-	ID        string     `json:"id,omitempty"`
+	Version   string     `json:"Version,omitempty"` //nolint:kubeapilinter
+	Statement Statements `json:"Statement,omitempty"` //nolint:kubeapilinter
+	ID        string     `json:"Id,omitempty"` //nolint:kubeapilinter
 }
 
 // StatementEntry represents each "statement" block in an AWS IAM policy document.
+// Note: JSON field names must be capitalized to match AWS IAM policy format.
 type StatementEntry struct {
-	Sid          string     `json:"sid,omitempty"`
-	Principal    Principals `json:"principal,omitempty"`
-	NotPrincipal Principals `json:"notPrincipal,omitempty"`
-	Effect       Effect     `json:"effect"`
-	Action       Actions    `json:"action"`
-	Resource     Resources  `json:"resource,omitempty"`
-	Condition    Conditions `json:"condition,omitempty"`
+	Sid          string     `json:"Sid,omitempty"` //nolint:kubeapilinter
+	Principal    Principals `json:"Principal,omitempty"` //nolint:kubeapilinter
+	NotPrincipal Principals `json:"NotPrincipal,omitempty"` //nolint:kubeapilinter
+	Effect       Effect     `json:"Effect"` //nolint:kubeapilinter
+	Action       Actions    `json:"Action"` //nolint:kubeapilinter
+	Resource     Resources  `json:"Resource,omitempty"` //nolint:kubeapilinter
+	Condition    Conditions `json:"Condition,omitempty"` //nolint:kubeapilinter
 }
 
 // Statements is the list of StatementEntries.


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

This PR enables the `jsontags` rule in Kube API Linter (KAL) and ensures it is enforced only on Kubernetes API types.

The `jsontags` rule is meant to validate the public API surface. When enabled globally, it also reports violations in internal runtime structs (scopes, helpers, controllers), which are not part of the API and should not require JSON tags.

Although the configuration already attempts to scope KAL to `api/**`, the custom `golangci-lint-kal` build does not reliably honor path-based exclusions for individual KAL rules. As a result, `jsontags` still fires outside API packages.

This change makes the intent explicit at the invocation level:

- Enable `jsontags` in `.golangci-kal.yml`.
- Update the `lint-api` target to run KAL only on known API directories.

With this approach, KAL is executed exclusively against API packages, so `jsontags` is enforced exactly where it belongson Kubernetes API types and never on internal runtime code.

In addition, missing and incorrect JSON tags in API types have been fixed to satisfy the new rule and align with Kubernetes API conventions.

**Which issue this PR fixes**:
Fixes #5487 

**Special notes for your reviewer**:

This intentionally avoids adding JSON tags to internal structs. The Makefile change is a workaround for current limitations in the custom KAL build with respect to path-based exclusions.

**Release note**:

```release-note
NONE
```