### PR TITLE
🐛  Expose IPv6 addresses on AWSMachine Status

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 	"time"
@@ -1066,6 +1067,20 @@ func (s *Service) getInstanceAddresses(instance types.Instance) []clusterv1beta1
 					Address: addr,
 				}
 				addresses = append(addresses, publicIPAddress)
+			}
+		}
+
+		for _, ipv6 := range eni.Ipv6Addresses {
+			if addr := aws.ToString(ipv6.Ipv6Address); addr != "" {
+				ip := net.ParseIP(addr)
+				if ip == nil || ip.IsLinkLocalUnicast() {
+					continue
+				}
+				ipv6Address := clusterv1beta1.MachineAddress{
+					Type:    clusterv1beta1.MachineInternalIP,
+					Address: ip.String(),
+				}
+				addresses = append(addresses, ipv6Address)
 			}
 		}
 	}

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -6539,6 +6539,203 @@ func TestGetDHCPOptionSetDomainName(t *testing.T) {
 	}
 }
 
+func TestGetInstanceAddresses(t *testing.T) {
+	testCases := []struct {
+		name              string
+		networkInterfaces []types.InstanceNetworkInterface
+		expectedAddresses []clusterv1beta1.MachineAddress
+	}{
+		{
+			name: "IPv4 only instance returns IPv4 internal and external addresses",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					PrivateDnsName:   aws.String("ip-10-0-1-5.us-west-2.compute.internal"),
+					PrivateIpAddress: aws.String("10.0.1.5"),
+					Association: &types.InstanceNetworkInterfaceAssociation{
+						PublicDnsName: aws.String("ec2-1-2-3-4.us-west-2.compute.amazonaws.com"),
+						PublicIp:      aws.String("1.2.3.4"),
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalDNS, Address: "ip-10-0-1-5.us-west-2.compute.internal"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "10.0.1.5"},
+				{Type: clusterv1beta1.MachineExternalDNS, Address: "ec2-1-2-3-4.us-west-2.compute.amazonaws.com"},
+				{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+			},
+		},
+		{
+			name: "IPv6-only instance returns IPv6 address as InternalIP",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("2600:1f13:abc:de00::1")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalIP, Address: "2600:1f13:abc:de00::1"},
+			},
+		},
+		{
+			name: "dual-stack instance returns both IPv4 and IPv6 addresses",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					PrivateDnsName:   aws.String("ip-10-0-1-5.us-west-2.compute.internal"),
+					PrivateIpAddress: aws.String("10.0.1.5"),
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("2600:1f13:abc:de00::1")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalDNS, Address: "ip-10-0-1-5.us-west-2.compute.internal"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "10.0.1.5"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "2600:1f13:abc:de00::1"},
+			},
+		},
+		{
+			name: "multiple IPv6 addresses in the same ENI are all included",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("2600:1f13:abc:de00::1")},
+						{Ipv6Address: aws.String("2600:1f13:abc:de00::2")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalIP, Address: "2600:1f13:abc:de00::1"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "2600:1f13:abc:de00::2"},
+			},
+		},
+		{
+			name: "link-local unicast IPv6 address is skipped",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					PrivateIpAddress: aws.String("10.0.1.5"),
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("fe80::1")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalIP, Address: "10.0.1.5"},
+			},
+		},
+		{
+			name: "invalid IPv6 address is skipped",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					PrivateIpAddress: aws.String("10.0.1.5"),
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("not-an-ip")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalIP, Address: "10.0.1.5"},
+			},
+		},
+		{
+			name: "only link-local IPv6 address present yields no IPv6 entry",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("fe80::abcd:ef01")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{},
+		},
+		{
+			name: "mix of link-local and global IPv6 addresses: only global is included",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("fe80::1")},
+						{Ipv6Address: aws.String("2600:1f13:abc:de00::1")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalIP, Address: "2600:1f13:abc:de00::1"},
+			},
+		},
+		{
+			name: "empty IPv6 address in ENI is skipped",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					PrivateIpAddress: aws.String("10.0.1.5"),
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalIP, Address: "10.0.1.5"},
+			},
+		},
+		{
+			name: "multiple ENIs with IPv6 addresses",
+			networkInterfaces: []types.InstanceNetworkInterface{
+				{
+					PrivateDnsName:   aws.String("ip-10-0-1-5.us-west-2.compute.internal"),
+					PrivateIpAddress: aws.String("10.0.1.5"),
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("2600:1f13:abc:de00::1")},
+					},
+				},
+				{
+					PrivateDnsName:   aws.String("ip-10-0-2-5.us-west-2.compute.internal"),
+					PrivateIpAddress: aws.String("10.0.2.5"),
+					Ipv6Addresses: []types.InstanceIpv6Address{
+						{Ipv6Address: aws.String("2600:1f13:abc:de00::2")},
+					},
+				},
+			},
+			expectedAddresses: []clusterv1beta1.MachineAddress{
+				{Type: clusterv1beta1.MachineInternalDNS, Address: "ip-10-0-1-5.us-west-2.compute.internal"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "10.0.1.5"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "2600:1f13:abc:de00::1"},
+				{Type: clusterv1beta1.MachineInternalDNS, Address: "ip-10-0-2-5.us-west-2.compute.internal"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "10.0.2.5"},
+				{Type: clusterv1beta1.MachineInternalIP, Address: "2600:1f13:abc:de00::2"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			ec2Mock := mocks.NewMockEC2API(mockCtrl)
+			scheme, err := setupScheme()
+			g.Expect(err).ToNot(HaveOccurred())
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			cs, err := scope.NewClusterScope(scope.ClusterScopeParams{
+				Client:  client,
+				Cluster: &clusterv1.Cluster{},
+				AWSCluster: &infrav1.AWSCluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			ec2Svc := NewService(cs)
+			ec2Svc.EC2Client = ec2Mock
+
+			instance := types.Instance{
+				NetworkInterfaces: tc.networkInterfaces,
+			}
+			addresses := ec2Svc.getInstanceAddresses(instance)
+			g.Expect(addresses).To(ConsistOf(tc.expectedAddresses))
+		})
+	}
+}
+
 func mockedGetPrivateDNSDomainNameFromDHCPOptionsCalls(m *mocks.MockEC2APIMockRecorder) {
 	m.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{
 		VpcIds: []string{"vpc-exists"},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

This PR populates the `AWSMachine .status.addresses` with IPv6 addresses for self-managed clusters.

When IPv6 is enabled for self-managed clusters, the VM is properly assigned an IPv6 address in AWS. However, the AWSMachine resource does not surface this IPv6 address in its `.status.addresses` field. This makes it difficult for external consumers, operators, or automation tools to discover or work with the IPv6 address when provisioning dual-stack or IPv6-only clusters.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #5979

**Special notes for your reviewer**:

**AI Usage**: 

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.


NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

GitHub Copilot is used to investigate the issue and propose and draft the solution. 

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ N/A ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ N/A ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Expose IPv6 addresses on AWSMachine Status
```
