### PR TITLE
🐛 fix: isolate ROSAExpiredCreds test from local AWS credentials

### DIFF
--- a/exp/controllers/rosaroleconfig_controller_test.go
+++ b/exp/controllers/rosaroleconfig_controller_test.go
@@ -637,6 +637,14 @@ func TestROSARoleConfigSetUpRuntimeWithExpiredAWSCredentials(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.TODO()
 
+	// Mock empty AWS credentials
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+
 	// Create a miniaml scope for testing
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -702,8 +710,6 @@ func TestROSARoleConfigSetUpRuntimeWithExpiredAWSCredentials(t *testing.T) {
 		},
 		Runtime: nil, // Start with nil Runtime
 	}
-
-	// AWS credentials are not set by default in the test env
 
 	// ==================== FIRST RECONCILIATION ====================
 	t.Log("First reconciliation: AWS credentials are missing/expired")


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
  <!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

  **What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:

  Fixes test isolation issue in `TestROSARoleConfigSetUpRuntimeWithExpiredAWSCredentials` which was failing when run locally with valid AWS credentials.

  The test expects AWS client creation to fail due to missing/expired credentials, but the AWS SDK was automatically picking up valid credentials from the local environment (environment variables or
  `~/.aws/credentials`), causing the test to succeed when it should have failed.

  Uses `t.Setenv()` to isolate the test from all AWS credential sources ensuring consistent behavior regardless of the user's local AWS configuration.

  **Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
  N/A

  **Special notes for your reviewer**:
  N/A

**AI Usage**:

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

None

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
None
```
