### PR TITLE
🌱 Re-enable dependency report generation in main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,7 +620,7 @@ release-manifests: ## Release manifest files
 
 .PHONY: release-changelog
 release-changelog: $(RELEASE_NOTES) check-release-tag check-previous-release-tag check-github-token $(RELEASE_DIR)
-	$(RELEASE_NOTES) --debug --org $(GH_ORG_NAME) --repo $(GH_REPO_NAME) --start-sha $(shell git rev-list -n 1 ${PREVIOUS_VERSION}) --end-sha $(shell git rev-list -n 1 ${RELEASE_TAG}) --output $(RELEASE_DIR)/CHANGELOG.md --go-template go-template:$(REPO_ROOT)/hack/changelog.tpl --dependencies=false --branch=${RELEASE_BRANCH} --required-author=""
+	$(RELEASE_NOTES) --debug --org $(GH_ORG_NAME) --repo $(GH_REPO_NAME) --start-sha $(shell git rev-list -n 1 ${PREVIOUS_VERSION}) --end-sha $(shell git rev-list -n 1 ${RELEASE_TAG}) --output $(RELEASE_DIR)/CHANGELOG.md --go-template go-template:$(REPO_ROOT)/hack/changelog.tpl --dependencies=true --branch=${RELEASE_BRANCH} --required-author=""
 
 .PHONY: promote-images
 promote-images: $(KPROMO) $(YQ)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Dependency report generation was previously disabled as a temporary workaround due to Go toolchain incompatibilities.

Since the project now uses Go 1.24.x across build and tooling images, the original limitation no longer applies. This PR enables the dependency flag which was earlier disabled by #4825 and restores the default behavior of generating dependency reports as part of the release changelog process.

The release-notes tool and dependency report generation were validated locally using the current toolchain to ensure the workflow runs successfully.


**Which issue this PR fixes**:
Fixes #4826 

**Special notes for your reviewer**:

**Checklist**:


- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
