### PR TITLE
🌱 e2e: implement CAPI LogCollector to collect machine os logs in framework's e2e test

### DIFF
--- a/test/e2e/shared/cluster.go
+++ b/test/e2e/shared/cluster.go
@@ -54,7 +54,7 @@ func createClusterctlLocalRepository(e2eCtx *E2EContext, repositoryFolder string
 }
 
 // setupBootstrapCluster installs Cluster API components via clusterctl.
-func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme, useExistingCluster bool) (bootstrap.ClusterProvider, framework.ClusterProxy) {
+func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme, useExistingCluster bool, options ...framework.Option) (bootstrap.ClusterProvider, framework.ClusterProxy) {
 	var clusterProvider bootstrap.ClusterProvider
 	kubeconfigPath := ""
 	if !useExistingCluster {
@@ -70,7 +70,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 		Expect(kubeconfigPath).To(BeAnExistingFile(), "Failed to get the kubeconfig file for the bootstrap cluster")
 	}
 
-	clusterProxy := framework.NewClusterProxy("bootstrap", kubeconfigPath, scheme)
+	clusterProxy := framework.NewClusterProxy("bootstrap", kubeconfigPath, scheme, options...)
 	Expect(clusterProxy).ToNot(BeNil(), "Failed to get a bootstrap cluster proxy")
 
 	return clusterProvider, clusterProxy

--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -102,6 +102,52 @@ type AWSStackLogCollector struct {
 	E2EContext *E2EContext
 }
 
+// CollectMachineLog collects logs from a machine using AWS SSM.
+func (k AWSStackLogCollector) CollectMachineLog(ctx context.Context, managementClusterClient crclient.Client, m *clusterv1.Machine, outputPath string) error {
+	if k.E2EContext == nil {
+		return fmt.Errorf("E2EContext is nil, cannot collect machine logs")
+	}
+
+	awsMachine := &infrav1.AWSMachine{}
+	key := crclient.ObjectKey{
+		Namespace: m.Namespace,
+		Name:      m.Spec.InfrastructureRef.Name,
+	}
+	if err := managementClusterClient.Get(ctx, key, awsMachine); err != nil {
+		return fmt.Errorf("getting AWSMachine %s: %w", key, err)
+	}
+
+	if awsMachine.Spec.InstanceID == nil || *awsMachine.Spec.InstanceID == "" {
+		return fmt.Errorf("AWSMachine %s has no instance ID set", key)
+	}
+	instanceID := *awsMachine.Spec.InstanceID
+
+	if err := os.MkdirAll(outputPath, 0o750); err != nil {
+		return fmt.Errorf("creating directory %q: %w", outputPath, err)
+	}
+
+	metaLog := path.Join(outputPath, "instance.log")
+	f, err := os.OpenFile(metaLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("creating log file %q: %w", metaLog, err)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "instance found: instance-id=%q\n", instanceID)
+	commandsForMachine(ctx, k.E2EContext, f, instanceID, machineLogCommands())
+
+	if err := postProcessBase64LogData(outputPath, "pod-logs.log", "pod-logs.tar.gz"); err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to post-process pod-logs for machine %s: %v\n", m.Name, err)
+	}
+
+	return nil
+}
+
+// CollectMachinePoolLog collects logs from a machine pool.
+func (k AWSStackLogCollector) CollectMachinePoolLog(_ context.Context, _ crclient.Client, _ *clusterv1.MachinePool, _ string) error {
+	return nil
+}
+
 // CollectInfrastructureLogs collects log from the infrastructure.
 func (k AWSStackLogCollector) CollectInfrastructureLogs(_ context.Context, _ crclient.Client, _ *clusterv1.Cluster, _ string) error {
 	return nil
@@ -176,47 +222,43 @@ func DumpMachine(ctx context.Context, e2eCtx *E2EContext, machine infrav1.AWSMac
 	}
 	defer f.Close()
 	fmt.Fprintf(f, "instance found: instance-id=%q\n", instanceID)
-	commandsForMachine(
-		ctx,
-		e2eCtx,
-		f,
-		instanceID,
-		[]command{
-			{
-				title: "systemd",
-				cmd:   "journalctl --no-pager --output=short-precise | grep -v  'audit:\\|audit\\['",
-			},
-			{
-				title: "kern",
-				cmd:   "journalctl --no-pager --output=short-precise -k",
-			},
-			{
-				title: "containerd-info",
-				cmd:   "crictl info",
-			},
-			{
-				title: "cloud-final",
-				cmd:   "journalctl --no-pager -u cloud-final",
-			},
-			{
-				title: "kubelet",
-				cmd:   "journalctl --no-pager -u kubelet.service",
-			},
-			{
-				title: "containerd",
-				cmd:   "journalctl --no-pager -u containerd.service",
-			},
-			{
-				title: "pod-logs",
-				cmd:   "sudo tar -czf - -C /var/log pods | base64 -w0",
-			},
-		},
-	)
+	commandsForMachine(ctx, e2eCtx, f, instanceID, machineLogCommands())
 
-	// Post-process pod-logs to have a tar.gz file instead of base64 date encoded in the log file.
-	// Note: It is not possible to directly output the raw tar.gz data because something truncates it.
 	if err := postProcessBase64LogData(filepath.Dir(f.Name()), "pod-logs.log", "pod-logs.tar.gz"); err != nil {
 		fmt.Fprintf(GinkgoWriter, "Failed to post-process pod-logs: %v\n", err)
+	}
+}
+
+func machineLogCommands() []command {
+	return []command{
+		{
+			title: "systemd",
+			cmd:   "journalctl --no-pager --output=short-precise | grep -v  'audit:\\|audit\\['",
+		},
+		{
+			title: "kern",
+			cmd:   "journalctl --no-pager --output=short-precise -k",
+		},
+		{
+			title: "containerd-info",
+			cmd:   "crictl info",
+		},
+		{
+			title: "cloud-final",
+			cmd:   "journalctl --no-pager -u cloud-final",
+		},
+		{
+			title: "kubelet",
+			cmd:   "journalctl --no-pager -u kubelet.service",
+		},
+		{
+			title: "containerd",
+			cmd:   "journalctl --no-pager -u containerd.service",
+		},
+		{
+			title: "pod-logs",
+			cmd:   "sudo tar -czf - -C /var/log pods | base64 -w0",
+		},
 	}
 }
 

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -172,7 +172,10 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 	e2eCtx.Environment.ClusterctlConfigPath = createClusterctlLocalRepository(e2eCtx, filepath.Join(e2eCtx.Settings.ArtifactFolder, "repository"))
 
 	By("Setting up the bootstrap cluster")
-	e2eCtx.Environment.BootstrapClusterProvider, e2eCtx.Environment.BootstrapClusterProxy = setupBootstrapCluster(e2eCtx.E2EConfig, e2eCtx.Environment.Scheme, e2eCtx.Settings.UseExistingCluster)
+	e2eCtx.Environment.BootstrapClusterProvider, e2eCtx.Environment.BootstrapClusterProxy = setupBootstrapCluster(
+		e2eCtx.E2EConfig, e2eCtx.Environment.Scheme, e2eCtx.Settings.UseExistingCluster,
+		framework.WithMachineLogCollector(AWSStackLogCollector{E2EContext: e2eCtx}),
+	)
 
 	base64EncodedCredentials := encodeCredentials(e2eCtx.Environment.BootstrapAccessKey, bootstrapTemplate.Spec.Region)
 	SetEnvVar("AWS_B64ENCODED_CREDENTIALS", base64EncodedCredentials, true)
@@ -226,7 +229,9 @@ func AllNodesBeforeSuite(e2eCtx *E2EContext, data []byte) {
 	e2eCtx.Settings.ArtifactFolder = conf.ArtifactFolder
 	e2eCtx.Settings.ConfigPath = conf.ConfigPath
 	e2eCtx.Environment.ClusterctlConfigPath = conf.ClusterctlConfigPath
-	e2eCtx.Environment.BootstrapClusterProxy = framework.NewClusterProxy("bootstrap", conf.KubeconfigPath, e2eCtx.Environment.Scheme)
+	e2eCtx.Environment.BootstrapClusterProxy = framework.NewClusterProxy("bootstrap", conf.KubeconfigPath, e2eCtx.Environment.Scheme,
+		framework.WithMachineLogCollector(AWSStackLogCollector{E2EContext: e2eCtx}),
+	)
 	e2eCtx.E2EConfig = &conf.E2EConfig
 	e2eCtx.BootstrapUserAWSSession = NewAWSSessionWithKey(conf.BootstrapAccessKey)
 	e2eCtx.Settings.FileLock = flock.New(ResourceQuotaFilePath)


### PR DESCRIPTION
**What type of PR is this?**

/kind support

**What this PR does / why we need it**:

The CAPI framework's e2e test infrastructure supports collecting machine logs (cloud-init, kubelet, containerd, etc.) before cluster teardown via the ClusterLogCollector interface.

CAPA had its own polling-based DumpMachines mechanism, but never implemented the interface, so the ClusterProxy's logCollector was nil. This meant the CAPI framework tests (e.g. QuickStartSpec used in the PR-Blocking job) printed "log collector is nil" and skipped log collection entirely.

So this:
- Adds CollectMachineLog and CollectMachinePoolLog methods to AWSStackLogCollector, completing the ClusterLogCollector interface. CollectMachineLog looks up the AWSMachine to get the EC2 instance ID, then collects logs via SSM using the existing commandsForMachine logic.
- Passes the AWSStackLogCollector via WithMachineLogCollector when creating the ClusterProxy in both setupBootstrapCluster and AllNodesBeforeSuite.
- Extracts the shared command list into machineLogCommands() to avoid duplication between DumpMachine and CollectMachineLog.

#### Example:

An example of the new available logs in the CI artifacts that this PRs brings in, can be found here:

https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/5869/pull-cluster-api-provider-aws-e2e-blocking/2030734387036819456/artifacts/clusters/quick-start-bgu9ds/machines/quick-start-bgu9ds-control-plane-k57nl/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
