### PR TITLE
✨ ci: add input for customizable image builder repository in workflows

### DIFF
--- a/.github/workflows/build-ami-varsfile.yml
+++ b/.github/workflows/build-ami-varsfile.yml
@@ -3,6 +3,10 @@ name: build-and-publish-ami-with-vars
 on:
   workflow_dispatch:
     inputs:
+      image_builder_repo:
+        description: "Image builder repository (format: user/repo-name)"
+        required: true
+        default: 'kubernetes-sigs/image-builder'
       image_builder_version:
         description: "Image builder version"
         required: true
@@ -31,7 +35,7 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v5
         with:
-          repository: kubernetes-sigs/image-builder
+          repository: ${{ inputs.image_builder_repo }}
           ref: ${{ inputs.image_builder_version }}
           fetch-depth: 0
       - name: Create packer vars file

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -3,6 +3,10 @@ name: build-and-publish-ami
 on:
   workflow_dispatch:
     inputs:
+      image_builder_repo:
+        description: "Image builder repository (format: user/repo-name)"
+        required: true
+        default: 'kubernetes-sigs/image-builder'
       image_builder_version:
         description: "Image builder version"
         required: true
@@ -50,7 +54,7 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v5
         with:
-          repository: kubernetes-sigs/image-builder
+          repository: ${{ inputs.image_builder_repo }}
           ref: ${{ inputs.image_builder_version }}
           fetch-depth: 0
       - name: Configure AWS credentials


### PR DESCRIPTION
/kind support

This update introduces a new input parameter, `image_builder_repo`,
to the `build-ami` and `build-ami-varsfile` workflows, allowing users to specify the image builder repository.
The default value is set to 'kubernetes-sigs/image-builder'.
This change enhances flexibility in the CI/CD process allowing to use images build from forks for debugging purposes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
