### PR TITLE
🌱 Chore: Hardening Git Workflows

### DIFF
--- a/.github/workflows/build-ami-v2.yml
+++ b/.github/workflows/build-ami-v2.yml
@@ -61,6 +61,7 @@ jobs:
           repository: ${{ inputs.image_builder_repo }}
           ref: ${{ inputs.image_builder_version }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:

--- a/.github/workflows/build-ami-varsfile.yml
+++ b/.github/workflows/build-ami-varsfile.yml
@@ -38,6 +38,7 @@ jobs:
           repository: ${{ inputs.image_builder_repo }}
           ref: ${{ inputs.image_builder_version }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Create packer vars file
         if: inputs.packer_vars != ''
         env:

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -96,4 +96,3 @@ jobs:
       - name: Build AMI
         working-directory: ./images/capi
         run: PACKER_VAR_FILES=vars.json make build-ami-${{ matrix.target }}
-

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/md-link-checker.yml
+++ b/.github/workflows/md-link-checker.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: artyom/mdlinks@3d49483ce078798ed3aee5abc1c65476040654dd # v0.4.2
         with:
           dir: 'docs/book'

--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -2,7 +2,7 @@ name: PR golangci-lint
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 # Remove all permissions from GITHUB_TOKEN except metadata.
 permissions: {}
@@ -18,6 +18,8 @@ jobs:
           - ""
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # tag=v4.2.2
+        with:
+          persist-credentials: false
       - name: Calculate go version
         id: vars
         run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -1,8 +1,8 @@
 name: PR verify
 
 on:
-  pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   verify:
@@ -10,6 +10,8 @@ jobs:
     name: verify PR contents
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # tag=v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Check if PR title is valid
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it: 
Hardens the security of GitHub Actions workflows by:

 - Pinning all `actions/checkout` steps to full commit SHAs instead of mutable tags
 - Adding persist-credentials: false to all checkout steps that do not require git credentials after checkout
 - Adding explicit permissions: {} to workflows that require no token permissions
 - Fixing pull_request_target to pull_request in the PR verify workflow to prevent potential code execution with elevated privileges from fork PRs

Which issue(s) this PR fixes: 

Fixes #
1. The `dependabot` workflow intentionally keeps `persist-credentials: true` as it requires git credentials for the EndBug/add-and-commit step to push generated code back to the branch.

2. One critical fixe is to change the `pr-verify` workflow was changed from `pull_request_target` to `pull_request` as it does not require write permissions or access to secrets from the base repo.

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title  🌱
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```NONE```