### PR TITLE
🐛 fix: fully bypass CloudFormation when -skip-cloudformation-creation is set

### DIFF
--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -872,14 +872,31 @@ func encodeCredentials(accessKey *iamtypes.AccessKey, region string) string {
 	return encCreds
 }
 
+// accessKeyFromSession returns an iamtypes.AccessKey populated from the
+// caller's resolved AWS credentials. It is used when -skip-cloudformation-creation
+// is set so that downstream consumers of BootstrapAccessKey (e.g. encodeCredentials
+// and NewAWSSessionWithKey) keep working without needing the CloudFormation
+// bootstrap user to exist.
+func accessKeyFromSession(ctx context.Context, cfg *aws.Config) *iamtypes.AccessKey {
+	creds, err := cfg.Credentials.Retrieve(ctx)
+	Expect(err).NotTo(HaveOccurred(), "should be able to resolve AWS credentials from the calling session when skipping CloudFormation creation")
+	Expect(creds.AccessKeyID).NotTo(BeEmpty(), "calling session must have a non-empty access key id when skipping CloudFormation creation")
+	Expect(creds.SecretAccessKey).NotTo(BeEmpty(), "calling session must have a non-empty secret access key when skipping CloudFormation creation")
+	return &iamtypes.AccessKey{
+		AccessKeyId:     aws.String(creds.AccessKeyID),
+		SecretAccessKey: aws.String(creds.SecretAccessKey),
+	}
+}
+
 // newUserAccessKey generates a new AWS Access Key pair based off of the
 // bootstrap user. This tests that the CloudFormation policy is correct.
 func newUserAccessKey(ctx context.Context, cfg *aws.Config, userName string) *iamtypes.AccessKey {
 	iamSvc := iam.NewFromConfig(*cfg)
 
-	keyOuts, _ := iamSvc.ListAccessKeys(ctx, &iam.ListAccessKeysInput{
+	keyOuts, err := iamSvc.ListAccessKeys(ctx, &iam.ListAccessKeysInput{
 		UserName: aws.String(userName),
 	})
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("listing access keys for bootstrap user %q", userName))
 	for i := range keyOuts.AccessKeyMetadata {
 		By(fmt.Sprintf("Deleting an existing access key: user-name=%s", userName))
 		_, err := iamSvc.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -872,20 +872,42 @@ func encodeCredentials(accessKey *iamtypes.AccessKey, region string) string {
 	return encCreds
 }
 
-// accessKeyFromSession returns an iamtypes.AccessKey populated from the
-// caller's resolved AWS credentials. It is used when -skip-cloudformation-creation
-// is set so that downstream consumers of BootstrapAccessKey (e.g. encodeCredentials
-// and NewAWSSessionWithKey) keep working without needing the CloudFormation
-// bootstrap user to exist.
-func accessKeyFromSession(ctx context.Context, cfg *aws.Config) *iamtypes.AccessKey {
-	creds, err := cfg.Credentials.Retrieve(ctx)
-	Expect(err).NotTo(HaveOccurred(), "should be able to resolve AWS credentials from the calling session when skipping CloudFormation creation")
-	Expect(creds.AccessKeyID).NotTo(BeEmpty(), "calling session must have a non-empty access key id when skipping CloudFormation creation")
-	Expect(creds.SecretAccessKey).NotTo(BeEmpty(), "calling session must have a non-empty secret access key when skipping CloudFormation creation")
-	return &iamtypes.AccessKey{
-		AccessKeyId:     aws.String(creds.AccessKeyID),
-		SecretAccessKey: aws.String(creds.SecretAccessKey),
+// iamUserExists reports whether the named IAM user exists. Used by the
+// -skip-cloudformation-creation path: the bootstrap user might still exist
+// (deployed manually, or in a previous suite run) even when CF creation is
+// skipped, in which case we rotate its access key as usual.
+func iamUserExists(ctx context.Context, cfg *aws.Config, userName string) bool {
+	iamSvc := iam.NewFromConfig(*cfg)
+	_, err := iamSvc.GetUser(ctx, &iam.GetUserInput{UserName: aws.String(userName)})
+	if err != nil {
+		var nse *iamtypes.NoSuchEntityException
+		if errors.As(err, &nse) {
+			return false
+		}
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("checking whether bootstrap user %q exists", userName))
 	}
+	return true
+}
+
+// encodeCredentialsFromSession encodes the calling session's credentials into
+// the base64 AWS-default-profile string used by clusterctl. It preserves any
+// SessionToken so STS-based principals (assumed roles, SSO, instance profiles)
+// continue to work when -skip-cloudformation-creation is set and there is no
+// bootstrap IAM user to mint long-lived keys for.
+func encodeCredentialsFromSession(ctx context.Context, cfg *aws.Config, region string) string {
+	retrieved, err := cfg.Credentials.Retrieve(ctx)
+	Expect(err).NotTo(HaveOccurred(), "should be able to resolve AWS credentials from the calling session when skipping CloudFormation creation")
+	Expect(retrieved.AccessKeyID).NotTo(BeEmpty(), "calling session must have a non-empty access key id when skipping CloudFormation creation")
+	Expect(retrieved.SecretAccessKey).NotTo(BeEmpty(), "calling session must have a non-empty secret access key when skipping CloudFormation creation")
+	creds := credentials.AWSCredentials{
+		Region:          region,
+		AccessKeyID:     retrieved.AccessKeyID,
+		SecretAccessKey: retrieved.SecretAccessKey,
+		SessionToken:    retrieved.SessionToken,
+	}
+	encCreds, err := creds.RenderBase64EncodedAWSDefaultProfile()
+	Expect(err).NotTo(HaveOccurred())
+	return encCreds
 }
 
 // newUserAccessKey generates a new AWS Access Key pair based off of the

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -150,16 +150,26 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 			}
 			return success
 		}, 45*time.Minute, 30*time.Second).Should(BeTrue(), "Should've eventually succeeded creating an AWS CloudFormation stack")
+
+		ensureStackTags(e2eCtx.AWSSession, bootstrapTemplate.Spec.StackName, bootstrapTags)
+	} else {
+		By("Skipping CloudFormation stack tag verification because -skip-cloudformation-creation is set")
 	}
 
-	ensureStackTags(e2eCtx.AWSSession, bootstrapTemplate.Spec.StackName, bootstrapTags)
 	ensureNoServiceLinkedRoles(context.TODO(), e2eCtx.AWSSession)
 	ensureSSHKeyPair(*e2eCtx.AWSSession, DefaultSSHKeyPairName)
-	e2eCtx.Environment.BootstrapAccessKey = newUserAccessKey(context.TODO(), e2eCtx.AWSSession, bootstrapTemplate.Spec.BootstrapUser.UserName)
-	e2eCtx.BootstrapUserAWSSession = NewAWSSessionWithKey(e2eCtx.Environment.BootstrapAccessKey)
 
-	By("Waiting for access key to propagate...")
-	time.Sleep(10 * time.Second)
+	if !e2eCtx.Settings.SkipCloudFormationCreation {
+		e2eCtx.Environment.BootstrapAccessKey = newUserAccessKey(context.TODO(), e2eCtx.AWSSession, bootstrapTemplate.Spec.BootstrapUser.UserName)
+		e2eCtx.BootstrapUserAWSSession = NewAWSSessionWithKey(e2eCtx.Environment.BootstrapAccessKey)
+
+		By("Waiting for access key to propagate...")
+		time.Sleep(10 * time.Second)
+	} else {
+		By("Skipping bootstrap user access key creation; reusing the calling session credentials")
+		e2eCtx.Environment.BootstrapAccessKey = accessKeyFromSession(context.TODO(), e2eCtx.AWSSession)
+		e2eCtx.BootstrapUserAWSSession = e2eCtx.AWSSession
+	}
 
 	Expect(ensureTestImageUploaded(context.TODO(), e2eCtx)).NotTo(HaveOccurred())
 

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -159,15 +159,14 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 	ensureNoServiceLinkedRoles(context.TODO(), e2eCtx.AWSSession)
 	ensureSSHKeyPair(*e2eCtx.AWSSession, DefaultSSHKeyPairName)
 
-	if !e2eCtx.Settings.SkipCloudFormationCreation {
+	if iamUserExists(context.TODO(), e2eCtx.AWSSession, bootstrapTemplate.Spec.BootstrapUser.UserName) {
 		e2eCtx.Environment.BootstrapAccessKey = newUserAccessKey(context.TODO(), e2eCtx.AWSSession, bootstrapTemplate.Spec.BootstrapUser.UserName)
 		e2eCtx.BootstrapUserAWSSession = NewAWSSessionWithKey(e2eCtx.Environment.BootstrapAccessKey)
 
 		By("Waiting for access key to propagate...")
 		time.Sleep(10 * time.Second)
 	} else {
-		By("Skipping bootstrap user access key creation; reusing the calling session credentials")
-		e2eCtx.Environment.BootstrapAccessKey = accessKeyFromSession(context.TODO(), e2eCtx.AWSSession)
+		By("Bootstrap user does not exist; reusing the calling session credentials")
 		e2eCtx.BootstrapUserAWSSession = e2eCtx.AWSSession
 	}
 
@@ -187,7 +186,12 @@ func Node1BeforeSuite(e2eCtx *E2EContext) []byte {
 		framework.WithMachineLogCollector(AWSStackLogCollector{E2EContext: e2eCtx}),
 	)
 
-	base64EncodedCredentials := encodeCredentials(e2eCtx.Environment.BootstrapAccessKey, bootstrapTemplate.Spec.Region)
+	var base64EncodedCredentials string
+	if e2eCtx.Environment.BootstrapAccessKey != nil {
+		base64EncodedCredentials = encodeCredentials(e2eCtx.Environment.BootstrapAccessKey, bootstrapTemplate.Spec.Region)
+	} else {
+		base64EncodedCredentials = encodeCredentialsFromSession(context.TODO(), e2eCtx.AWSSession, bootstrapTemplate.Spec.Region)
+	}
 	SetEnvVar("AWS_B64ENCODED_CREDENTIALS", base64EncodedCredentials, true)
 
 	if !e2eCtx.Settings.SkipQuotas {
@@ -243,7 +247,11 @@ func AllNodesBeforeSuite(e2eCtx *E2EContext, data []byte) {
 		framework.WithMachineLogCollector(AWSStackLogCollector{E2EContext: e2eCtx}),
 	)
 	e2eCtx.E2EConfig = &conf.E2EConfig
-	e2eCtx.BootstrapUserAWSSession = NewAWSSessionWithKey(conf.BootstrapAccessKey)
+	if conf.BootstrapAccessKey != nil {
+		e2eCtx.BootstrapUserAWSSession = NewAWSSessionWithKey(conf.BootstrapAccessKey)
+	} else {
+		e2eCtx.BootstrapUserAWSSession = NewAWSSession()
+	}
 	e2eCtx.Settings.FileLock = flock.New(ResourceQuotaFilePath)
 	e2eCtx.Settings.KubetestConfigFilePath = conf.KubetestConfigFilePath
 	e2eCtx.Settings.UseCIArtifacts = conf.UseCIArtifacts


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`-skip-cloudformation-creation` only guarded the `createCloudFormationStack` call. Two follow-on calls assumed the stack existed in the current region:

- `ensureStackTags` (suite.go:155) calls `CloudFormation:DescribeStacks` and fails with `ValidationError: Stack ... does not exist` when the stack lives in a different region (CloudFormation is regional).
- `newUserAccessKey` (aws.go:877) calls `IAM:ListAccessKeys` for the bootstrap user. If the existing stack was deployed without `BootstrapUser.Enable = true`, the user does not exist; the error from `ListAccessKeys` was being silently discarded (`keyOuts, _ := ...`) and the next loop iteration nil-derefs `keyOuts.AccessKeyMetadata`.

This PR moves both calls inside the existing `if !SkipCloudFormationCreation` guard. When skipping, it derives `BootstrapAccessKey` from the calling session's resolved credentials so downstream consumers (`encodeCredentials`, `BootstrapUserAWSSession`, `EnsureServiceQuotas`, etc.) keep working. It also surfaces the previously discarded `ListAccessKeys` error so any future failure produces a real diagnostic instead of a nil-pointer panic.

**Which issue(s) this PR fixes**:
Fixes #5944

**Special notes for your reviewer**:

The skip path assumes the calling session uses long-lived IAM credentials (which is the typical setup when the CF stack has been pre-deployed). `iamtypes.AccessKey` has no `SessionToken` field, so STS temporary credentials would lose their token; this matches the behavior of `NewAWSSessionWithKey` already in the file.

**AI Usage**:

Claude Code (Sonnet/Opus) assisted with locating the affected call sites and drafting the patch. I reviewed every line before commit, validated the control flow against the issue reporter's repro, and confirmed `go build -tags=e2e ./test/e2e/shared/...` and `go vet` pass cleanly.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Fix `-skip-cloudformation-creation` so it also bypasses the CloudFormation `DescribeStacks` tag check and the bootstrap user access-key creation, allowing e2e tests to run against a pre-deployed stack in a different region or one without `BootstrapUser` enabled. Also surface a previously discarded `ListAccessKeys` error that masked the real failure as a nil-pointer panic.
```