### PR TITLE
🌱 test(e2e): increase rootVolume size to avoid disk pressure

### DIFF
--- a/test/e2e/data/infrastructure-aws/capi-upgrades/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-aws/capi-upgrades/v1beta1/cluster-template.yaml
@@ -67,6 +67,8 @@ spec:
       iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
       sshKeyName: ${AWS_SSH_KEY_NAME}
+      rootVolume:
+        size: 10
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -101,6 +103,8 @@ spec:
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ${AWS_NODE_MACHINE_TYPE}
       sshKeyName: ${AWS_SSH_KEY_NAME}
+      rootVolume:
+        size: 10
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-aws/withclusterclass/clusterclassbase/clusterclass-ci-default.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/clusterclassbase/clusterclass-ci-default.yaml
@@ -311,6 +311,8 @@ spec:
       instanceType: REPLACEME
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
       cloudInit: {}
+      rootVolume:
+        size: 10
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
@@ -323,6 +325,8 @@ spec:
       instanceType: REPLACEME
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       cloudInit: {}
+      rootVolume:
+        size: 10
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-aws/withclusterclass/clusterclassbase/clusterclass-multi-tenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/clusterclassbase/clusterclass-multi-tenancy.yaml
@@ -185,6 +185,8 @@ spec:
       # instanceType is a required field (OpenAPI schema).
       instanceType: REPLACEME
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+      rootVolume:
+        size: 10
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
@@ -196,6 +198,8 @@ spec:
       # instanceType is a required field (OpenAPI schema).
       instanceType: REPLACEME
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
+      rootVolume:
+        size: 10
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/clusterclass-multi-tenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/clusterclass-multi-tenancy.yaml
@@ -188,6 +188,8 @@ spec:
       # instanceType is a required field (OpenAPI schema).
       instanceType: REPLACEME
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+      rootVolume:
+        size: 10
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
@@ -199,6 +201,8 @@ spec:
       # instanceType is a required field (OpenAPI schema).
       instanceType: REPLACEME
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
+      rootVolume:
+        size: 10
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/topology/clusterclass-ci-default.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/topology/clusterclass-ci-default.yaml
@@ -314,6 +314,8 @@ spec:
       instanceType: REPLACEME
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
       cloudInit: {}
+      rootVolume:
+        size: 10
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
@@ -326,6 +328,8 @@ spec:
       instanceType: REPLACEME
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       cloudInit: {}
+      rootVolume:
+        size: 10
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/base/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/base/cluster-template.yaml
@@ -65,3 +65,5 @@ spec:
       instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
+      rootVolume:
+        size: 10

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/dedicated-host/dedicated-host-resource-set.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/dedicated-host/dedicated-host-resource-set.yaml
@@ -32,6 +32,8 @@ spec:
       instanceType: "${AWS_NODE_MACHINE_TYPE}"
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
+      rootVolume:
+        size: 10
       hostID: "${HOST_ID}"
       hostAffinity: "${HOST_AFFINITY}"
 ---

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/default/machine-deployment.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/default/machine-deployment.yaml
@@ -32,6 +32,8 @@ spec:
       instanceType: "${AWS_NODE_MACHINE_TYPE}"
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
+      rootVolume:
+        size: 10
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/intree-cloud-provider/machine-deployment.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/intree-cloud-provider/machine-deployment.yaml
@@ -32,6 +32,8 @@ spec:
       instanceType: "${AWS_NODE_MACHINE_TYPE}"
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
+      rootVolume:
+        size: 10
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/kustomization.yaml
@@ -2,4 +2,3 @@ resources:
   - ../limit-az
 patchesStrategicMerge:
   - patches/image-injection.yaml
-  - patches/root-volume-size.yaml

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/patches/root-volume-size.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/remote-management-cluster/patches/root-volume-size.yaml
@@ -1,9 +1,0 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-kind: AWSMachineTemplate
-metadata:
-  name: ${CLUSTER_NAME}-control-plane
-spec:
-  template:
-    spec:
-      rootVolume:
-        size: 10

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/upgrade-to-main/machinetemplates.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/upgrade-to-main/machinetemplates.yaml
@@ -11,6 +11,8 @@ spec:
       instanceType: "${AWS_CONTROL_PLANE_MACHINE_TYPE}"
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
+      rootVolume:
+        size: 10
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
@@ -24,3 +26,5 @@ spec:
       instanceType: "${AWS_NODE_MACHINE_TYPE}"
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       sshKeyName: "${AWS_SSH_KEY_NAME}"
+      rootVolume:
+        size: 10


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Switching to external cloud provider adds ~173 MiB of additional container images (CCM, EBS CSI driver + 5 sidecars). Combined with the Calico v3.31.4 bump this pushed the 8 GiB volume past the breaking point for nodes.

Increased the volumes to 10GiB to have enough space, as it was patched for remote management clusters, which has been removed as redundant.

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:
```release-note
None
```