### PR TITLE
🌱 Revert "🌱 test: enable clusterctl upgrade test (v1beta1→v1beta2)"

### DIFF
--- a/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
+++ b/test/e2e/suites/unmanaged/unmanaged_CAPI_test.go
@@ -113,7 +113,7 @@ var _ = ginkgo.Context("[unmanaged] [Cluster API Framework]", func() {
 		})
 	})
 
-	ginkgo.Describe("Clusterctl Upgrade Spec [from latest v1beta1 release to v1beta2]", func() {
+	ginkgo.PDescribe("Clusterctl Upgrade Spec [from latest v1beta1 release to v1beta2]", func() {
 		ginkgo.BeforeEach(func() {
 			if !e2eCtx.Settings.SkipQuotas {
 				// As the resources cannot be defined by the It() clause in CAPI tests, using the largest values required for all It() tests in this CAPI test.


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-aws#5843

The test has been disabled (made pending) back in v2.7.0 by @richardcase ([here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/commit/29e991bed569e5db4c1df19e4f82bd0dc25cf205)) because it stopped working if uncompatibility reasons.

> feat: update e2e test config and docs changes
This updates the kubernetes versions used in the e2e tests to use k8s
versions that we AMIs for. It also marks some of the old CSI tests as
pending and some upgrade tests as pending (which will be re-enabled
at a later time).

The original PR https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5843 straight re-enabled it without running the full e2e suite (`pull-cluster-api-provider-aws-e2e`) and not just the blocking one (`pull-cluster-api-provider-aws-e2e-blocking`), that didn't exercise this test anymore, and things started failing.

First failing PR: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-aws-e2e/2016244471020130304

### Evidence

Used to work before  kubernetes-sigs/cluster-api-provider-aws#5843 merged on (2026-01-27):
<img width="1015" height="471" alt="Screenshot 2026-03-07 at 10 07 29" src="https://github.com/user-attachments/assets/30117b36-57c7-4ecc-aa32-9fc5c043a70f" />

Stopped working after https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5843 merged on (2026-01-27):

<img width="1022" height="344" alt="Screenshot 2026-03-07 at 10 09 04" src="https://github.com/user-attachments/assets/77835b8f-0630-4544-8f07-4a903af862c6" />

