### PR TITLE
🌱 gitignore: add CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ dist
 _artifacts
 awsiamconfiguration.yaml
 cloudformation.yaml
+
+# local Claude Code instructions
+CLAUDE.local.md


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Add `CLAUDE.local.md` to `.gitignore` so that developers can add their own additional instructions and prevent accidental commits of local Claude Code instructions.

`CLAUDE.local.md` is a user-local override file loaded by Claude Code but intentionally excluded from version control.
See: https://code.claude.com/docs/en/memory#how-claude-md-files-load

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**AI Usage**:

Claude Code

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
NONE
```
