### PR TITLE
🌱 chore: update github workflows to use sha hashes

### DIFF
--- a/.github/workflows/build-ami-varsfile.yml
+++ b/.github/workflows/build-ami-varsfile.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: ${{ inputs.image_builder_repo }}
           ref: ${{ inputs.image_builder_version }}
@@ -46,7 +46,7 @@ jobs:
           echo "$PACKER_VARS" | jq -r > ./images/capi/vars.json
           cat ./images/capi/vars.json
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::819546954734:role/gh-image-builder

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: ${{ inputs.image_builder_repo }}
           ref: ${{ inputs.image_builder_version }}
           fetch-depth: 0
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::819546954734:role/gh-image-builder

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,18 +21,18 @@ jobs:
         language: [ 'go' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         languages: ${{ matrix.language }}
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.24'
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v5
-    - uses: actions/cache@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       name: Restore go cache
       with:
         path: |
@@ -42,7 +42,7 @@ jobs:
       run: make modules
     - name: Update generated code
       run: make generate
-    - uses: EndBug/add-and-commit@v9
+    - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
       name: Commit changes
       with:
         author_name: dependabot[bot]

--- a/.github/workflows/md-link-checker.yml
+++ b/.github/workflows/md-link-checker.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: artyom/mdlinks@v0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: artyom/mdlinks@9528aa17663c803d885a1a5d0931d28b221f57bd # v0.2.0
         with:
           dir: 'docs/book'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.24'
       - name: Set version info

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ matrix.branch }}
       - name: Setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: '${{ github.workspace }}/go.mod'
       - name: Run verify container script


### PR DESCRIPTION
**What type of PR is this?**

/kind support

**What this PR does / why we need it**:

Update the CAPA workflows so that each action uses the SHA hash in addition to the version number as per the Kubernetes [GitHub Actions Security policy](https://github.com/kubernetes/community/blob/main/github-management/github-actions-policy.md).

When doing the v2.11.0 release we ran into this problem: https://github.com/kubernetes-sigs/cluster-api-provider-aws/actions/runs/24525514369

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

None

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Update GitHub Actions to use SHA hashes
```
