### PR TITLE
🌱 Replace static sleep with active polling for IAM access key propagation

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -902,10 +902,10 @@ func newUserAccessKey(ctx context.Context, cfg *aws.Config, userName string) *ia
 }
 
 // waitForAccessKeyPropagation actively polls AWS STS until the new access key
-// is recognized, replacing a static time.Sleep. IAM credentials are eventually
-// consistent, so a newly created key may not be immediately usable across all
-// AWS services. STS GetCallerIdentity is a lightweight call that validates the
-// credential without requiring any IAM permissions.
+// is recognized. IAM credentials are eventually consistent, so a newly created
+// key may not be immediately usable across all AWS services. STS GetCallerIdentity
+// is a lightweight call that validates the credential without requiring any IAM
+// permissions.
 func waitForAccessKeyPropagation(cfg *aws.Config) {
 	By("Waiting for access key to propagate via STS GetCallerIdentity...")
 	stsSvc := sts.NewFromConfig(*cfg)

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -901,6 +901,21 @@ func newUserAccessKey(ctx context.Context, cfg *aws.Config, userName string) *ia
 	}
 }
 
+// waitForAccessKeyPropagation actively polls AWS STS until the new access key
+// is recognized, replacing a static time.Sleep. IAM credentials are eventually
+// consistent, so a newly created key may not be immediately usable across all
+// AWS services. STS GetCallerIdentity is a lightweight call that validates the
+// credential without requiring any IAM permissions.
+func waitForAccessKeyPropagation(cfg *aws.Config) {
+	By("Waiting for access key to propagate via STS GetCallerIdentity...")
+	stsSvc := sts.NewFromConfig(*cfg)
+	Eventually(func() error {
+		_, err := stsSvc.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
+		return err
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "Access key should eventually be recognized by STS")
+	By("Access key propagated successfully")
+}
+
 func DumpCloudTrailEvents(e2eCtx *E2EContext) {
 	if e2eCtx.BootstrapUserAWSSession == nil {
 		Fail("Couldn't dump cloudtrail events: no AWS client was set up (please look at previous errors)")

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -158,8 +158,7 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 	e2eCtx.Environment.BootstrapAccessKey = newUserAccessKey(context.TODO(), e2eCtx.AWSSession, bootstrapTemplate.Spec.BootstrapUser.UserName)
 	e2eCtx.BootstrapUserAWSSession = NewAWSSessionWithKey(e2eCtx.Environment.BootstrapAccessKey)
 
-	By("Waiting for access key to propagate...")
-	time.Sleep(10 * time.Second)
+	waitForAccessKeyPropagation(e2eCtx.BootstrapUserAWSSession)
 
 	Expect(ensureTestImageUploaded(context.TODO(), e2eCtx)).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
This change replaces a hard-coded 10-second sleep with active polling using `sts:GetCallerIdentity` to verify iam access key propagation. this avoids intermittent e2e test failures caused by aws iam eventual consistency.


**Which issue(s) this PR fixes**:
Fixes #5551

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
