### PR TITLE
🐛 Prevent access entries delete+recreate cycle on EKS reconciliation

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2464,7 +2464,9 @@ spec:
                       - hyperpod_linux
                       type: string
                     username:
-                      description: Username is the username for the access entry
+                      description: |-
+                        Username is the username for the access entry
+                        If left empty, EKS generates one and it is left unmanaged
                       type: string
                   required:
                   - principalARN

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
@@ -149,8 +149,9 @@ spec:
                               - hyperpod_linux
                               type: string
                             username:
-                              description: Username is the username for the access
-                                entry
+                              description: |-
+                                Username is the username for the access entry
+                                If left empty, EKS generates one and it is left unmanaged
                               type: string
                           required:
                           - principalARN

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
@@ -311,6 +311,7 @@ type AccessEntry struct {
 	KubernetesGroups []string `json:"kubernetesGroups,omitempty"`
 
 	// Username is the username for the access entry
+	// If left empty, EKS generates one and it is left unmanaged
 	// +optional
 	Username string `json:"username,omitempty"`
 

--- a/pkg/cloud/services/eks/accessentry.go
+++ b/pkg/cloud/services/eks/accessentry.go
@@ -167,13 +167,19 @@ func (s *Service) updateAccessEntry(ctx context.Context, accessEntry ekscontrolp
 		return errors.Wrapf(err, "failed to describe access entry for principal %s", accessEntry.PrincipalARN)
 	}
 
+	// Use the actual type from AWS when not specified in spec (defaults to STANDARD on EKS)
+	desiredType := accessEntry.Type
+	if desiredType == "" {
+		desiredType = ekscontrolplanev1.AccessEntryTypeStandard
+	}
+
 	// EKS requires recreate when changing type or removing username
 	existingUsername := ""
 	if describeOutput.AccessEntry.Username != nil {
 		existingUsername = *describeOutput.AccessEntry.Username
 	}
 
-	if *accessEntry.Type.APIValue() != *describeOutput.AccessEntry.Type || accessEntry.Username != existingUsername {
+	if *desiredType.APIValue() != *describeOutput.AccessEntry.Type || accessEntry.Username != existingUsername {
 		if err = s.deleteAccessEntry(ctx, accessEntry.PrincipalARN); err != nil {
 			return errors.Wrapf(err, "failed to delete access entry for principal %s during recreation", accessEntry.PrincipalARN)
 		}
@@ -220,7 +226,12 @@ func (s *Service) deleteAccessEntry(ctx context.Context, principalArn string) er
 }
 
 func (s *Service) reconcileAccessPolicies(ctx context.Context, accessEntry ekscontrolplanev1.AccessEntry) error {
-	if accessEntry.Type == ekscontrolplanev1.AccessEntryTypeEC2Linux || accessEntry.Type == ekscontrolplanev1.AccessEntryTypeEC2Windows {
+	// Normalize type: empty means STANDARD, which needs policy reconciliation
+	entryType := accessEntry.Type
+	if entryType == "" {
+		entryType = ekscontrolplanev1.AccessEntryTypeStandard
+	}
+	if entryType == ekscontrolplanev1.AccessEntryTypeEC2Linux || entryType == ekscontrolplanev1.AccessEntryTypeEC2Windows {
 		s.scope.Info("Skipping access policy reconciliation for EC2 access type", "principalARN", accessEntry.PrincipalARN)
 		return nil
 	}
@@ -233,6 +244,12 @@ func (s *Service) reconcileAccessPolicies(ctx context.Context, accessEntry eksco
 	clusterName := s.scope.KubernetesClusterName()
 
 	for _, policy := range accessEntry.AccessPolicies {
+		existing, alreadyAssociated := existingPolicies[policy.PolicyARN]
+		if alreadyAssociated && s.policyScopeMatches(policy.AccessScope, existing.AccessScope) {
+			delete(existingPolicies, policy.PolicyARN)
+			continue
+		}
+
 		input := &eks.AssociateAccessPolicyInput{
 			ClusterName:  &clusterName,
 			PrincipalArn: &accessEntry.PrincipalARN,
@@ -264,6 +281,19 @@ func (s *Service) reconcileAccessPolicies(ctx context.Context, accessEntry eksco
 	}
 
 	return nil
+}
+
+func (s *Service) policyScopeMatches(desired ekscontrolplanev1.AccessScope, existing *ekstypes.AccessScope) bool {
+	if existing == nil {
+		return false
+	}
+	if string(desired.Type) != string(existing.Type) {
+		return false
+	}
+	if desired.Type == ekscontrolplanev1.AccessScopeTypeNamespace {
+		return slices.Equal(desired.Namespaces, existing.Namespaces)
+	}
+	return true
 }
 
 func (s *Service) getExistingAccessPolicies(ctx context.Context, principalARN string) (map[string]ekstypes.AssociatedAccessPolicy, error) {

--- a/pkg/cloud/services/eks/accessentry.go
+++ b/pkg/cloud/services/eks/accessentry.go
@@ -167,19 +167,16 @@ func (s *Service) updateAccessEntry(ctx context.Context, accessEntry ekscontrolp
 		return errors.Wrapf(err, "failed to describe access entry for principal %s", accessEntry.PrincipalARN)
 	}
 
-	// Use the actual type from AWS when not specified in spec (defaults to STANDARD on EKS)
+	// Normalize empty spec Type to STANDARD to match what EKS reports for a
+	// default STANDARD entry, so an unset Type is not seen as drift.
 	desiredType := accessEntry.Type
 	if desiredType == "" {
 		desiredType = ekscontrolplanev1.AccessEntryTypeStandard
 	}
 
-	// EKS requires recreate when changing type or removing username
-	existingUsername := ""
-	if describeOutput.AccessEntry.Username != nil {
-		existingUsername = *describeOutput.AccessEntry.Username
-	}
-
-	if *desiredType.APIValue() != *describeOutput.AccessEntry.Type || accessEntry.Username != existingUsername {
+	// Type is the only immutable field, so it is the only one requiring a recreate.
+	// UpdateAccessEntry accepts username and Kubernetes groups.
+	if *desiredType.APIValue() != *describeOutput.AccessEntry.Type {
 		if err = s.deleteAccessEntry(ctx, accessEntry.PrincipalARN); err != nil {
 			return errors.Wrapf(err, "failed to delete access entry for principal %s during recreation", accessEntry.PrincipalARN)
 		}
@@ -197,9 +194,25 @@ func (s *Service) updateAccessEntry(ctx context.Context, accessEntry ekscontrolp
 		ClusterName:  &clusterName,
 		PrincipalArn: &accessEntry.PrincipalARN,
 	}
+	needsUpdate := false
 
 	if !slices.Equal(accessEntry.KubernetesGroups, describeOutput.AccessEntry.KubernetesGroups) {
 		updateInput.KubernetesGroups = accessEntry.KubernetesGroups
+		needsUpdate = true
+	}
+
+	// An unset username means EKS generates one, so the generated value is not drift.
+	existingUsername := ""
+	if describeOutput.AccessEntry.Username != nil {
+		existingUsername = *describeOutput.AccessEntry.Username
+	}
+
+	if accessEntry.Username != "" && accessEntry.Username != existingUsername {
+		updateInput.Username = &accessEntry.Username
+		needsUpdate = true
+	}
+
+	if needsUpdate {
 		if _, err := s.EKSClient.UpdateAccessEntry(ctx, updateInput); err != nil {
 			return errors.Wrapf(err, "failed to update access entry for principal %s", accessEntry.PrincipalARN)
 		}

--- a/pkg/cloud/services/eks/accessentry_test.go
+++ b/pkg/cloud/services/eks/accessentry_test.go
@@ -160,6 +160,7 @@ func TestReconcileAccessEntries(t *testing.T) {
 
 				m.UpdateAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.UpdateAccessEntryOutput{}, nil)
 
+				// Policy already matches, should NOT re-associate
 				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
 					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{
 						{
@@ -170,15 +171,137 @@ func TestReconcileAccessEntries(t *testing.T) {
 						},
 					},
 				}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "no drift - skip reconciliation when entry matches",
+			accessEntries: []ekscontrolplanev1.AccessEntry{
+				{
+					PrincipalARN: principalARN,
+					Type:         ekscontrolplanev1.AccessEntryTypeStandard,
+					Username:     "admin",
+					AccessPolicies: []ekscontrolplanev1.AccessPolicyReference{
+						{
+							PolicyARN: policyARN,
+							AccessScope: ekscontrolplanev1.AccessScope{
+								Type: ekscontrolplanev1.AccessScopeTypeCluster,
+							},
+						},
+					},
+				},
+			},
+			expect: func(m *mock_eksiface.MockEKSAPIMockRecorder) {
+				m.ListAccessEntries(gomock.Any(), gomock.Any()).Return(&eks.ListAccessEntriesOutput{
+					AccessEntries: []string{principalARN},
+				}, nil)
 
-				m.AssociateAccessPolicy(gomock.Any(), &eks.AssociateAccessPolicyInput{
+				// First DescribeAccessEntry in getManagedAccessEntries
+				m.DescribeAccessEntry(gomock.Any(), &eks.DescribeAccessEntryInput{
 					ClusterName:  aws.String(clusterName),
 					PrincipalArn: aws.String(principalARN),
-					PolicyArn:    aws.String(policyARN),
-					AccessScope: &ekstypes.AccessScope{
-						Type: ekstypes.AccessScopeTypeCluster,
+				}).Return(&eks.DescribeAccessEntryOutput{
+					AccessEntry: &ekstypes.AccessEntry{
+						PrincipalArn: aws.String(principalARN),
+						Username:     aws.String("admin"),
+						Type:         ekscontrolplanev1.AccessEntryTypeStandard.APIValue(),
+						Tags: map[string]string{
+							"kubernetes.io/cluster/test-cluster": "owned",
+						},
 					},
-				}).Return(&eks.AssociateAccessPolicyOutput{}, nil)
+				}, nil)
+
+				// Second DescribeAccessEntry in updateAccessEntry
+				m.DescribeAccessEntry(gomock.Any(), &eks.DescribeAccessEntryInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+				}).Return(&eks.DescribeAccessEntryOutput{
+					AccessEntry: &ekstypes.AccessEntry{
+						PrincipalArn: aws.String(principalARN),
+						Username:     aws.String("admin"),
+						Type:         ekscontrolplanev1.AccessEntryTypeStandard.APIValue(),
+						Tags: map[string]string{
+							"kubernetes.io/cluster/test-cluster": "owned",
+						},
+					},
+				}, nil)
+
+				// Policy already matches, no AssociateAccessPolicy call
+				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
+					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{
+						{
+							PolicyArn: aws.String(policyARN),
+							AccessScope: &ekstypes.AccessScope{
+								Type: ekstypes.AccessScopeTypeCluster,
+							},
+						},
+					},
+				}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "no drift with empty type - should treat as STANDARD",
+			accessEntries: []ekscontrolplanev1.AccessEntry{
+				{
+					PrincipalARN: principalARN,
+					Username:     "admin",
+					AccessPolicies: []ekscontrolplanev1.AccessPolicyReference{
+						{
+							PolicyARN: policyARN,
+							AccessScope: ekscontrolplanev1.AccessScope{
+								Type: ekscontrolplanev1.AccessScopeTypeCluster,
+							},
+						},
+					},
+				},
+			},
+			expect: func(m *mock_eksiface.MockEKSAPIMockRecorder) {
+				m.ListAccessEntries(gomock.Any(), gomock.Any()).Return(&eks.ListAccessEntriesOutput{
+					AccessEntries: []string{principalARN},
+				}, nil)
+
+				// First DescribeAccessEntry in getManagedAccessEntries
+				m.DescribeAccessEntry(gomock.Any(), &eks.DescribeAccessEntryInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+				}).Return(&eks.DescribeAccessEntryOutput{
+					AccessEntry: &ekstypes.AccessEntry{
+						PrincipalArn: aws.String(principalARN),
+						Username:     aws.String("admin"),
+						Type:         ekscontrolplanev1.AccessEntryTypeStandard.APIValue(),
+						Tags: map[string]string{
+							"kubernetes.io/cluster/test-cluster": "owned",
+						},
+					},
+				}, nil)
+
+				// Second DescribeAccessEntry in updateAccessEntry
+				m.DescribeAccessEntry(gomock.Any(), &eks.DescribeAccessEntryInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+				}).Return(&eks.DescribeAccessEntryOutput{
+					AccessEntry: &ekstypes.AccessEntry{
+						PrincipalArn: aws.String(principalARN),
+						Username:     aws.String("admin"),
+						Type:         ekscontrolplanev1.AccessEntryTypeStandard.APIValue(),
+						Tags: map[string]string{
+							"kubernetes.io/cluster/test-cluster": "owned",
+						},
+					},
+				}, nil)
+
+				// Policy already matches, no AssociateAccessPolicy call
+				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
+					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{
+						{
+							PolicyArn: aws.String(policyARN),
+							AccessScope: &ekstypes.AccessScope{
+								Type: ekstypes.AccessScopeTypeCluster,
+							},
+						},
+					},
+				}, nil)
 			},
 			expectError: false,
 		},
@@ -258,15 +381,7 @@ func TestReconcileAccessEntries(t *testing.T) {
 					},
 				}, nil)
 
-				m.AssociateAccessPolicy(gomock.Any(), &eks.AssociateAccessPolicyInput{
-					ClusterName:  aws.String(clusterName),
-					PrincipalArn: aws.String(principalARN),
-					PolicyArn:    aws.String(policyARN),
-					AccessScope: &ekstypes.AccessScope{
-						Type: ekstypes.AccessScopeTypeCluster,
-					},
-				}).Return(&eks.AssociateAccessPolicyOutput{}, nil)
-
+				// Policy already matches, should NOT re-associate
 				m.DeleteAccessEntry(gomock.Any(), &eks.DeleteAccessEntryInput{
 					ClusterName:  aws.String(clusterName),
 					PrincipalArn: aws.String(secondPrincipalARN),
@@ -347,15 +462,7 @@ func TestReconcileAccessEntries(t *testing.T) {
 						},
 					},
 				}, nil)
-
-				m.AssociateAccessPolicy(gomock.Any(), &eks.AssociateAccessPolicyInput{
-					ClusterName:  aws.String(clusterName),
-					PrincipalArn: aws.String(principalARN),
-					PolicyArn:    aws.String(policyARN),
-					AccessScope: &ekstypes.AccessScope{
-						Type: ekstypes.AccessScopeTypeCluster,
-					},
-				}).Return(&eks.AssociateAccessPolicyOutput{}, nil)
+				// Policy already matches, should NOT re-associate
 			},
 			expectError: false,
 		},
@@ -524,6 +631,74 @@ func TestReconcileAccessPolicies(t *testing.T) {
 					AccessScope: &ekstypes.AccessScope{
 						Type:       ekstypes.AccessScopeTypeNamespace,
 						Namespaces: []string{"kube-system", "default"},
+					},
+				}).Return(&eks.AssociateAccessPolicyOutput{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "policy already matches - skip association",
+			accessEntry: ekscontrolplanev1.AccessEntry{
+				PrincipalARN: principalARN,
+				Type:         ekscontrolplanev1.AccessEntryTypeStandard,
+				AccessPolicies: []ekscontrolplanev1.AccessPolicyReference{
+					{
+						PolicyARN: policyARN,
+						AccessScope: ekscontrolplanev1.AccessScope{
+							Type: ekscontrolplanev1.AccessScopeTypeCluster,
+						},
+					},
+				},
+			},
+			expect: func(m *mock_eksiface.MockEKSAPIMockRecorder) {
+				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
+					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{
+						{
+							PolicyArn: aws.String(policyARN),
+							AccessScope: &ekstypes.AccessScope{
+								Type: ekstypes.AccessScopeTypeCluster,
+							},
+						},
+					},
+				}, nil)
+				// Should NOT call AssociateAccessPolicy when policy already matches
+			},
+			expectError: false,
+		},
+		{
+			name: "policy scope changed - re-associate",
+			accessEntry: ekscontrolplanev1.AccessEntry{
+				PrincipalARN: principalARN,
+				Type:         ekscontrolplanev1.AccessEntryTypeStandard,
+				AccessPolicies: []ekscontrolplanev1.AccessPolicyReference{
+					{
+						PolicyARN: policyARN,
+						AccessScope: ekscontrolplanev1.AccessScope{
+							Type:       ekscontrolplanev1.AccessScopeTypeNamespace,
+							Namespaces: []string{"kube-system"},
+						},
+					},
+				},
+			},
+			expect: func(m *mock_eksiface.MockEKSAPIMockRecorder) {
+				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
+					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{
+						{
+							PolicyArn: aws.String(policyARN),
+							AccessScope: &ekstypes.AccessScope{
+								Type: ekstypes.AccessScopeTypeCluster,
+							},
+						},
+					},
+				}, nil)
+
+				m.AssociateAccessPolicy(gomock.Any(), &eks.AssociateAccessPolicyInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+					PolicyArn:    aws.String(policyARN),
+					AccessScope: &ekstypes.AccessScope{
+						Type:       ekstypes.AccessScopeTypeNamespace,
+						Namespaces: []string{"kube-system"},
 					},
 				}).Return(&eks.AssociateAccessPolicyOutput{}, nil)
 			},

--- a/pkg/cloud/services/eks/accessentry_test.go
+++ b/pkg/cloud/services/eks/accessentry_test.go
@@ -936,7 +936,7 @@ func TestUpdateAccessEntry(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "username change requires recreate",
+			name: "username change is applied in place",
 			accessEntry: ekscontrolplanev1.AccessEntry{
 				PrincipalARN:     principalARN,
 				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
@@ -953,9 +953,11 @@ func TestUpdateAccessEntry(t *testing.T) {
 					},
 				}, nil)
 
-				m.DeleteAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DeleteAccessEntryOutput{}, nil)
-
-				m.CreateAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.CreateAccessEntryOutput{}, nil)
+				m.UpdateAccessEntry(gomock.Any(), &eks.UpdateAccessEntryInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+					Username:     aws.String("new-admin"),
+				}).Return(&eks.UpdateAccessEntryOutput{}, nil)
 
 				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
 					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},
@@ -994,7 +996,7 @@ func TestUpdateAccessEntry(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "username cleared requires recreate",
+			name: "empty username in spec does not trigger a recreate",
 			accessEntry: ekscontrolplanev1.AccessEntry{
 				PrincipalARN:     principalARN,
 				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
@@ -1011,10 +1013,6 @@ func TestUpdateAccessEntry(t *testing.T) {
 					},
 				}, nil)
 
-				m.DeleteAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DeleteAccessEntryOutput{}, nil)
-
-				m.CreateAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.CreateAccessEntryOutput{}, nil)
-
 				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
 					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},
 				}, nil)
@@ -1022,7 +1020,7 @@ func TestUpdateAccessEntry(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "username added requires recreate",
+			name: "username added is applied in place",
 			accessEntry: ekscontrolplanev1.AccessEntry{
 				PrincipalARN:     principalARN,
 				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
@@ -1039,9 +1037,42 @@ func TestUpdateAccessEntry(t *testing.T) {
 					},
 				}, nil)
 
-				m.DeleteAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DeleteAccessEntryOutput{}, nil)
+				m.UpdateAccessEntry(gomock.Any(), &eks.UpdateAccessEntryInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+					Username:     aws.String("admin"),
+				}).Return(&eks.UpdateAccessEntryOutput{}, nil)
 
-				m.CreateAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.CreateAccessEntryOutput{}, nil)
+				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
+					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},
+				}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "username and groups change in a single update",
+			accessEntry: ekscontrolplanev1.AccessEntry{
+				PrincipalARN:     principalARN,
+				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
+				Username:         "new-admin",
+				KubernetesGroups: []string{"developers"},
+			},
+			expect: func(m *mock_eksiface.MockEKSAPIMockRecorder) {
+				m.DescribeAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DescribeAccessEntryOutput{
+					AccessEntry: &ekstypes.AccessEntry{
+						PrincipalArn:     aws.String(principalARN),
+						Type:             ekscontrolplanev1.AccessEntryTypeStandard.APIValue(),
+						Username:         aws.String("admin"),
+						KubernetesGroups: []string{"system:masters"},
+					},
+				}, nil)
+
+				m.UpdateAccessEntry(gomock.Any(), &eks.UpdateAccessEntryInput{
+					ClusterName:      aws.String(clusterName),
+					PrincipalArn:     aws.String(principalARN),
+					KubernetesGroups: []string{"developers"},
+					Username:         aws.String("new-admin"),
+				}).Return(&eks.UpdateAccessEntryOutput{}, nil)
 
 				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
 					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When `accessEntries` with an unspecified `type` field are defined in `AWSManagedControlPlane`, the reconciler detects drift on every cycle because an empty `Type` is compared as `""` against `"STANDARD"` (the EKS default) from the AWS API. This triggers a continuous delete-and-recreate loop every ~7s, with each deletion removing the access policy association and the subsequent recreation racing against the next reconcile before the policy can be re-associated.

This change:

1. Normalizes empty `Type` to `AccessEntryTypeStandard` before comparison in `updateAccessEntry`, so unspecified types no longer appear as drift.
2. Skips re-associating access policies that already match the desired scope to avoid unnecessary API calls.

**Which issue(s) this PR fixes**
Fixes #6003

**Special notes for your reviewer**:

The fix touches two functions in `pkg/cloud/services/eks/accessentry.go`:
- `updateAccessEntry` — normalizes empty type before drift detection
- `reconcileAccessPolicies` — skips already-matching policy associations; new helper `policyScopeMatches` compares desired vs existing scope

**AI Usage**:

This PR benefited from AI assistance (Qwen3.6-27B via Opencode) for:
- Initial code exploration and understanding the drift detection logic
- Drafting the PR description and release note
- Reviewing case-sensitivity of the `AccessEntryType.APIValue()` comparison

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Fix infinite delete-and-recreate loop for EKS access entries when the type field is left unspecified (defaults to STANDARD).
```