### PR TITLE
:bug: Validate GP3 volume throughput is within the documented range of 125-2000 MiB/s

### DIFF
--- a/api/v1beta2/awsmachine_webhook.go
+++ b/api/v1beta2/awsmachine_webhook.go
@@ -349,8 +349,9 @@ func (r *AWSMachine) validateRootVolume() field.ErrorList {
 		if r.Spec.RootVolume.Type != VolumeTypeGP3 {
 			allErrs = append(allErrs, field.Required(field.NewPath("spec.rootVolume.throughput"), "throughput is valid only for type 'gp3'"))
 		}
-		if *r.Spec.RootVolume.Throughput < 0 {
-			allErrs = append(allErrs, field.Required(field.NewPath("spec.rootVolume.throughput"), "throughput must be nonnegative"))
+		// See https://aws.amazon.com/ebs/general-purpose/ for gp3 limits
+		if *r.Spec.RootVolume.Throughput < 125 || *r.Spec.RootVolume.Throughput > 2000 {
+			allErrs = append(allErrs, field.Required(field.NewPath("spec.awsLaunchTemplate.rootVolume.throughput"), "throughput must be between 125 Mib/s and 2000 MiB/s"))
 		}
 	}
 

--- a/api/v1beta2/awsmachine_webhook_test.go
+++ b/api/v1beta2/awsmachine_webhook_test.go
@@ -71,7 +71,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "ensure root volume throughput is nonnegative",
+			name: "ensure root volume throughput is within range",
 			machine: &AWSMachine{
 				Spec: AWSMachineSpec{
 					RootVolume: &Volume{

--- a/exp/api/v1beta2/awsmachinepool_webhook.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook.go
@@ -79,8 +79,9 @@ func (r *AWSMachinePool) validateRootVolume() field.ErrorList {
 		if r.Spec.AWSLaunchTemplate.RootVolume.Type != infrav1.VolumeTypeGP3 {
 			allErrs = append(allErrs, field.Required(field.NewPath("spec.awsLaunchTemplate.rootVolume.throughput"), "throughput is valid only for type 'gp3'"))
 		}
-		if *r.Spec.AWSLaunchTemplate.RootVolume.Throughput < 0 {
-			allErrs = append(allErrs, field.Required(field.NewPath("spec.awsLaunchTemplate.rootVolume.throughput"), "throughput must be nonnegative"))
+		// See https://aws.amazon.com/ebs/general-purpose/ for gp3 limits
+		if *r.Spec.AWSLaunchTemplate.RootVolume.Throughput < 125 || *r.Spec.AWSLaunchTemplate.RootVolume.Throughput > 2000 {
+			allErrs = append(allErrs, field.Required(field.NewPath("spec.awsLaunchTemplate.rootVolume.throughput"), "throughput must be between 125 Mib/s and 2000 MiB/s"))
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
GP3 volumes support values from 125 to 2000 MiB/s.  Currently, only negative values are checked. This update validates the value is within the proper range. 

See https://aws.amazon.com/ebs/general-purpose/ for throughput limits. 

Documented in the SDK: https://github.com/aws/aws-sdk-go-v2/blob/f3f1e54552ce88d7fe213d1eaa28f363de5a9c6f/service/ec2/types/types.go#L4656

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [X] includes documentation
- [X] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Validate GP3 volume throughput is within the documented range of 125-2000 MiB/s
```
