### PR TITLE
🐛 ROSA Fix cross account creation issues-6037 

### DIFF
--- a/controllers/rosacluster_controller.go
+++ b/controllers/rosacluster_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
@@ -41,9 +40,7 @@ import (
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/exp/utils"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	stsservice "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/util/paused"
@@ -58,7 +55,6 @@ type ROSAClusterReconciler struct {
 	client.Client
 	Recorder         record.EventRecorder
 	WatchFilterValue string
-	NewStsClient     func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsservice.STSClient
 	NewOCMClient     func(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (rosa.OCMClient, error)
 }
 
@@ -137,7 +133,6 @@ func (r *ROSAClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		ControlPlane:   controlPlane,
 		ControllerName: "",
 		Logger:         log,
-		NewStsClient:   r.NewStsClient,
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create rosa controlplane scope: %w", err)
@@ -156,7 +151,6 @@ func (r *ROSAClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *ROSAClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	log := logger.FromContext(ctx)
 	r.NewOCMClient = rosa.NewWrappedOCMClient
-	r.NewStsClient = scope.NewSTSClient
 
 	rosaCluster := &expinfrav1.ROSACluster{}
 

--- a/controllers/rosacluster_controller_test.go
+++ b/controllers/rosacluster_controller_test.go
@@ -27,7 +27,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -37,11 +36,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	stsiface "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts/mock_stsiface"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -222,8 +217,6 @@ func TestRosaClusterReconcile(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 		ctx := context.TODO()
 		ocmMock := mocks.NewMockOCMClient(mockCtrl)
-		stsMock := mock_stsiface.NewMockSTSClient(mockCtrl)
-		stsMock.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).AnyTimes()
 
 		nodePoolName := "nodepool-1"
 		expect := func(m *mocks.MockOCMClientMockRecorder) {
@@ -272,9 +265,6 @@ func TestRosaClusterReconcile(t *testing.T) {
 			Recorder:         recorder,
 			WatchFilterValue: "",
 			Client:           testEnv,
-			NewStsClient: func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsiface.STSClient {
-				return stsMock
-			},
 			NewOCMClient: func(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (rosa.OCMClient, error) {
 				return ocmMock, nil
 			},

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -29,7 +29,10 @@ import (
 	"strings"
 	"time"
 
-	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	stsv2sdk "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/google/go-cmp/cmp"
 	idputils "github.com/openshift-online/ocm-common/pkg/idp/utils"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -40,7 +43,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -59,9 +61,7 @@ import (
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/annotations"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	stsiface "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/utils"
@@ -92,8 +92,9 @@ type ROSAControlPlaneReconciler struct {
 	client.Client
 	WatchFilterValue string
 	WaitInfraPeriod  time.Duration
-	NewStsClient     func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsiface.STSClient
 	NewOCMClient     func(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (rosa.OCMClient, error)
+	// awsClientFactory overrides AWS client creation per reconciliation. Used in tests to inject mock clients.
+	awsClientFactory func(scope *scope.ROSAControlPlaneScope) (rosaaws.Client, error)
 	// Exposing the restClientConfig for integration test. No need to initialize.
 	restClientConfig *restclient.Config
 }
@@ -102,7 +103,6 @@ type ROSAControlPlaneReconciler struct {
 func (r *ROSAControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	log := logger.FromContext(ctx)
 	r.NewOCMClient = rosa.NewWrappedOCMClient
-	r.NewStsClient = scope.NewSTSClient
 
 	rosaControlPlane := &rosacontrolplanev1.ROSAControlPlane{}
 	c, err := ctrl.NewControllerManagedBy(mgr).
@@ -180,10 +180,33 @@ func (r *ROSAControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		ControlPlane:   rosaControlPlane,
 		ControllerName: strings.ToLower(rosaControlPlaneKind),
 		Logger:         log,
-		NewStsClient:   r.NewStsClient,
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create scope: %w", err)
+	}
+
+	// Create a new ROSA AWS client per reconciliation from the scope's session so that the
+	// credentials always reflect the identityRef (including any cross-account role assumption).
+	awsClient, err := r.newAWSClient(rosaScope)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create AWS client: %w", err)
+	}
+
+	// Derive the creator from the live AWS session.This ensures the creator's AccountID and ARN
+	// are both from the identity that the session credentials resolve to
+	// (e.g. a cross-account assumed role in the target account).
+	creator, err := awsClient.GetCreator()
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get AWS creator: %w", err)
+	}
+
+	// In cross-account deployments the management-cluster identity is in a different account than
+	// the target account (where the role ARNs live). OCM validates that creator.AccountID, the
+	// account in creator.ARN, and every role ARN account are all the same. When they differ,
+	// assume the InstallerRoleARN so we get a real STS identity in the target account.
+	creator, err = r.resolveCreatorForTargetAccount(ctx, rosaScope, creator)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to resolve creator for target account: %w", err)
 	}
 
 	// Always close the scope
@@ -195,14 +218,14 @@ func (r *ROSAControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if !rosaControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Handle deletion reconciliation loop.
-		return r.reconcileDelete(ctx, rosaScope)
+		return r.reconcileDelete(ctx, rosaScope, creator)
 	}
 
 	// Handle normal reconciliation loop.
-	return r.reconcileNormal(ctx, rosaScope)
+	return r.reconcileNormal(ctx, rosaScope, creator)
 }
 
-func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (res ctrl.Result, reterr error) {
+func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope, creator *rosaaws.Creator) (res ctrl.Result, reterr error) {
 	rosaScope.Info("Reconciling ROSAControlPlane")
 
 	if controllerutil.AddFinalizer(rosaScope.ControlPlane, ROSAControlPlaneFinalizer) {
@@ -218,15 +241,6 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 	if err != nil || ocmClient == nil {
 		// TODO: need to expose in status, as likely the credentials are invalid
 		return ctrl.Result{}, fmt.Errorf("failed to create OCM client: %w", err)
-	}
-
-	creator, err := rosaaws.CreatorForCallerIdentity(&stsv2.GetCallerIdentityOutput{
-		Account: rosaScope.Identity.Account,
-		Arn:     rosaScope.Identity.Arn,
-		UserId:  rosaScope.Identity.UserId,
-	})
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to transform caller identity to creator: %w", err)
 	}
 
 	rosaRoleConfig, err := r.reconcileRosaRoleConfig(ctx, rosaScope)
@@ -411,7 +425,7 @@ func (r *ROSAControlPlaneReconciler) reconcileRosaRoleConfig(ctx context.Context
 	return rosaRoleConfig, nil
 }
 
-func (r *ROSAControlPlaneReconciler) reconcileDelete(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (res ctrl.Result, reterr error) {
+func (r *ROSAControlPlaneReconciler) reconcileDelete(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope, creator *rosaaws.Creator) (res ctrl.Result, reterr error) {
 	rosaScope.Info("Reconciling ROSAControlPlane delete")
 
 	// Deleting MachinePools first.
@@ -424,19 +438,10 @@ func (r *ROSAControlPlaneReconciler) reconcileDelete(ctx context.Context, rosaSc
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 
-	ocmClient, err := rosa.NewOCMClient(ctx, rosaScope)
+	ocmClient, err := r.NewOCMClient(ctx, rosaScope)
 	if err != nil || ocmClient == nil {
 		// TODO: need to expose in status, as likely the credentials are invalid
 		return ctrl.Result{}, fmt.Errorf("failed to create OCM client: %w", err)
-	}
-
-	creator, err := rosaaws.CreatorForCallerIdentity(&stsv2.GetCallerIdentityOutput{
-		Account: rosaScope.Identity.Account,
-		Arn:     rosaScope.Identity.Arn,
-		UserId:  rosaScope.Identity.UserId,
-	})
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to transform caller identity to creator: %w", err)
 	}
 
 	cluster, err := ocmClient.GetCluster(rosaScope.ControlPlane.Spec.RosaClusterName, creator)
@@ -1361,6 +1366,101 @@ func operatorIAMRoles(rolesRef rosacontrolplanev1.AWSRolesRef) []ocm.OperatorIAM
 			RoleARN:   rolesRef.NodePoolManagementARN,
 		},
 	}
+}
+
+// resolveCreatorForTargetAccount handles cross-account deployments: when the management-cluster
+// identity is in a different AWS account than the target account (where the InstallerRoleARN and
+// other role ARNs reside), it assumes the InstallerRoleARN using the current session credentials
+// and calls GetCreator() on the resulting client to obtain a real STS identity in the target account.
+//
+// OCM requires that creator.AccountID, the account parsed from creator.ARN, and every role ARN
+// account are all the same (target) account. Assuming the InstallerRole gives a genuine
+// sts:assumed-role ARN in the target account, satisfying both OCM validations.
+func (r *ROSAControlPlaneReconciler) resolveCreatorForTargetAccount(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope, creator *rosaaws.Creator) (*rosaaws.Creator, error) {
+	installerRoleARN := rosaScope.ControlPlane.Spec.InstallerRoleARN
+	if rosaScope.ControlPlane.Spec.RosaRoleConfigRef != nil {
+		rosaRoleConfig := &expinfrav1.ROSARoleConfig{}
+		if err := r.Client.Get(ctx, client.ObjectKey{
+			Name:      rosaScope.ControlPlane.Spec.RosaRoleConfigRef.Name,
+			Namespace: rosaScope.ControlPlane.Namespace,
+		}, rosaRoleConfig); err != nil {
+			return nil, err
+		}
+		if rosaRoleConfig.Status.AccountRolesRef.InstallerRoleARN == "" {
+			return nil, fmt.Errorf("RosaRoleConfig %s/%s is not ready", rosaScope.ControlPlane.Namespace, rosaScope.ControlPlane.Spec.RosaRoleConfigRef.Name)
+		}
+		installerRoleARN = rosaRoleConfig.Status.AccountRolesRef.InstallerRoleARN
+	}
+
+	if installerRoleARN == "" {
+		return creator, nil
+	}
+
+	targetAccountID, err := accountIDFromRoleARN(installerRoleARN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse account ID from InstallerRoleARN %q: %w", installerRoleARN, err)
+	}
+	if targetAccountID == creator.AccountID {
+		return creator, nil // same account — no cross-account assumption needed
+	}
+
+	session := rosaScope.Session()
+	// Fall back to the control plane spec region when the session carries no region
+	// (e.g. when the scope is constructed without a full AWS session in tests).
+	if session.Region == "" {
+		session.Region = rosaScope.ControlPlane.Spec.Region
+	}
+
+	stsSvc := stsv2sdk.NewFromConfig(session)
+	assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsSvc, installerRoleARN, func(o *stscreds.AssumeRoleOptions) {
+		o.RoleSessionName = fmt.Sprintf("%s-%s", "capa-session", rosaScope.ControlPlane.Spec.RosaClusterName)
+	})
+
+	rosaScope.Info("Assuming cross-account deployment", "targetAccount", targetAccountID, "installerRoleARN", installerRoleARN)
+
+	// Build targetSession based on old session default values and load the new credential.
+	targetSession := session.Copy()
+	targetSession.Credentials = awsv2.NewCredentialsCache(assumeRoleProvider)
+
+	log := rosaScope.Logger.GetLogger()
+	targetClient, err := rosaaws.NewClient().
+		CapaLogger(&log).
+		ExternalConfig(&targetSession).
+		Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build AWS client for target account %s: %w", targetAccountID, err)
+	}
+
+	targetCreator, err := targetClient.GetCreator()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get creator for target account %s via role %s: %w", targetAccountID, installerRoleARN, err)
+	}
+
+	return targetCreator, nil
+}
+
+// accountIDFromRoleARN parses the AWS account ID from a role ARN.
+func accountIDFromRoleARN(roleARN string) (string, error) {
+	parsed, err := arn.Parse(roleARN)
+	if err != nil {
+		return "", err
+	}
+	return parsed.AccountID, nil
+}
+
+// newAWSClient creates a ROSA AWS client per reconciliation using the scope's session so that
+// credentials always reflect the identityRef (including cross-account role assumption).
+// Tests inject via awsClientFactory.
+func (r *ROSAControlPlaneReconciler) newAWSClient(rosaScope *scope.ROSAControlPlaneScope) (rosaaws.Client, error) {
+	if r.awsClientFactory != nil {
+		return r.awsClientFactory(rosaScope)
+	}
+	session := rosaScope.Session()
+	log := rosaScope.Logger.GetLogger()
+	return rosaaws.NewClient().
+		CapaLogger(&log).
+		ExternalConfig(&session).
+		Build()
 }
 
 func (r *ROSAControlPlaneReconciler) rosaClusterToROSAControlPlane(log *logger.Logger) handler.MapFunc {

--- a/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
@@ -30,15 +30,16 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	rosaaws "github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,10 +48,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	stsiface "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts/mock_stsiface"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
@@ -59,6 +57,46 @@ import (
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
+
+// fakeStsAPIClient is a minimal implementation of rosaaws.StsApiClient for use in tests.
+// It returns a fixed caller identity without needing a mock framework.
+type fakeStsAPIClient struct {
+	account string
+	arn     string
+	userID  string
+}
+
+func (f *fakeStsAPIClient) GetCallerIdentity(_ context.Context, _ *stsv2.GetCallerIdentityInput, _ ...func(*stsv2.Options)) (*stsv2.GetCallerIdentityOutput, error) {
+	return &stsv2.GetCallerIdentityOutput{
+		Account: aws.String(f.account),
+		Arn:     aws.String(f.arn),
+		UserId:  aws.String(f.userID),
+	}, nil
+}
+
+func (f *fakeStsAPIClient) AssumeRole(_ context.Context, _ *stsv2.AssumeRoleInput, _ ...func(*stsv2.Options)) (*stsv2.AssumeRoleOutput, error) {
+	return nil, nil
+}
+
+func (f *fakeStsAPIClient) AssumeRoleWithWebIdentity(_ context.Context, _ *stsv2.AssumeRoleWithWebIdentityInput, _ ...func(*stsv2.Options)) (*stsv2.AssumeRoleWithWebIdentityOutput, error) {
+	return nil, nil
+}
+
+// newFakeAWSClientFactory returns an awsClientFactory that injects a rosaaws.Client backed by
+// the given fakeStsAPIClient. GetCreator() on the returned client will use that STS stub.
+func newFakeAWSClientFactory(fakeSts *fakeStsAPIClient) func(*scope.ROSAControlPlaneScope) (rosaaws.Client, error) {
+	return func(_ *scope.ROSAControlPlaneScope) (rosaaws.Client, error) {
+		return rosaaws.New(
+			aws.Config{},
+			rosaaws.NewLoggerWrapper(logrus.New(), nil),
+			nil, nil, nil, nil, nil,
+			fakeSts,
+			nil, nil, nil,
+			&rosaaws.AccessKey{},
+			false,
+		), nil
+	}
+}
 
 func TestUpdateOCMClusterSpec(t *testing.T) {
 	g := NewWithT(t)
@@ -452,9 +490,9 @@ func TestRosaControlPlaneReconcileStatusVersion(t *testing.T) {
 				KMSProviderARN:          "op-arn8",
 			},
 			OIDCID:           "iodcid1",
-			InstallerRoleARN: "arn1",
-			WorkerRoleARN:    "arn2",
-			SupportRoleARN:   "arn3",
+			InstallerRoleARN: "arn:aws:iam::123456789012:role/installer",
+			WorkerRoleARN:    "arn:aws:iam::123456789012:role/worker",
+			SupportRoleARN:   "arn:aws:iam::123456789012:role/support",
 			CredentialsSecretRef: &corev1.LocalObjectReference{
 				Name: secret.Name,
 			},
@@ -514,10 +552,12 @@ func TestRosaControlPlaneReconcileStatusVersion(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	ctx := context.TODO()
 	ocmMock := mocks.NewMockOCMClient(mockCtrl)
-	stsMock := mock_stsiface.NewMockSTSClient(mockCtrl)
 
-	getCallerIdentityResult := &stsv2.GetCallerIdentityOutput{Account: aws.String("foo"), Arn: aws.String("arn:aws:iam::123456789012:rosa/foo")}
-	stsMock.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Return(getCallerIdentityResult, nil).Times(1)
+	fakeSts := &fakeStsAPIClient{
+		account: "foo",
+		arn:     "arn:aws:iam::123456789012:rosa/foo",
+		userID:  "user-id",
+	}
 
 	expect := func(m *mocks.MockOCMClientMockRecorder) {
 		m.ValidateHypershiftVersion(gomock.Any(), gomock.Any()).DoAndReturn(func(clusterId string, nodePoolID string) (bool, error) {
@@ -625,9 +665,7 @@ func TestRosaControlPlaneReconcileStatusVersion(t *testing.T) {
 		WatchFilterValue: "",
 		Client:           testEnv,
 		restClientConfig: cfg,
-		NewStsClient: func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsiface.STSClient {
-			return stsMock
-		},
+		awsClientFactory: newFakeAWSClientFactory(fakeSts),
 		NewOCMClient: func(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (rosa.OCMClient, error) {
 			return ocmMock, nil
 		},
@@ -865,6 +903,598 @@ func cleanupObject(g *WithT, obj client.Object) {
 	if obj.DeepCopyObject() != nil {
 		g.Expect(testEnv.Cleanup(ctx, obj)).To(Succeed())
 	}
+}
+
+// generateTestID returns a unique suffix for test object names.
+func generateTestID() string {
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}
+
+// fakeStsHTTPResponse writes a valid STS AssumeRole XML response for use in httptest servers.
+func fakeStsHTTPResponse(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/xml")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIAIOSFODNN7EXAMPLE</AccessKeyId>
+      <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY</SecretAccessKey>
+      <SessionToken>AQoXnyc4MCrrlandlJKwBQ==</SessionToken>
+      <Expiration>2030-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/fake-rosa-role/test</Arn>
+      <AssumedRoleId>ARO123EXAMPLE123:test</AssumedRoleId>
+    </AssumedRoleUser>
+  </AssumeRoleResult>
+  <ResponseMetadata>
+    <RequestId>12345678-1234-1234-1234-123456789012</RequestId>
+  </ResponseMetadata>
+</AssumeRoleResponse>`)
+}
+
+// TestROSAControlPlaneReconcilerWithRoleIdentity verifies that when an AWSClusterRoleIdentity
+// (with AllowedNamespaces permitting all namespaces) is referenced as the identity, the
+// ROSAControlPlaneReconciler successfully resolves credentials and reaches the AWS client
+// factory (our canary), rather than failing at scope creation.
+func TestROSAControlPlaneReconcilerWithRoleIdentity(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	stsServer := httptest.NewServer(http.HandlerFunc(fakeStsHTTPResponse))
+	defer stsServer.Close()
+
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key-id")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	testID := generateTestID()
+
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-cp-ri-%s", testID[:12]))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	controllerIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterControllerIdentity"))
+	createObject(g, controllerIdentity, ns.Name)
+	defer cleanupObject(g, controllerIdentity)
+
+	roleIdentity := &infrav1.AWSClusterRoleIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("fake-role-%s", testID[:12]),
+		},
+		Spec: infrav1.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: infrav1.AWSRoleSpec{
+				RoleArn:     fmt.Sprintf("arn:aws:iam::123456789012:role/fake-cp-role-%s", testID[:12]),
+				SessionName: "test-session",
+			},
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+			SourceIdentityRef: &infrav1.AWSIdentityReference{
+				Name: controllerIdentity.Name,
+				Kind: infrav1.ControllerIdentityKind,
+			},
+		},
+	}
+	roleIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterRoleIdentity"))
+	createObject(g, roleIdentity, ns.Name)
+	defer cleanupObject(g, roleIdentity)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("rosa-secret-%s", testID[:12]),
+			Namespace: ns.Name,
+		},
+		Data: map[string][]byte{"ocmToken": []byte("fake-token")},
+	}
+	createObject(g, secret, ns.Name)
+	defer cleanupObject(g, secret)
+
+	cpName := fmt.Sprintf("rosa-cp-%s", testID[:12])
+	rosaControlPlane := &rosacontrolplanev1.ROSAControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpName,
+			Namespace: ns.Name,
+			UID:       types.UID(cpName),
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ROSAControlPlane",
+			APIVersion: rosacontrolplanev1.GroupVersion.String(),
+		},
+		Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+			RosaClusterName:   cpName,
+			Subnets:           []string{"subnet-0ac99a6230b408813"},
+			AvailabilityZones: []string{"us-east-1a"},
+			Network: &rosacontrolplanev1.NetworkSpec{
+				MachineCIDR: "10.0.0.0/16",
+				PodCIDR:     "10.128.0.0/14",
+				ServiceCIDR: "172.30.0.0/16",
+			},
+			Region:           "us-east-1",
+			Version:          "4.15.0",
+			ChannelGroup:     "stable",
+			OIDCID:           "oidcid-test",
+			InstallerRoleARN: "arn:aws:iam::123456789012:role/installer",
+			WorkerRoleARN:    "arn:aws:iam::123456789012:role/worker",
+			SupportRoleARN:   "arn:aws:iam::123456789012:role/support",
+			RolesRef: rosacontrolplanev1.AWSRolesRef{
+				IngressARN:              "op-arn1",
+				ImageRegistryARN:        "op-arn2",
+				StorageARN:              "op-arn3",
+				NetworkARN:              "op-arn4",
+				KubeCloudControllerARN:  "op-arn5",
+				NodePoolManagementARN:   "op-arn6",
+				ControlPlaneOperatorARN: "op-arn7",
+				KMSProviderARN:          "op-arn8",
+			},
+			CredentialsSecretRef: &corev1.LocalObjectReference{Name: secret.Name},
+			VersionGate:          "Acknowledge",
+			IdentityRef: &infrav1.AWSIdentityReference{
+				Name: roleIdentity.Name,
+				Kind: infrav1.ClusterRoleIdentityKind,
+			},
+		},
+	}
+
+	ownerCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("owner-cluster-%s", testID[:12]),
+			Namespace: ns.Name,
+			UID:       types.UID(fmt.Sprintf("owner-cluster-%s", testID[:12])),
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: clusterv1.ContractVersionedObjectReference{
+				Name:     rosaControlPlane.Name,
+				Kind:     "ROSAControlPlane",
+				APIGroup: rosacontrolplanev1.GroupVersion.Group,
+			},
+		},
+	}
+
+	rosaControlPlane.OwnerReferences = []metav1.OwnerReference{
+		{
+			Name:       ownerCluster.Name,
+			UID:        ownerCluster.UID,
+			Kind:       "Cluster",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+	}
+
+	for _, obj := range []client.Object{ownerCluster, rosaControlPlane} {
+		createObject(g, obj, ns.Name)
+	}
+	defer cleanupObject(g, rosaControlPlane)
+	defer cleanupObject(g, ownerCluster)
+
+	awsClientCalled := false
+	reconciler := &ROSAControlPlaneReconciler{
+		Client: testEnv,
+		// awsClientFactory is the canary: it is called only when scope creation
+		// (including AWSClusterRoleIdentity credential resolution) succeeds.
+		awsClientFactory: func(_ *scope.ROSAControlPlaneScope) (rosaaws.Client, error) {
+			awsClientCalled = true
+			return nil, fmt.Errorf("sentinel: awsClientFactory reached after role-identity scope creation")
+		},
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: rosaControlPlane.Name, Namespace: rosaControlPlane.Namespace},
+	}
+
+	// EnsurePausedCondition on first call returns early (conditionChanged=true).
+	// Retry until scope creation succeeds and awsClientFactory is reached.
+	g.Eventually(func(g Gomega) {
+		_, errReconcile := reconciler.Reconcile(ctx, req)
+		g.Expect(errReconcile).To(HaveOccurred())
+		g.Expect(errReconcile.Error()).To(ContainSubstring("failed to create AWS client"))
+		g.Expect(errReconcile.Error()).NotTo(ContainSubstring("failed to create scope"))
+		g.Expect(awsClientCalled).To(BeTrue())
+	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
+// TestROSAControlPlaneReconcilerWithRoleIdentityNamespaceNotAllowed verifies that when an
+// AWSClusterRoleIdentity restricts usage to a namespace that does not contain the
+// ROSAControlPlane, scope creation is rejected before the AWS client factory is reached.
+func TestROSAControlPlaneReconcilerWithRoleIdentityNamespaceNotAllowed(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	stsServer := httptest.NewServer(http.HandlerFunc(fakeStsHTTPResponse))
+	defer stsServer.Close()
+
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key-id")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	testID := generateTestID()
+
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-cp-ri-denied-%s", testID[:12]))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	controllerIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterControllerIdentity"))
+	createObject(g, controllerIdentity, ns.Name)
+	defer cleanupObject(g, controllerIdentity)
+
+	// AllowedNamespaces permits only "other-namespace" — the control plane's namespace is excluded.
+	roleIdentity := &infrav1.AWSClusterRoleIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("restricted-role-%s", testID[:12]),
+		},
+		Spec: infrav1.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: infrav1.AWSRoleSpec{
+				RoleArn:     fmt.Sprintf("arn:aws:iam::123456789012:role/restricted-cp-role-%s", testID[:12]),
+				SessionName: "test-session",
+			},
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{
+					NamespaceList: []string{"other-namespace"},
+				},
+			},
+			SourceIdentityRef: &infrav1.AWSIdentityReference{
+				Name: controllerIdentity.Name,
+				Kind: infrav1.ControllerIdentityKind,
+			},
+		},
+	}
+	roleIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterRoleIdentity"))
+	createObject(g, roleIdentity, ns.Name)
+	defer cleanupObject(g, roleIdentity)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("rosa-secret-denied-%s", testID[:12]),
+			Namespace: ns.Name,
+		},
+		Data: map[string][]byte{"ocmToken": []byte("fake-token")},
+	}
+	createObject(g, secret, ns.Name)
+	defer cleanupObject(g, secret)
+
+	cpName := fmt.Sprintf("rosa-cp-denied-%s", testID[:12])
+	rosaControlPlane := &rosacontrolplanev1.ROSAControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpName,
+			Namespace: ns.Name,
+			UID:       types.UID(cpName),
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ROSAControlPlane",
+			APIVersion: rosacontrolplanev1.GroupVersion.String(),
+		},
+		Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+			RosaClusterName:   cpName,
+			Subnets:           []string{"subnet-0ac99a6230b408813"},
+			AvailabilityZones: []string{"us-east-1a"},
+			Network: &rosacontrolplanev1.NetworkSpec{
+				MachineCIDR: "10.0.0.0/16",
+				PodCIDR:     "10.128.0.0/14",
+				ServiceCIDR: "172.30.0.0/16",
+			},
+			Region:           "us-east-1",
+			Version:          "4.15.0",
+			ChannelGroup:     "stable",
+			OIDCID:           "oidcid-test",
+			InstallerRoleARN: "arn:aws:iam::123456789012:role/installer",
+			WorkerRoleARN:    "arn:aws:iam::123456789012:role/worker",
+			SupportRoleARN:   "arn:aws:iam::123456789012:role/support",
+			RolesRef: rosacontrolplanev1.AWSRolesRef{
+				IngressARN:              "op-arn1",
+				ImageRegistryARN:        "op-arn2",
+				StorageARN:              "op-arn3",
+				NetworkARN:              "op-arn4",
+				KubeCloudControllerARN:  "op-arn5",
+				NodePoolManagementARN:   "op-arn6",
+				ControlPlaneOperatorARN: "op-arn7",
+				KMSProviderARN:          "op-arn8",
+			},
+			CredentialsSecretRef: &corev1.LocalObjectReference{Name: secret.Name},
+			VersionGate:          "Acknowledge",
+			IdentityRef: &infrav1.AWSIdentityReference{
+				Name: roleIdentity.Name,
+				Kind: infrav1.ClusterRoleIdentityKind,
+			},
+		},
+	}
+
+	ownerCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("owner-cluster-denied-%s", testID[:12]),
+			Namespace: ns.Name,
+			UID:       types.UID(fmt.Sprintf("owner-cluster-denied-%s", testID[:12])),
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: clusterv1.ContractVersionedObjectReference{
+				Name:     rosaControlPlane.Name,
+				Kind:     "ROSAControlPlane",
+				APIGroup: rosacontrolplanev1.GroupVersion.Group,
+			},
+		},
+	}
+
+	rosaControlPlane.OwnerReferences = []metav1.OwnerReference{
+		{
+			Name:       ownerCluster.Name,
+			UID:        ownerCluster.UID,
+			Kind:       "Cluster",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+	}
+
+	for _, obj := range []client.Object{ownerCluster, rosaControlPlane} {
+		createObject(g, obj, ns.Name)
+	}
+	defer cleanupObject(g, rosaControlPlane)
+	defer cleanupObject(g, ownerCluster)
+
+	awsClientCalled := false
+	reconciler := &ROSAControlPlaneReconciler{
+		Client: testEnv,
+		awsClientFactory: func(_ *scope.ROSAControlPlaneScope) (rosaaws.Client, error) {
+			awsClientCalled = true
+			return nil, nil
+		},
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: rosaControlPlane.Name, Namespace: rosaControlPlane.Namespace},
+	}
+
+	// Retry until the informer cache has indexed the control plane and the namespace
+	// restriction is enforced, causing scope creation to fail.
+	g.Eventually(func(g Gomega) {
+		_, errReconcile := reconciler.Reconcile(ctx, req)
+		g.Expect(errReconcile).To(HaveOccurred())
+		g.Expect(errReconcile.Error()).To(ContainSubstring("failed to create scope"))
+		g.Expect(awsClientCalled).To(BeFalse())
+	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
+// fakeMultiActionStsHandler handles both AssumeRole and GetCallerIdentity STS requests.
+// It dispatches based on the Action form value, returning canned XML responses so that
+// cross-account creator resolution can be exercised without real AWS credentials.
+func fakeMultiActionStsHandler(targetAccount, targetARN string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		action := r.FormValue("Action")
+		w.Header().Set("Content-Type", "text/xml")
+		switch action {
+		case "AssumeRole":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIAIOSFODNN7EXAMPLE</AccessKeyId>
+      <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY</SecretAccessKey>
+      <SessionToken>AQoXnyc4MCrrlandlJKwBQ==</SessionToken>
+      <Expiration>2030-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>%s</Arn>
+      <AssumedRoleId>ARO123EXAMPLE123:capa-session</AssumedRoleId>
+    </AssumedRoleUser>
+  </AssumeRoleResult>
+  <ResponseMetadata><RequestId>12345678-1234-1234-1234-123456789012</RequestId></ResponseMetadata>
+</AssumeRoleResponse>`, targetARN)
+		case "GetCallerIdentity":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+    <Account>%s</Account>
+    <Arn>%s</Arn>
+    <UserId>ARO123EXAMPLE123:capa-session</UserId>
+  </GetCallerIdentityResult>
+  <ResponseMetadata><RequestId>12345678-1234-1234-1234-123456789012</RequestId></ResponseMetadata>
+</GetCallerIdentityResponse>`, targetAccount, targetARN)
+		default:
+			http.Error(w, "unknown action", http.StatusBadRequest)
+		}
+	}
+}
+
+func TestResolveCreatorForTargetAccount(t *testing.T) {
+	const (
+		sourceAccount   = "111111111111"
+		targetAccount   = "999999999999"
+		rosaClusterName = "test-cluster"
+		// targetARN reflects the actual RoleSessionName generated by resolveCreatorForTargetAccount:
+		// "capa-session-<RosaClusterName>"
+		targetARN          = "arn:aws:sts::999999999999:assumed-role/installer/capa-session-" + rosaClusterName
+		expectedCreatorARN = "arn:aws:iam::999999999999:role/installer" // ROSA normalizes assumed-role ARNs to the base IAM role ARN
+	)
+
+	sourceCreator := &rosaaws.Creator{
+		AccountID: sourceAccount,
+		ARN:       "arn:aws:iam::111111111111:user/management-user",
+	}
+
+	t.Run("EmptyInstallerRoleARN_returnsCreatorUnchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					InstallerRoleARN: "",
+				},
+			},
+			Logger: *logger.FromContext(context.TODO()),
+		}
+		reconciler := &ROSAControlPlaneReconciler{}
+		result, err := reconciler.resolveCreatorForTargetAccount(context.TODO(), rosaScope, sourceCreator)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(Equal(sourceCreator))
+	})
+
+	t.Run("SameAccountInstallerRoleARN_returnsCreatorUnchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					// Same account as sourceCreator
+					InstallerRoleARN: "arn:aws:iam::111111111111:role/installer",
+				},
+			},
+			Logger: *logger.FromContext(context.TODO()),
+		}
+		reconciler := &ROSAControlPlaneReconciler{}
+		result, err := reconciler.resolveCreatorForTargetAccount(context.TODO(), rosaScope, sourceCreator)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(Equal(sourceCreator))
+	})
+
+	t.Run("InvalidInstallerRoleARN_returnsError", func(t *testing.T) {
+		g := NewWithT(t)
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					InstallerRoleARN: "not-a-valid-arn",
+				},
+			},
+			Logger: *logger.FromContext(context.TODO()),
+		}
+		reconciler := &ROSAControlPlaneReconciler{}
+		result, err := reconciler.resolveCreatorForTargetAccount(context.TODO(), rosaScope, sourceCreator)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to parse account ID from InstallerRoleARN"))
+		g.Expect(result).To(BeNil())
+	})
+
+	t.Run("RosaRoleConfigRef_NotFound_returnsError", func(t *testing.T) {
+		g := NewWithT(t)
+		ns, err := testEnv.CreateNamespace(ctx, "test-resolve-creator-notfound")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+				},
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					RosaRoleConfigRef: &corev1.LocalObjectReference{
+						Name: "non-existent-role-config",
+					},
+				},
+			},
+			Logger: *logger.FromContext(context.TODO()),
+		}
+		reconciler := &ROSAControlPlaneReconciler{Client: testEnv}
+		result, err := reconciler.resolveCreatorForTargetAccount(context.TODO(), rosaScope, sourceCreator)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(result).To(BeNil())
+	})
+
+	t.Run("RosaRoleConfigRef_SameAccount_returnsCreatorUnchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		ns, err := testEnv.CreateNamespace(ctx, "test-resolve-creator-sameaccount")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		roleConfig := &expinfrav1.ROSARoleConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "role-config-same-account",
+				Namespace: ns.Name,
+			},
+			Spec: expinfrav1.ROSARoleConfigSpec{
+				OidcProviderType: "Managed",
+				AccountRoleConfig: expinfrav1.AccountRoleConfig{
+					Prefix:  "test",
+					Version: "4.19.0",
+				},
+				OperatorRoleConfig: expinfrav1.OperatorRoleConfig{
+					Prefix: "test",
+				},
+			},
+		}
+		createObject(g, roleConfig, ns.Name)
+		defer cleanupObject(g, roleConfig)
+
+		// Patch status to set InstallerRoleARN to the same account as sourceCreator
+		roleConfig.Status = expinfrav1.ROSARoleConfigStatus{
+			AccountRolesRef: expinfrav1.AccountRolesRef{
+				InstallerRoleARN: "arn:aws:iam::111111111111:role/installer",
+			},
+		}
+		g.Expect(testEnv.Status().Update(ctx, roleConfig)).To(Succeed())
+
+		// The cached client is updated asynchronously after a status write. Wait for
+		// the cache to reflect the new InstallerRoleARN before calling into the function
+		// under test, otherwise it may see an empty status and return "not ready".
+		g.Eventually(func(g Gomega) {
+			fresh := &expinfrav1.ROSARoleConfig{}
+			g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(roleConfig), fresh)).To(Succeed())
+			g.Expect(fresh.Status.AccountRolesRef.InstallerRoleARN).ToNot(BeEmpty())
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+				},
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					RosaRoleConfigRef: &corev1.LocalObjectReference{
+						Name: roleConfig.Name,
+					},
+				},
+			},
+			Logger: *logger.FromContext(context.TODO()),
+		}
+		reconciler := &ROSAControlPlaneReconciler{Client: testEnv}
+		result, err := reconciler.resolveCreatorForTargetAccount(context.TODO(), rosaScope, sourceCreator)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(Equal(sourceCreator))
+	})
+
+	t.Run("CrossAccountInstallerRoleARN_assumesRoleAndReturnsTargetCreator", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stsServer := httptest.NewServer(fakeMultiActionStsHandler(targetAccount, targetARN))
+		defer stsServer.Close()
+
+		t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+		t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key-id")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+
+		fakeSession, err := awsconfig.LoadDefaultConfig(context.TODO(), awsconfig.WithRegion("us-east-1"))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					RosaClusterName:  rosaClusterName,
+					Region:           "us-east-1",
+					InstallerRoleARN: "arn:aws:iam::999999999999:role/installer",
+				},
+			},
+			Logger: *logger.FromContext(context.TODO()),
+		}
+		rosaScope.SetSession(fakeSession)
+
+		reconciler := &ROSAControlPlaneReconciler{}
+		result, err := reconciler.resolveCreatorForTargetAccount(context.TODO(), rosaScope, sourceCreator)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.AccountID).To(Equal(targetAccount))
+		g.Expect(result.ARN).To(Equal(expectedCreatorARN))
+	})
 }
 
 func TestBuildOCMClusterSpec(t *testing.T) {

--- a/controlplane/rosa/controllers/suite_test.go
+++ b/controlplane/rosa/controllers/suite_test.go
@@ -73,8 +73,14 @@ func setup() {
 	if err := (&capawebhooks.AWSClusterControllerIdentity{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSClusterControllerIdentity webhook: %v", err))
 	}
+	if err := (&capawebhooks.AWSClusterRoleIdentity{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSClusterRoleIdentity webhook: %v", err))
+	}
 	if err := (&expwebhooks.ROSAMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup ROSAMachinePool webhook: %v", err))
+	}
+	if err := (&expwebhooks.ROSARoleConfig{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup ROSARoleConfig webhook: %v", err))
 	}
 	if err := (&rosawebhooks.ROSAControlPlane{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup ROSAMachinePool webhook: %v", err))

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -30,9 +29,7 @@ import (
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/exp/utils"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	stsservice "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/util/paused"
@@ -50,7 +47,6 @@ type ROSAMachinePoolReconciler struct {
 	client.Client
 	Recorder         record.EventRecorder
 	WatchFilterValue string
-	NewStsClient     func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsservice.STSClient
 	NewOCMClient     func(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (rosa.OCMClient, error)
 }
 
@@ -58,7 +54,6 @@ type ROSAMachinePoolReconciler struct {
 func (r *ROSAMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	log := logger.FromContext(ctx)
 	r.NewOCMClient = rosa.NewWrappedOCMClient
-	r.NewStsClient = scope.NewSTSClient
 
 	gvk, err := apiutil.GVKForObject(new(expinfrav1.ROSAMachinePool), mgr.GetScheme())
 	if err != nil {
@@ -171,7 +166,6 @@ func (r *ROSAMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		Cluster:        cluster,
 		ControlPlane:   controlPlane,
 		ControllerName: "rosaControlPlane",
-		NewStsClient:   r.NewStsClient,
 	})
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to create rosaControlPlane scope")

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -11,7 +11,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
@@ -23,10 +22,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	stsiface "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts/mock_stsiface"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
@@ -575,16 +571,10 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 			ocmMock := mocks.NewMockOCMClient(mockCtrl)
 			test.expect(ocmMock.EXPECT())
 
-			stsMock := mock_stsiface.NewMockSTSClient(mockCtrl)
-			stsMock.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Times(1)
-
 			r := ROSAMachinePoolReconciler{
 				Recorder:         recorder,
 				WatchFilterValue: "",
 				Client:           testEnv,
-				NewStsClient: func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsiface.STSClient {
-					return stsMock
-				},
 				NewOCMClient: func(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (rosa.OCMClient, error) {
 					return ocmMock, nil
 				},
@@ -671,16 +661,10 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 		}
 		expect(ocmMock.EXPECT())
 
-		stsMock := mock_stsiface.NewMockSTSClient(mockCtrl)
-		stsMock.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Times(1)
-
 		r := ROSAMachinePoolReconciler{
 			Recorder:         recorder,
 			WatchFilterValue: "",
 			Client:           testEnv,
-			NewStsClient: func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsiface.STSClient {
-				return stsMock
-			},
 			NewOCMClient: func(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (rosa.OCMClient, error) {
 				return ocmMock, nil
 			},
@@ -703,7 +687,6 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 			Cluster:        oc,
 			ControlPlane:   cp,
 			ControllerName: "rosaControlPlane",
-			NewStsClient:   r.NewStsClient,
 		})
 		g.Expect(err2).ToNot(HaveOccurred())
 

--- a/exp/controllers/rosanetwork_controller.go
+++ b/exp/controllers/rosanetwork_controller.go
@@ -53,9 +53,9 @@ type ROSANetworkReconciler struct {
 	client.Client
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
-	awsClient        rosaAWSClient.Client
-	cfStack          *cloudformationtypes.Stack
 	WatchFilterValue string
+	// awsClientFactory overrides AWS client creation per reconciliation. Used in tests to inject mock clients.
+	awsClientFactory func(scope *scope.ROSANetworkScope) (rosaAWSClient.Client, error)
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=rosanetworks,verbs=get;list;watch;create;update;patch;delete
@@ -86,26 +86,18 @@ func (r *ROSANetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, fmt.Errorf("failed to create rosanetwork scope: %w", err)
 	}
 
-	// Create a new AWS/CloudFormation Client using the session cache
-	if r.awsClient == nil {
-		session := rosaNetworkScope.Session()
-		logger := rosaNetworkScope.Logger.GetLogger()
-		awsClient, err := rosaAWSClient.NewClient().
-			CapaLogger(&logger).
-			ExternalConfig(&session).
-			Build()
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to create AWS Client: %w", err)
-		}
-		r.awsClient = awsClient
+	// Create a new AWS/CloudFormation Client per reconciliation so the correct identity is always used.
+	awsClient, err := r.newAWSClient(rosaNetworkScope)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create AWS Client: %w", err)
 	}
 
 	// Try to fetch CF stack with a given name
-	r.cfStack, err = r.awsClient.GetCFStack(ctx, rosaNetworkScope.ROSANetwork.Spec.StackName)
+	cfStack, err := awsClient.GetCFStack(ctx, rosaNetworkScope.ROSANetwork.Spec.StackName)
 	if err != nil {
 		var apiErr smithy.APIError // in case the stack does not exist, AWS returns ValidationError
 		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "ValidationError" {
-			r.cfStack = nil
+			cfStack = nil
 		} else {
 			return ctrl.Result{}, fmt.Errorf("error fetching CF stack details: %w", err)
 		}
@@ -120,14 +112,14 @@ func (r *ROSANetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if !rosaNetwork.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Handle deletion reconciliation loop.
-		return r.reconcileDelete(ctx, rosaNetworkScope)
+		return r.reconcileDelete(ctx, rosaNetworkScope, awsClient, cfStack)
 	}
 
 	// Handle normal reconciliation loop.
-	return r.reconcileNormal(ctx, rosaNetworkScope)
+	return r.reconcileNormal(ctx, rosaNetworkScope, awsClient, cfStack)
 }
 
-func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScope *scope.ROSANetworkScope) (res ctrl.Result, reterr error) {
+func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScope *scope.ROSANetworkScope, awsClient rosaAWSClient.Client, cfStack *cloudformationtypes.Stack) (res ctrl.Result, reterr error) {
 	rosaNetScope.Info("Reconciling ROSANetwork")
 
 	if controllerutil.AddFinalizer(rosaNetScope.ROSANetwork, expinfrav1.ROSANetworkFinalizer) {
@@ -136,7 +128,7 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 		}
 	}
 
-	if r.cfStack == nil { // The CF stack does not exist yet
+	if cfStack == nil { // The CF stack does not exist yet
 		templateBody := string(rosaCFNetwork.CloudFormationTemplateFile)
 
 		zoneCount := 1
@@ -155,7 +147,7 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 		}
 
 		// Call the AWS CF stack create API
-		_, err := r.awsClient.CreateStackWithParamsTags(ctx, templateBody, rosaNetScope.ROSANetwork.Spec.StackName, cfParams, rosaNetScope.ROSANetwork.Spec.StackTags)
+		_, err := awsClient.CreateStackWithParamsTags(ctx, templateBody, rosaNetScope.ROSANetwork.Spec.StackName, cfParams, rosaNetScope.ROSANetwork.Spec.StackTags)
 		if err != nil {
 			v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
 				expinfrav1.ROSANetworkReadyCondition,
@@ -173,12 +165,12 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 		return ctrl.Result{}, nil
 	}
 	// The cloudformation stack already exists
-	if err := r.updateROSANetworkResources(ctx, rosaNetScope.ROSANetwork); err != nil {
+	if err := r.updateROSANetworkResources(ctx, rosaNetScope.ROSANetwork, awsClient); err != nil {
 		rosaNetScope.Info("error fetching CF stack resources: %w", err)
 		return ctrl.Result{RequeueAfter: time.Second * 60}, nil
 	}
 
-	switch r.cfStack.StackStatus {
+	switch cfStack.StackStatus {
 	case cloudformationtypes.StackStatusCreateInProgress: // Create in progress
 		// Set the reason of false ROSANetworkReadyCondition to Creating
 		v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
@@ -188,7 +180,7 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 			"")
 		return ctrl.Result{RequeueAfter: time.Second * 60}, nil
 	case cloudformationtypes.StackStatusCreateComplete: // Create complete
-		if err := r.parseSubnets(rosaNetScope.ROSANetwork); err != nil {
+		if err := r.parseSubnets(rosaNetScope.ROSANetwork, awsClient); err != nil {
 			return ctrl.Result{}, fmt.Errorf("parsing stack subnets failed: %w", err)
 		}
 
@@ -209,22 +201,22 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 			expinfrav1.ROSANetworkFailedReason,
 			clusterv1beta1.ConditionSeverityError,
 			"")
-		return ctrl.Result{}, fmt.Errorf("cloudformation stack %s creation failed, see the stack resources for more information", *r.cfStack.StackName)
+		return ctrl.Result{}, fmt.Errorf("cloudformation stack %s creation failed, see the stack resources for more information", *cfStack.StackName)
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *ROSANetworkReconciler) reconcileDelete(ctx context.Context, rosaNetScope *scope.ROSANetworkScope) (res ctrl.Result, reterr error) {
+func (r *ROSANetworkReconciler) reconcileDelete(ctx context.Context, rosaNetScope *scope.ROSANetworkScope, awsClient rosaAWSClient.Client, cfStack *cloudformationtypes.Stack) (res ctrl.Result, reterr error) {
 	rosaNetScope.Info("Reconciling ROSANetwork delete")
 
-	if r.cfStack != nil { // The CF stack still exists
-		if err := r.updateROSANetworkResources(ctx, rosaNetScope.ROSANetwork); err != nil {
+	if cfStack != nil { // The CF stack still exists
+		if err := r.updateROSANetworkResources(ctx, rosaNetScope.ROSANetwork, awsClient); err != nil {
 			rosaNetScope.Info("error fetching CF stack resources: %w", err)
 			return ctrl.Result{RequeueAfter: time.Second * 60}, nil
 		}
 
-		switch r.cfStack.StackStatus {
+		switch cfStack.StackStatus {
 		case cloudformationtypes.StackStatusDeleteInProgress: // Deletion in progress
 			return ctrl.Result{RequeueAfter: time.Second * 60}, nil
 		case cloudformationtypes.StackStatusDeleteFailed: // Deletion failed
@@ -235,7 +227,7 @@ func (r *ROSANetworkReconciler) reconcileDelete(ctx context.Context, rosaNetScop
 				"")
 			return ctrl.Result{}, fmt.Errorf("CF stack deletion failed")
 		default: // All the other states
-			err := r.awsClient.DeleteCFStack(ctx, rosaNetScope.ROSANetwork.Spec.StackName)
+			err := awsClient.DeleteCFStack(ctx, rosaNetScope.ROSANetwork.Spec.StackName)
 			if err != nil {
 				v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
 					expinfrav1.ROSANetworkReadyCondition,
@@ -259,8 +251,8 @@ func (r *ROSANetworkReconciler) reconcileDelete(ctx context.Context, rosaNetScop
 	return ctrl.Result{}, nil
 }
 
-func (r *ROSANetworkReconciler) updateROSANetworkResources(ctx context.Context, rosaNet *expinfrav1.ROSANetwork) error {
-	resources, err := r.awsClient.DescribeCFStackResources(ctx, rosaNet.Spec.StackName)
+func (r *ROSANetworkReconciler) updateROSANetworkResources(ctx context.Context, rosaNet *expinfrav1.ROSANetwork, awsClient rosaAWSClient.Client) error {
+	resources, err := awsClient.DescribeCFStackResources(ctx, rosaNet.Spec.StackName)
 	if err != nil {
 		return fmt.Errorf("error calling AWS DescribeStackResources(): %w", err)
 	}
@@ -279,7 +271,7 @@ func (r *ROSANetworkReconciler) updateROSANetworkResources(ctx context.Context, 
 	return nil
 }
 
-func (r *ROSANetworkReconciler) parseSubnets(rosaNet *expinfrav1.ROSANetwork) error {
+func (r *ROSANetworkReconciler) parseSubnets(rosaNet *expinfrav1.ROSANetwork, awsClient rosaAWSClient.Client) error {
 	subnets := make(map[string]expinfrav1.ROSANetworkSubnet)
 
 	for _, resource := range rosaNet.Status.Resources {
@@ -287,7 +279,7 @@ func (r *ROSANetworkReconciler) parseSubnets(rosaNet *expinfrav1.ROSANetwork) er
 			continue
 		}
 
-		az, err := r.awsClient.GetSubnetAvailabilityZone(resource.PhysicalID)
+		az, err := awsClient.GetSubnetAvailabilityZone(resource.PhysicalID)
 		if err != nil {
 			return fmt.Errorf("failed to get AZ for subnet %s: %w", resource.PhysicalID, err)
 		}
@@ -307,6 +299,20 @@ func (r *ROSANetworkReconciler) parseSubnets(rosaNet *expinfrav1.ROSANetwork) er
 	rosaNet.Status.Subnets = slices.Collect(maps.Values(subnets))
 
 	return nil
+}
+
+// newAWSClient creates a new ROSA AWS client per reconciliation using the scope's session,
+// ensuring the correct identity (identityRef) is always used. Tests inject via awsClientFactory.
+func (r *ROSANetworkReconciler) newAWSClient(rosaNetworkScope *scope.ROSANetworkScope) (rosaAWSClient.Client, error) {
+	if r.awsClientFactory != nil {
+		return r.awsClientFactory(rosaNetworkScope)
+	}
+	session := rosaNetworkScope.Session()
+	log := rosaNetworkScope.Logger.GetLogger()
+	return rosaAWSClient.NewClient().
+		CapaLogger(&log).
+		ExternalConfig(&session).
+		Build()
 }
 
 // SetupWithManager is used to setup the controller.

--- a/exp/controllers/rosanetwork_controller_test.go
+++ b/exp/controllers/rosanetwork_controller_test.go
@@ -16,6 +16,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -39,6 +41,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 )
@@ -108,7 +111,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("Empty result when ROSANetwork object not found", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, _, _, reconciler := createMockClients(mockCtrl)
+		_, _, _, _, reconciler := createMockClients(mockCtrl)
 
 		req := ctrl.Request{}
 		req.NamespacedName = types.NamespacedName{Name: "non-existent-object", Namespace: "non-existent-namespace"}
@@ -121,7 +124,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("Error result when CF stack GET returns error", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 		mockDescribeStacksCall(mockCFClient, &cloudformation.DescribeStacksOutput{}, fmt.Errorf("test-error"), 1)
@@ -137,7 +140,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("Initial CF stack creation fails", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -171,7 +174,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("Initial CF stack creation succeeds", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -204,7 +207,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("CF stack creation is in progress", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -239,7 +242,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("CF stack creation completed", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -274,7 +277,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("CF stack creation failed", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -309,7 +312,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("CF stack deletion start failed", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -346,7 +349,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("CF stack deletion start succeeded", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -383,7 +386,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("CF stack deletion in progress", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -410,7 +413,7 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 	t.Run("CF stack deletion failed", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, mockCFClient, mockSTSClient, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, mockSTSClient, _, reconciler := createMockClients(mockCtrl)
 
 		mockSTSIdentity(mockSTSClient)
 
@@ -467,17 +470,17 @@ func TestROSANetworkReconciler_updateROSANetworkResources(t *testing.T) {
 	}
 
 	t.Run("Handle cloudformation client error", func(t *testing.T) {
-		_, mockCFClient, _, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, _, awsClient, reconciler := createMockClients(mockCtrl)
 
 		mockDescribeStackResourcesCall(mockCFClient, &cloudformation.DescribeStackResourcesOutput{}, fmt.Errorf("test-error"), 1)
 
-		err := reconciler.updateROSANetworkResources(ctx, rosaNetwork)
+		err := reconciler.updateROSANetworkResources(ctx, rosaNetwork, awsClient)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(len(rosaNetwork.Status.Resources)).To(Equal(0))
 	})
 
 	t.Run("Update ROSANetwork.Status.Resources", func(t *testing.T) {
-		_, mockCFClient, _, reconciler := createMockClients(mockCtrl)
+		_, mockCFClient, _, awsClient, reconciler := createMockClients(mockCtrl)
 
 		logicalResourceID := "logical-resource-id"
 		resourceStatus := cloudformationtypes.ResourceStatusCreateComplete
@@ -499,7 +502,7 @@ func TestROSANetworkReconciler_updateROSANetworkResources(t *testing.T) {
 
 		mockDescribeStackResourcesCall(mockCFClient, describeStackResourcesOutput, nil, 1)
 
-		err := reconciler.updateROSANetworkResources(ctx, rosaNetwork)
+		err := reconciler.updateROSANetworkResources(ctx, rosaNetwork, awsClient)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(rosaNetwork.Status.Resources[0].LogicalID).To(Equal(logicalResourceID))
 		g.Expect(rosaNetwork.Status.Resources[0].Status).To(Equal(string(resourceStatus)))
@@ -550,17 +553,17 @@ func TestROSANetworkReconciler_parseSubnets(t *testing.T) {
 	}
 
 	t.Run("Handle EC2 client error", func(t *testing.T) {
-		mockEC2Client, _, _, reconciler := createMockClients(mockCtrl)
+		mockEC2Client, _, _, awsClient, reconciler := createMockClients(mockCtrl)
 
 		mockDescribeSubnetsCall(mockEC2Client, &ec2.DescribeSubnetsOutput{}, nil, 1)
 
-		err := reconciler.parseSubnets(rosaNetwork)
+		err := reconciler.parseSubnets(rosaNetwork, awsClient)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(len(rosaNetwork.Status.Subnets)).To(Equal(0))
 	})
 
 	t.Run("Update ROSANetwork.Status.Subnets", func(t *testing.T) {
-		mockEC2Client, _, _, reconciler := createMockClients(mockCtrl)
+		mockEC2Client, _, _, awsClient, reconciler := createMockClients(mockCtrl)
 
 		az := "az01"
 
@@ -574,7 +577,7 @@ func TestROSANetworkReconciler_parseSubnets(t *testing.T) {
 
 		mockDescribeSubnetsCall(mockEC2Client, describeSubnetsOutput, nil, 2)
 
-		err := reconciler.parseSubnets(rosaNetwork)
+		err := reconciler.parseSubnets(rosaNetwork, awsClient)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(rosaNetwork.Status.Subnets[0].AvailabilityZone).To(Equal(az))
 		g.Expect(rosaNetwork.Status.Subnets[0].PrivateSubnet).To(Equal(subnet1Id))
@@ -582,7 +585,7 @@ func TestROSANetworkReconciler_parseSubnets(t *testing.T) {
 	})
 }
 
-func createMockClients(mockCtrl *gomock.Controller) (*rosaMocks.MockEc2ApiClient, *rosaMocks.MockCloudFormationApiClient, *rosaMocks.MockStsApiClient, *ROSANetworkReconciler) {
+func createMockClients(mockCtrl *gomock.Controller) (*rosaMocks.MockEc2ApiClient, *rosaMocks.MockCloudFormationApiClient, *rosaMocks.MockStsApiClient, rosaAWSClient.Client, *ROSANetworkReconciler) {
 	mockEC2Client := rosaMocks.NewMockEc2ApiClient(mockCtrl)
 	mockCFClient := rosaMocks.NewMockCloudFormationApiClient(mockCtrl)
 	mockSTSClient := rosaMocks.NewMockStsApiClient(mockCtrl)
@@ -603,11 +606,13 @@ func createMockClients(mockCtrl *gomock.Controller) (*rosaMocks.MockEc2ApiClient
 	)
 
 	reconciler := &ROSANetworkReconciler{
-		Client:    testEnv.Client,
-		awsClient: awsClient,
+		Client: testEnv.Client,
+		awsClientFactory: func(_ *scope.ROSANetworkScope) (rosaAWSClient.Client, error) {
+			return awsClient, nil
+		},
 	}
 
-	return mockEC2Client, mockCFClient, mockSTSClient, reconciler
+	return mockEC2Client, mockCFClient, mockSTSClient, awsClient, reconciler
 }
 
 func mockSTSIdentity(mockSTSClient *rosaMocks.MockStsApiClient) {
@@ -723,4 +728,217 @@ func getROSANetworkReadyCondition(reconciler *ROSANetworkReconciler, rosaNet *ex
 	}
 
 	return v1beta1conditions.Get(updatedROSANetwork, expinfrav1.ROSANetworkReadyCondition), nil
+}
+
+// TestROSANetworkReconcilerWithRoleIdentity verifies that ROSANetworkReconciler can create its
+// scope (resolving credentials) when the ROSANetwork's IdentityRef points to an
+// AWSClusterRoleIdentity backed by a fake IAM role.
+//
+// The fake STS server satisfies the AssumeRole call that happens during scope creation.
+// The awsClientFactory is used as a canary: if it is called, scope creation (including
+// credential resolution via AWSClusterRoleIdentity) succeeded.
+func TestROSANetworkReconcilerWithRoleIdentity(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	// Start a local STS server that returns fake AssumeRole credentials.
+	stsServer := httptest.NewServer(http.HandlerFunc(fakeSTSAssumeRoleResponse))
+	defer stsServer.Close()
+
+	// Point the AWS SDK at the fake STS server and supply dummy source credentials so
+	// config.LoadDefaultConfig has something to work with when building the STS client.
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key-id")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	testID := generateTestID()
+
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-net-roleident-%s", testID))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// AWSClusterControllerIdentity is required as the SourceIdentityRef — the webhook
+	// rejects AWSClusterRoleIdentity with a nil sourceIdentityRef.
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	createObject(g, controllerIdentity, ns.Name)
+	defer cleanupObject(g, controllerIdentity)
+
+	roleIdentity := &infrav1.AWSClusterRoleIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("fake-role-identity-%s", testID),
+		},
+		Spec: infrav1.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: infrav1.AWSRoleSpec{
+				RoleArn:     fmt.Sprintf("arn:aws:iam::123456789012:role/fake-rosa-net-role-%s", testID),
+				SessionName: "test-session",
+			},
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+			SourceIdentityRef: &infrav1.AWSIdentityReference{
+				Name: controllerIdentity.Name,
+				Kind: infrav1.ControllerIdentityKind,
+			},
+		},
+	}
+	roleIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterRoleIdentity"))
+	createObject(g, roleIdentity, ns.Name)
+	defer cleanupObject(g, roleIdentity)
+
+	rosaNetwork := &expinfrav1.ROSANetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-rosa-network-%s", testID),
+			Namespace: ns.Name,
+		},
+		Spec: expinfrav1.ROSANetworkSpec{
+			StackName:             fmt.Sprintf("test-stack-%s", testID),
+			CIDRBlock:             "10.0.0.0/8",
+			AvailabilityZoneCount: 1,
+			Region:                "us-east-1",
+			IdentityRef: &infrav1.AWSIdentityReference{
+				Name: roleIdentity.Name,
+				Kind: infrav1.ClusterRoleIdentityKind,
+			},
+		},
+	}
+	createObject(g, rosaNetwork, ns.Name)
+	defer cleanupObject(g, rosaNetwork)
+
+	awsClientCalled := false
+	reconciler := &ROSANetworkReconciler{
+		Client: testEnv.Client,
+		// awsClientFactory acts as a canary: if it is invoked, scope creation (and
+		// therefore AWSClusterRoleIdentity credential resolution) succeeded.
+		awsClientFactory: func(_ *scope.ROSANetworkScope) (rosaAWSClient.Client, error) {
+			awsClientCalled = true
+			return nil, fmt.Errorf("sentinel: awsClientFactory reached after role-identity scope creation")
+		},
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: rosaNetwork.Name, Namespace: rosaNetwork.Namespace},
+	}
+
+	g.Eventually(func(g Gomega) {
+		_, errReconcile := reconciler.Reconcile(ctx, req)
+
+		// The reconciler must have advanced past scope creation and reached awsClientFactory.
+		// A "failed to create rosanetwork scope" error would mean credential resolution failed.
+		g.Expect(errReconcile).To(HaveOccurred())
+		g.Expect(errReconcile.Error()).To(ContainSubstring("failed to create AWS Client"))
+		g.Expect(errReconcile.Error()).NotTo(ContainSubstring("failed to create rosanetwork scope"))
+		g.Expect(awsClientCalled).To(BeTrue())
+	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
+// TestROSANetworkReconcilerWithRoleIdentityNamespaceNotAllowed verifies that when the
+// AWSClusterRoleIdentity's AllowedNamespaces does not include the ROSANetwork's namespace,
+// scope creation fails with a credential error and awsClientFactory is never called.
+func TestROSANetworkReconcilerWithRoleIdentityNamespaceNotAllowed(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	stsServer := httptest.NewServer(http.HandlerFunc(fakeSTSAssumeRoleResponse))
+	defer stsServer.Close()
+
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key-id")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	testID := generateTestID()
+
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-net-roleident-denied-%s", testID))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	createObject(g, controllerIdentity, ns.Name)
+	defer cleanupObject(g, controllerIdentity)
+
+	// AllowedNamespaces lists only "other-namespace", so ns.Name is not permitted.
+	roleIdentity := &infrav1.AWSClusterRoleIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("restricted-role-identity-%s", testID),
+		},
+		Spec: infrav1.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: infrav1.AWSRoleSpec{
+				RoleArn:     fmt.Sprintf("arn:aws:iam::123456789012:role/restricted-rosa-net-role-%s", testID),
+				SessionName: "test-session",
+			},
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{
+					NamespaceList: []string{"other-namespace"},
+				},
+			},
+			SourceIdentityRef: &infrav1.AWSIdentityReference{
+				Name: controllerIdentity.Name,
+				Kind: infrav1.ControllerIdentityKind,
+			},
+		},
+	}
+	roleIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterRoleIdentity"))
+	createObject(g, roleIdentity, ns.Name)
+	defer cleanupObject(g, roleIdentity)
+
+	rosaNetwork := &expinfrav1.ROSANetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-rosa-network-denied-%s", testID),
+			Namespace: ns.Name,
+		},
+		Spec: expinfrav1.ROSANetworkSpec{
+			StackName:             fmt.Sprintf("test-stack-denied-%s", testID),
+			CIDRBlock:             "10.0.0.0/8",
+			AvailabilityZoneCount: 1,
+			Region:                "us-east-1",
+			IdentityRef: &infrav1.AWSIdentityReference{
+				Name: roleIdentity.Name,
+				Kind: infrav1.ClusterRoleIdentityKind,
+			},
+		},
+	}
+	createObject(g, rosaNetwork, ns.Name)
+	defer cleanupObject(g, rosaNetwork)
+
+	awsClientCalled := false
+	reconciler := &ROSANetworkReconciler{
+		Client: testEnv.Client,
+		awsClientFactory: func(_ *scope.ROSANetworkScope) (rosaAWSClient.Client, error) {
+			awsClientCalled = true
+			return nil, nil
+		},
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: rosaNetwork.Name, Namespace: rosaNetwork.Namespace},
+	}
+
+	// Use Eventually so the reconcile is retried until the informer cache has indexed
+	// the newly created ROSANetwork. Once it is found, scope creation must fail because
+	// the namespace is not in AllowedNamespaces.
+	g.Eventually(func(g Gomega) {
+		_, errReconcile := reconciler.Reconcile(ctx, req)
+		g.Expect(errReconcile).To(HaveOccurred())
+		g.Expect(errReconcile.Error()).To(ContainSubstring("failed to create rosanetwork scope"))
+		g.Expect(awsClientCalled).To(BeFalse())
+	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 }

--- a/exp/controllers/rosaroleconfig_controller.go
+++ b/exp/controllers/rosaroleconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"strings"
 
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	accountroles "github.com/openshift/rosa/cmd/create/accountroles"
 	oidcconfig "github.com/openshift/rosa/cmd/create/oidcconfig"
 	oidcprovider "github.com/openshift/rosa/cmd/create/oidcprovider"
@@ -35,7 +36,6 @@ import (
 	rosacli "github.com/openshift/rosa/pkg/rosa"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -46,9 +46,7 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	stsiface "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -61,15 +59,20 @@ type ROSARoleConfigReconciler struct {
 	client.Client
 	Recorder         record.EventRecorder
 	WatchFilterValue string
-	NewStsClient     func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsiface.STSClient
 	NewOCMClient     func(ctx context.Context, scope rosa.OCMSecretsRetriever) (rosa.OCMClient, error)
-	Runtime          *rosacli.Runtime
+	// runtimeFactory overrides runtime creation per reconciliation. Used in tests to inject mock clients.
+	runtimeFactory func(ctx context.Context, scope *scope.RosaRoleConfigScope) (*rosacli.Runtime, error)
+}
+
+// roleNameLookup pairs an IAM role name with the string field that should receive its ARN.
+type roleNameLookup struct {
+	name string
+	dest *string
 }
 
 func (r *ROSARoleConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	log := logger.FromContext(ctx)
 	r.NewOCMClient = rosa.NewWrappedOCMClientWithoutControlPlane
-	r.NewStsClient = scope.NewSTSClient
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&expinfrav1.ROSARoleConfig{}).
@@ -115,14 +118,15 @@ func (r *ROSARoleConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}()
 
-	if err := r.setUpRuntime(ctx, scope); err != nil {
+	rt, err := r.setUpRuntime(ctx, scope)
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set up runtime: %w", err)
 	}
 
 	if !roleConfig.DeletionTimestamp.IsZero() {
 		scope.Info("Deleting ROSARoleConfig.")
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigDeletionStarted, clusterv1beta1.ConditionSeverityInfo, "Deletion of RosaRolesConfig started")
-		err = r.reconcileDelete(scope)
+		err = r.reconcileDelete(scope, rt)
 		if err == nil {
 			controllerutil.RemoveFinalizer(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigFinalizer)
 		}
@@ -134,7 +138,7 @@ func (r *ROSARoleConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcileAccountRoles(scope); err != nil {
+	if err := r.reconcileAccountRoles(scope, rt); err != nil {
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError, "Account Roles failure: %v", err)
 		return ctrl.Result{}, fmt.Errorf("account Roles: %w", err)
 	}
@@ -150,12 +154,12 @@ func (r *ROSARoleConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	if err := r.reconcileOIDC(scope); err != nil {
+	if err := r.reconcileOIDC(scope, rt); err != nil {
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError, "OIDC Config/provider failure: %v", err)
 		return ctrl.Result{}, fmt.Errorf("oicd Config: %w", err)
 	}
 
-	if err := r.reconcileOperatorRoles(scope); err != nil {
+	if err := r.reconcileOperatorRoles(scope, rt); err != nil {
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError, "Operator Roles failure: %v", err)
 		return ctrl.Result{}, fmt.Errorf("operator Roles: %w", err)
 	}
@@ -183,18 +187,18 @@ func (r *ROSARoleConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, nil
 }
 
-func (r *ROSARoleConfigReconciler) reconcileDelete(scope *scope.RosaRoleConfigScope) error {
-	if err := r.deleteOperatorRoles(scope); err != nil {
+func (r *ROSARoleConfigReconciler) reconcileDelete(scope *scope.RosaRoleConfigScope, rt *rosacli.Runtime) error {
+	if err := r.deleteOperatorRoles(scope, rt); err != nil {
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigDeletionFailedReason, clusterv1beta1.ConditionSeverityError, "Failed to delete operator roles: %v", err)
 		return err
 	}
 
-	if err := r.deleteOIDC(scope); err != nil {
+	if err := r.deleteOIDC(scope, rt); err != nil {
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigDeletionFailedReason, clusterv1beta1.ConditionSeverityError, "Failed to delete OIDC provider: %v", err)
 		return err
 	}
 
-	if err := r.deleteAccountRoles(scope); err != nil {
+	if err := r.deleteAccountRoles(scope, rt); err != nil {
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigDeletionFailedReason, clusterv1beta1.ConditionSeverityError, "Failed to delete account roles: %v", err)
 		return err
 	}
@@ -202,31 +206,14 @@ func (r *ROSARoleConfigReconciler) reconcileDelete(scope *scope.RosaRoleConfigSc
 	return nil
 }
 
-func (r *ROSARoleConfigReconciler) reconcileOperatorRoles(scope *scope.RosaRoleConfigScope) error {
-	operatorRoles, err := r.Runtime.AWSClient.ListOperatorRoles("", "", scope.RosaRoleConfig.Spec.OperatorRoleConfig.Prefix)
+func (r *ROSARoleConfigReconciler) reconcileOperatorRoles(scope *scope.RosaRoleConfigScope, rt *rosacli.Runtime) error {
+	prefix := scope.RosaRoleConfig.Spec.OperatorRoleConfig.Prefix
+
+	// Use targeted GetRoleByName lookups instead of ListOperatorRoles. ListOperatorRoles
+	// calls ListRoleTags for every IAM role in the account, which causes throttling.
+	operatorRolesRef, err := r.lookupOperatorRolesRef(rt, prefix)
 	if err != nil {
 		return err
-	}
-
-	operatorRolesRef := v1beta2.AWSRolesRef{}
-	for _, role := range operatorRoles[scope.RosaRoleConfig.Spec.OperatorRoleConfig.Prefix] {
-		if strings.Contains(role.RoleName, expinfrav1.IngressOperatorARNSuffix) {
-			operatorRolesRef.IngressARN = role.RoleARN
-		} else if strings.Contains(role.RoleName, expinfrav1.ImageRegistryARNSuffix) {
-			operatorRolesRef.ImageRegistryARN = role.RoleARN
-		} else if strings.Contains(role.RoleName, expinfrav1.StorageARNSuffix) {
-			operatorRolesRef.StorageARN = role.RoleARN
-		} else if strings.Contains(role.RoleName, expinfrav1.NetworkARNSuffix) {
-			operatorRolesRef.NetworkARN = role.RoleARN
-		} else if strings.Contains(role.RoleName, expinfrav1.KubeCloudControllerARNSuffix) {
-			operatorRolesRef.KubeCloudControllerARN = role.RoleARN
-		} else if strings.Contains(role.RoleName, expinfrav1.NodePoolManagementARNSuffix) {
-			operatorRolesRef.NodePoolManagementARN = role.RoleARN
-		} else if strings.Contains(role.RoleName, expinfrav1.ControlPlaneOperatorARNSuffix) {
-			operatorRolesRef.ControlPlaneOperatorARN = role.RoleARN
-		} else if strings.Contains(role.RoleName, expinfrav1.KMSProviderARNSuffix) {
-			operatorRolesRef.KMSProviderARN = role.RoleARN
-		}
 	}
 
 	if r.operatorRolesReady(operatorRolesRef) {
@@ -245,30 +232,52 @@ func (r *ROSARoleConfigReconciler) reconcileOperatorRoles(scope *scope.RosaRoleC
 		return nil
 	}
 
-	policies, err := r.Runtime.OCMClient.GetPolicies("OperatorRole")
+	policies, err := rt.OCMClient.GetPolicies("OperatorRole")
 	if err != nil {
 		return err
 	}
 
-	// create operator roles
 	config := scope.RosaRoleConfig.Spec.OperatorRoleConfig
-	return operatorroles.CreateOperatorRoles(r.Runtime, rosa.GetOCMClientEnv(r.Runtime.OCMClient), config.PermissionsBoundaryARN,
+	return operatorroles.CreateOperatorRoles(rt, rosa.GetOCMClientEnv(rt.OCMClient), config.PermissionsBoundaryARN,
 		interactive.ModeAuto, policies, "", config.SharedVPCConfig.IsSharedVPC(), config.Prefix, true, installerRoleArn,
 		true, oidcConfigID, config.SharedVPCConfig.RouteRoleARN, ocm.DefaultChannelGroup,
 		config.SharedVPCConfig.VPCEndpointRoleARN)
 }
 
-func (r *ROSARoleConfigReconciler) reconcileOIDC(scope *scope.RosaRoleConfigScope) error {
+// lookupOperatorRolesRef fetches each operator role ARN by its exact name using GetRoleByName.
+// This avoids ListOperatorRoles, which calls ListRoleTags for every IAM role in the account.
+func (r *ROSARoleConfigReconciler) lookupOperatorRolesRef(rt *rosacli.Runtime, prefix string) (v1beta2.AWSRolesRef, error) {
+	ref := v1beta2.AWSRolesRef{}
+	err := lookupRoleARNs(rt.AWSClient, []roleNameLookup{
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.IngressOperatorARNSuffix), &ref.IngressARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.ImageRegistryARNSuffix), &ref.ImageRegistryARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.StorageARNSuffix), &ref.StorageARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.NetworkARNSuffix), &ref.NetworkARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.KubeCloudControllerARNSuffix), &ref.KubeCloudControllerARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.NodePoolManagementARNSuffix), &ref.NodePoolManagementARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.ControlPlaneOperatorARNSuffix), &ref.ControlPlaneOperatorARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.KMSProviderARNSuffix), &ref.KMSProviderARN},
+	})
+	return ref, err
+}
+
+func (r *ROSARoleConfigReconciler) reconcileOIDC(scope *scope.RosaRoleConfigScope, rt *rosacli.Runtime) error {
 	oidcID := ""
 	switch scope.RosaRoleConfig.Spec.OidcProviderType {
 	case expinfrav1.Managed:
 		// Create oidcConfig if not exist
 		if scope.RosaRoleConfig.Status.OIDCID == "" {
-			oidcID, createErr := oidcconfig.CreateOIDCConfig(r.Runtime, true, "", "")
+			var createErr error
+			oidcID, createErr = oidcconfig.CreateOIDCConfig(rt, true, "", "")
 			if createErr != nil {
 				return fmt.Errorf("failed to Create OIDC config: %w", createErr)
 			}
 			scope.RosaRoleConfig.Status.OIDCID = oidcID
+			// Persist the OIDC config ID immediately so a subsequent reconcile does not
+			// create a second config if anything after this point fails.
+			if err := scope.PatchObject(); err != nil {
+				return fmt.Errorf("failed to persist OIDC config ID: %w", err)
+			}
 		}
 		oidcID = scope.RosaRoleConfig.Status.OIDCID
 	case expinfrav1.Unmanaged:
@@ -276,80 +285,102 @@ func (r *ROSARoleConfigReconciler) reconcileOIDC(scope *scope.RosaRoleConfigScop
 	}
 
 	// Check if oidc Config exist
-	oidcConfig, err := r.Runtime.OCMClient.GetOidcConfig(oidcID)
+	oidcConfig, err := rt.OCMClient.GetOidcConfig(oidcID)
 	if err != nil || oidcConfig == nil {
 		return fmt.Errorf("failed to get OIDC config: %w", err)
 	}
 
 	scope.RosaRoleConfig.Status.OIDCID = oidcConfig.ID()
 
-	// check oidc providers
-	providers, err := r.Runtime.AWSClient.ListOidcProviders("", oidcConfig)
+	// Look up the provider by issuer URL. GetOpenIDConnectProviderByOidcEndpointUrl only
+	// calls ListOpenIDConnectProviders once and matches by ARN string; unlike
+	// ListOidcProviders it does not call ListOpenIDConnectProviderTags per provider,
+	// which is the IAM API that triggers throttling under load.
+	providerArn, err := rt.AWSClient.GetOpenIDConnectProviderByOidcEndpointUrl(oidcConfig.IssuerUrl())
 	if err != nil {
 		return err
 	}
-
-	// set oidc Provider Arn
-	for _, provider := range providers {
-		if strings.Contains(provider.Arn, oidcID) {
-			scope.RosaRoleConfig.Status.OIDCProviderARN = provider.Arn
-			return nil
-		}
+	if providerArn != "" {
+		scope.RosaRoleConfig.Status.OIDCProviderARN = providerArn
+		return nil
 	}
 
-	// create oidc provider if not exist.
-	if scope.RosaRoleConfig.Status.OIDCProviderARN == "" {
-		if err := oidcprovider.CreateOIDCProvider(r.Runtime, oidcID, "", true); err != nil {
-			return err
-		}
-		providerArn, err := r.Runtime.AWSClient.GetOpenIDConnectProviderByOidcEndpointUrl(oidcConfig.IssuerUrl())
-		if err != nil {
-			return err
-		}
-		scope.RosaRoleConfig.Status.OIDCProviderARN = providerArn
+	if err := oidcprovider.CreateOIDCProvider(rt, oidcID, "", true); err != nil {
+		return err
+	}
+	providerArn, err = rt.AWSClient.GetOpenIDConnectProviderByOidcEndpointUrl(oidcConfig.IssuerUrl())
+	if err != nil {
+		return err
+	}
+	scope.RosaRoleConfig.Status.OIDCProviderARN = providerArn
+	// Persist the provider ARN immediately so a subsequent reconcile does not
+	// create a second provider if anything after this point fails.
+	if err := scope.PatchObject(); err != nil {
+		return fmt.Errorf("failed to persist OIDC provider ARN: %w", err)
 	}
 
 	return nil
 }
 
-func (r *ROSARoleConfigReconciler) reconcileAccountRoles(scope *scope.RosaRoleConfigScope) error {
-	accountRoles, err := r.Runtime.AWSClient.ListAccountRoles(scope.RosaRoleConfig.Spec.AccountRoleConfig.Version)
+func (r *ROSARoleConfigReconciler) reconcileAccountRoles(scope *scope.RosaRoleConfigScope, rt *rosacli.Runtime) error {
+	prefix := scope.RosaRoleConfig.Spec.AccountRoleConfig.Prefix
+
+	// Use targeted GetRoleByName lookups instead of ListAccountRoles. ListAccountRoles
+	// calls ListRoleTags for every IAM role in the account, which causes throttling.
+	accountRolesRef, err := r.lookupAccountRolesRef(rt, prefix)
 	if err != nil {
-		// ListAccountRoles return error if roles does not exist. return for any other error
-		if !strings.Contains(err.Error(), "no account roles found") {
-			return err
-		}
+		return err
 	}
 
-	accountRolesRef := expinfrav1.AccountRolesRef{}
-	for _, role := range accountRoles {
-		if role.RoleName == fmt.Sprintf("%s%s", scope.RosaRoleConfig.Spec.AccountRoleConfig.Prefix, expinfrav1.HCPROSAInstallerRole) {
-			accountRolesRef.InstallerRoleARN = role.RoleARN
-		} else if role.RoleName == fmt.Sprintf("%s%s", scope.RosaRoleConfig.Spec.AccountRoleConfig.Prefix, expinfrav1.HCPROSASupportRole) {
-			accountRolesRef.SupportRoleARN = role.RoleARN
-		} else if role.RoleName == fmt.Sprintf("%s%s", scope.RosaRoleConfig.Spec.AccountRoleConfig.Prefix, expinfrav1.HCPROSAWorkerRole) {
-			accountRolesRef.WorkerRoleARN = role.RoleARN
-		}
-	}
-
-	// Set account role ref if ready
 	if r.accountRolesReady(accountRolesRef) {
 		scope.RosaRoleConfig.Status.AccountRolesRef = accountRolesRef
 		return nil
 	}
 
-	policies, err := r.Runtime.OCMClient.GetPolicies("AccountRole")
+	policies, err := rt.OCMClient.GetPolicies("AccountRole")
 	if err != nil {
 		return err
 	}
 
-	return accountroles.CreateHCPRoles(r.Runtime, scope.RosaRoleConfig.Spec.AccountRoleConfig.Prefix, true, scope.RosaRoleConfig.Spec.AccountRoleConfig.PermissionsBoundaryARN,
-		rosa.GetOCMClientEnv(r.Runtime.OCMClient), policies, scope.RosaRoleConfig.Spec.AccountRoleConfig.Version, scope.RosaRoleConfig.Spec.AccountRoleConfig.Path,
+	return accountroles.CreateHCPRoles(rt, prefix, true, scope.RosaRoleConfig.Spec.AccountRoleConfig.PermissionsBoundaryARN,
+		rosa.GetOCMClientEnv(rt.OCMClient), policies, scope.RosaRoleConfig.Spec.AccountRoleConfig.Version, scope.RosaRoleConfig.Spec.AccountRoleConfig.Path,
 		scope.RosaRoleConfig.Spec.AccountRoleConfig.SharedVPCConfig.IsSharedVPC(), scope.RosaRoleConfig.Spec.AccountRoleConfig.SharedVPCConfig.RouteRoleARN,
 		scope.RosaRoleConfig.Spec.AccountRoleConfig.SharedVPCConfig.VPCEndpointRoleARN)
 }
 
-func (r *ROSARoleConfigReconciler) deleteAccountRoles(scope *scope.RosaRoleConfigScope) error {
+// lookupAccountRolesRef fetches each account role ARN by its exact name using GetRoleByName.
+// This avoids ListAccountRoles, which calls ListRoleTags for every IAM role in the account.
+func (r *ROSARoleConfigReconciler) lookupAccountRolesRef(rt *rosacli.Runtime, prefix string) (expinfrav1.AccountRolesRef, error) {
+	ref := expinfrav1.AccountRolesRef{}
+	err := lookupRoleARNs(rt.AWSClient, []roleNameLookup{
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.HCPROSAInstallerRole), &ref.InstallerRoleARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.HCPROSASupportRole), &ref.SupportRoleARN},
+		{fmt.Sprintf("%s%s", prefix, expinfrav1.HCPROSAWorkerRole), &ref.WorkerRoleARN},
+	})
+	return ref, err
+}
+
+// lookupRoleARNs calls GetRoleByName for each entry and writes the ARN into dest.
+// Roles that do not yet exist are silently skipped; any other error is returned immediately.
+// This avoids List*Roles calls that enumerate every IAM role and call ListRoleTags per role.
+func lookupRoleARNs(awsClient aws.Client, lookups []roleNameLookup) error {
+	for _, lk := range lookups {
+		role, err := awsClient.GetRoleByName(lk.name)
+		if err != nil {
+			var notFound *iamtypes.NoSuchEntityException
+			if errors.As(err, &notFound) {
+				continue
+			}
+			return err
+		}
+		if role.Arn != nil {
+			*lk.dest = *role.Arn
+		}
+	}
+	return nil
+}
+
+func (r *ROSARoleConfigReconciler) deleteAccountRoles(scope *scope.RosaRoleConfigScope, rt *rosacli.Runtime) error {
 	// list all account role names.
 	prefix := scope.RosaRoleConfig.Spec.AccountRoleConfig.Prefix
 	hasSharedVpcPolicies := scope.RosaRoleConfig.Spec.AccountRoleConfig.SharedVPCConfig.IsSharedVPC()
@@ -361,7 +392,7 @@ func (r *ROSARoleConfigReconciler) deleteAccountRoles(scope *scope.RosaRoleConfi
 
 	var errs []error
 	for _, roleName := range roleNames {
-		if err := r.Runtime.AWSClient.DeleteAccountRole(roleName, prefix, true, hasSharedVpcPolicies); err != nil {
+		if err := rt.AWSClient.DeleteAccountRole(roleName, prefix, true, hasSharedVpcPolicies); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -369,34 +400,34 @@ func (r *ROSARoleConfigReconciler) deleteAccountRoles(scope *scope.RosaRoleConfi
 	return kerrors.NewAggregate(errs)
 }
 
-func (r *ROSARoleConfigReconciler) deleteOIDC(scope *scope.RosaRoleConfigScope) error {
+func (r *ROSARoleConfigReconciler) deleteOIDC(scope *scope.RosaRoleConfigScope, rt *rosacli.Runtime) error {
 	// Delete only managed oidc
 	if scope.RosaRoleConfig.Spec.OidcProviderType == expinfrav1.Managed && scope.RosaRoleConfig.Status.OIDCID != "" {
-		oidcConfig, err := r.Runtime.OCMClient.GetOidcConfig(scope.RosaRoleConfig.Status.OIDCID)
+		oidcConfig, err := rt.OCMClient.GetOidcConfig(scope.RosaRoleConfig.Status.OIDCID)
 		if err != nil {
 			return err
 		}
 
 		oidcEndpointURL := oidcConfig.IssuerUrl()
-		if usedOidcProvider, err := r.Runtime.OCMClient.HasAClusterUsingOidcProvider(oidcEndpointURL, r.Runtime.Creator.AccountID); err != nil {
+		if usedOidcProvider, err := rt.OCMClient.HasAClusterUsingOidcProvider(oidcEndpointURL, rt.Creator.AccountID); err != nil {
 			return err
 		} else if usedOidcProvider {
 			return fmt.Errorf("clusters using OIDC provider '%s', cannot be deleted", oidcEndpointURL)
 		}
 
-		if err = r.Runtime.AWSClient.DeleteOpenIDConnectProvider(scope.RosaRoleConfig.Status.OIDCProviderARN); err != nil {
+		if err = rt.AWSClient.DeleteOpenIDConnectProvider(scope.RosaRoleConfig.Status.OIDCProviderARN); err != nil {
 			return err
 		}
 
-		return r.Runtime.OCMClient.DeleteOidcConfig(oidcConfig.ID())
+		return rt.OCMClient.DeleteOidcConfig(oidcConfig.ID())
 	}
 
 	return nil
 }
 
-func (r *ROSARoleConfigReconciler) deleteOperatorRoles(scope *scope.RosaRoleConfigScope) error {
+func (r *ROSARoleConfigReconciler) deleteOperatorRoles(scope *scope.RosaRoleConfigScope, rt *rosacli.Runtime) error {
 	prefix := scope.RosaRoleConfig.Spec.OperatorRoleConfig.Prefix
-	if usedOperatorRoles, err := r.Runtime.OCMClient.HasAClusterUsingOperatorRolesPrefix(prefix); err != nil {
+	if usedOperatorRoles, err := rt.OCMClient.HasAClusterUsingOperatorRolesPrefix(prefix); err != nil {
 		return err
 	} else if usedOperatorRoles {
 		return fmt.Errorf("operator Roles with Prefix '%s' are in use cannot be deleted", prefix)
@@ -417,7 +448,7 @@ func (r *ROSARoleConfigReconciler) deleteOperatorRoles(scope *scope.RosaRoleConf
 	allSharedVpcPoliciesNotDeleted := make(map[string]bool)
 	var errs []error
 	for _, roleName := range roleNames {
-		policiesNotDeleted, err := r.Runtime.AWSClient.DeleteOperatorRole(roleName, true, true)
+		policiesNotDeleted, err := rt.AWSClient.DeleteOperatorRole(roleName, true, true)
 		if err != nil && (!strings.Contains(err.Error(), "does not exists") && !strings.Contains(err.Error(), "NoSuchEntity")) {
 			errs = append(errs, err)
 		}
@@ -457,45 +488,44 @@ func (r ROSARoleConfigReconciler) operatorRolesReady(operatorRolesRef v1beta2.AW
 		operatorRolesRef.StorageARN != ""
 }
 
-// setUpRuntime sets up the ROSA runtime if it doesn't exist.
-func (r *ROSARoleConfigReconciler) setUpRuntime(ctx context.Context, scope *scope.RosaRoleConfigScope) error {
-	if r.Runtime != nil {
-		return nil
+// setUpRuntime creates a ROSA runtime for the current reconciliation using the scope's AWS session.
+// A new runtime is created per reconciliation so that the AWSClient always uses the correct
+// identity (identityRef) for the ROSARoleConfig being reconciled.
+func (r *ROSARoleConfigReconciler) setUpRuntime(ctx context.Context, scope *scope.RosaRoleConfigScope) (*rosacli.Runtime, error) {
+	if r.runtimeFactory != nil {
+		return r.runtimeFactory(ctx, scope)
 	}
-
 	// Create OCM client
 	ocm, err := r.NewOCMClient(ctx, scope)
 	if err != nil {
-		return fmt.Errorf("failed to create OCM client: %w", err)
+		return nil, fmt.Errorf("failed to create OCM client: %w", err)
 	}
 
 	ocmClient, err := rosa.ConvertToRosaOcmClient(ocm)
 	if err != nil || ocmClient == nil {
-		return fmt.Errorf("failed to create OCM client: %w", err)
+		return nil, fmt.Errorf("failed to create OCM client: %w", err)
 	}
 
-	runtime := rosacli.NewRuntime()
-	runtime.OCMClient = ocmClient
-	runtime.Reporter = reporter.CreateReporter() // &rosa.Reporter{}
-	runtime.Logger = rosalogging.NewLogger()
+	rt := rosacli.NewRuntime()
+	rt.OCMClient = ocmClient
+	rt.Reporter = reporter.CreateReporter()
+	rt.Logger = rosalogging.NewLogger()
 
 	session := scope.Session()
 	awsClient, err := aws.NewClient().
-		Logger(runtime.Logger).
+		Logger(rt.Logger).
 		ExternalConfig(&session).
 		Build()
 	if err != nil {
-		return fmt.Errorf("failed to create aws client: %w", err)
+		return nil, fmt.Errorf("failed to create aws client: %w", err)
 	}
-	runtime.AWSClient = awsClient
+	rt.AWSClient = awsClient
 
 	creator, err := awsClient.GetCreator()
 	if err != nil {
-		return fmt.Errorf("failed to get creator: %w", err)
+		return nil, fmt.Errorf("failed to get creator: %w", err)
 	}
-	runtime.Creator = creator
+	rt.Creator = creator
 
-	// atomic assignment - only when fully initialized
-	r.Runtime = runtime
-	return nil
+	return rt, nil
 }

--- a/exp/controllers/rosaroleconfig_controller_test.go
+++ b/exp/controllers/rosaroleconfig_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -44,16 +45,24 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
-	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 )
 
 // generateTestID creates a unique identifier for test resources.
 func generateTestID() string {
 	return fmt.Sprintf("%d-%d", time.Now().UnixNano(), rand.Intn(10000))
+}
+
+// makeRuntimeFactory returns a runtimeFactory that always returns the given pre-built runtime.
+// This replaces the old pattern of setting reconciler.Runtime directly.
+func makeRuntimeFactory(rt *rosacli.Runtime) func(context.Context, *scope.RosaRoleConfigScope) (*rosacli.Runtime, error) {
+	return func(_ context.Context, _ *scope.RosaRoleConfigScope) (*rosacli.Runtime, error) {
+		return rt, nil
+	}
 }
 
 func TestROSARoleConfigReconcileCreate(t *testing.T) {
@@ -205,10 +214,10 @@ func TestROSARoleConfigReconcileCreate(t *testing.T) {
 		false,
 	)
 
-	r := rosacli.NewRuntime()
-	r.OCMClient = ocmClient
-	r.AWSClient = awsClient
-	r.Creator = &aws.Creator{
+	rt := rosacli.NewRuntime()
+	rt.OCMClient = ocmClient
+	rt.AWSClient = awsClient
+	rt.Creator = &aws.Creator{
 		ARN:       "fake",
 		AccountID: "123",
 		IsSTS:     false,
@@ -363,10 +372,10 @@ func TestROSARoleConfigReconcileCreate(t *testing.T) {
 	createObject(g, rosaRoleConfig, ns.Name)
 	defer cleanupObject(g, rosaRoleConfig)
 
-	// Setup the reconciler with these mocks
+	// Setup the reconciler using runtimeFactory to inject mock clients per reconciliation.
 	reconciler := &ROSARoleConfigReconciler{
-		Client:  testEnv.Client,
-		Runtime: r,
+		Client:         testEnv.Client,
+		runtimeFactory: makeRuntimeFactory(rt),
 	}
 	req := ctrl.Request{}
 	req.NamespacedName = types.NamespacedName{Name: rosaRoleConfig.Name, Namespace: rosaRoleConfig.Namespace}
@@ -442,65 +451,35 @@ func TestROSARoleConfigReconcileExist(t *testing.T) {
 	mockAWSClient.EXPECT().HasManagedPolicies(gomock.Any()).Return(false, nil).AnyTimes()
 	mockAWSClient.EXPECT().HasHostedCPPolicies(gomock.Any()).Return(true, nil).AnyTimes()
 
-	// Return existing account roles
-	mockAWSClient.EXPECT().ListAccountRoles(gomock.Any()).Return([]aws.Role{
-		{
-			RoleName: "test-HCP-ROSA-Installer-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Installer-Role",
-		},
-		{
-			RoleName: "test-HCP-ROSA-Support-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Support-Role",
-		},
-		{
-			RoleName: "test-HCP-ROSA-Worker-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Worker-Role",
-		},
-	}, nil).AnyTimes()
+	// Return existing account roles by exact name (avoids ListAccountRoles → ListRoleTags throttling).
+	mockAWSClient.EXPECT().GetRoleByName("test-HCP-ROSA-Installer-Role").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-HCP-ROSA-Installer-Role")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-HCP-ROSA-Support-Role").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-HCP-ROSA-Support-Role")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-HCP-ROSA-Worker-Role").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-HCP-ROSA-Worker-Role")}, nil).AnyTimes()
 
-	// Return existing operator roles
-	mockAWSClient.EXPECT().ListOperatorRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string][]aws.OperatorRoleDetail{
-		"test": {
-			{
-				RoleName: "test-openshift-ingress-operator-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-ingress-operator-cloud-credentials",
-			},
-			{
-				RoleName: "test-openshift-image-registry-installer-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-image-registry-installer-cloud-credentials",
-			},
-			{
-				RoleName: "test-openshift-cluster-csi-drivers-ebs-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-cluster-csi-drivers-ebs-cloud-credentials",
-			},
-			{
-				RoleName: "test-openshift-cloud-network-config-controller-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-cloud-network-config-controller-cloud-credentials",
-			},
-			{
-				RoleName: "test-kube-system-kube-controller-manager",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-kube-controller-manager",
-			},
-			{
-				RoleName: "test-kube-system-capa-controller-manager",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-capa-controller-manager",
-			},
-			{
-				RoleName: "test-kube-system-control-plane-operator",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-control-plane-operator",
-			},
-			{
-				RoleName: "test-kube-system-kms-provider",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-kms-provider",
-			},
-		},
-	}, nil).AnyTimes()
-	// Return existing OIDC providers
-	mockAWSClient.EXPECT().ListOidcProviders(gomock.Any(), gomock.Any()).Return([]aws.OidcProviderOutput{
-		{
-			Arn: "arn:aws:iam::123456789012:oidc-provider/test-existing-oidc-id",
-		},
-	}, nil).AnyTimes()
+	// Return existing operator roles by exact name (avoids ListOperatorRoles → ListRoleTags throttling).
+	mockAWSClient.EXPECT().GetRoleByName("test-openshift-ingress-operator-cloud-credentials").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-openshift-ingress-operator-cloud-credentials")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-openshift-image-registry-installer-cloud-credentials").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-openshift-image-registry-installer-cloud-credentials")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-openshift-cluster-csi-drivers-ebs-cloud-credentials").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-openshift-cluster-csi-drivers-ebs-cloud-credentials")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-openshift-cloud-network-config-controller-cloud-credentials").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-openshift-cloud-network-config-controller-cloud-credentials")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-kube-system-kube-controller-manager").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-kube-system-kube-controller-manager")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-kube-system-capa-controller-manager").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-kube-system-capa-controller-manager")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-kube-system-control-plane-operator").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-kube-system-control-plane-operator")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-kube-system-kms-provider").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-kube-system-kms-provider")}, nil).AnyTimes()
+
+	// Return existing OIDC provider ARN by issuer URL (avoids ListOpenIDConnectProviderTags throttling).
+	mockAWSClient.EXPECT().GetOpenIDConnectProviderByOidcEndpointUrl("https://test.existing.oidc.url").Return(
+		"arn:aws:iam::123456789012:oidc-provider/test-existing-oidc-id", nil).AnyTimes()
 
 	mockAWSClient.EXPECT().GetCreator().Return(&aws.Creator{
 		ARN:       "arn:aws:iam::123456789012:user/test-user",
@@ -508,12 +487,10 @@ func TestROSARoleConfigReconcileExist(t *testing.T) {
 		IsSTS:     false,
 	}, nil).AnyTimes()
 
-	awsClient := mockAWSClient
-
-	r := rosacli.NewRuntime()
-	r.OCMClient = ocmClient
-	r.AWSClient = awsClient
-	r.Creator = &aws.Creator{
+	rt := rosacli.NewRuntime()
+	rt.OCMClient = ocmClient
+	rt.AWSClient = mockAWSClient
+	rt.Creator = &aws.Creator{
 		ARN:       "arn:aws:iam::123456789012:user/test-user",
 		AccountID: "123456789012",
 		IsSTS:     false,
@@ -585,10 +562,10 @@ func TestROSARoleConfigReconcileExist(t *testing.T) {
 	createObject(g, rosaRoleConfig, ns.Name)
 	defer cleanupObject(g, rosaRoleConfig)
 
-	// Setup the reconciler with these mocks
+	// Setup the reconciler using runtimeFactory to inject mock clients per reconciliation.
 	reconciler := &ROSARoleConfigReconciler{
-		Client:  testEnv.Client,
-		Runtime: r,
+		Client:         testEnv.Client,
+		runtimeFactory: makeRuntimeFactory(rt),
 	}
 
 	req := ctrl.Request{}
@@ -632,200 +609,97 @@ func TestROSARoleConfigReconcileExist(t *testing.T) {
 	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 }
 
-func TestROSARoleConfigSetUpRuntimeWithExpiredAWSCredentials(t *testing.T) {
+// TestROSARoleConfigSetUpRuntimePerReconciliation verifies that setUpRuntime always invokes
+// runtimeFactory on every call — i.e. no singleton caching across reconciliations.
+// This is the regression test for the bug where the first reconciliation's AWSClient was
+// reused for all subsequent ones regardless of identityRef.
+//
+// The test calls setUpRuntime directly with two distinct stub scopes so it doesn't depend
+// on the reconciler's Get/scope-creation path, avoiding any environment-specific flakiness.
+func TestROSARoleConfigSetUpRuntimePerReconciliation(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	callCount := 0
+	var capturedScopes []*scope.RosaRoleConfigScope
+
+	reconciler := &ROSARoleConfigReconciler{
+		runtimeFactory: func(_ context.Context, s *scope.RosaRoleConfigScope) (*rosacli.Runtime, error) {
+			callCount++
+			capturedScopes = append(capturedScopes, s)
+			return rosacli.NewRuntime(), nil
+		},
+	}
+
+	scope1 := &scope.RosaRoleConfigScope{}
+	scope2 := &scope.RosaRoleConfigScope{}
+
+	_, err := reconciler.setUpRuntime(ctx, scope1)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = reconciler.setUpRuntime(ctx, scope2)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// runtimeFactory must be called once per setUpRuntime call — no early-return caching.
+	g.Expect(callCount).To(Equal(2), "runtimeFactory must be called for every reconciliation")
+
+	// Each call received the scope it was given, not a shared/cached one.
+	g.Expect(capturedScopes).To(HaveLen(2))
+	g.Expect(capturedScopes[0]).To(BeIdenticalTo(scope1))
+	g.Expect(capturedScopes[1]).To(BeIdenticalTo(scope2))
+}
+
+// TestROSARoleConfigSetUpRuntimeError verifies that when runtimeFactory fails, the error
+// propagates and no stale runtime leaks into subsequent reconciliations.
+func TestROSARoleConfigSetUpRuntimeError(t *testing.T) {
 	RegisterTestingT(t)
 	g := NewWithT(t)
 	ctx := context.TODO()
 
-	// Mock empty AWS credentials
-	t.Setenv("AWS_ACCESS_KEY_ID", "")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	t.Setenv("AWS_SESSION_TOKEN", "")
-	t.Setenv("AWS_PROFILE", "")
-	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
-	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
-
-	// Create a miniaml scope for testing
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("test-ns-%s", generateTestID()),
-		},
-	}
-	createObject(g, ns, "")
-	defer cleanupObject(g, ns)
-
-	rosaRoleConfig := &expinfrav1.ROSARoleConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-role-config",
-			Namespace: ns.Namespace,
-		},
-		Spec: expinfrav1.ROSARoleConfigSpec{
-			AccountRoleConfig: expinfrav1.AccountRoleConfig{
-				Prefix:  "test",
-				Version: "4.15.0",
-			},
-			OperatorRoleConfig: expinfrav1.OperatorRoleConfig{
-				Prefix: "test",
-			},
-			OidcProviderType: expinfrav1.Managed,
-		},
-	}
-	createObject(g, rosaRoleConfig, ns.Name)
-	defer cleanupObject(g, rosaRoleConfig)
-
-	scope, err := scope.NewRosaRoleConfigScope(scope.RosaRoleConfigScopeParams{
-		Client:         testEnv.Client,
-		RosaRoleConfig: rosaRoleConfig,
-		ControllerName: "rosaroleconfig",
-	})
-	g.Expect(err).ToNot(HaveOccurred())
-
-	ssoServer := ocmsdk.MakeTCPServer()
-	apiServer := ocmsdk.MakeTCPServer()
-	defer ssoServer.Close()
-	defer apiServer.Close()
-
-	accessToken := ocmsdk.MakeTokenString("Bearer", 15*time.Minute)
-	ssoServer.AppendHandlers(ocmsdk.RespondWithAccessToken(accessToken))
-
-	logger, err := ocmlogging.NewGoLoggerBuilder().Debug(false).Build()
-	Expect(err).ToNot(HaveOccurred())
-	connection, err := sdk.NewConnectionBuilder().
-		Logger(logger).
-		Tokens(accessToken).
-		URL(apiServer.URL()).
-		Build()
-	Expect(err).To(BeNil())
-
-	ocmClient := ocm.NewClientWithConnection(connection)
-
-	// Track NewOCMClient call count to verify retry behavior
-	ocmClientCallCount := 0
-
-	reconciler := &ROSARoleConfigReconciler{
-		Client: testEnv.Client,
-		NewOCMClient: func(ctx context.Context, scope rosa.OCMSecretsRetriever) (rosa.OCMClient, error) {
-			ocmClientCallCount++
-			return ocmClient, nil
-		},
-		Runtime: nil, // Start with nil Runtime
-	}
-
-	// ==================== FIRST RECONCILIATION ====================
-	t.Log("First reconciliation: AWS credentials are missing/expired")
-
-	err = reconciler.setUpRuntime(ctx, scope)
-
-	g.Expect(err).To(HaveOccurred(),
-		"setUpRuntime should return error when AWS client creation fails")
-	g.Expect(err.Error()).To(ContainSubstring("failed to create aws client"),
-		"Error should indicate AWS client failure")
-
-	g.Expect(reconciler.Runtime).To(BeNil(),
-		"Runtime MUST be nil after failed initialization (atomic assignment fix)")
-
-	g.Expect(ocmClientCallCount).To(Equal(1),
-		"NewOCMClient should be called once on first attempt")
-
-	// ==================== SECOND RECONCILIATION ====================
-	t.Log("Second reconciliation: Retry with still-missing AWS credentials")
-
-	err = reconciler.setUpRuntime(ctx, scope)
-
-	g.Expect(err).To(HaveOccurred(),
-		"setUpRuntime should still fail with missing AWS credentials")
-
-	g.Expect(reconciler.Runtime).To(BeNil(),
-		"Runtime should still be nil after second failed attempt")
-
-	// NewOCMClient was called AGAIN (proves no early return)
-	g.Expect(ocmClientCallCount).To(Equal(2),
-		"NewOCMClient should be called twice - proves guard clause allows retry when Runtime is nil")
-}
-
-// TestSetUpRuntimeIdempotency verifies that setUpRuntime returns early
-// when Runtime is already fully initialized.
-func TestROSARoleConfigSetUpRuntimeIdempotency(t *testing.T) {
-	RegisterTestingT(t)
-	g := NewWithT(t)
-
-	ssoServer := ocmsdk.MakeTCPServer()
-	apiServer := ocmsdk.MakeTCPServer()
-	defer ssoServer.Close()
-	defer apiServer.Close()
-
-	accessToken := ocmsdk.MakeTokenString("Bearer", 15*time.Minute)
-	ssoServer.AppendHandlers(ocmsdk.RespondWithAccessToken(accessToken))
-
-	logger, err := ocmlogging.NewGoLoggerBuilder().Debug(false).Build()
-	Expect(err).ToNot(HaveOccurred())
-	connection, err := sdk.NewConnectionBuilder().
-		Logger(logger).
-		Tokens(accessToken).
-		URL(apiServer.URL()).
-		Build()
-	Expect(err).To(BeNil())
-
-	ocmClient := ocm.NewClientWithConnection(connection)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockIamClient := rosaMocks.NewMockIamApiClient(mockCtrl)
-	mockSTSClient := rosaMocks.NewMockStsApiClient(mockCtrl)
-
-	awsClient := aws.New(
-		awsSdk.Config{},
-		aws.NewLoggerWrapper(logrus.New(), nil),
-		mockIamClient,
-		rosaMocks.NewMockEc2ApiClient(mockCtrl),
-		rosaMocks.NewMockOrganizationsApiClient(mockCtrl),
-		rosaMocks.NewMockS3ApiClient(mockCtrl),
-		rosaMocks.NewMockSecretsManagerApiClient(mockCtrl),
-		mockSTSClient,
-		rosaMocks.NewMockCloudFormationApiClient(mockCtrl),
-		rosaMocks.NewMockServiceQuotasApiClient(mockCtrl),
-		rosaMocks.NewMockServiceQuotasApiClient(mockCtrl),
-		&aws.AccessKey{},
-		false,
-	)
-
-	runtime := rosacli.NewRuntime()
-	runtime.OCMClient = ocmClient
-	runtime.AWSClient = awsClient
-	runtime.Creator = &aws.Creator{
-		ARN:       "arn:aws:iam:123456789012:user/test",
-		AccountID: "123456789012",
-		IsSTS:     false,
-	}
-
 	callCount := 0
 	reconciler := &ROSARoleConfigReconciler{
-		Runtime: runtime, // already initialized
-		NewOCMClient: func(ctx context.Context, scope rosa.OCMSecretsRetriever) (rosa.OCMClient, error) {
+		Client: testEnv.Client,
+		runtimeFactory: func(c context.Context, s *scope.RosaRoleConfigScope) (*rosacli.Runtime, error) {
 			callCount++
-			return ocmClient, nil
+			return nil, fmt.Errorf("simulated AWS credential failure (call %d)", callCount)
 		},
 	}
 
-	scope := &scope.RosaRoleConfigScope{}
-
-	// Call setUpRuntime - should return early
-	err = reconciler.setUpRuntime(ctx, scope)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-err-%s", generateTestID()))
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// Runtime should be unchanged (same instance)
-	g.Expect(reconciler.Runtime).To(BeIdenticalTo(runtime),
-		"Runtime should not be recreated when already initialized")
+	rc := &expinfrav1.ROSARoleConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("rc-err-%s", generateTestID()),
+			Namespace: ns.Name,
+		},
+		Spec: expinfrav1.ROSARoleConfigSpec{
+			AccountRoleConfig:  expinfrav1.AccountRoleConfig{Prefix: "err", Version: "4.15.0"},
+			OperatorRoleConfig: expinfrav1.OperatorRoleConfig{Prefix: "err"},
+			OidcProviderType:   expinfrav1.Managed,
+		},
+	}
+	createObject(g, rc, ns.Name)
+	defer cleanupObject(g, rc)
 
-	// NewOCMClient should NOT be called (early return)
-	g.Expect(callCount).To(Equal(0),
-		"NewOCMClient should not be called when Runtime already exists")
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: rc.Name, Namespace: rc.Namespace}}
 
-	// Call again - should still return early
-	err = reconciler.setUpRuntime(ctx, scope)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(callCount).To(Equal(0), "Still should not call NewOCMClient")
+	// Wait for the cache to sync the newly created object before reconciling.
+	g.Eventually(func(g Gomega) {
+		got := &expinfrav1.ROSARoleConfig{}
+		g.Expect(testEnv.Client.Get(ctx, req.NamespacedName, got)).To(Succeed())
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// First reconciliation: runtimeFactory fails.
+	_, err1 := reconciler.Reconcile(ctx, req)
+	g.Expect(err1).To(HaveOccurred())
+	g.Expect(err1.Error()).To(ContainSubstring("failed to set up runtime"))
+	g.Expect(callCount).To(Equal(1))
+
+	// Second reconciliation: runtimeFactory is called again (no early-return / stale runtime).
+	_, err2 := reconciler.Reconcile(ctx, req)
+	g.Expect(err2).To(HaveOccurred())
+	g.Expect(callCount).To(Equal(2), "runtimeFactory must be called on every reconciliation, even after a previous failure")
 }
 
 func TestROSARoleConfigReconcileDelete(t *testing.T) {
@@ -880,66 +754,6 @@ func TestROSARoleConfigReconcileDelete(t *testing.T) {
 		"test-kube-system-kms-provider",
 	}, nil).AnyTimes()
 
-	// Return existing account roles that will be deleted
-	mockAWSClient.EXPECT().ListAccountRoles(gomock.Any()).Return([]aws.Role{
-		{
-			RoleName: "test-HCP-ROSA-Installer-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Installer-Role",
-		},
-		{
-			RoleName: "test-HCP-ROSA-Support-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Support-Role",
-		},
-		{
-			RoleName: "test-HCP-ROSA-Worker-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Worker-Role",
-		},
-	}, nil).AnyTimes()
-
-	mockAWSClient.EXPECT().ListOperatorRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string][]aws.OperatorRoleDetail{
-		"test": {
-			{
-				RoleName: "test-openshift-ingress-operator-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-ingress-operator-cloud-credentials",
-			},
-			{
-				RoleName: "test-openshift-image-registry-installer-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-image-registry-installer-cloud-credentials",
-			},
-			{
-				RoleName: "test-openshift-cluster-csi-drivers-ebs-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-cluster-csi-drivers-ebs-cloud-credentials",
-			},
-			{
-				RoleName: "test-openshift-cloud-network-config-controller-cloud-credentials",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-openshift-cloud-network-config-controller-cloud-credentials",
-			},
-			{
-				RoleName: "test-kube-system-kube-controller-manager",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-kube-controller-manager",
-			},
-			{
-				RoleName: "test-kube-system-capa-controller-manager",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-capa-controller-manager",
-			},
-			{
-				RoleName: "test-kube-system-control-plane-operator",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-control-plane-operator",
-			},
-			{
-				RoleName: "test-kube-system-kms-provider",
-				RoleARN:  "arn:aws:iam::123456789012:role/test-kube-system-kms-provider",
-			},
-		},
-	}, nil).AnyTimes()
-
-	// Return existing OIDC providers that will be deleted
-	mockAWSClient.EXPECT().ListOidcProviders(gomock.Any(), gomock.Any()).Return([]aws.OidcProviderOutput{
-		{
-			Arn: "arn:aws:iam::123456789012:oidc-provider/test-existing-oidc-id",
-		},
-	}, nil).AnyTimes()
-
 	// Delete operator roles (called individually for each role)
 	mockAWSClient.EXPECT().DeleteOperatorRole(gomock.Any(), gomock.Any(), true).Return(map[string]bool{}, nil).AnyTimes()
 
@@ -955,12 +769,10 @@ func TestROSARoleConfigReconcileDelete(t *testing.T) {
 		IsSTS:     false,
 	}, nil).AnyTimes()
 
-	awsClient := mockAWSClient
-
-	r := rosacli.NewRuntime()
-	r.OCMClient = ocmClient
-	r.AWSClient = awsClient
-	r.Creator = &aws.Creator{
+	rt := rosacli.NewRuntime()
+	rt.OCMClient = ocmClient
+	rt.AWSClient = mockAWSClient
+	rt.Creator = &aws.Creator{
 		ARN:       "arn:aws:iam::123456789012:user/test-user",
 		AccountID: "123456789012",
 		IsSTS:     false,
@@ -1058,10 +870,10 @@ func TestROSARoleConfigReconcileDelete(t *testing.T) {
 	createObject(g, rosaRoleConfig, ns.Name)
 	defer cleanupObject(g, rosaRoleConfig)
 
-	// Setup the reconciler with these mocks
+	// Setup the reconciler using runtimeFactory to inject mock clients per reconciliation.
 	reconciler := &ROSARoleConfigReconciler{
-		Client:  testEnv.Client,
-		Runtime: r,
+		Client:         testEnv.Client,
+		runtimeFactory: makeRuntimeFactory(rt),
 	}
 
 	// Call the Reconcile function
@@ -1071,27 +883,276 @@ func TestROSARoleConfigReconcileDelete(t *testing.T) {
 	err = reconciler.Client.Delete(ctx, rosaRoleConfig)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// Sleep to ensure the status is updated
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the cache to reflect the deletion timestamp before reconciling.
+	g.Eventually(func(g Gomega) {
+		got := &expinfrav1.ROSARoleConfig{}
+		g.Expect(testEnv.Client.Get(ctx, req.NamespacedName, got)).To(Succeed())
+		g.Expect(got.DeletionTimestamp).ToNot(BeNil())
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	_, errReconcile := reconciler.Reconcile(ctx, req)
+	g.Expect(errReconcile).ToNot(HaveOccurred())
+
+	// Wait for finalizers to be removed after reconciliation.
+	g.Eventually(func(g Gomega) {
+		deletedRoleConfig := &expinfrav1.ROSARoleConfig{}
+		if err := reconciler.Client.Get(ctx, req.NamespacedName, deletedRoleConfig); err != nil {
+			return // Object fully deleted — desired state.
+		}
+		g.Expect(deletedRoleConfig.Finalizers).To(BeEmpty(), "Finalizers should be removed after successful deletion")
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+// fakeSTSAssumeRoleResponse returns valid STS AssumeRole XML for the fake STS httptest server.
+func fakeSTSAssumeRoleResponse(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/xml")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIAIOSFODNN7EXAMPLE</AccessKeyId>
+      <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY</SecretAccessKey>
+      <SessionToken>AQoXnyc4MCrrlandlJKwBQ==</SessionToken>
+      <Expiration>2030-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/fake-rosa-role/test</Arn>
+      <AssumedRoleId>ARO123EXAMPLE123:test</AssumedRoleId>
+    </AssumedRoleUser>
+  </AssumeRoleResult>
+  <ResponseMetadata>
+    <RequestId>12345678-1234-1234-1234-123456789012</RequestId>
+  </ResponseMetadata>
+</AssumeRoleResponse>`)
+}
+
+// TestROSARoleConfigReconcilerWithRoleIdentity verifies that ROSARoleConfigReconciler can
+// create its scope (resolving credentials) when the ROSARoleConfig's IdentityRef points
+// to an AWSClusterRoleIdentity backed by a fake IAM role.
+//
+// The fake STS server satisfies the AssumeRole call that happens during scope creation.
+// The runtimeFactory is used as a canary: if it is called, scope creation (including
+// credential resolution via AWSClusterRoleIdentity) succeeded.
+func TestROSARoleConfigReconcilerWithRoleIdentity(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	// Start a local STS server that returns fake AssumeRole credentials.
+	stsServer := httptest.NewServer(http.HandlerFunc(fakeSTSAssumeRoleResponse))
+	defer stsServer.Close()
+
+	// Point the AWS SDK at the fake STS server and supply dummy source credentials so
+	// config.LoadDefaultConfig has something to work with when building the STS client.
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key-id")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	testID := generateTestID()
+
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-roleident-%s", testID))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// AWSClusterControllerIdentity is the source for the role identity.
+	// The webhook requires sourceIdentityRef to be non-nil, so we use the controller
+	// identity as a source — it returns no providers of its own, causing the role
+	// provider to fall back to the env-var credentials when calling STS.
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	createObject(g, controllerIdentity, ns.Name)
+	defer cleanupObject(g, controllerIdentity)
+
+	// AWSClusterRoleIdentity with a fake IAM role ARN — AllowedNamespaces is empty,
+	// meaning every namespace may use this identity.
+	roleIdentity := &infrav1.AWSClusterRoleIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("fake-role-identity-%s", testID),
+		},
+		Spec: infrav1.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: infrav1.AWSRoleSpec{
+				RoleArn:     fmt.Sprintf("arn:aws:iam::123456789012:role/fake-rosa-role-%s", testID),
+				SessionName: "test-session",
+			},
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+			SourceIdentityRef: &infrav1.AWSIdentityReference{
+				Name: controllerIdentity.Name,
+				Kind: infrav1.ControllerIdentityKind,
+			},
+		},
+	}
+	roleIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterRoleIdentity"))
+	createObject(g, roleIdentity, ns.Name)
+	defer cleanupObject(g, roleIdentity)
+
+	rosaRoleConfig := &expinfrav1.ROSARoleConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       fmt.Sprintf("test-role-config-%s", testID),
+			Namespace:  ns.Name,
+			Finalizers: []string{expinfrav1.RosaRoleConfigFinalizer},
+		},
+		Spec: expinfrav1.ROSARoleConfigSpec{
+			AccountRoleConfig: expinfrav1.AccountRoleConfig{
+				Prefix:  "test",
+				Version: "4.15.0",
+			},
+			OperatorRoleConfig: expinfrav1.OperatorRoleConfig{
+				Prefix: "test",
+			},
+			OidcProviderType: expinfrav1.Managed,
+			IdentityRef: &infrav1.AWSIdentityReference{
+				Name: roleIdentity.Name,
+				Kind: infrav1.ClusterRoleIdentityKind,
+			},
+		},
+	}
+	createObject(g, rosaRoleConfig, ns.Name)
+	defer cleanupObject(g, rosaRoleConfig)
+
+	runtimeCalled := false
+	reconciler := &ROSARoleConfigReconciler{
+		Client: testEnv.Client,
+		// runtimeFactory acts as a canary: if it is invoked, scope creation (and
+		// therefore AWSClusterRoleIdentity credential resolution) succeeded.
+		runtimeFactory: func(_ context.Context, _ *scope.RosaRoleConfigScope) (*rosacli.Runtime, error) {
+			runtimeCalled = true
+			return nil, fmt.Errorf("sentinel: runtimeFactory reached after role-identity scope creation")
+		},
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: rosaRoleConfig.Name, Namespace: rosaRoleConfig.Namespace},
+	}
+
+	g.Eventually(func(g Gomega) {
+		_, errReconcile := reconciler.Reconcile(ctx, req)
+
+		// The reconciler must have advanced past scope creation and reached runtimeFactory.
+		// A "failed to create rosaroleconfig scope" error here would mean credential
+		// resolution via AWSClusterRoleIdentity failed.
+		g.Expect(errReconcile).To(HaveOccurred())
+		g.Expect(errReconcile.Error()).To(ContainSubstring("failed to set up runtime"))
+		g.Expect(errReconcile.Error()).NotTo(ContainSubstring("failed to create rosaroleconfig scope"))
+		g.Expect(runtimeCalled).To(BeTrue())
+	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
+// TestROSARoleConfigReconcilerWithRoleIdentityNamespaceNotAllowed verifies that when the
+// AWSClusterRoleIdentity's AllowedNamespaces does not include the ROSARoleConfig's namespace,
+// scope creation fails with a credential error and the runtimeFactory is never called.
+func TestROSARoleConfigReconcilerWithRoleIdentityNamespaceNotAllowed(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	stsServer := httptest.NewServer(http.HandlerFunc(fakeSTSAssumeRoleResponse))
+	defer stsServer.Close()
+
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key-id")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	testID := generateTestID()
+
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-roleident-denied-%s", testID))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	createObject(g, controllerIdentity, ns.Name)
+	defer cleanupObject(g, controllerIdentity)
+
+	// AllowedNamespaces lists only "other-namespace", so ns.Name is not permitted.
+	roleIdentity := &infrav1.AWSClusterRoleIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("restricted-role-identity-%s", testID),
+		},
+		Spec: infrav1.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: infrav1.AWSRoleSpec{
+				RoleArn:     fmt.Sprintf("arn:aws:iam::123456789012:role/restricted-rosa-role-%s", testID),
+				SessionName: "test-session",
+			},
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{
+					NamespaceList: []string{"other-namespace"},
+				},
+			},
+			SourceIdentityRef: &infrav1.AWSIdentityReference{
+				Name: controllerIdentity.Name,
+				Kind: infrav1.ControllerIdentityKind,
+			},
+		},
+	}
+	roleIdentity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterRoleIdentity"))
+	createObject(g, roleIdentity, ns.Name)
+	defer cleanupObject(g, roleIdentity)
+
+	rosaRoleConfig := &expinfrav1.ROSARoleConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       fmt.Sprintf("test-role-config-denied-%s", testID),
+			Namespace:  ns.Name,
+			Finalizers: []string{expinfrav1.RosaRoleConfigFinalizer},
+		},
+		Spec: expinfrav1.ROSARoleConfigSpec{
+			AccountRoleConfig: expinfrav1.AccountRoleConfig{
+				Prefix:  "test",
+				Version: "4.15.0",
+			},
+			OperatorRoleConfig: expinfrav1.OperatorRoleConfig{Prefix: "test"},
+			OidcProviderType:   expinfrav1.Managed,
+			IdentityRef: &infrav1.AWSIdentityReference{
+				Name: roleIdentity.Name,
+				Kind: infrav1.ClusterRoleIdentityKind,
+			},
+		},
+	}
+	createObject(g, rosaRoleConfig, ns.Name)
+	defer cleanupObject(g, rosaRoleConfig)
+
+	runtimeCalled := false
+	reconciler := &ROSARoleConfigReconciler{
+		Client: testEnv.Client,
+		runtimeFactory: func(_ context.Context, _ *scope.RosaRoleConfigScope) (*rosacli.Runtime, error) {
+			runtimeCalled = true
+			return nil, nil
+		},
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: rosaRoleConfig.Name, Namespace: rosaRoleConfig.Namespace},
+	}
+
+	// Wait for the cache to sync all created objects before reconciling.
+	g.Eventually(func(g Gomega) {
+		got := &expinfrav1.ROSARoleConfig{}
+		g.Expect(testEnv.Client.Get(ctx, req.NamespacedName, got)).To(Succeed())
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 	_, errReconcile := reconciler.Reconcile(ctx, req)
 
-	// Assertions - deletion should succeed
-	g.Expect(errReconcile).ToNot(HaveOccurred())
-
-	// Sleep to ensure the status is updated
-	time.Sleep(100 * time.Millisecond)
-
-	deletedRoleConfig := &expinfrav1.ROSARoleConfig{}
-
-	// Verify the resource has been deleted (finalizers removed)
-	err = reconciler.Client.Get(ctx, req.NamespacedName, deletedRoleConfig)
-
-	// The object should either be not found (fully deleted) or have no finalizers
-	if err == nil {
-		// If object still exists, verify finalizers are removed
-		g.Expect(deletedRoleConfig.Finalizers).To(BeEmpty(), "Finalizers should be removed after successful deletion")
-	}
+	// Scope creation must fail because the namespace is not in AllowedNamespaces.
+	g.Expect(errReconcile).To(HaveOccurred())
+	g.Expect(errReconcile.Error()).To(ContainSubstring("failed to create rosaroleconfig scope"))
+	g.Expect(runtimeCalled).To(BeFalse())
 }
 
 func TestROSARoleConfigReconcileExistWithTrustPolicyExternalID(t *testing.T) {
@@ -1131,37 +1192,12 @@ func TestROSARoleConfigReconcileExistWithTrustPolicyExternalID(t *testing.T) {
 	mockAWSClient.EXPECT().HasManagedPolicies(gomock.Any()).Return(false, nil).AnyTimes()
 	mockAWSClient.EXPECT().HasHostedCPPolicies(gomock.Any()).Return(true, nil).AnyTimes()
 
-	mockAWSClient.EXPECT().ListAccountRoles(gomock.Any()).Return([]aws.Role{
-		{
-			RoleName: "test-HCP-ROSA-Installer-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Installer-Role",
-		},
-		{
-			RoleName: "test-HCP-ROSA-Support-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Support-Role",
-		},
-		{
-			RoleName: "test-HCP-ROSA-Worker-Role",
-			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Worker-Role",
-		},
-	}, nil).AnyTimes()
-
-	mockAWSClient.EXPECT().ListOperatorRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string][]aws.OperatorRoleDetail{
-		"test": {
-			{RoleName: "test-openshift-ingress-operator-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-ingress-operator-cloud-credentials"},
-			{RoleName: "test-openshift-image-registry-installer-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-image-registry-installer-cloud-credentials"},
-			{RoleName: "test-openshift-cluster-csi-drivers-ebs-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-cluster-csi-drivers-ebs-cloud-credentials"},
-			{RoleName: "test-openshift-cloud-network-config-controller-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-cloud-network-config-controller-cloud-credentials"},
-			{RoleName: "test-kube-system-kube-controller-manager", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-kube-controller-manager"},
-			{RoleName: "test-kube-system-capa-controller-manager", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-capa-controller-manager"},
-			{RoleName: "test-kube-system-control-plane-operator", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-control-plane-operator"},
-			{RoleName: "test-kube-system-kms-provider", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-kms-provider"},
-		},
-	}, nil).AnyTimes()
-
-	mockAWSClient.EXPECT().ListOidcProviders(gomock.Any(), gomock.Any()).Return([]aws.OidcProviderOutput{
-		{Arn: "arn:aws:iam::123456789012:oidc-provider/test-existing-oidc-id"},
-	}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-HCP-ROSA-Installer-Role").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-HCP-ROSA-Installer-Role")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-HCP-ROSA-Support-Role").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-HCP-ROSA-Support-Role")}, nil).AnyTimes()
+	mockAWSClient.EXPECT().GetRoleByName("test-HCP-ROSA-Worker-Role").Return(
+		iamTypes.Role{Arn: awsSdk.String("arn:aws:iam::123456789012:role/test-HCP-ROSA-Worker-Role")}, nil).AnyTimes()
 
 	mockAWSClient.EXPECT().GetCreator().Return(&aws.Creator{
 		ARN:       "arn:aws:iam::123456789012:user/test-user",
@@ -1228,8 +1264,8 @@ func TestROSARoleConfigReconcileExistWithTrustPolicyExternalID(t *testing.T) {
 	defer cleanupObject(g, rosaRoleConfig)
 
 	reconciler := &ROSARoleConfigReconciler{
-		Client:  testEnv.Client,
-		Runtime: r,
+		Client:         testEnv.Client,
+		runtimeFactory: makeRuntimeFactory(r),
 	}
 
 	req := ctrl.Request{}

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -84,6 +84,9 @@ func setup() {
 	if err := (&capawebhooks.AWSClusterControllerIdentity{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup AWSClusterControllerIdentity webhook: %v", err))
 	}
+	if err := (&capawebhooks.AWSClusterRoleIdentity{}).SetupWebhookWithManager(testEnv); err != nil {
+		panic(fmt.Sprintf("Unable to setup AWSClusterRoleIdentity webhook: %v", err))
+	}
 	if err := (&expwebhooks.ROSAMachinePool{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup ROSAMachinePool webhook: %v", err))
 	}

--- a/pkg/cloud/scope/rosacontrolplane.go
+++ b/pkg/cloud/scope/rosacontrolplane.go
@@ -21,18 +21,15 @@ import (
 	"fmt"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
-	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
-	stsservice "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/throttle"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -47,7 +44,6 @@ type ROSAControlPlaneScopeParams struct {
 	Cluster        *clusterv1.Cluster
 	ControlPlane   *rosacontrolplanev1.ROSAControlPlane
 	ControllerName string
-	NewStsClient   func(cloud.ScopeUsage, cloud.Session, logger.Wrapper, runtime.Object) stsservice.STSClient
 }
 
 // NewROSAControlPlaneScope creates a new ROSAControlPlaneScope from the supplied parameters.
@@ -86,13 +82,6 @@ func NewROSAControlPlaneScope(params ROSAControlPlaneScopeParams) (*ROSAControlP
 	managedScope.session = *session
 	managedScope.serviceLimiters = serviceLimiters
 
-	stsClient := params.NewStsClient(managedScope, managedScope, managedScope, managedScope.ControlPlane)
-	identity, err := stsClient.GetCallerIdentity(context.TODO(), &stsv2.GetCallerIdentityInput{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to identify the AWS caller: %w", err)
-	}
-	managedScope.Identity = identity
-
 	return managedScope, nil
 }
 
@@ -108,7 +97,6 @@ type ROSAControlPlaneScope struct {
 	session         awsv2.Config
 	serviceLimiters throttle.ServiceLimiters
 	controllerName  string
-	Identity        *stsv2.GetCallerIdentityOutput
 }
 
 // InfraCluster returns the AWSManagedControlPlane object.
@@ -124,6 +112,11 @@ func (s *ROSAControlPlaneScope) IdentityRef() *infrav1.AWSIdentityReference {
 // Session returns the AWS SDK V2 session. Used for creating clients.
 func (s *ROSAControlPlaneScope) Session() awsv2.Config {
 	return s.session
+}
+
+// SetSession replaces the AWS SDK V2 session. Intended for use in tests to inject a pre-configured session.
+func (s *ROSAControlPlaneScope) SetSession(session awsv2.Config) {
+	s.session = session
 }
 
 // ServiceLimiter returns the AWS SDK session. Used for creating clients.


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
bug 
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

All ROSA-HCP controllers were sharing a single cached AWS session. As a result, when multiple AWS accounts were configured and mapped to different AWSClusterController identities, AWS resources were incorrectly created using the client associated with the first AWS account initialized in the cache.

The fix ensures that the AWS client session is re-established during each reconcile loop whenever the currently cached session belongs to a different target AWS account. This guarantees that all AWS operations are executed against the correct account associated with the reconciled AWSClusterController identity.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #6073

**Special notes for your reviewer**:

**AI Usage**:

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fix ROSA-HCP usage with aws cross accounts. 
```
