### PR TITLE
✨ feat: add automated AMI detection workflow

### DIFF
--- a/.github/processed-k8s-versions.json
+++ b/.github/processed-k8s-versions.json
@@ -1,0 +1,3 @@
+{
+  "processed_versions": []
+}

--- a/.github/workflows/auto-ami-detection.yml
+++ b/.github/workflows/auto-ami-detection.yml
@@ -1,0 +1,148 @@
+name: Auto AMI Detection
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Run every 6 hours
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  check-releases:
+    runs-on: ubuntu-latest
+    outputs:
+      new_versions: ${{ steps.fetch-releases.outputs.new_versions }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch and Filter Releases
+        id: fetch-releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch releases from Kubernetes repo
+          releases=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/kubernetes/kubernetes/releases)
+          
+          # Check if we got valid JSON
+          if ! echo "$releases" | jq -e . >/dev/null 2>&1; then
+            echo "Error: Failed to fetch releases or invalid JSON"
+            exit 1
+          fi
+
+          # Filter for stable releases (no pre-release), get tag_name
+          # We only take the top 5 most recent stable releases to avoid processing too many at once
+          stable_releases=$(echo "$releases" | jq -r '.[] | select(.prerelease == false) | .tag_name' | head -n 5)
+          
+          # Read processed versions
+          if [ -f .github/processed-k8s-versions.json ]; then
+            processed=$(jq -r '.processed_versions[]' .github/processed-k8s-versions.json)
+          else
+            processed=""
+          fi
+          
+          new_versions=""
+          echo "### Release Detection Summary 🔍" >> $GITHUB_STEP_SUMMARY
+          
+          for version in $stable_releases; do
+            # Check if version is already processed
+            if echo "$processed" | grep -q "^$version$"; then
+               echo "- $version: Already processed" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "New version detected: $version"
+              new_versions="$new_versions $version"
+              echo "- **$version**: NEW - Will trigger build 🚀" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+          
+          # Clean up whitespace
+          new_versions=$(echo $new_versions | xargs)
+          
+          if [ -z "$new_versions" ]; then
+             echo "No new versions found." >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # Export to next step
+          echo "new_versions=$new_versions" >> $GITHUB_OUTPUT
+
+  trigger-builds:
+    needs: check-releases
+    if: needs.check-releases.outputs.new_versions != ''
+    runs-on: ubuntu-latest
+    environment: ami-production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Process New Versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSIONS: ${{ needs.check-releases.outputs.new_versions }}
+        run: |
+          # Configure git for committing the tracking file update
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          echo "### AMI Build Trigger Summary 🏗️" >> $GITHUB_STEP_SUMMARY
+          
+          for version in $NEW_VERSIONS; do
+            echo "Processing version: $version"
+            
+            # Run the script and capture output
+            script_output=$(./scripts/find-ami-publishing-inputs.sh "$version") || {
+                echo "Error converting version $version to inputs"
+                echo "- $version: ❌ Script Failed" >> $GITHUB_STEP_SUMMARY
+                continue
+            }
+            
+            # Parse variables
+            k8s_semver=$(echo "$script_output" | grep "K8s Semver" | awk -F ':' '{print $2}' | xargs)
+            k8s_series=$(echo "$script_output" | grep "K8s Release Series" | awk -F ':' '{print $2}' | xargs)
+            k8s_rpm=$(echo "$script_output" | grep "K8s RPM Package Version" | awk -F ':' '{print $2}' | xargs)
+            k8s_deb=$(echo "$script_output" | grep "K8s Deb Package Version" | awk -F ':' '{print $2}' | xargs)
+            cni_semver=$(echo "$script_output" | grep "CNI Semver" | awk -F ':' '{print $2}' | xargs)
+            cni_deb=$(echo "$script_output" | grep "CNI Deb Package Version" | awk -F ':' '{print $2}' | xargs)
+            crictl_ver=$(echo "$script_output" | grep "CRICTL Version" | awk -F ':' '{print $2}' | xargs)
+            
+            if [[ -z "$k8s_semver" || -z "$k8s_rpm" ]]; then
+               echo "Failed to parse inputs for $version. Skipping."
+               echo "- $version: ❌ Input Parsing Failed" >> $GITHUB_STEP_SUMMARY
+               continue
+            fi
+            
+            echo "Triggering build-and-publish-ami workflow for $version..."
+            
+            # Reduced regions list for cost optimization
+            # us-east-1, us-west-2, eu-west-1, ap-southeast-1
+            # We can expand this list later by updating this workflow file
+            COST_OPTIMIZED_REGIONS="us-east-1,us-west-2,eu-west-1,ap-southeast-1"
+            
+            # Trigger the workflow
+            gh workflow run build-ami.yml \
+              -f k8s_semver="$k8s_semver" \
+              -f k8s_series="$k8s_series" \
+              -f k8s_rpm_version="$k8s_rpm" \
+              -f k8s_deb_version="$k8s_deb" \
+              -f cni_semver="$cni_semver" \
+              -f cni_deb_version="$cni_deb" \
+              -f crictl_version="$crictl_ver" \
+              -f regions="$COST_OPTIMIZED_REGIONS"
+            
+            echo "- **$version**: Triggered ✅" >> $GITHUB_STEP_SUMMARY
+            
+            # Update tracking file
+            tmp=$(mktemp)
+            jq --arg v "$version" '.processed_versions += [$v]' .github/processed-k8s-versions.json > "$tmp" && mv "$tmp" .github/processed-k8s-versions.json
+            
+          done
+          
+          # Commit and push changes to tracking file
+          git add .github/processed-k8s-versions.json
+          git commit -m "Update processed K8s versions [skip ci]" || echo "No changes to commit"
+          git push

--- a/docs/book/src/development/amis.md
+++ b/docs/book/src/development/amis.md
@@ -4,6 +4,15 @@ Publishing new AMIs is done via manually invoking a GitHub Actions workflow.
 
 > NOTE: the plan is to ultimately fully automate the process in the future (see [this issue](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1982) for progress).
 
+## Automated Detection and Build
+
+A workflow `auto-ami-detection.yml` runs periodically (every 6 hours) to check for new stable Kubernetes releases.
+It compares found releases against `.github/processed-k8s-versions.json`.
+For any new release, it:
+1. Calculates the required build inputs using `scripts/find-ami-publishing-inputs.sh`.
+2. Triggers the `build-and-publish-ami` workflow.
+3. Updates `.github/processed-k8s-versions.json` to prevent duplicate builds.
+
 > NOTE: there are some issues with the RHEL based images at present.
 
 ## Get build inputs


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR introduces an automated workflow to detect new stable Kubernetes releases and trigger AMI builds for them. This replaces the manual process of constantly watching for new releases and manually triggering builds.

Key features:
- **New Workflow**: [.github/workflows/auto-ami-detection.yml](cci:7://file:///Users/krrishbiswas/Desktop/LFX/cluster-api-provider-aws/.github/workflows/auto-ami-detection.yml:0:0-0:0) runs every 6 hours.
- **State Tracking**: Uses [.github/processed-k8s-versions.json](cci:7://file:///Users/krrishbiswas/Desktop/LFX/cluster-api-provider-aws/.github/processed-k8s-versions.json:0:0-0:0) to prevent duplicate builds for the same version.
- **Safety**: 
  - Splits detection and triggering into separate jobs.
  - Requires **manual approval** via the `ami-production` GitHub Environment before triggering expensive builds.
  - Uses `concurrency` to prevent overlapping runs.
- **Cost Optimization**: Default configuration triggers builds for a reduced set of critical regions (`us-east-1`, `us-west-2`, `eu-west-1`, `ap-southeast-1`) to verify functionality before expanding.
- **Documentation**: Updated [docs/book/src/development/amis.md](cci:7://file:///Users/krrishbiswas/Desktop/LFX/cluster-api-provider-aws/docs/book/src/development/amis.md:0:0-0:0) with details on the new automation.

**Which issue(s) this PR fixes**:
Fixes #5837

**Special notes for your reviewer**:

- This workflow requires a GitHub Environment named `ami-production` to be configured in the repository settings with "Required reviewers" enabled.
- The workflow has `contents: write` permissions to update the tracking file and `actions: write` permissions to trigger the build workflow.

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
Action Required: Configure a GitHub Environment named `ami-production` with required reviewers to enable manual approval for the new automated AMI build trigger.
✨ Added automated workflow for detecting new Kubernetes releases and triggering AMI builds.