### PR TITLE
🌱 test(api): cover additionalTags keys with spaces

### DIFF
--- a/api/v1beta1/tags_test.go
+++ b/api/v1beta1/tags_test.go
@@ -187,6 +187,13 @@ func TestTagsValidate(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "no errors - spaces allowed in key",
+			self: Tags{
+				"Patch Group": "validValue",
+			},
+			expected: nil,
+		},
+		{
 			name: "key cannot be empty",
 			self: Tags{
 				"": "validValue",

--- a/api/v1beta2/tags_test.go
+++ b/api/v1beta2/tags_test.go
@@ -187,6 +187,13 @@ func TestTagsValidate(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "no errors - spaces allowed in key",
+			self: Tags{
+				"Patch Group": "validValue",
+			},
+			expected: nil,
+		},
+		{
 			name: "key cannot be empty",
 			self: Tags{
 				"": "validValue",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The existing `no errors - spaces allowed` test in `api/v1beta1/tags_test.go` and `api/v1beta2/tags_test.go` only exercises a tag *value* containing a space (`{"validKey": "valid Value"}`). Keys with spaces — the actual scenario reported in #4642 (e.g. `Patch Group: nopatch`) — are not covered, even though the regex `^[a-zA-Z0-9\s\_\.\:\=\+\-\@\/]*$` is meant to allow them.

This PR adds a regression case that uses `"Patch Group"` as the key in both v1beta1 and v1beta2 test tables, so future regex churn cannot silently re-break this scenario.

The actual validation regex was fixed in commit `4b69599` (Sept 2022) and ships in all currently supported v2.x releases, so no production code change is needed; this is just locking down the behaviour.

**Which issue(s) this PR fixes**:
Fixes #4642

**Special notes for your reviewer**:

I verified the regex behaviour manually and via the new test cases — both v1beta1 and v1beta2 `Tags.Validate()` accept keys with spaces today.

**AI Usage**:
Used Claude to summarise the regex history and draft the test cases; verified by running `go test ./api/v1beta1/ ./api/v1beta2/ -run TestTagsValidate` locally.

```release-note
NONE
```