### PR TITLE
✨ feat(awsmanagedcontrolplane): support resource marked as externally managed

### DIFF
--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -56,7 +56,6 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
-
 	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -56,6 +56,8 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
+
+	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -172,6 +174,7 @@ func (r *AWSManagedControlPlaneReconciler) SetupWithManager(ctx context.Context,
 		For(awsManagedControlPlane).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceIsNotExternallyManaged(mgr.GetScheme(), log.GetLogger())).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("failed setting up the AWSManagedControlPlane controller manager: %w", err)
@@ -225,6 +228,12 @@ func (r *AWSManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	log = log.WithValues("awsManagedControlPlane", klog.KObj(awsManagedControlPlane))
+
+	// Check if the control plane is externally managed, if so skip reconciliation
+	if capiannotations.IsExternallyManaged(awsManagedControlPlane) {
+		log.Info("AWSManagedControlPlane is externally managed, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
 
 	// Get the cluster
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, awsManagedControlPlane.ObjectMeta)

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
@@ -58,6 +58,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts/mock_stsiface"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
@@ -65,6 +66,123 @@ import (
 const (
 	maxActiveUpdateDeleteWait = 30 * time.Minute
 )
+
+func TestAWSManagedControlPlaneReconcilerExternallyManaged(t *testing.T) {
+	var (
+		reconciler AWSManagedControlPlaneReconciler
+		recorder   *record.FakeRecorder
+	)
+
+	setup := func(t *testing.T) {
+		t.Helper()
+		recorder = record.NewFakeRecorder(10)
+		reconciler = AWSManagedControlPlaneReconciler{
+			Client:    testEnv.Client,
+			Recorder:  recorder,
+			EnableIAM: true,
+		}
+	}
+
+	t.Run("Should skip reconciliation when AWSManagedControlPlane is externally managed", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+
+		controllerIdentity := createControllerIdentity(g)
+		ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("integ-test-%s", util.RandomString(5)))
+		g.Expect(err).To(BeNil())
+
+		cluster, awsManagedCluster, awsManagedControlPlane := getManagedClusterObjects("test-ext-managed", ns.Name)
+
+		// Add the externally managed annotation
+		awsManagedControlPlane.Annotations = map[string]string{
+			clusterv1.ManagedByAnnotation: "external-system",
+		}
+
+		g.Expect(testEnv.Create(ctx, &cluster)).To(Succeed())
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
+		g.Expect(testEnv.Client.Status().Update(ctx, &cluster)).To(Succeed())
+		g.Expect(testEnv.Create(ctx, &awsManagedCluster)).To(Succeed())
+		g.Expect(testEnv.Create(ctx, &awsManagedControlPlane)).To(Succeed())
+		g.Eventually(func() bool {
+			controlPlane := &ekscontrolplanev1.AWSManagedControlPlane{}
+			key := client.ObjectKey{
+				Name:      awsManagedControlPlane.Name,
+				Namespace: ns.Name,
+			}
+			err := testEnv.Get(ctx, key, controlPlane)
+			return err == nil
+		}, 10*time.Second).Should(BeTrue(), fmt.Sprintf("Eventually failed getting the newly created AWSManagedControlPlane %q", awsManagedControlPlane.Name))
+
+		defer t.Cleanup(func() {
+			g.Expect(testEnv.Cleanup(ctx, &cluster, &awsManagedCluster, &awsManagedControlPlane, controllerIdentity, ns)).To(Succeed())
+		})
+
+		// Reconcile with the externally managed annotation - should return
+		// immediately without performing any reconciliation.
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: awsManagedControlPlane.Namespace,
+				Name:      awsManagedControlPlane.Name,
+			},
+		})
+		g.Expect(err).To(BeNil())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+
+		// Verify that reconciliation was skipped: no status conditions
+		// should have been set, since the externally managed check returns
+		// before any reconciliation logic modifies the object.
+		g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(&awsManagedControlPlane), &awsManagedControlPlane)).To(Succeed())
+		g.Expect(awsManagedControlPlane.Finalizers).To(BeEmpty())
+		g.Expect(awsManagedControlPlane.Status.Conditions).To(BeEmpty(), "no status conditions should be set when externally managed annotation is present, as side effect of reconciliation being skipped")
+	})
+
+	t.Run("Should reconcile when AWSManagedControlPlane is not externally managed", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+
+		controllerIdentity := createControllerIdentity(g)
+		ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("integ-test-%s", util.RandomString(5)))
+		g.Expect(err).To(BeNil())
+
+		cluster, awsManagedCluster, awsManagedControlPlane := getManagedClusterObjects("test-no-ext", ns.Name)
+
+		// No externally managed annotation
+		g.Expect(testEnv.Create(ctx, &cluster)).To(Succeed())
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
+		g.Expect(testEnv.Client.Status().Update(ctx, &cluster)).To(Succeed())
+		g.Expect(testEnv.Create(ctx, &awsManagedCluster)).To(Succeed())
+		g.Expect(testEnv.Create(ctx, &awsManagedControlPlane)).To(Succeed())
+		g.Eventually(func() bool {
+			controlPlane := &ekscontrolplanev1.AWSManagedControlPlane{}
+			key := client.ObjectKey{
+				Name:      awsManagedControlPlane.Name,
+				Namespace: ns.Name,
+			}
+			err := testEnv.Get(ctx, key, controlPlane)
+			return err == nil
+		}, 10*time.Second).Should(BeTrue(), fmt.Sprintf("Eventually failed getting the newly created AWSManagedControlPlane %q", awsManagedControlPlane.Name))
+
+		defer t.Cleanup(func() {
+			g.Expect(testEnv.Cleanup(ctx, &cluster, &awsManagedCluster, &awsManagedControlPlane, controllerIdentity, ns)).To(Succeed())
+		})
+
+		// Reconcile without the externally managed annotation - reconciliation
+		// should proceed past the annotation check and modify status conditions.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: awsManagedControlPlane.Namespace,
+				Name:      awsManagedControlPlane.Name,
+			},
+		})
+		// err may or may not be nil depending on how far reconciliation gets
+		_ = err
+
+		// Verify that reconciliation proceeded: status conditions should have
+		// been set, proving the reconciler did NOT skip at the annotation check.
+		g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(&awsManagedControlPlane), &awsManagedControlPlane)).To(Succeed())
+		g.Expect(awsManagedControlPlane.Status.Conditions).ToNot(BeEmpty(), "status conditions should be set when externally managed annotation is absent, proving reconciliation proceeded past the annotation check")
+	})
+}
 
 func TestAWSManagedControlPlaneReconcilerIntegrationTests(t *testing.T) {
 	var (

--- a/docs/book/src/topics/bring-your-own-aws-infrastructure.md
+++ b/docs/book/src/topics/bring-your-own-aws-infrastructure.md
@@ -275,6 +275,65 @@ Once the user has created externally managed AWSCluster, it is not allowed to co
 
 User should only use this feature if their cluster infrastructure lifecycle management has constraints that the reference implementation does not support. See [user stories](https://github.com/kubernetes-sigs/cluster-api/blob/10d89ceca938e4d3d94a1d1c2b60515bcdf39829/docs/proposals/20210203-externally-managed-cluster-infrastructure.md#user-stories) for more details.
 
+## Using Externally Managed AWSManagedControlPlane (EKS)
+
+### Overview
+
+Similarly to `AWSCluster`, CAPA supports externally managing `AWSManagedControlPlane` resources. This is useful when an EKS cluster's control plane is provisioned and managed by an external system (e.g., Terraform, Crossplane, or a custom controller) while still using CAPI for machine/node management.
+
+### How to use externally managed AWSManagedControlPlane?
+
+Add the `cluster.x-k8s.io/managed-by` annotation to the `AWSManagedControlPlane` resource:
+
+```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: my-eks-control-plane
+  namespace: default
+  annotations:
+    cluster.x-k8s.io/managed-by: "my-external-system"
+spec:
+  region: us-west-2
+  eksClusterName: my-eks-cluster
+  controlPlaneEndpoint:
+    host: "ABCDEF1234567890.gr7.us-west-2.eks.amazonaws.com"
+    port: 443
+  # ... other fields as required
+```
+
+### Requirements for the external system
+
+The external system must populate the following fields for the cluster and its downstream controllers to function correctly.
+
+#### Spec fields (must be set on the object):
+
+- `spec.controlPlaneEndpoint` (host and port) — required for the `AWSManagedCluster` controller to propagate the endpoint to CAPI, and for worker nodes to discover the API server.
+- `spec.eksClusterName` — required by the EKS bootstrap controllers to generate worker node userdata.
+
+#### Status fields (must be patched via the status subresource):
+
+- `status.ready: true`
+- `status.initialized: true`
+- `status.failureDomains`
+
+#### Conditions (must be patched via the status subresource):
+
+- `EKSControlPlaneReady = True`
+
+#### Additional resources:
+
+- **Kubeconfig Secret** — a secret named `<cluster-name>-kubeconfig` in the cluster's namespace must be created.
+
+#### Conditional requirements:
+
+- `status.network.securityGroups` - required if using EKS managed nodegroups.
+
+### Caveats
+
+- Once created with the externally managed annotation, the external system is fully responsible for the lifecycle of the resource and it's dependencies.
+- The `AWSManagedCluster` resource will still be reconciled normally (unless also marked as externally managed).
+- Converting from externally managed back to CAPA-managed is not supported and may result in unexpected behavior.
 
 ## Bring your own (BYO) Public IPv4 addresses
 

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -132,6 +132,8 @@ providers:
       - sourcePath: "./infrastructure-aws/withclusterclass/generated/cluster-template-eks-nodeadm-clusterclass.yaml"
       - sourcePath: "./eks/cluster-template-eks-nitro-enclave-managedmachinepool.yaml"
         targetName: "cluster-template-eks-nitro-enclave-managedmachinepool.yaml"
+      - sourcePath: "./eks/cluster-template-eks-externally-managed.yaml"
+        targetName: "cluster-template-eks-externally-managed.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.32.0"

--- a/test/e2e/data/eks/cluster-template-eks-externally-managed.yaml
+++ b/test/e2e/data/eks/cluster-template-eks-externally-managed.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    kind: AWSManagedCluster
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    name: "${CLUSTER_NAME}-control-plane"
+---
+kind: AWSManagedCluster
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+metadata:
+  name: "${CLUSTER_NAME}"
+  annotations:
+    cluster.x-k8s.io/managed-by: "e2e-test"
+spec: {}
+---
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+  annotations:
+    cluster.x-k8s.io/managed-by: "e2e-test"
+spec:
+  region: "${AWS_REGION}"
+  version: "${KUBERNETES_VERSION}"
+  eksClusterName: "${CLUSTER_NAME}"
+  controlPlaneEndpoint:
+    host: "example.gr7.${AWS_REGION}.eks.amazonaws.com"
+    port: 443
+  identityRef:
+    kind: AWSClusterStaticIdentity
+    name: e2e-account

--- a/test/e2e/suites/managed/eks_externally_managed_test.go
+++ b/test/e2e/suites/managed/eks_externally_managed_test.go
@@ -1,0 +1,178 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util"
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+)
+
+// Externally managed AWSManagedControlPlane e2e test.
+var _ = ginkgo.Describe("[managed] [general] EKS externally managed control plane", func() {
+	var (
+		namespace   *corev1.Namespace
+		ctx         context.Context
+		specName    = "eks-externally-managed"
+		clusterName string
+	)
+
+	shared.ConditionalIt(runGeneralTests, "should skip reconciliation when AWSManagedControlPlane is externally managed", func() {
+		ginkgo.By("should have a valid test configuration")
+		Expect(e2eCtx.Environment.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. BootstrapClusterProxy can't be nil")
+		Expect(e2eCtx.E2EConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(e2eCtx.E2EConfig.Variables).To(HaveKey(shared.KubernetesVersion))
+
+		ctx = context.TODO()
+		namespace = shared.SetupSpecNamespace(ctx, specName, e2eCtx)
+		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+
+		ginkgo.By("applying the externally managed cluster template")
+		configCluster := defaultConfigCluster(clusterName, namespace.Name)
+		configCluster.Flavor = EKSExternallyManagedFlavor
+		configCluster.ControlPlaneMachineCount = ptr.To[int64](1)
+		configCluster.WorkerMachineCount = ptr.To[int64](0)
+		err := shared.ApplyTemplate(ctx, configCluster, e2eCtx.Environment.BootstrapClusterProxy)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		mgmtClient := e2eCtx.Environment.BootstrapClusterProxy.GetClient()
+		controlPlaneName := getControlPlaneName(clusterName)
+
+		ginkgo.By("waiting for AWSManagedControlPlane to exist")
+		controlPlane := &ekscontrolplanev1.AWSManagedControlPlane{}
+		Eventually(func() error {
+			return mgmtClient.Get(ctx, crclient.ObjectKey{
+				Namespace: namespace.Name,
+				Name:      controlPlaneName,
+			}, controlPlane)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(), "failed to get AWSManagedControlPlane")
+
+		ginkgo.By("verifying the externally managed annotation is present")
+		Expect(controlPlane.Annotations).To(HaveKeyWithValue("cluster.x-k8s.io/managed-by", "e2e-test"))
+
+		ginkgo.By("verifying no EKS cluster was created in AWS")
+		eksClusterName := getEKSClusterName(namespace.Name, clusterName)
+		eksClient := eks.NewFromConfig(*e2eCtx.AWSSession)
+		Consistently(func() error {
+			_, err := eksClient.DescribeCluster(ctx, &eks.DescribeClusterInput{
+				Name: &eksClusterName,
+			})
+			if err != nil {
+				return nil
+			}
+			return fmt.Errorf("EKS cluster %q should not exist since control plane is externally managed", eksClusterName)
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		ginkgo.By("patching AWSManagedCluster status to simulate external management")
+		awsManagedCluster := &infrav1.AWSManagedCluster{}
+		Expect(mgmtClient.Get(ctx, crclient.ObjectKey{
+			Namespace: namespace.Name,
+			Name:      clusterName,
+		}, awsManagedCluster)).To(Succeed())
+		awsManagedCluster.Status.Ready = true
+		Expect(mgmtClient.Status().Update(ctx, awsManagedCluster)).To(Succeed())
+
+		ginkgo.By("patching AWSManagedControlPlane status to simulate external management")
+		// Re-fetch the control plane to get the latest version
+		Expect(mgmtClient.Get(ctx, crclient.ObjectKey{
+			Namespace: namespace.Name,
+			Name:      controlPlaneName,
+		}, controlPlane)).To(Succeed())
+
+		// Patch status fields
+		controlPlane.Status.Ready = true
+		controlPlane.Status.Initialized = true
+		controlPlane.Status.ExternalManagedControlPlane = ptr.To(true)
+		controlPlane.Status.FailureDomains = clusterv1beta1.FailureDomains{
+			"us-east-1a": clusterv1beta1.FailureDomainSpec{
+				ControlPlane: true,
+			},
+		}
+		// Set the EKSControlPlaneReady condition
+		v1beta1conditions.MarkTrue(controlPlane, ekscontrolplanev1.EKSControlPlaneReadyCondition)
+		Expect(mgmtClient.Status().Update(ctx, controlPlane)).To(Succeed())
+
+		ginkgo.By("waiting for CAPI Cluster to report infrastructure provisioned")
+		Eventually(func() bool {
+			cluster := &clusterv1.Cluster{}
+			if err := mgmtClient.Get(ctx, crclient.ObjectKey{
+				Namespace: namespace.Name,
+				Name:      clusterName,
+			}, cluster); err != nil {
+				return false
+			}
+			return ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false)
+		}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "CAPI Cluster should report InfrastructureProvisioned=true")
+
+		ginkgo.By("waiting for CAPI Cluster to report control plane initialized")
+		Eventually(func() bool {
+			cluster := &clusterv1.Cluster{}
+			if err := mgmtClient.Get(ctx, crclient.ObjectKey{
+				Namespace: namespace.Name,
+				Name:      clusterName,
+			}, cluster); err != nil {
+				return false
+			}
+			return ptr.Deref(cluster.Status.Initialization.ControlPlaneInitialized, false)
+		}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "CAPI Cluster should report ControlPlaneInitialized=true")
+
+		ginkgo.By("verifying AWSManagedControlPlane has no finalizer (reconciliation was skipped)")
+		Expect(mgmtClient.Get(ctx, crclient.ObjectKey{
+			Namespace: namespace.Name,
+			Name:      controlPlaneName,
+		}, controlPlane)).To(Succeed())
+		Expect(controlPlane.Finalizers).To(BeEmpty(), "externally managed control plane should have no finalizer")
+
+		ginkgo.By("deleting the cluster")
+		cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+			Getter:    mgmtClient,
+			Namespace: namespace.Name,
+			Name:      clusterName,
+		})
+		Expect(cluster).NotTo(BeNil(), "couldn't find CAPI cluster")
+
+		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+			Deleter: mgmtClient,
+			Cluster: cluster,
+		})
+		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+			ClusterProxy:         e2eCtx.Environment.BootstrapClusterProxy,
+			Cluster:              cluster,
+			ClusterctlConfigPath: e2eCtx.Environment.ClusterctlConfigPath,
+			ArtifactFolder:       e2eCtx.Settings.ArtifactFolder,
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-delete-cluster")...)
+	})
+})

--- a/test/e2e/suites/managed/helpers.go
+++ b/test/e2e/suites/managed/helpers.go
@@ -58,6 +58,7 @@ const (
 	EKSControlPlaneOnlyWithAccessEntriesFlavor        = "eks-control-plane-only-with-accessentries"
 	EKSNodeadmClusterClassFlavor                      = "eks-nodeadm-clusterclass"
 	EKSNitroEnclaveManagedMachinePoolFlavor           = "eks-nitro-enclave-managedmachinepool"
+	EKSExternallyManagedFlavor                         = "eks-externally-managed"
 )
 
 const (

--- a/test/e2e/suites/managed/helpers.go
+++ b/test/e2e/suites/managed/helpers.go
@@ -58,7 +58,7 @@ const (
 	EKSControlPlaneOnlyWithAccessEntriesFlavor        = "eks-control-plane-only-with-accessentries"
 	EKSNodeadmClusterClassFlavor                      = "eks-nodeadm-clusterclass"
 	EKSNitroEnclaveManagedMachinePoolFlavor           = "eks-nitro-enclave-managedmachinepool"
-	EKSExternallyManagedFlavor                         = "eks-externally-managed"
+	EKSExternallyManagedFlavor                        = "eks-externally-managed"
 )
 
 const (


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
Adds support for `AWSManagedControlPlane` resources to be marked as externally managed using the standard `cluster.x-k8s.io/managed-by` annotation.  This allows operators to use CAPI/CAPA to manage machines with pre-existing EKS clusters managed by external-systems (eg, Terraform).

**Which issue(s) this PR fixes**:
Fixes #6031

**Special notes for your reviewer**:
The second test added is a little redundant with the existing `TestAWSManagedControlPlaneReconcilerIntegrationTests` test but IMO a positive/negative check sitting close together will make identifying a regression easier in the future.

I'm not sure how detailed to go in the docs.  Too detailed and it'll likely just become out of date quickly as the status/conditions required will change as the internal controllers logic changes. IMO it's a pretty 'power-user' feature so some thing can be left up to the operator to determine for their environment, like the `kubeconfig` credential generation.  Alternatively we could to a longer/more detailed guide.

**AI Usage**:
My usage of CAPA doesn't extend to all of its features, so AI was used as an additional review before opening the PR and to try and capture any missed status/conditions or fields required for a minimal working `AWSManagedControlPlane` resource that's externally managed.

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [x] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [x] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Support for externally managed `AWSManagedControlPlane` resources using the `cluster.x-k8s.io/managed-by` annotation.
```
