### PR TITLE
🌱 test(e2e): fix race between periodic resource dump and cluster deletion

### DIFF
--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -262,7 +262,12 @@ func AllNodesBeforeSuite(e2eCtx *E2EContext, data []byte) {
 				return
 			case <-e2eCtx.Environment.ResourceTicker.C:
 				for k := range e2eCtx.Environment.Namespaces {
-					DumpSpecResources(resourceCtx, e2eCtx, k)
+					// Warn instead of error when dumping resources fails due to a cluster being deleted.
+					if err := InterceptGomegaFailure(func() {
+						DumpSpecResources(resourceCtx, e2eCtx, k)
+					}); err != nil {
+						fmt.Fprintf(GinkgoWriter, "WARNING: periodic DumpSpecResources for namespace %q failed (can occur when a cluster is being deleted): %v\n", k.Name, err)
+					}
 				}
 			}
 		}
@@ -278,7 +283,12 @@ func AllNodesBeforeSuite(e2eCtx *E2EContext, data []byte) {
 				return
 			case <-e2eCtx.Environment.MachineTicker.C:
 				for k := range e2eCtx.Environment.Namespaces {
-					DumpMachines(machineCtx, e2eCtx, k)
+					// Warn instead of error when dumping machines fails due to a cluster being deleted.
+					if err := InterceptGomegaFailure(func() {
+						DumpMachines(machineCtx, e2eCtx, k)
+					}); err != nil {
+						fmt.Fprintf(GinkgoWriter, "WARNING: periodic DumpMachines for namespace %q failed (can occur when a cluster is being deleted): %v\n", k.Name, err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind flake


**What this PR does / why we need it**:

### Background

The e2e test suite starts background goroutines that call `DumpSpecResources()` and `DumpMachines()` every 5s and 60s respectively, to collect diagnostic data for all tracked namespaces.

`DumpSpecResources()` calls into the upstream CAPI test framework's `DumpAllResources -> DescribeAllCluster -> DescribeCluster` chain, which uses hard `Expect()` assertions internally.

### Issue

When a test deletes a cluster, there is a race window where the background goroutine fires mid-deletion: `DescribeAllCluster` lists clusters (still finds the one being deleted), then `DescribeCluster` tries to GET its details, but by then the Cluster CR (or its InfraCluster ref) has been fully removed.
The resulting "not found" error hits an Expect() that panics,
which GinkgoRecover propagates as a failure of the currently running test spec.

This is a known race that has been observed across multiple e2e jobs (e.g. `pull-cluster-api-provider-aws-e2e-eks`) and affects any test that performs manual cluster deletion while its namespace is still tracked in the periodic dump loop.

Prior investigation: https://kubernetes.slack.com/archives/CD6U2V71N/p1758795545213209

### Fix
Since the upstream CAPI framework `DescribeCluster` doesn't cover our use-case, fix this on the CAPA side by wrapping each `DumpSpecResources` and` DumpMachines` call with a deferred `recover()`.
This catches the Expect-induced panic before `GinkgoRecover` can propagate it, logs a warning with the namespace name for debuggability, and lets the goroutine continue to the next iteration.
The diagnostic dump is best-effort, so we can silently recover from transient not-found errors.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
