### PR TITLE
✨ Add missing, desired routes during route table reconciliation

### DIFF
--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -71,16 +72,13 @@ func (s *Service) reconcileRouteTables() error {
 			s.scope.Debug("Subnet is already associated with route table", "subnet-id", sn.GetResourceID(), "route-table-id", aws.ToString(rt.RouteTableId))
 			// TODO(vincepri): check that everything is in order, e.g. routes match the subnet type.
 
-			// For managed environments we need to reconcile the routes of our tables if there is a mistmatch.
-			// For example, a gateway can be deleted and our controller will re-create it, then we replace the route
-			// for the subnet to allow traffic to flow.
-			for _, currentRoute := range rt.Routes {
-				for i := range routes {
-					// Routes destination cidr blocks must be unique within a routing table.
-					// If there is a mistmatch, we replace the routing association.
-					if err := s.fixMismatchedRouting(routes[i], currentRoute, rt); err != nil {
-						return err
-					}
+			// For managed environments we reconcile every desired route. A route whose
+			// destination is missing gets created (e.g. for bring-your-own VPC that didn't have it),
+			// and a route whose destination matches but points at the wrong target gets
+			// replaced (e.g. a gateway that was deleted and re-created).
+			for _, route := range routes {
+				if err := s.reconcileRoute(route, rt); err != nil {
+					return err
 				}
 			}
 
@@ -126,48 +124,51 @@ func (s *Service) reconcileRouteTables() error {
 	return nil
 }
 
-func (s *Service) fixMismatchedRouting(specRoute *ec2.CreateRouteInput, currentRoute types.Route, rt types.RouteTable) error {
-	var input *ec2.ReplaceRouteInput
-	if specRoute.DestinationCidrBlock != nil {
-		if (currentRoute.DestinationCidrBlock != nil &&
-			aws.ToString(currentRoute.DestinationCidrBlock) == aws.ToString(specRoute.DestinationCidrBlock)) &&
-			((currentRoute.GatewayId != nil && aws.ToString(currentRoute.GatewayId) != aws.ToString(specRoute.GatewayId)) ||
-				(currentRoute.NatGatewayId != nil && aws.ToString(currentRoute.NatGatewayId) != aws.ToString(specRoute.NatGatewayId))) {
-			input = &ec2.ReplaceRouteInput{
-				RouteTableId:         rt.RouteTableId,
-				DestinationCidrBlock: specRoute.DestinationCidrBlock,
-				GatewayId:            specRoute.GatewayId,
-				NatGatewayId:         specRoute.NatGatewayId,
-			}
+// reconcileRoute ensures a single desired route exists in the route table pointing
+// at the desired target.
+func (s *Service) reconcileRoute(specRoute *ec2.CreateRouteInput, rt types.RouteTable) error {
+	var current *types.Route
+	for i := range rt.Routes {
+		route := &rt.Routes[i]
+		if (specRoute.DestinationCidrBlock != nil && aws.ToString(route.DestinationCidrBlock) == aws.ToString(specRoute.DestinationCidrBlock)) ||
+			(specRoute.DestinationIpv6CidrBlock != nil && aws.ToString(route.DestinationIpv6CidrBlock) == aws.ToString(specRoute.DestinationIpv6CidrBlock)) {
+			current = route
+			break
 		}
 	}
-	if specRoute.DestinationIpv6CidrBlock != nil {
-		if (currentRoute.DestinationIpv6CidrBlock != nil &&
-			aws.ToString(currentRoute.DestinationIpv6CidrBlock) == aws.ToString(specRoute.DestinationIpv6CidrBlock)) &&
-			((currentRoute.GatewayId != nil && aws.ToString(currentRoute.GatewayId) != aws.ToString(specRoute.GatewayId)) ||
-				(currentRoute.NatGatewayId != nil && aws.ToString(currentRoute.NatGatewayId) != aws.ToString(specRoute.NatGatewayId)) ||
-				(currentRoute.EgressOnlyInternetGatewayId != nil && aws.ToString(currentRoute.EgressOnlyInternetGatewayId) != aws.ToString(specRoute.EgressOnlyInternetGatewayId))) {
-			input = &ec2.ReplaceRouteInput{
-				RouteTableId:                rt.RouteTableId,
-				DestinationIpv6CidrBlock:    specRoute.DestinationIpv6CidrBlock,
-				DestinationPrefixListId:     specRoute.DestinationPrefixListId,
-				GatewayId:                   specRoute.GatewayId,
-				NatGatewayId:                specRoute.NatGatewayId,
-				EgressOnlyInternetGatewayId: specRoute.EgressOnlyInternetGatewayId,
-			}
-		}
+
+	if current != nil &&
+		aws.ToString(current.GatewayId) == aws.ToString(specRoute.GatewayId) &&
+		aws.ToString(current.NatGatewayId) == aws.ToString(specRoute.NatGatewayId) &&
+		aws.ToString(current.EgressOnlyInternetGatewayId) == aws.ToString(specRoute.EgressOnlyInternetGatewayId) &&
+		aws.ToString(current.CarrierGatewayId) == aws.ToString(specRoute.CarrierGatewayId) {
+		// The route already exists with the desired target, nothing to do
+		return nil
 	}
-	if input != nil {
-		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
-			if _, err := s.EC2Client.ReplaceRoute(context.TODO(), input); err != nil {
-				return false, err
-			}
-			return true, nil
-		}); err != nil {
-			record.Warnf(s.scope.InfraCluster(), "FailedReplaceRoute", "Failed to replace outdated route on managed RouteTable %q: %v", aws.ToString(rt.RouteTableId), err)
-			return errors.Wrapf(err, "failed to replace outdated route on route table %q", aws.ToString(rt.RouteTableId))
+
+	routeDesc := describeRoute(specRoute)
+	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		if current == nil {
+			specRoute.RouteTableId = rt.RouteTableId
+			_, err := s.EC2Client.CreateRoute(context.TODO(), specRoute)
+			return err == nil, err
 		}
+		_, err := s.EC2Client.ReplaceRoute(context.TODO(), &ec2.ReplaceRouteInput{
+			RouteTableId:                rt.RouteTableId,
+			DestinationCidrBlock:        specRoute.DestinationCidrBlock,
+			DestinationIpv6CidrBlock:    specRoute.DestinationIpv6CidrBlock,
+			DestinationPrefixListId:     specRoute.DestinationPrefixListId,
+			GatewayId:                   specRoute.GatewayId,
+			NatGatewayId:                specRoute.NatGatewayId,
+			EgressOnlyInternetGatewayId: specRoute.EgressOnlyInternetGatewayId,
+			CarrierGatewayId:            specRoute.CarrierGatewayId,
+		})
+		return err == nil, err
+	}, awserrors.RouteTableNotFound, awserrors.NATGatewayNotFound, awserrors.GatewayNotFound); err != nil {
+		record.Warnf(s.scope.InfraCluster(), "FailedReconcileRoute", "Failed to reconcile route %s on managed RouteTable %q: %v", routeDesc, aws.ToString(rt.RouteTableId), err)
+		return errors.Wrapf(err, "failed to reconcile route %s on route table %q", routeDesc, aws.ToString(rt.RouteTableId))
 	}
+	record.Eventf(s.scope.InfraCluster(), "SuccessfulReconcileRoute", "Reconciled route %s on RouteTable %q", routeDesc, aws.ToString(rt.RouteTableId))
 	return nil
 }
 
@@ -285,14 +286,15 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.CreateRouteInput, isP
 			}
 			return true, nil
 		}, awserrors.RouteTableNotFound, awserrors.NATGatewayNotFound, awserrors.GatewayNotFound); err != nil {
-			record.Warnf(s.scope.InfraCluster(), "FailedCreateRoute", "Failed to create route %s for RouteTable %q: %v", route, aws.ToString(out.RouteTable.RouteTableId), err)
+			routeDesc := describeRoute(route)
+			record.Warnf(s.scope.InfraCluster(), "FailedCreateRoute", "Failed to create route %s for RouteTable %q: %v", routeDesc, aws.ToString(out.RouteTable.RouteTableId), err)
 			errDel := s.deleteRouteTable(*out.RouteTable)
 			if errDel != nil {
 				record.Warnf(s.scope.InfraCluster(), "FailedDeleteRouteTable", "Failed to delete managed RouteTable %q: %v", aws.ToString(out.RouteTable.RouteTableId), errDel)
 			}
-			return nil, errors.Wrapf(err, "failed to create route in route table %q: %v", aws.ToString(out.RouteTable.RouteTableId), route)
+			return nil, errors.Wrapf(err, "failed to create route in route table %q: %s", aws.ToString(out.RouteTable.RouteTableId), routeDesc)
 		}
-		record.Eventf(s.scope.InfraCluster(), "SuccessfulCreateRoute", "Created route %s for RouteTable %q", route, aws.ToString(out.RouteTable.RouteTableId))
+		record.Eventf(s.scope.InfraCluster(), "SuccessfulCreateRoute", "Created route %s for RouteTable %q", describeRoute(route), aws.ToString(out.RouteTable.RouteTableId))
 	}
 
 	return &infrav1.RouteTable{
@@ -445,4 +447,25 @@ func (s *Service) getRoutesForSubnet(sn *infrav1.SubnetSpec) ([]*ec2.CreateRoute
 		return s.getRoutesToPublicSubnet(sn)
 	}
 	return s.getRoutesToPrivateSubnet(sn)
+}
+
+// describeRoute renders a CreateRouteInput as a human-readable string for logs and events.
+func describeRoute(route *ec2.CreateRouteInput) string {
+	if route == nil {
+		return "<nil>"
+	}
+	var parts []string
+	addPart := func(name string, value *string) {
+		if v := aws.ToString(value); v != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", name, v))
+		}
+	}
+	addPart("destinationCidrBlock", route.DestinationCidrBlock)
+	addPart("destinationIpv6CidrBlock", route.DestinationIpv6CidrBlock)
+	addPart("destinationPrefixListId", route.DestinationPrefixListId)
+	addPart("gatewayId", route.GatewayId)
+	addPart("natGatewayId", route.NatGatewayId)
+	addPart("egressOnlyInternetGatewayId", route.EgressOnlyInternetGatewayId)
+	addPart("carrierGatewayId", route.CarrierGatewayId)
+	return "{" + strings.Join(parts, ", ") + "}"
 }

--- a/pkg/cloud/services/network/routetables.go
+++ b/pkg/cloud/services/network/routetables.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -71,16 +72,13 @@ func (s *Service) reconcileRouteTables() error {
 			s.scope.Debug("Subnet is already associated with route table", "subnet-id", sn.GetResourceID(), "route-table-id", aws.ToString(rt.RouteTableId))
 			// TODO(vincepri): check that everything is in order, e.g. routes match the subnet type.
 
-			// For managed environments we need to reconcile the routes of our tables if there is a mistmatch.
-			// For example, a gateway can be deleted and our controller will re-create it, then we replace the route
-			// for the subnet to allow traffic to flow.
-			for _, currentRoute := range rt.Routes {
-				for i := range routes {
-					// Routes destination cidr blocks must be unique within a routing table.
-					// If there is a mistmatch, we replace the routing association.
-					if err := s.fixMismatchedRouting(routes[i], currentRoute, rt); err != nil {
-						return err
-					}
+			// For managed environments we reconcile every desired route. A route whose
+			// destination is missing gets created (e.g. for bring-your-own VPC that didn't have it),
+			// and a route whose destination matches but points at the wrong target gets
+			// replaced (e.g. a gateway that was deleted and re-created).
+			for _, route := range routes {
+				if err := s.reconcileRoute(route, rt); err != nil {
+					return err
 				}
 			}
 
@@ -126,48 +124,51 @@ func (s *Service) reconcileRouteTables() error {
 	return nil
 }
 
-func (s *Service) fixMismatchedRouting(specRoute *ec2.CreateRouteInput, currentRoute types.Route, rt types.RouteTable) error {
-	var input *ec2.ReplaceRouteInput
-	if specRoute.DestinationCidrBlock != nil {
-		if (currentRoute.DestinationCidrBlock != nil &&
-			aws.ToString(currentRoute.DestinationCidrBlock) == aws.ToString(specRoute.DestinationCidrBlock)) &&
-			((currentRoute.GatewayId != nil && aws.ToString(currentRoute.GatewayId) != aws.ToString(specRoute.GatewayId)) ||
-				(currentRoute.NatGatewayId != nil && aws.ToString(currentRoute.NatGatewayId) != aws.ToString(specRoute.NatGatewayId))) {
-			input = &ec2.ReplaceRouteInput{
-				RouteTableId:         rt.RouteTableId,
-				DestinationCidrBlock: specRoute.DestinationCidrBlock,
-				GatewayId:            specRoute.GatewayId,
-				NatGatewayId:         specRoute.NatGatewayId,
-			}
+// reconcileRoute ensures a single desired route exists in the route table pointing
+// at the desired target.
+func (s *Service) reconcileRoute(specRoute *ec2.CreateRouteInput, rt types.RouteTable) error {
+	var current *types.Route
+	for i := range rt.Routes {
+		route := &rt.Routes[i]
+		if (specRoute.DestinationCidrBlock != nil && aws.ToString(route.DestinationCidrBlock) == aws.ToString(specRoute.DestinationCidrBlock)) ||
+			(specRoute.DestinationIpv6CidrBlock != nil && aws.ToString(route.DestinationIpv6CidrBlock) == aws.ToString(specRoute.DestinationIpv6CidrBlock)) {
+			current = route
+			break
 		}
 	}
-	if specRoute.DestinationIpv6CidrBlock != nil {
-		if (currentRoute.DestinationIpv6CidrBlock != nil &&
-			aws.ToString(currentRoute.DestinationIpv6CidrBlock) == aws.ToString(specRoute.DestinationIpv6CidrBlock)) &&
-			((currentRoute.GatewayId != nil && aws.ToString(currentRoute.GatewayId) != aws.ToString(specRoute.GatewayId)) ||
-				(currentRoute.NatGatewayId != nil && aws.ToString(currentRoute.NatGatewayId) != aws.ToString(specRoute.NatGatewayId)) ||
-				(currentRoute.EgressOnlyInternetGatewayId != nil && aws.ToString(currentRoute.EgressOnlyInternetGatewayId) != aws.ToString(specRoute.EgressOnlyInternetGatewayId))) {
-			input = &ec2.ReplaceRouteInput{
-				RouteTableId:                rt.RouteTableId,
-				DestinationIpv6CidrBlock:    specRoute.DestinationIpv6CidrBlock,
-				DestinationPrefixListId:     specRoute.DestinationPrefixListId,
-				GatewayId:                   specRoute.GatewayId,
-				NatGatewayId:                specRoute.NatGatewayId,
-				EgressOnlyInternetGatewayId: specRoute.EgressOnlyInternetGatewayId,
-			}
-		}
+
+	if current != nil &&
+		aws.ToString(current.GatewayId) == aws.ToString(specRoute.GatewayId) &&
+		aws.ToString(current.NatGatewayId) == aws.ToString(specRoute.NatGatewayId) &&
+		aws.ToString(current.EgressOnlyInternetGatewayId) == aws.ToString(specRoute.EgressOnlyInternetGatewayId) &&
+		aws.ToString(current.CarrierGatewayId) == aws.ToString(specRoute.CarrierGatewayId) {
+		// The route already exists with the desired target, nothing to do
+		return nil
 	}
-	if input != nil {
-		if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
-			if _, err := s.EC2Client.ReplaceRoute(context.TODO(), input); err != nil {
-				return false, err
-			}
-			return true, nil
-		}); err != nil {
-			record.Warnf(s.scope.InfraCluster(), "FailedReplaceRoute", "Failed to replace outdated route on managed RouteTable %q: %v", aws.ToString(rt.RouteTableId), err)
-			return errors.Wrapf(err, "failed to replace outdated route on route table %q", aws.ToString(rt.RouteTableId))
+
+	routeDesc := describeRoute(specRoute)
+	if err := wait.WaitForWithRetryable(wait.NewBackoff(), func() (bool, error) {
+		if current == nil {
+			specRoute.RouteTableId = rt.RouteTableId
+			_, err := s.EC2Client.CreateRoute(context.TODO(), specRoute)
+			return err == nil, err
 		}
+		_, err := s.EC2Client.ReplaceRoute(context.TODO(), &ec2.ReplaceRouteInput{
+			RouteTableId:                rt.RouteTableId,
+			DestinationCidrBlock:        specRoute.DestinationCidrBlock,
+			DestinationIpv6CidrBlock:    specRoute.DestinationIpv6CidrBlock,
+			DestinationPrefixListId:     specRoute.DestinationPrefixListId,
+			GatewayId:                   specRoute.GatewayId,
+			NatGatewayId:                specRoute.NatGatewayId,
+			EgressOnlyInternetGatewayId: specRoute.EgressOnlyInternetGatewayId,
+			CarrierGatewayId:            specRoute.CarrierGatewayId,
+		})
+		return err == nil, err
+	}, awserrors.RouteTableNotFound, awserrors.NATGatewayNotFound, awserrors.GatewayNotFound); err != nil {
+		record.Warnf(s.scope.InfraCluster(), "FailedReconcileRoute", "Failed to reconcile route %s on managed RouteTable %q: %v", routeDesc, aws.ToString(rt.RouteTableId), err)
+		return errors.Wrapf(err, "failed to reconcile route %s on route table %q", routeDesc, aws.ToString(rt.RouteTableId))
 	}
+	record.Eventf(s.scope.InfraCluster(), "SuccessfulReconcileRoute", "Reconciled route %s on RouteTable %q", routeDesc, aws.ToString(rt.RouteTableId))
 	return nil
 }
 
@@ -285,14 +286,15 @@ func (s *Service) createRouteTableWithRoutes(routes []*ec2.CreateRouteInput, isP
 			}
 			return true, nil
 		}, awserrors.RouteTableNotFound, awserrors.NATGatewayNotFound, awserrors.GatewayNotFound); err != nil {
-			record.Warnf(s.scope.InfraCluster(), "FailedCreateRoute", "Failed to create route %v for RouteTable %q: %v", route, aws.ToString(out.RouteTable.RouteTableId), err)
+			routeDesc := describeRoute(route)
+			record.Warnf(s.scope.InfraCluster(), "FailedCreateRoute", "Failed to create route %s for RouteTable %q: %v", routeDesc, aws.ToString(out.RouteTable.RouteTableId), err)
 			errDel := s.deleteRouteTable(*out.RouteTable)
 			if errDel != nil {
 				record.Warnf(s.scope.InfraCluster(), "FailedDeleteRouteTable", "Failed to delete managed RouteTable %q: %v", aws.ToString(out.RouteTable.RouteTableId), errDel)
 			}
-			return nil, errors.Wrapf(err, "failed to create route in route table %q: %v", aws.ToString(out.RouteTable.RouteTableId), route)
+			return nil, errors.Wrapf(err, "failed to create route in route table %q: %s", aws.ToString(out.RouteTable.RouteTableId), routeDesc)
 		}
-		record.Eventf(s.scope.InfraCluster(), "SuccessfulCreateRoute", "Created route %v for RouteTable %q", route, aws.ToString(out.RouteTable.RouteTableId))
+		record.Eventf(s.scope.InfraCluster(), "SuccessfulCreateRoute", "Created route %s for RouteTable %q", describeRoute(route), aws.ToString(out.RouteTable.RouteTableId))
 	}
 
 	return &infrav1.RouteTable{
@@ -445,4 +447,25 @@ func (s *Service) getRoutesForSubnet(sn *infrav1.SubnetSpec) ([]*ec2.CreateRoute
 		return s.getRoutesToPublicSubnet(sn)
 	}
 	return s.getRoutesToPrivateSubnet(sn)
+}
+
+// describeRoute renders a CreateRouteInput as a human-readable string for logs and events.
+func describeRoute(route *ec2.CreateRouteInput) string {
+	if route == nil {
+		return "<nil>"
+	}
+	var parts []string
+	addPart := func(name string, value *string) {
+		if v := aws.ToString(value); v != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", name, v))
+		}
+	}
+	addPart("destinationCidrBlock", route.DestinationCidrBlock)
+	addPart("destinationIpv6CidrBlock", route.DestinationIpv6CidrBlock)
+	addPart("destinationPrefixListId", route.DestinationPrefixListId)
+	addPart("gatewayId", route.GatewayId)
+	addPart("natGatewayId", route.NatGatewayId)
+	addPart("egressOnlyInternetGatewayId", route.EgressOnlyInternetGatewayId)
+	addPart("carrierGatewayId", route.CarrierGatewayId)
+	return "{" + strings.Join(parts, ", ") + "}"
 }

--- a/pkg/cloud/services/network/routetables_test.go
+++ b/pkg/cloud/services/network/routetables_test.go
@@ -437,6 +437,114 @@ func TestReconcileRouteTables(t *testing.T) {
 			},
 		},
 		{
+			// Public subnet's IPv4 default route points at an outdated internet gateway,
+			// so ReplaceRoute must be called with the correct DestinationCidrBlock and GatewayId
+			name: "ipv4 route exists, but the internet gateway ID is incorrect, replace it",
+			input: &infrav1.NetworkSpec{
+				VPC: infrav1.VPCSpec{
+					InternetGatewayID: aws.String("igw-01"),
+					ID:                "vpc-routetables",
+					Tags: infrav1.Tags{
+						infrav1.ClusterTagKey("test-cluster"): "owned",
+					},
+				},
+				Subnets: infrav1.Subnets{
+					infrav1.SubnetSpec{
+						ID:               "subnet-routetables-private",
+						IsPublic:         false,
+						AvailabilityZone: "us-east-1a",
+					},
+					infrav1.SubnetSpec{
+						ID:               "subnet-routetables-public",
+						IsPublic:         true,
+						NatGatewayID:     aws.String("nat-01"),
+						AvailabilityZone: "us-east-1a",
+						RouteTableID:     aws.String("route-table-1"),
+					},
+				},
+			},
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.DescribeRouteTables(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{
+						RouteTables: []types.RouteTable{
+							{
+								RouteTableId: aws.String("route-table-private"),
+								Associations: []types.RouteTableAssociation{
+									{
+										SubnetId: aws.String("subnet-routetables-private"),
+									},
+								},
+								Routes: []types.Route{
+									{
+										DestinationCidrBlock: aws.String("0.0.0.0/0"),
+										NatGatewayId:         aws.String("nat-01"),
+									},
+								},
+								Tags: []types.Tag{
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("common"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("test-cluster-rt-private-us-east-1a"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+								},
+							},
+							{
+								RouteTableId: aws.String("route-table-public"),
+								Associations: []types.RouteTableAssociation{
+									{
+										SubnetId: aws.String("subnet-routetables-public"),
+									},
+								},
+								Routes: []types.Route{
+									{
+										DestinationCidrBlock: aws.String("0.0.0.0/0"),
+										GatewayId:            aws.String("outdated-igw-01"),
+									},
+								},
+								Tags: []types.Tag{
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("common"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("test-cluster-rt-public-us-east-1a"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+								},
+							},
+						},
+					}, nil)
+
+				m.ReplaceRoute(context.TODO(), gomock.Eq(
+					&ec2.ReplaceRouteInput{
+						DestinationCidrBlock: aws.String("0.0.0.0/0"),
+						RouteTableId:         aws.String("route-table-public"),
+						GatewayId:            aws.String("igw-01"),
+					},
+				)).
+					Return(nil, nil)
+			},
+		},
+		{
 			name: "extra routes exist, do nothing",
 			input: &infrav1.NetworkSpec{
 				VPC: infrav1.VPCSpec{
@@ -534,6 +642,115 @@ func TestReconcileRouteTables(t *testing.T) {
 							},
 						},
 					}, nil)
+			},
+		},
+		{
+			// A bring-your-own VPC was taken over by CAPA, but the private route table had no
+			// 0.0.0.0/0 route. CAPA must add desired routes that are missing.
+			name: "route exists but desired default route is missing, add it",
+			input: &infrav1.NetworkSpec{
+				VPC: infrav1.VPCSpec{
+					InternetGatewayID: aws.String("igw-01"),
+					ID:                "vpc-routetables",
+					Tags: infrav1.Tags{
+						infrav1.ClusterTagKey("test-cluster"): "owned",
+					},
+				},
+				Subnets: infrav1.Subnets{
+					infrav1.SubnetSpec{
+						ID:               "subnet-routetables-private",
+						IsPublic:         false,
+						AvailabilityZone: "us-east-1a",
+					},
+					infrav1.SubnetSpec{
+						ID:               "subnet-routetables-public",
+						IsPublic:         true,
+						NatGatewayID:     aws.String("nat-01"),
+						AvailabilityZone: "us-east-1a",
+					},
+				},
+			},
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.DescribeRouteTables(context.TODO(), gomock.AssignableToTypeOf(&ec2.DescribeRouteTablesInput{})).
+					Return(&ec2.DescribeRouteTablesOutput{
+						RouteTables: []types.RouteTable{
+							{
+								RouteTableId: aws.String("route-table-private"),
+								Associations: []types.RouteTableAssociation{
+									{
+										SubnetId: aws.String("subnet-routetables-private"),
+									},
+								},
+								// The prepared VPC's route table has no 0.0.0.0/0 route at all, but a
+								// custom route which must be preserved for backward compatibility (the implementation
+								// never did full reconciliation i.e. create/update/delete according to the manifest,
+								// so keep it that way to not accidentally delete desired routes).
+								Routes: []types.Route{
+									{
+										DestinationCidrBlock: aws.String("1.2.3.4/32"),
+										GatewayId:            aws.String("igw-01"),
+									},
+								},
+								Tags: []types.Tag{
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("common"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("test-cluster-rt-private-us-east-1a"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+								},
+							},
+							{
+								RouteTableId: aws.String("route-table-public"),
+								Associations: []types.RouteTableAssociation{
+									{
+										SubnetId: aws.String("subnet-routetables-public"),
+									},
+								},
+								Routes: []types.Route{
+									{
+										DestinationCidrBlock: aws.String("0.0.0.0/0"),
+										GatewayId:            aws.String("igw-01"),
+									},
+								},
+								Tags: []types.Tag{
+									{
+										Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("common"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("test-cluster-rt-public-us-east-1a"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+										Value: aws.String("owned"),
+									},
+								},
+							},
+						},
+					}, nil)
+
+				m.CreateRoute(context.TODO(), gomock.Eq(&ec2.CreateRouteInput{
+					NatGatewayId:         aws.String("nat-01"),
+					DestinationCidrBlock: aws.String("0.0.0.0/0"),
+					RouteTableId:         aws.String("route-table-private"),
+				})).
+					Return(&ec2.CreateRouteOutput{}, nil)
 			},
 		},
 		{
@@ -1372,6 +1589,57 @@ func TestService_getRoutesForSubnet(t *testing.T) {
 				if !cmp.Equal(got, tc.want, cmp.AllowUnexported(ec2.CreateRouteInput{})) {
 					t.Errorf("got unexpect routes:\n%v", cmp.Diff(got, tc.want))
 				}
+			}
+		})
+	}
+}
+
+func TestDescribeRoute(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *ec2.CreateRouteInput
+		want  string
+	}{
+		{
+			name:  "nil input",
+			route: nil,
+			want:  "<nil>",
+		},
+		{
+			name:  "empty input",
+			route: &ec2.CreateRouteInput{},
+			want:  "{}",
+		},
+		{
+			name: "ipv4 route via NAT gateway",
+			route: &ec2.CreateRouteInput{
+				DestinationCidrBlock: aws.String("0.0.0.0/0"),
+				NatGatewayId:         aws.String("nat-1234567890abcdef0"),
+			},
+			want: "{destinationCidrBlock=0.0.0.0/0, natGatewayId=nat-1234567890abcdef0}",
+		},
+		{
+			name: "ipv6 route via egress-only internet gateway",
+			route: &ec2.CreateRouteInput{
+				DestinationIpv6CidrBlock:    aws.String("::/0"),
+				EgressOnlyInternetGatewayId: aws.String("eigw-1234567890abcdef0"),
+			},
+			want: "{destinationIpv6CidrBlock=::/0, egressOnlyInternetGatewayId=eigw-1234567890abcdef0}",
+		},
+		{
+			name: "skips empty string pointers",
+			route: &ec2.CreateRouteInput{
+				DestinationCidrBlock: aws.String("0.0.0.0/0"),
+				GatewayId:            aws.String("igw-1234567890abcdef0"),
+				NatGatewayId:         aws.String(""),
+			},
+			want: "{destinationCidrBlock=0.0.0.0/0, gatewayId=igw-1234567890abcdef0}",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeRoute(tc.route); got != tc.want {
+				t.Errorf("describeRoute() = %q, want %q", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

For bring-your-own VPCs that miss routes such as `0.0.0.0/0`, CAPA should create the desired routes. Therefore I implemented _creation_, while previously the code only fixed mismatching, existing routes (_update_). I specifically did not implement full reconciliation, i.e. _deletion_, since that could be a breaking, dangerous change.

This also includes an improvement for event/log formatting since `%s` can't format a struct reasonably.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:


**Special notes for your reviewer**:

**AI Usage**:

I used Claude to create a failing test, then to rewrite and simplify existing logic to do both create+update. Basically the same as I would've done on my own, plus human check all along the way.

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Add missing, desired routes during route table reconciliation
```
