### PR TITLE
🌱 Bump AWS CCM to v1.32.5 and add variable for it in E2Es

### DIFF
--- a/templates/cluster-template-flatcar-machinepool.yaml
+++ b/templates/cluster-template-flatcar-machinepool.yaml
@@ -252,7 +252,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.3
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
                 - --cloud-provider=aws

--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -235,7 +235,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.3
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
                 - --cloud-provider=aws

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -199,7 +199,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.3
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
                 - --cloud-provider=aws

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -182,7 +182,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.3
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
                 - --cloud-provider=aws

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -190,6 +190,7 @@ variables:
   KUBERNETES_VERSION: "v1.32.0"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.32.0"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.31.0"
+  KUBERNETES_AWS_CCM_VERSION: "v1.32.5"
   CNI: "../../data/cni/calico.yaml"
   KUBETEST_CONFIGURATION: "../../data/kubetest/conformance.yaml"
   EVENT_BRIDGE_INSTANCE_STATE: "true"

--- a/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-nested-multitenancy-clusterclass.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-nested-multitenancy-clusterclass.yaml
@@ -160,9 +160,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -238,6 +241,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -274,6 +280,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-self-hosted-clusterclass.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-self-hosted-clusterclass.yaml
@@ -135,9 +135,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -213,6 +216,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -249,6 +255,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-topology.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-topology.yaml
@@ -131,9 +131,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -209,6 +212,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -245,6 +251,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-efs-support.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-efs-support.yaml
@@ -215,9 +215,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -293,6 +296,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -329,6 +335,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-external-cloud-provider.yaml
@@ -208,9 +208,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -286,6 +289,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -322,6 +328,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-gpu.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-gpu.yaml
@@ -217,9 +217,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -295,6 +298,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -331,6 +337,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ignition.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ignition.yaml
@@ -263,9 +263,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -341,6 +344,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -377,6 +383,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-internal-elb.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-internal-elb.yaml
@@ -241,9 +241,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -319,6 +322,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -355,6 +361,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-remediation.yaml
@@ -213,9 +213,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -291,6 +294,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -327,6 +333,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-kcp-scale-in.yaml
@@ -216,9 +216,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -294,6 +297,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -330,6 +336,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-limit-az.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-limit-az.yaml
@@ -213,9 +213,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -291,6 +294,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -327,6 +333,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-machine-pool.yaml
@@ -256,9 +256,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -334,6 +337,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -370,6 +376,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-md-remediation.yaml
@@ -215,9 +215,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -293,6 +296,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -329,6 +335,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-multi-az.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-multi-az.yaml
@@ -226,9 +226,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -304,6 +307,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -340,6 +346,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
@@ -226,9 +226,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -304,6 +307,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -340,6 +346,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-peered-remote.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-peered-remote.yaml
@@ -240,9 +240,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -318,6 +321,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -354,6 +360,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-remote-management-cluster.yaml
@@ -220,9 +220,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -298,6 +301,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -334,6 +340,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
@@ -216,9 +216,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -294,6 +297,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -330,6 +336,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-spot-instances.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-spot-instances.yaml
@@ -212,9 +212,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -290,6 +293,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -326,6 +332,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ssm.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-ssm.yaml
@@ -216,9 +216,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -294,6 +297,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -330,6 +336,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-external-cloud-provider.yaml
@@ -211,9 +211,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -289,6 +292,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -325,6 +331,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-main.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrade-to-main.yaml
@@ -210,9 +210,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -288,6 +291,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -324,6 +330,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-upgrades.yaml
@@ -210,9 +210,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -288,6 +291,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -324,6 +330,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template.yaml
@@ -210,9 +210,12 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager
-              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
               args:
                 - --v=2
+                - --cloud-provider=aws
+                - --use-service-account-credentials=true
+                - --configure-cloud-routes=false
               resources:
                 requests:
                   cpu: 200m
@@ -288,6 +291,9 @@ data:
           - serviceaccounts
         verbs:
           - create
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:
@@ -324,6 +330,12 @@ data:
           - list
           - watch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/addons/ccm/data/aws-ccm-external.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/addons/ccm/data/aws-ccm-external.yaml
@@ -46,9 +46,12 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager
-          image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+          image: registry.k8s.io/provider-aws/cloud-controller-manager:${KUBERNETES_AWS_CCM_VERSION:-v1.32.5}
           args:
             - --v=2
+            - --cloud-provider=aws
+            - --use-service-account-credentials=true
+            - --configure-cloud-routes=false
           resources:
             requests:
               cpu: 200m
@@ -124,6 +127,9 @@ rules:
       - serviceaccounts
     verbs:
       - create
+      - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -160,6 +166,12 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Stacked on top of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5894

**What type of PR is this?**

/kind support

**What this PR does / why we need it**:

Bump AWS CCM to v1.32.5 and add variable for it in E2Es

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
templates: bump AWS CCM to v1.32.5 and add variable to control it
```
