### PR TITLE
:seedling: Use auto-detected parallelism for EKS e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ test-e2e: $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) generate-test-flavors e2e-image ## 
 
 .PHONY: test-e2e-eks ## Run EKS e2e tests using clusterctl
 test-e2e-eks: generate-test-flavors $(KIND) $(SSM_PLUGIN) $(KUSTOMIZE) e2e-image ## Run eks e2e tests
-	time go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e $(GINKGO_ARGS) -nodes 2 ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" --source-template="$(EKS_SOURCE_TEMPLATE)" $(E2E_ARGS) $(EKS_E2E_ARGS)
+	time go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e $(GINKGO_ARGS) -p ./test/e2e/suites/managed/... -- -config-path="$(E2E_EKS_CONF_PATH)" --source-template="$(EKS_SOURCE_TEMPLATE)" $(E2E_ARGS) $(EKS_E2E_ARGS)
 
 CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)
 CONFORMANCE_E2E_ARGS += $(E2E_ARGS)


### PR DESCRIPTION
**What type of PR is this?**

/kind support

**AI Usage**: 
None

**What this PR does / why we need it**:

Replace hardcoded `-nodes 2` with `-p` (auto-detect) in the `test-e2e-eks` Makefile target.
This matches the behavior of the unmanaged `test-e2e` target, which already uses `-p`.
Allows the EKS e2e suite to scale with the number of available CPUs on the runner


**Release note**:

```release-note
NONE
```

