### PR TITLE
🐛  fix: cloud build image not found

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -3,7 +3,7 @@ timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:63840f133e0dfeea0af9ef391210da7fab9d2676172e2967fccab0cd6110c4e7' # v20250513-9264efb079 go 1.24.3
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:8d6a3a5b895e6776dbe9115b75db1412fbe57299b8db329d45cb54680e462b0b" # v20251211-4c812d4cd8
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -14,5 +14,5 @@ steps:
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
-  _GIT_TAG: '12345'
-  _PULL_BASE_REF: 'dev'
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "dev"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,16 +3,16 @@ timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:63840f133e0dfeea0af9ef391210da7fab9d2676172e2967fccab0cd6110c4e7' # v20250513-9264efb079 go 1.24.3
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:8d6a3a5b895e6776dbe9115b75db1412fbe57299b8db329d45cb54680e462b0b" # v20251211-4c812d4cd8
     entrypoint: make
     env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
-    - TAG=$_GIT_TAG
-    - PULL_BASE_REF=$_PULL_BASE_REF
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=$_GIT_TAG
+      - PULL_BASE_REF=$_PULL_BASE_REF
     args:
-    - release-staging
+      - release-staging
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
-  _GIT_TAG: '12345'
-  _PULL_BASE_REF: 'dev'
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "dev"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

The image we are using for cloud build isn't found in the registry. Update to use the version CAPI is currently using.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

None

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Update cloud build image for release-2.10 branch
```
