### PR TITLE
🐛 Fix nil pointer panic in ROSARoleConfig when AWS client initialization fails

### DIFF
--- a/exp/controllers/rosaroleconfig_controller.go
+++ b/exp/controllers/rosaroleconfig_controller.go
@@ -463,20 +463,28 @@ func (r *ROSARoleConfigReconciler) setUpRuntime(ctx context.Context, scope *scop
 		return fmt.Errorf("failed to create OCM client: %w", err)
 	}
 
-	r.Runtime = rosacli.NewRuntime()
-	r.Runtime.OCMClient = ocmClient
-	r.Runtime.Reporter = reporter.CreateReporter() // &rosa.Reporter{}
-	r.Runtime.Logger = rosalogging.NewLogger()
+	runtime := rosacli.NewRuntime()
+	runtime.OCMClient = ocmClient
+	runtime.Reporter = reporter.CreateReporter() // &rosa.Reporter{}
+	runtime.Logger = rosalogging.NewLogger()
 
-	r.Runtime.AWSClient, err = aws.NewClient().Logger(r.Runtime.Logger).Build()
+	session := scope.Session()
+	awsClient, err := aws.NewClient().
+		Logger(runtime.Logger).
+		ExternalConfig(&session).
+		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create aws client: %w", err)
 	}
+	runtime.AWSClient = awsClient
 
-	r.Runtime.Creator, err = r.Runtime.AWSClient.GetCreator()
+	creator, err := awsClient.GetCreator()
 	if err != nil {
 		return fmt.Errorf("failed to get creator: %w", err)
 	}
+	runtime.Creator = creator
 
+	// atomic assignment - only when fully initialized
+	r.Runtime = runtime
 	return nil
 }

--- a/exp/controllers/rosaroleconfig_controller_test.go
+++ b/exp/controllers/rosaroleconfig_controller_test.go
@@ -46,6 +46,8 @@ import (
 
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 )
 
@@ -628,6 +630,196 @@ func TestROSARoleConfigReconcileExist(t *testing.T) {
 		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionTrue))
 		g.Expect(readyCondition.Reason).To(Equal(expinfrav1.RosaRoleConfigCreatedReason))
 	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
+func TestROSARoleConfigSetUpRuntimeWithExpiredAWSCredentials(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	// Create a miniaml scope for testing
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("test-ns-%s", generateTestID()),
+		},
+	}
+	createObject(g, ns, "")
+	defer cleanupObject(g, ns)
+
+	rosaRoleConfig := &expinfrav1.ROSARoleConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role-config",
+			Namespace: ns.Namespace,
+		},
+		Spec: expinfrav1.ROSARoleConfigSpec{
+			AccountRoleConfig: expinfrav1.AccountRoleConfig{
+				Prefix:  "test",
+				Version: "4.15.0",
+			},
+			OperatorRoleConfig: expinfrav1.OperatorRoleConfig{
+				Prefix: "test",
+			},
+			OidcProviderType: expinfrav1.Managed,
+		},
+	}
+	createObject(g, rosaRoleConfig, ns.Name)
+	defer cleanupObject(g, rosaRoleConfig)
+
+	scope, err := scope.NewRosaRoleConfigScope(scope.RosaRoleConfigScopeParams{
+		Client:         testEnv.Client,
+		RosaRoleConfig: rosaRoleConfig,
+		ControllerName: "rosaroleconfig",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ssoServer := ocmsdk.MakeTCPServer()
+	apiServer := ocmsdk.MakeTCPServer()
+	defer ssoServer.Close()
+	defer apiServer.Close()
+
+	accessToken := ocmsdk.MakeTokenString("Bearer", 15*time.Minute)
+	ssoServer.AppendHandlers(ocmsdk.RespondWithAccessToken(accessToken))
+
+	logger, err := ocmlogging.NewGoLoggerBuilder().Debug(false).Build()
+	Expect(err).ToNot(HaveOccurred())
+	connection, err := sdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(accessToken).
+		URL(apiServer.URL()).
+		Build()
+	Expect(err).To(BeNil())
+
+	ocmClient := ocm.NewClientWithConnection(connection)
+
+	// Track NewOCMClient call count to verify retry behavior
+	ocmClientCallCount := 0
+
+	reconciler := &ROSARoleConfigReconciler{
+		Client: testEnv.Client,
+		NewOCMClient: func(ctx context.Context, scope rosa.OCMSecretsRetriever) (rosa.OCMClient, error) {
+			ocmClientCallCount++
+			return ocmClient, nil
+		},
+		Runtime: nil, // Start with nil Runtime
+	}
+
+	// AWS credentials are not set by default in the test env
+
+	// ==================== FIRST RECONCILIATION ====================
+	t.Log("First reconciliation: AWS credentials are missing/expired")
+
+	err = reconciler.setUpRuntime(ctx, scope)
+
+	g.Expect(err).To(HaveOccurred(),
+		"setUpRuntime should return error when AWS client creation fails")
+	g.Expect(err.Error()).To(ContainSubstring("failed to create aws client"),
+		"Error should indicate AWS client failure")
+
+	g.Expect(reconciler.Runtime).To(BeNil(),
+		"Runtime MUST be nil after failed initialization (atomic assignment fix)")
+
+	g.Expect(ocmClientCallCount).To(Equal(1),
+		"NewOCMClient should be called once on first attempt")
+
+	// ==================== SECOND RECONCILIATION ====================
+	t.Log("Second reconciliation: Retry with still-missing AWS credentials")
+
+	err = reconciler.setUpRuntime(ctx, scope)
+
+	g.Expect(err).To(HaveOccurred(),
+		"setUpRuntime should still fail with missing AWS credentials")
+
+	g.Expect(reconciler.Runtime).To(BeNil(),
+		"Runtime should still be nil after second failed attempt")
+
+	// NewOCMClient was called AGAIN (proves no early return)
+	g.Expect(ocmClientCallCount).To(Equal(2),
+		"NewOCMClient should be called twice - proves guard clause allows retry when Runtime is nil")
+}
+
+// TestSetUpRuntimeIdempotency verifies that setUpRuntime returns early
+// when Runtime is already fully initialized.
+func TestROSARoleConfigSetUpRuntimeIdempotency(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+
+	ssoServer := ocmsdk.MakeTCPServer()
+	apiServer := ocmsdk.MakeTCPServer()
+	defer ssoServer.Close()
+	defer apiServer.Close()
+
+	accessToken := ocmsdk.MakeTokenString("Bearer", 15*time.Minute)
+	ssoServer.AppendHandlers(ocmsdk.RespondWithAccessToken(accessToken))
+
+	logger, err := ocmlogging.NewGoLoggerBuilder().Debug(false).Build()
+	Expect(err).ToNot(HaveOccurred())
+	connection, err := sdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(accessToken).
+		URL(apiServer.URL()).
+		Build()
+	Expect(err).To(BeNil())
+
+	ocmClient := ocm.NewClientWithConnection(connection)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockIamClient := rosaMocks.NewMockIamApiClient(mockCtrl)
+	mockSTSClient := rosaMocks.NewMockStsApiClient(mockCtrl)
+
+	awsClient := aws.New(
+		awsSdk.Config{},
+		aws.NewLoggerWrapper(logrus.New(), nil),
+		mockIamClient,
+		rosaMocks.NewMockEc2ApiClient(mockCtrl),
+		rosaMocks.NewMockOrganizationsApiClient(mockCtrl),
+		rosaMocks.NewMockS3ApiClient(mockCtrl),
+		rosaMocks.NewMockSecretsManagerApiClient(mockCtrl),
+		mockSTSClient,
+		rosaMocks.NewMockCloudFormationApiClient(mockCtrl),
+		rosaMocks.NewMockServiceQuotasApiClient(mockCtrl),
+		rosaMocks.NewMockServiceQuotasApiClient(mockCtrl),
+		&aws.AccessKey{},
+		false,
+	)
+
+	runtime := rosacli.NewRuntime()
+	runtime.OCMClient = ocmClient
+	runtime.AWSClient = awsClient
+	runtime.Creator = &aws.Creator{
+		ARN:       "arn:aws:iam:123456789012:user/test",
+		AccountID: "123456789012",
+		IsSTS:     false,
+	}
+
+	callCount := 0
+	reconciler := &ROSARoleConfigReconciler{
+		Runtime: runtime, // already initialized
+		NewOCMClient: func(ctx context.Context, scope rosa.OCMSecretsRetriever) (rosa.OCMClient, error) {
+			callCount++
+			return ocmClient, nil
+		},
+	}
+
+	scope := &scope.RosaRoleConfigScope{}
+
+	// Call setUpRuntime - should return early
+	err = reconciler.setUpRuntime(ctx, scope)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Runtime should be unchanged (same instance)
+	g.Expect(reconciler.Runtime).To(BeIdenticalTo(runtime),
+		"Runtime should not be recreated when already initialized")
+
+	// NewOCMClient should NOT be called (early return)
+	g.Expect(callCount).To(Equal(0),
+		"NewOCMClient should not be called when Runtime already exists")
+
+	// Call again - should still return early
+	err = reconciler.setUpRuntime(ctx, scope)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(callCount).To(Equal(0), "Still should not call NewOCMClient")
 }
 
 func TestROSARoleConfigReconcileDelete(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->

  **What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:

  Fixes a nil pointer dereference bug in `ROSARoleConfigReconciler.setUpRuntime()` that occurs when AWS client initialization fails (e.g., expired credentials). This addresses the
crash reported in #5860 where the controller would panic when accessing `r.Runtime.AWSClient`.

  **Root cause:** The original code created `r.Runtime` before all components were successfully initialized. When AWS client creation failed, `r.Runtime` existed but `r.Runtime.AWSClient` was nil (partial initialization). On retry, the guard clause `if r.Runtime != nil` returned early, preventing re-initialization. Later code accessing `r.Runtime.AWSClient` would panic.

  **Fix:**
  1. **Atomic assignment pattern**: Build `Runtime` in a local variable; only assign to `r.Runtime` after ALL components (`OCMClient`, `AWSClient`, `Creator`) succeed. On error, the local variable is discarded
  and `r.Runtime` remains nil, allowing retry on next reconciliation.
  2. **Session configuration**: Added `.ExternalConfig(&session)` to `aws.NewClient()` to properly configure AWS region and credentials from scope, matching the pattern used in `rosanetwork_controller.go`.

  **Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
  Fixes #5860

  **Special notes for your reviewer**:

  This fix follows the same atomic assignment pattern already used in `exp/controllers/rosanetwork_controller.go` (lines 90-101) for consistency across ROSA controllers.

  **Testing performed:**
  - **Integration test** (`TestROSARoleConfigSetUpRuntimeWithExpiredAWSCredentials`): Validates atomic assignment prevents partial initialization by simulating credential failures
  - **Manual validation**: Built and deployed patched controller to kind cluster (v1.35.0) with expired AWS STS credentials:
    - ✅ No panics with expired credentials (previously panicked)
    - ✅ Graceful error handling with clear error messages
    - ✅ Automatic recovery after credential refresh (no pod restart required)
    - ✅ Controller remained healthy and continued reconciling other resources

  **Checklist**:

  - [ ] squashed commits
  - [ ] includes documentation
  - [ ] includes AI generated content
  - [x] includes emoji in title
  - [x] adds unit tests
  - [ ] adds or updates e2e tests

  **Release note**:

  ```release-note
   Fixed nil pointer panic in ROSARoleConfig controller when AWS client initialization failed due to expired credentials or missing region configuration.
```