### PR TITLE
🐛 fix: grandfather hostAffinity validation on AWSMachine updates

### DIFF
--- a/webhooks/awsmachine_webhook.go
+++ b/webhooks/awsmachine_webhook.go
@@ -112,10 +112,15 @@ func (w *AWSMachine) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.
 
 	var allErrs field.ErrorList
 
+	old, ok := oldObj.(*infrav1.AWSMachine)
+	if !ok {
+		return nil, fmt.Errorf("expected an AWSMachine object but got %T", oldObj)
+	}
+
 	allErrs = append(allErrs, w.validateCloudInitSecret(r)...)
 	allErrs = append(allErrs, w.validateAdditionalSecurityGroups(r)...)
 	allErrs = append(allErrs, r.Spec.AdditionalTags.Validate()...)
-	allErrs = append(allErrs, w.validateHostAllocation(r)...)
+	allErrs = append(allErrs, w.validateHostAllocationUpdate(old, r)...)
 
 	newAWSMachineSpec := newAWSMachine["spec"].(map[string]interface{})
 	oldAWSMachineSpec := oldAWSMachine["spec"].(map[string]interface{})
@@ -508,6 +513,66 @@ func (w *AWSMachine) validateHostAllocation(r *infrav1.AWSMachine) field.ErrorLi
 
 	// DHA needs to have hostAffinity set to "host" to make sure it does not drift off its allocated host when the instance is restarted, otherwise there will be a host not in use still allocated.
 	if hasDynamicHostAllocation && (r.Spec.HostAffinity == nil || *r.Spec.HostAffinity != hostAffinity) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when hostAffinity is 'host'"))
+	}
+
+	return allErrs
+}
+
+// validateHostAllocationUpdate runs the same checks as validateHostAllocation but
+// grandfathers the hostAffinity vs tenancy check for pre-existing invalid objects.
+//
+// Background: PR #5631 (v2.10.0) introduced the hostAffinity field with a default
+// of "host". PR #5801 (v2.10.1) corrected the default to "default". PR #5825 and
+// its cherry-pick PR #5871 (v2.10.2) then added webhook validation requiring
+// tenancy="host" when hostAffinity="host".
+//
+// This created a backward-compatibility issue: AWSMachines created under v2.10.0
+// were defaulted to hostAffinity="host" even when not using dedicated hosts
+// (tenancy != "host"). After upgrading to v2.10.2+ or v2.11.0+, those objects
+// fail the new validation on any update, effectively becoming unmodifiable.
+//
+// This function solves the problem by skipping the hostAffinity vs tenancy check
+// on update when the old object already had the same invalid combination, so when
+// the invalid state was inherited, not newly introduced. All other host allocation
+// validations remain fully enforced on update.
+func (w *AWSMachine) validateHostAllocationUpdate(oldMachine, newMachine *infrav1.AWSMachine) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Check if both hostID and dynamicHostAllocation are specified.
+	hasHostID := newMachine.Spec.HostID != nil && len(*newMachine.Spec.HostID) > 0
+	hasDynamicHostAllocation := newMachine.Spec.DynamicHostAllocation != nil
+
+	// If both hostID and dynamicHostAllocation are specified, return an error.
+	if hasHostID && hasDynamicHostAllocation {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.hostID"), "hostID and dynamicHostAllocation are mutually exclusive"), field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "hostID and dynamicHostAllocation are mutually exclusive"))
+	}
+
+	// HostID, HostAffinity, and DynamicHostAllocation can only be set when Tenancy is "host".
+	if hasHostID && newMachine.Spec.Tenancy != hostTenancy {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.hostID"), "hostID can only be set when tenancy is 'host'"))
+	}
+
+	// Grandfather the hostAffinity vs tenancy check: if the old object already carried
+	// hostAffinity="host" without tenancy="host" (the v2.10.0 default combination),
+	// allow the update to proceed without rejecting it. This only applies when the new
+	// object preserves the same pre-existing invalid state, it does not allow a user to
+	// newly introduce this combination on update (that is still rejected).
+	if newMachine.Spec.HostAffinity != nil && *newMachine.Spec.HostAffinity == hostAffinity && newMachine.Spec.Tenancy != hostTenancy {
+		oldHadSameInvalidCombo := oldMachine.Spec.HostAffinity != nil && *oldMachine.Spec.HostAffinity == hostAffinity && oldMachine.Spec.Tenancy != hostTenancy
+		if !oldHadSameInvalidCombo {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.hostAffinity"), "hostAffinity can only be set to 'host' when tenancy is 'host'"))
+		}
+	}
+
+	if hasDynamicHostAllocation && newMachine.Spec.Tenancy != hostTenancy {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when tenancy is 'host'"))
+	}
+
+	// DHA needs to have hostAffinity set to "host" to make sure it does not drift off
+	// its allocated host when the instance is restarted, otherwise there will be a host
+	// not in use still allocated.
+	if hasDynamicHostAllocation && (newMachine.Spec.HostAffinity == nil || *newMachine.Spec.HostAffinity != hostAffinity) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.dynamicHostAllocation"), "dynamicHostAllocation can only be set when hostAffinity is 'host'"))
 	}
 

--- a/webhooks/awsmachine_webhook_test.go
+++ b/webhooks/awsmachine_webhook_test.go
@@ -856,6 +856,141 @@ func TestAWSMachineUpdate(t *testing.T) {
 	}
 }
 
+func TestValidateHostAllocationUpdate(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldMachine *infrav1.AWSMachine
+		newMachine *infrav1.AWSMachine
+		wantErr    bool
+	}{
+		{
+			name: "grandfathered: old and new both have hostAffinity=host without tenancy=host",
+			oldMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					HostAffinity: ptr.To("host"),
+				},
+			},
+			newMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					HostAffinity: ptr.To("host"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "not grandfathered: old has hostAffinity=default, new has hostAffinity=host without tenancy=host",
+			oldMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					HostAffinity: ptr.To("default"),
+				},
+			},
+			newMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					HostAffinity: ptr.To("host"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "not grandfathered: old has no hostAffinity, new has hostAffinity=host without tenancy=host",
+			oldMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+				},
+			},
+			newMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					HostAffinity: ptr.To("host"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid: hostAffinity=host with tenancy=host still passes",
+			oldMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					Tenancy:      "host",
+					HostAffinity: ptr.To("host"),
+				},
+			},
+			newMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					Tenancy:      "host",
+					HostAffinity: ptr.To("host"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "hostID and dynamicHostAllocation mutually exclusive still enforced on update",
+			oldMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					Tenancy:      "host",
+					HostAffinity: ptr.To("host"),
+					HostID:       ptr.To("h-09dcf61cb388b0149"),
+					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
+						Tags: map[string]string{"env": "test"},
+					},
+				},
+			},
+			newMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					Tenancy:      "host",
+					HostAffinity: ptr.To("host"),
+					HostID:       ptr.To("h-09dcf61cb388b0149"),
+					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
+						Tags: map[string]string{"env": "test"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dynamicHostAllocation without tenancy=host still enforced on update",
+			oldMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					HostAffinity: ptr.To("host"),
+					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
+						Tags: map[string]string{"env": "test"},
+					},
+				},
+			},
+			newMachine: &infrav1.AWSMachine{
+				Spec: infrav1.AWSMachineSpec{
+					InstanceType: "test",
+					HostAffinity: ptr.To("host"),
+					DynamicHostAllocation: &infrav1.DynamicHostAllocationSpec{
+						Tags: map[string]string{"env": "test"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			w := &AWSMachine{}
+			errs := w.validateHostAllocationUpdate(tt.oldMachine, tt.newMachine)
+			if tt.wantErr {
+				g.Expect(errs).NotTo(BeEmpty())
+			} else {
+				g.Expect(errs).To(BeEmpty())
+			}
+		})
+	}
+}
+
 func TestAWSMachineSecretsBackend(t *testing.T) {
 	baseMachine := &infrav1.AWSMachine{
 		Spec: infrav1.AWSMachineSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

AWSMachines created under `v2.10.0` were defaulted to `hostAffinity="host"` (PR #5631) even when not using dedicated hosts (`tenancy != "host"`).

The default was later corrected to `"default"` (PR #5801, `v2.10.1`), but existing objects retained the stale value. When webhook validation requiring `tenancy="host"` for `hostAffinity="host"` was added (PR #5825, `v2.10.2`), those pre-existing objects became unmodifiable, any update was rejected by the admission webhook.

This commit introduces `validateHostAllocationUpdate`, which skips the `hostAffinity` vs `tenancy` check on update when the old object already carried the same invalid combination (inherited state). The check is still fully enforced on create and when the invalid combination is newly introduced on update. All other host allocation validations remain unchanged.

**Which issue(s) this PR fixes**:
Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5970

**Special notes for your reviewer**:

**AI Usage**:
Yes, Claude

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: grandfather hostAffinity validation on AWSMachine updates
```
