### PR TITLE
🐛  Letting CAPA bypass updating nodegroup version API call for custom AMI

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -340,8 +340,20 @@ func (s *NodegroupService) reconcileNodegroupVersion(ctx context.Context, ng *ek
 		ngLaunchTemplateVersion = ng.LaunchTemplate.Version
 	}
 
+	// For CUSTOM AMI nodegroups the k8s version is baked into the AMI; AWS rejects
+	// UpdateNodegroupVersion without launch template details for these nodegroups, and a
+	// version-only bump is meaningless because the actual kubelet version is determined by
+	// the AMI, not the EKS version field. CAPI propagates the cluster control-plane version
+	// (e.g. 1.34) to all MachinePools, so there is always a perceived version mismatch when
+	// a CUSTOM AMI carries an older kubelet — leading to a 100k+ failure event loop on scale.
+	// Version upgrades for CUSTOM AMI pools happen implicitly when the user updates the launch
+	// template with a compatible AMI; that change is handled by the launchTemplateChanged path
+	// which correctly passes the launch template to UpdateNodegroupVersion.
+	ngIsCustomAMI := ng.AmiType == ekstypes.AMITypesCustom
+	versionUpgradeNeeded := specVersion != nil && ngVersion.LessThan(specVersion) && !ngIsCustomAMI
+
 	eksClusterName := s.scope.KubernetesClusterName()
-	if (specVersion != nil && ngVersion.LessThan(specVersion)) || (specAMI != nil && *specAMI != ngAMI) || (statusLaunchTemplateVersion != nil && *statusLaunchTemplateVersion != *ngLaunchTemplateVersion) {
+	if versionUpgradeNeeded || (specAMI != nil && *specAMI != ngAMI) || (statusLaunchTemplateVersion != nil && *statusLaunchTemplateVersion != *ngLaunchTemplateVersion) {
 		input := &eks.UpdateNodegroupVersionInput{
 			ClusterName:   aws.String(eksClusterName),
 			NodegroupName: aws.String(s.scope.NodegroupName()),
@@ -356,7 +368,7 @@ func (s *NodegroupService) reconcileNodegroupVersion(ctx context.Context, ng *ek
 				Version: statusLaunchTemplateVersion,
 			}
 			updateMsg = fmt.Sprintf("to launch template version %s", *statusLaunchTemplateVersion)
-		case specVersion != nil && ngVersion.LessThan(specVersion):
+		case versionUpgradeNeeded:
 			// NOTE: you can only upgrade increments of minor versions. If you want to upgrade 1.14 to 1.16 we
 			// need to go 1.14-> 1.15 and then 1.15 -> 1.16.
 			input.Version = aws.String(versionToEKS(ngVersion.WithMinor(ngVersion.Minor() + 1)))


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
The PR fixes an issue when user uses a custom AMI with EKS clusters.

When an EKS cluster is made using a certain k8s version using CAPA and any of the nodegroup's k8s version is lesser than that of cluster's k8s version, CAPA's code has the current flow of making an update nodegroup version API call to update the nodegroup's k8s version until it reaches cluster's k8s version.

But in the case where user specifically providers a custom AMI with lesser k8s version that the cluster in the launch template and wants the `AWSManagedMachinePool` to stay on the specified k8s version, CAPA complains with the following error:
```
Message_: "Launch template details can't be null for Custom ami type node group"  
```

This PR introduces a fix/change that bypasses CAPA to not make update nodegroup version API call and let the nodes get created & join the cluster gracefully.

It is expected from user to always provide custom AMI for nodegroup which has atmost `n-1` k8s version of cluster.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:
The PR contains changes done with the help of Cursor & Claude.

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
