### PR TITLE
🌱 ci: bump image-builder to include MachinePool cloud-init fix

### DIFF
--- a/.github/workflows/build-ami-varsfile.yml
+++ b/.github/workflows/build-ami-varsfile.yml
@@ -6,7 +6,7 @@ on:
       image_builder_version:
         description: "Image builder version"
         required: true
-        default: 'v0.1.48'
+        default: '990737c79abb37fd56faca64f46e5a385dd1a982' # post-v0.1.48, includes fix https://github.com/kubernetes-sigs/image-builder/pull/1919
       target:
         description: "target os"
         required: true

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -6,7 +6,7 @@ on:
       image_builder_version:
         description: "Image builder version"
         required: true
-        default: 'v0.1.48'
+        default: '990737c79abb37fd56faca64f46e5a385dd1a982' # post-v0.1.48, includes fix https://github.com/kubernetes-sigs/image-builder/pull/1919
       regions:
         description: 'Publication regions'
         required: true


### PR DESCRIPTION

**What type of PR is this?**

/kind support


**What this PR does / why we need it**:

The v1.33/v1.34 CAPA AMIs were built with image-builder v0.1.48, which includes a custom cloud-init datasource (DataSourceEc2Kubernetes) that unconditionally reads from /etc/secret-userdata.txt. This file is only created by the SecretsManager boothook for individual Machine nodes (control plane, MachineDeployment), but not for MachinePool/ASG nodes where bootstrap data is passed directly as EC2 user-data. The missing file causes a FileNotFoundError, crashing cloud-init and preventing MachinePool worker nodes from joining the cluster.

Pin the image-builder version to commit 990737c (post-v0.1.48) which adds a graceful fallback: when /etc/secret-userdata.txt is absent, the datasource uses the original EC2 metadata user-data instead.

The affected AMIs (ubuntu v1.33.4 and v1.34.3) need to be rebuilt with this version for the fix to take effect.

Ref: https://github.com/kubernetes-sigs/image-builder/commit/990737c

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
