### PR TITLE
🐛fix: return actual error from NAT gateway creation failures

### DIFF
--- a/pkg/cloud/services/network/natgateways.go
+++ b/pkg/cloud/services/network/natgateways.go
@@ -255,11 +255,13 @@ func (s *Service) getNatGatewayTagParams(id string) infrav1.BuildParams {
 	}
 }
 
-func (s *Service) createNatGateways(subnetIDs []string) (natgateways []*types.NatGateway, err error) {
+func (s *Service) createNatGateways(subnetIDs []string) ([]*types.NatGateway, error) {
 	eips, err := s.getOrAllocateAddresses(len(subnetIDs), infrav1.CommonRoleTagValue, s.scope.VPC().GetElasticIPPool())
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create one or more IP addresses for NAT gateways")
 	}
+
+	natgateways := make([]*types.NatGateway, 0, len(subnetIDs))
 	type ngwCreation struct {
 		natGateway *types.NatGateway
 		error      error
@@ -276,7 +278,7 @@ func (s *Service) createNatGateways(subnetIDs []string) (natgateways []*types.Na
 	for range subnetIDs {
 		ngwResult := <-c
 		if ngwResult.error != nil {
-			return nil, err
+			return nil, ngwResult.error
 		}
 		natgateways = append(natgateways, ngwResult.natGateway)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In `createNatGateways()`, when a goroutine fails to create a NAT gateway, the error handling at line 279 incorrectly returns the outer `err` variable (which is `nil`) instead of `ngwResult.error` from the failed goroutine.

This causes NAT gateway creation failures to be silently ignored, allowing reconciliation to continue with incomplete state. Fix by returning the actual error from the goroutine result.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

Fixes #5961 

**Special notes for your reviewer**:

N/A

**AI Usage**:

`claude-sonnet-4-5` assisted in tracing symptoms to the code block. Additionally, it is used to fine tune the PR description, commit message and release note.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content (PR description, commit message and release note)
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fixed silent NAT gateway creation failures by correcting error propagation in concurrent NAT gateway creation goroutines.
```