### PR TITLE
🐛 fix:  Enable GPU-enabled cluster e2e test

### DIFF
--- a/test/e2e/suites/unmanaged/unmanaged_functional_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_functional_test.go
@@ -119,7 +119,6 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 
 	ginkgo.Describe("GPU-enabled cluster test", func() {
 		ginkgo.It("should create cluster with single worker", func() {
-			ginkgo.Skip("Args field of clusterctl.ApplyClusterTemplateAndWaitInput was removed, need to add support for server-side filtering.")
 			specName := "functional-gpu-cluster"
 			namespace := shared.SetupSpecNamespace(ctx, specName, e2eCtx)
 			if !e2eCtx.Settings.SkipQuotas {
@@ -151,13 +150,8 @@ var _ = ginkgo.Context("[unmanaged] [functional]", func() {
 				WaitForClusterIntervals:      e2eCtx.E2EConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eCtx.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 				WaitForMachineDeployments:    e2eCtx.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
-				// nvidia-gpu flavor creates a config map as part of a crs, that exceeds the annotations size limit when we do kubectl apply.
-				// This is because the entire config map is stored in `last-applied` annotation for tracking.
-				// The workaround is to use server side apply by passing `--server-side` flag to kubectl apply.
-				// More on server side apply here: https://kubernetes.io/docs/reference/using-api/server-side-apply/
-				// TODO: Need a PR to re-add argument support to this type.
-				// It was removed in https://github.com/kubernetes-sigs/cluster-api/commit/b4349fecaa626865e71b058a8b01e0377fb9e444
-				// Args: []string{"--server-side"},
+				// GPU operator components are deployed via ClusterResourceSet which handles large ConfigMaps
+				// without the kubectl annotation size limit issues that occur with client-side apply.
 			}, result)
 
 			shared.AWSGPUSpec(ctx, e2eCtx, shared.AWSGPUSpecInput{


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
re-enables the previously skipped gpu cluster e2e test by removing the `ginkgo.Skip()` call.
the test was originally disabled due to the removal of the `Args` field in the capi framework, which blocked passing `--server-side` to `kubectl apply`. however, the gpu operator components are deployed through `ClusterResourceSet`, which uses `client.Patch()` instead of `kubectl apply`, so it doesn’t hit the annotation size limit issue.

**Which issue(s) this PR fixes**:
related : https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5176#issuecomment-3758454169

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
GPU-enabled cluster e2e test is now enabled after confirming ClusterResourceSet handles large ConfigMaps correctly
```
