### PR TITLE
:bug: Changed DHA to require hostAffinity to be host to prevent instance drift

### DIFF
--- a/examples/machine-with-dynamic-dedicated-host.yaml
+++ b/examples/machine-with-dynamic-dedicated-host.yaml
@@ -16,8 +16,11 @@ spec:
     Owner: "platform-team"
     CostCenter: "engineering"
 
-  # Dynamic dedicated host allocation configuration
+  # Dynamic dedicated host allocation (DHA) configuration
   # This will allocate a single dedicated host automatically
+  # DHA must have tenancy=host and hostAffinity=host
+  tenancy: "host"
+  hostAffinity: "host"
   dynamicHostAllocation:    
     # Tags to apply to the allocated dedicated host (optional)
     # These tags take precedence over additionalTags above

--- a/webhooks/awsmachine_webhook.go
+++ b/webhooks/awsmachine_webhook.go
@@ -506,6 +506,11 @@ func (w *AWSMachine) validateHostAllocation(r *infrav1.AWSMachine) field.ErrorLi
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when tenancy is 'host'"))
 	}
 
+	// DHA needs to have hostAffinity set to "host" to make sure it does not drift off its allocated host when the instance is restarted, otherwise there will be a host not in use still allocated.
+	if hasDynamicHostAllocation && (r.Spec.HostAffinity == nil || *r.Spec.HostAffinity != hostAffinity) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when hostAffinity is 'host'"))
+	}
+
 	return allErrs
 }
 

--- a/webhooks/awsmachine_webhook_test.go
+++ b/webhooks/awsmachine_webhook_test.go
@@ -539,7 +539,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "hostAffinity=default with dynamicHostAllocation is valid",
+			name: "hostAffinity=default with dynamicHostAllocation is invalid (DHA requires hostAffinity=host)",
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
@@ -550,7 +550,7 @@ func TestAWSMachineCreate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "hostAffinity omitted (=default) without hostID and dynamicHostAllocation is valid",
@@ -573,7 +573,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "hostAffinity omitted (=default) with dynamicHostAllocation is valid",
+			name: "hostAffinity omitted (=default) with dynamicHostAllocation is invalid (DHA requires hostAffinity=host)",
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",
@@ -583,7 +583,7 @@ func TestAWSMachineCreate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "hostAffinity=host with both hostID and dynamicHostAllocation is not valid (mutually exclusive)",
@@ -603,7 +603,7 @@ func TestAWSMachineCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "hostAffinity=default with both hostID and dynamicHostAllocation is not valid (mutually exclusive)",
+			name: "hostAffinity=default with both hostID and dynamicHostAllocation is not valid (mutually exclusive + DHA requires hostAffinity=host)",
 			machine: &infrav1.AWSMachine{
 				Spec: infrav1.AWSMachineSpec{
 					InstanceType: "test",

--- a/webhooks/awsmachinetemplate_webhook.go
+++ b/webhooks/awsmachinetemplate_webhook.go
@@ -204,6 +204,11 @@ func (w *AWSMachineTemplate) validateHostAllocation(r *infrav1.AWSMachineTemplat
 		allErrs = append(allErrs, field.Required(field.NewPath("spec.template.spec.hostID"), "hostID or dynamicHostAllocation must be set when hostAffinity is 'host'"))
 	}
 
+	// DHA needs to have hostAffinity set to "host" to make sure it does not drift off its allocated host when the instance is restarted, otherwise there will be a host not in use still allocated.
+	if hasDynamicHostAllocation && (spec.HostAffinity == nil || *spec.HostAffinity != hostAffinity) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.template.spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when hostAffinity is 'host'"))
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently if you use dynamic host allocation (DHA) to create an awsmachine and allocate a host, the instance can drift off that host if it is configured with anything but `hostAffinity=host`.  This PR is intended to make sure we require `hostAffinity=host` when configuring DHA

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [X] squashed commits
- [ ] includes documentation
- [X] includes emoji in title 
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Changed DHA behavior to require awsmachine to be configured with `hostAffinity=host`
```
