### PR TITLE
✨ feat(ROSA): add optional sts:ExternalId support for ROSA account roles and control plane

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
@@ -923,6 +923,24 @@ spec:
                   access to the cluster account in order to provide support.
                   Required if RosaRoleConfigRef is not specified.
                 type: string
+              trustPolicyExternalID:
+                description: |-
+                  TrustPolicyExternalID is an optional STS external ID that OCM will use when assuming
+                  the installer and support account roles.
+                  When using RosaRoleConfigRef, this field is ignored, the value is always read from
+                  the ROSARoleConfig, which owns the trust policies.
+                  When providing role ARNs directly (no RosaRoleConfigRef), the user is responsible for
+                  including the sts:ExternalId condition in the roles' trust policies; this field only
+                  tells OCM which external ID to present when assuming the roles.
+                  Worker roles are not affected.
+                  Must be 2–1224 characters matching [a-zA-Z0-9=,.@:/-]+ per AWS STS requirements.
+                maxLength: 1224
+                minLength: 2
+                pattern: ^[a-zA-Z0-9=,.@:\/-]+$
+                type: string
+                x-kubernetes-validations:
+                - message: trustPolicyExternalID is immutable
+                  rule: self == oldSelf
               version:
                 description: OpenShift semantic version, for example "4.14.5".
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_rosaroleconfigs.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_rosaroleconfigs.yaml
@@ -78,6 +78,21 @@ spec:
                           to be used with the VPC endpoint
                         type: string
                     type: object
+                  trustPolicyExternalID:
+                    description: |-
+                      TrustPolicyExternalID is an optional STS external ID that OCM will use when assuming
+                      the installer and support account roles. When set, the controller embeds an
+                      sts:ExternalId condition in the installer and support roles' trust policies, and
+                      passes the value to OCM for cluster creation.
+                      Worker roles are not affected.
+                      Must be 2–1224 characters matching [a-zA-Z0-9=,.@:/-]+ per AWS STS requirements.
+                    maxLength: 1224
+                    minLength: 2
+                    pattern: ^[a-zA-Z0-9=,.@:\/-]+$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: trustPolicyExternalID is immutable
+                      rule: self == oldSelf
                   version:
                     description: |-
                       Version of OpenShift that will be used to the roles tag in formate of x.y.z example; "4.19.0"

--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -226,6 +226,23 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	// +optional
 	WorkerRoleARN string `json:"workerRoleARN,omitempty"`
 
+	// TrustPolicyExternalID is an optional STS external ID that OCM will use when assuming
+	// the installer and support account roles.
+	// When using RosaRoleConfigRef, this field is ignored, the value is always read from
+	// the ROSARoleConfig, which owns the trust policies.
+	// When providing role ARNs directly (no RosaRoleConfigRef), the user is responsible for
+	// including the sts:ExternalId condition in the roles' trust policies; this field only
+	// tells OCM which external ID to present when assuming the roles.
+	// Worker roles are not affected.
+	// Must be 2–1224 characters matching [a-zA-Z0-9=,.@:/-]+ per AWS STS requirements.
+	//
+	// +kubebuilder:validation:MinLength=2
+	// +kubebuilder:validation:MaxLength=1224
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9=,.@:\/-]+$`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="trustPolicyExternalID is immutable"
+	// +optional
+	TrustPolicyExternalID string `json:"trustPolicyExternalID,omitempty"`
+
 	// BillingAccount is an optional AWS account to use for billing the subscription fees for ROSA HCP clusters.
 	// The cost of running each ROSA HCP cluster will be billed to the infrastructure account in which the cluster
 	// is running.

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -405,6 +405,7 @@ func (r *ROSAControlPlaneReconciler) reconcileRosaRoleConfig(ctx context.Context
 		rosaRoleConfig.Status.AccountRolesRef.SupportRoleARN = rosaScope.ControlPlane.Spec.SupportRoleARN
 		rosaRoleConfig.Status.AccountRolesRef.WorkerRoleARN = rosaScope.ControlPlane.Spec.WorkerRoleARN
 		rosaRoleConfig.Status.OperatorRolesRef = rosaScope.ControlPlane.Spec.RolesRef
+		rosaRoleConfig.Spec.AccountRoleConfig.TrustPolicyExternalID = rosaScope.ControlPlane.Spec.TrustPolicyExternalID
 	}
 
 	return rosaRoleConfig, nil
@@ -1199,6 +1200,7 @@ func buildOCMClusterSpec(controlPlaneSpec rosacontrolplanev1.RosaControlPlaneSpe
 		AuditLogRoleARN:              ptr.To(controlPlaneSpec.AuditLogRoleARN),
 		ExternalAuthProvidersEnabled: controlPlaneSpec.EnableExternalAuthProviders,
 		FIPS:                         controlPlaneSpec.FIPS == rosacontrolplanev1.FIPSEnabled,
+		ExternalID:                   roleConfig.Spec.AccountRoleConfig.TrustPolicyExternalID,
 	}
 
 	if controlPlaneSpec.EndpointAccess == rosacontrolplanev1.Private {

--- a/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
@@ -963,4 +963,96 @@ func TestBuildOCMClusterSpec(t *testing.T) {
 		g.Expect(ocmSpec.FIPS).To(BeFalse())
 		g.Expect(ocmSpec.Name).To(Equal("test-cluster-zero-fips"))
 	})
+
+	// Test case 4: TrustPolicyExternalID set on ROSARoleConfig (takes precedence)
+	t.Run("TrustPolicyExternalID Set", func(t *testing.T) {
+		g := NewWithT(t)
+		roleConfigWithExtID := mockRoleConfig.DeepCopy()
+		roleConfigWithExtID.Spec.AccountRoleConfig.TrustPolicyExternalID = "223B9588-36A5-ECA4-BE8D-7C673B77CEC1"
+
+		controlPlaneSpec := rosacontrolplanev1.RosaControlPlaneSpec{
+			RosaClusterName:   "test-cluster-extid",
+			Region:            "us-west-2",
+			Version:           "4.14.5",
+			Subnets:           []string{"subnet-1", "subnet-2"},
+			AvailabilityZones: []string{"us-west-2a"},
+			DefaultMachinePoolSpec: rosacontrolplanev1.DefaultMachinePoolSpec{
+				InstanceType: "m5.xlarge",
+			},
+		}
+
+		ocmSpec, err := buildOCMClusterSpec(controlPlaneSpec, roleConfigWithExtID, nil, mockCreator)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ocmSpec.ExternalID).To(Equal("223B9588-36A5-ECA4-BE8D-7C673B77CEC1"))
+		g.Expect(ocmSpec.Name).To(Equal("test-cluster-extid"))
+	})
+
+	// Test case 5: TrustPolicyExternalID empty (should remain empty)
+	t.Run("TrustPolicyExternalID Empty", func(t *testing.T) {
+		g := NewWithT(t)
+		controlPlaneSpec := rosacontrolplanev1.RosaControlPlaneSpec{
+			RosaClusterName:   "test-cluster-no-extid",
+			Region:            "us-west-2",
+			Version:           "4.14.5",
+			Subnets:           []string{"subnet-1", "subnet-2"},
+			AvailabilityZones: []string{"us-west-2a"},
+			DefaultMachinePoolSpec: rosacontrolplanev1.DefaultMachinePoolSpec{
+				InstanceType: "m5.xlarge",
+			},
+		}
+
+		ocmSpec, err := buildOCMClusterSpec(controlPlaneSpec, mockRoleConfig, nil, mockCreator)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ocmSpec.ExternalID).To(BeEmpty())
+	})
+
+	// Test case 6: TrustPolicyExternalID on controlPlane is ignored when ROSARoleConfig is present
+	t.Run("TrustPolicyExternalID ControlPlane Ignored With RoleConfig", func(t *testing.T) {
+		g := NewWithT(t)
+		controlPlaneSpec := rosacontrolplanev1.RosaControlPlaneSpec{
+			RosaClusterName:       "test-cluster-cp-extid",
+			Region:                "us-west-2",
+			Version:               "4.14.5",
+			TrustPolicyExternalID: "should-be-ignored",
+			Subnets:               []string{"subnet-1", "subnet-2"},
+			AvailabilityZones:     []string{"us-west-2a"},
+			DefaultMachinePoolSpec: rosacontrolplanev1.DefaultMachinePoolSpec{
+				InstanceType: "m5.xlarge",
+			},
+		}
+
+		ocmSpec, err := buildOCMClusterSpec(controlPlaneSpec, mockRoleConfig, nil, mockCreator)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ocmSpec.ExternalID).To(BeEmpty())
+	})
+
+	// Test case 7: TrustPolicyExternalID from controlPlane propagated via synthesized roleConfig
+	// (simulates direct-role-ARN flow where reconcileRosaRoleConfig copies the value)
+	t.Run("TrustPolicyExternalID ControlPlane Without RoleConfig", func(t *testing.T) {
+		g := NewWithT(t)
+		controlPlaneSpec := rosacontrolplanev1.RosaControlPlaneSpec{
+			RosaClusterName:       "test-cluster-direct",
+			Region:                "us-west-2",
+			Version:               "4.14.5",
+			TrustPolicyExternalID: "direct-external-id",
+			Subnets:               []string{"subnet-1", "subnet-2"},
+			AvailabilityZones:     []string{"us-west-2a"},
+			DefaultMachinePoolSpec: rosacontrolplanev1.DefaultMachinePoolSpec{
+				InstanceType: "m5.xlarge",
+			},
+		}
+
+		// Simulate what reconcileRosaRoleConfig does in the else branch:
+		// it copies TrustPolicyExternalID from the control plane spec onto the roleConfig
+		synthesizedRoleConfig := mockRoleConfig.DeepCopy()
+		synthesizedRoleConfig.Spec.AccountRoleConfig.TrustPolicyExternalID = controlPlaneSpec.TrustPolicyExternalID
+
+		ocmSpec, err := buildOCMClusterSpec(controlPlaneSpec, synthesizedRoleConfig, nil, mockCreator)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ocmSpec.ExternalID).To(Equal("direct-external-id"))
+	})
 }

--- a/controlplane/rosa/webhooks/rosacontrolplane_webhook.go
+++ b/controlplane/rosa/webhooks/rosacontrolplane_webhook.go
@@ -230,7 +230,8 @@ func (w *ROSAControlPlane) validateRosaRoleConfig(r *rosacontrolplanev1.ROSACont
 	hasRoleFields := r.Spec.OIDCID != "" || r.Spec.InstallerRoleARN != "" || r.Spec.SupportRoleARN != "" || r.Spec.WorkerRoleARN != "" ||
 		r.Spec.RolesRef.IngressARN != "" || r.Spec.RolesRef.ImageRegistryARN != "" || r.Spec.RolesRef.StorageARN != "" ||
 		r.Spec.RolesRef.NetworkARN != "" || r.Spec.RolesRef.KubeCloudControllerARN != "" || r.Spec.RolesRef.NodePoolManagementARN != "" ||
-		r.Spec.RolesRef.ControlPlaneOperatorARN != "" || r.Spec.RolesRef.KMSProviderARN != ""
+		r.Spec.RolesRef.ControlPlaneOperatorARN != "" || r.Spec.RolesRef.KMSProviderARN != "" ||
+		r.Spec.TrustPolicyExternalID != ""
 
 	if r.Spec.RosaRoleConfigRef != nil {
 		if hasRoleFields {

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -11318,6 +11318,19 @@ Required if RosaRoleConfigRef is not specified.</p>
 </tr>
 <tr>
 <td>
+<code>trustPolicyExternalID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TrustPolicyExternalID is an optional STS external ID that OCM uses when assuming the installer
+and support account roles. Must match the sts:ExternalId condition in those roles&rsquo; trust policies.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>billingAccount</code><br/>
 <em>
 string
@@ -12002,6 +12015,19 @@ string
 <em>(Optional)</em>
 <p>WorkerRoleARN is an AWS IAM role that will be attached to worker instances.
 Required if RosaRoleConfigRef is not specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>trustPolicyExternalID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TrustPolicyExternalID is an optional STS external ID that OCM uses when assuming the installer
+and support account roles. Must match the sts:ExternalId condition in those roles&rsquo; trust policies.</p>
 </td>
 </tr>
 <tr>
@@ -30465,6 +30491,20 @@ SharedVPCConfig
 <td>
 <em>(Optional)</em>
 <p>SharedVPCConfig is used to set up shared VPC.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>trustPolicyExternalID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TrustPolicyExternalID is an optional STS external ID to embed in installer and support
+account role trust policies. When set, new roles will include an sts:ExternalId condition.
+Worker roles are not affected. Must be 2–1224 characters matching [a-zA-Z0-9=,.@:/-]+.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/book/src/topics/rosa/creating-a-cluster.md
+++ b/docs/book/src/topics/rosa/creating-a-cluster.md
@@ -84,6 +84,7 @@ The CAPA controller requires service account credentials to provision ROSA HCP c
 
     **Note:** The `prefix` field has a maximum length of 4 characters.
 
+    Optionally, you can set `trustPolicyExternalID` in `accountRoleConfig` to embed an `sts:ExternalId` condition in the installer and support role trust policies. This adds an additional layer of cross-account protection when OCM assumes those roles.
 
     ```shell
     cat <<EOF > rosa-role-network.yaml
@@ -96,6 +97,7 @@ The CAPA controller requires service account credentials to provision ROSA HCP c
       accountRoleConfig:
         prefix: "rosa"
         version: "4.20.11"
+       # trustPolicyExternalID: "my-external-id"   optional 
       operatorRoleConfig:
         prefix: "rosa"
       credentialsSecretRef:
@@ -278,7 +280,7 @@ The CAPA controller requires service account credentials to provision ROSA HCP c
     kubectl apply -f rosa-cluster.yaml
     ```
 
-
+    **Note:** If you are providing pre-created role ARNs directly on `ROSAControlPlane` (without `rosaRoleConfigRef`) and your roles require an STS external ID, set `trustPolicyExternalID` on the `ROSAControlPlane` spec. In this case, you are responsible for ensuring the roles' trust policies already include the `sts:ExternalId` condition; CAPA will only pass the value to OCM, not modify the trust policies.
 
 1. Check the `ROSAControlPlane` status:
 

--- a/exp/api/v1beta2/rosaroleconfig_types.go
+++ b/exp/api/v1beta2/rosaroleconfig_types.go
@@ -141,6 +141,20 @@ type AccountRoleConfig struct {
 	// SharedVPCConfig is used to set up shared VPC.
 	// +optional
 	SharedVPCConfig SharedVPCConfig `json:"sharedVPCConfig,omitempty"`
+
+	// TrustPolicyExternalID is an optional STS external ID that OCM will use when assuming
+	// the installer and support account roles. When set, the controller embeds an
+	// sts:ExternalId condition in the installer and support roles' trust policies, and
+	// passes the value to OCM for cluster creation.
+	// Worker roles are not affected.
+	// Must be 2–1224 characters matching [a-zA-Z0-9=,.@:/-]+ per AWS STS requirements.
+	//
+	// +kubebuilder:validation:MinLength=2
+	// +kubebuilder:validation:MaxLength=1224
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9=,.@:\/-]+$`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="trustPolicyExternalID is immutable"
+	// +optional
+	TrustPolicyExternalID string `json:"trustPolicyExternalID,omitempty"`
 }
 
 // OperatorRoleConfig defines cluster-specific operator IAM roles based on your cluster configuration.

--- a/exp/controllers/rosaroleconfig_controller.go
+++ b/exp/controllers/rosaroleconfig_controller.go
@@ -139,6 +139,17 @@ func (r *ROSARoleConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, fmt.Errorf("account Roles: %w", err)
 	}
 
+	if externalID := scope.RosaRoleConfig.Spec.AccountRoleConfig.TrustPolicyExternalID; externalID != "" {
+		prefix := scope.RosaRoleConfig.Spec.AccountRoleConfig.Prefix
+		for _, suffix := range []string{expinfrav1.HCPROSAInstallerRole, expinfrav1.HCPROSASupportRole} {
+			roleName := prefix + suffix
+			if err := rosa.ApplyTrustPolicyExternalID(ctx, scope.IAMClient(), roleName, externalID); err != nil {
+				v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError, "Trust policy external ID failure: %v", err)
+				return ctrl.Result{}, fmt.Errorf("trust policy external ID: %w", err)
+			}
+		}
+	}
+
 	if err := r.reconcileOIDC(scope); err != nil {
 		v1beta1conditions.MarkFalse(scope.RosaRoleConfig, expinfrav1.RosaRoleConfigReadyCondition, expinfrav1.RosaRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError, "OIDC Config/provider failure: %v", err)
 		return ctrl.Result{}, fmt.Errorf("oicd Config: %w", err)

--- a/exp/controllers/rosaroleconfig_controller_test.go
+++ b/exp/controllers/rosaroleconfig_controller_test.go
@@ -1093,3 +1093,169 @@ func TestROSARoleConfigReconcileDelete(t *testing.T) {
 		g.Expect(deletedRoleConfig.Finalizers).To(BeEmpty(), "Finalizers should be removed after successful deletion")
 	}
 }
+
+func TestROSARoleConfigReconcileExistWithTrustPolicyExternalID(t *testing.T) {
+	RegisterTestingT(t)
+	g := NewWithT(t)
+
+	testID := generateTestID()
+
+	ssoServer := ocmsdk.MakeTCPServer()
+	apiServer := ocmsdk.MakeTCPServer()
+	defer ssoServer.Close()
+	defer apiServer.Close()
+	apiServer.SetAllowUnhandledRequests(true)
+	apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+	ctx := context.TODO()
+
+	accessToken := ocmsdk.MakeTokenString("Bearer", 15*time.Minute)
+	ssoServer.AppendHandlers(
+		ocmsdk.RespondWithAccessToken(accessToken),
+	)
+	logger, err := ocmlogging.NewGoLoggerBuilder().
+		Debug(false).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	connection, err := sdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(accessToken).
+		URL(apiServer.URL()).
+		Build()
+	Expect(err).To(BeNil())
+	ocmClient := ocm.NewClientWithConnection(connection)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockAWSClient := aws.NewMockClient(mockCtrl)
+	mockAWSClient.EXPECT().HasManagedPolicies(gomock.Any()).Return(false, nil).AnyTimes()
+	mockAWSClient.EXPECT().HasHostedCPPolicies(gomock.Any()).Return(true, nil).AnyTimes()
+
+	mockAWSClient.EXPECT().ListAccountRoles(gomock.Any()).Return([]aws.Role{
+		{
+			RoleName: "test-HCP-ROSA-Installer-Role",
+			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Installer-Role",
+		},
+		{
+			RoleName: "test-HCP-ROSA-Support-Role",
+			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Support-Role",
+		},
+		{
+			RoleName: "test-HCP-ROSA-Worker-Role",
+			RoleARN:  "arn:aws:iam::123456789012:role/test-HCP-ROSA-Worker-Role",
+		},
+	}, nil).AnyTimes()
+
+	mockAWSClient.EXPECT().ListOperatorRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string][]aws.OperatorRoleDetail{
+		"test": {
+			{RoleName: "test-openshift-ingress-operator-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-ingress-operator-cloud-credentials"},
+			{RoleName: "test-openshift-image-registry-installer-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-image-registry-installer-cloud-credentials"},
+			{RoleName: "test-openshift-cluster-csi-drivers-ebs-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-cluster-csi-drivers-ebs-cloud-credentials"},
+			{RoleName: "test-openshift-cloud-network-config-controller-cloud-credentials", RoleARN: "arn:aws:iam::123456789012:role/test-openshift-cloud-network-config-controller-cloud-credentials"},
+			{RoleName: "test-kube-system-kube-controller-manager", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-kube-controller-manager"},
+			{RoleName: "test-kube-system-capa-controller-manager", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-capa-controller-manager"},
+			{RoleName: "test-kube-system-control-plane-operator", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-control-plane-operator"},
+			{RoleName: "test-kube-system-kms-provider", RoleARN: "arn:aws:iam::123456789012:role/test-kube-system-kms-provider"},
+		},
+	}, nil).AnyTimes()
+
+	mockAWSClient.EXPECT().ListOidcProviders(gomock.Any(), gomock.Any()).Return([]aws.OidcProviderOutput{
+		{Arn: "arn:aws:iam::123456789012:oidc-provider/test-existing-oidc-id"},
+	}, nil).AnyTimes()
+
+	mockAWSClient.EXPECT().GetCreator().Return(&aws.Creator{
+		ARN:       "arn:aws:iam::123456789012:user/test-user",
+		AccountID: "123456789012",
+		IsSTS:     false,
+	}, nil).AnyTimes()
+
+	r := rosacli.NewRuntime()
+	r.OCMClient = ocmClient
+	r.AWSClient = mockAWSClient
+	r.Creator = &aws.Creator{
+		ARN:       "arn:aws:iam::123456789012:user/test-user",
+		AccountID: "123456789012",
+		IsSTS:     false,
+	}
+
+	// Mock OCM API calls in order: initial call, GetOidcConfig, GetAllClusters, GetAllCredRequests, HasAClusterUsingOperatorRolesPrefix
+	apiServer.AppendHandlers(
+		ocmsdk.RespondWithJSON(http.StatusOK, ""),
+	)
+	apiServer.AppendHandlers(
+		ocmsdk.RespondWithJSON(http.StatusOK, `{"id": "test-existing-oidc-id", "issuer_url": "https://test.existing.oidc.url"}`),
+	)
+	apiServer.AppendHandlers(
+		ocmsdk.RespondWithJSON(http.StatusOK, `{"items": []}`),
+	)
+	apiServer.AppendHandlers(
+		ocmsdk.RespondWithJSON(http.StatusOK, `{}`),
+	)
+	apiServer.AppendHandlers(
+		ocmsdk.RespondWithJSON(http.StatusOK, `false`),
+	)
+
+	apiServer.RouteToHandler("GET", "/api/clusters_mgmt/v1/oidc_configs/test-existing-oidc-id",
+		ocmsdk.RespondWithJSON(http.StatusOK, `{"id": "test-existing-oidc-id", "issuer_url": "https://test.existing.oidc.url"}`),
+	)
+
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("test-ns-extid-%s", testID))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	rosaRoleConfig := &expinfrav1.ROSARoleConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       fmt.Sprintf("test-rosarole-extid-%s", testID),
+			Namespace:  ns.Name,
+			Finalizers: []string{expinfrav1.RosaRoleConfigFinalizer},
+		},
+		Spec: expinfrav1.ROSARoleConfigSpec{
+			AccountRoleConfig: expinfrav1.AccountRoleConfig{
+				Prefix:                "test",
+				Version:               "4.15.0",
+				TrustPolicyExternalID: "223B9588-36A5-ECA4-BE8D-7C673B77CEC1",
+			},
+			OperatorRoleConfig: expinfrav1.OperatorRoleConfig{
+				Prefix: "test",
+			},
+			OidcProviderType: expinfrav1.Managed,
+		},
+		Status: expinfrav1.ROSARoleConfigStatus{
+			OIDCID: "test-existing-oidc-id",
+		},
+	}
+
+	createObject(g, rosaRoleConfig, ns.Name)
+	defer cleanupObject(g, rosaRoleConfig)
+
+	reconciler := &ROSARoleConfigReconciler{
+		Client:  testEnv.Client,
+		Runtime: r,
+	}
+
+	req := ctrl.Request{}
+	req.NamespacedName = types.NamespacedName{Name: rosaRoleConfig.Name, Namespace: rosaRoleConfig.Namespace}
+
+	g.Eventually(func(g Gomega) {
+		_, errReconcile := reconciler.Reconcile(ctx, req)
+		// Trust policy application requires real IAM access which is unavailable in envtest.
+		// The reconciliation will fail at that step, but account roles should still be populated
+		// and the spec field preserved.
+		g.Expect(errReconcile).To(HaveOccurred())
+		g.Expect(errReconcile.Error()).To(ContainSubstring("trust policy external ID"))
+
+		updatedRoleConfig := &expinfrav1.ROSARoleConfig{}
+		g.Expect(reconciler.Client.Get(ctx, req.NamespacedName, updatedRoleConfig)).ToNot(HaveOccurred())
+
+		g.Expect(updatedRoleConfig.Status.AccountRolesRef.InstallerRoleARN).To(Equal("arn:aws:iam::123456789012:role/test-HCP-ROSA-Installer-Role"))
+		g.Expect(updatedRoleConfig.Status.AccountRolesRef.SupportRoleARN).To(Equal("arn:aws:iam::123456789012:role/test-HCP-ROSA-Support-Role"))
+		g.Expect(updatedRoleConfig.Status.AccountRolesRef.WorkerRoleARN).To(Equal("arn:aws:iam::123456789012:role/test-HCP-ROSA-Worker-Role"))
+
+		// TrustPolicyExternalID on spec is preserved
+		g.Expect(updatedRoleConfig.Spec.AccountRoleConfig.TrustPolicyExternalID).To(Equal("223B9588-36A5-ECA4-BE8D-7C673B77CEC1"))
+
+		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.RosaRoleConfigReadyCondition)
+		g.Expect(readyCondition).ToNot(BeNil())
+		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionFalse))
+		g.Expect(readyCondition.Reason).To(Equal(expinfrav1.RosaRoleConfigReconciliationFailedReason))
+	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}

--- a/pkg/rosa/trust_policy.go
+++ b/pkg/rosa/trust_policy.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rosa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// ApplyTrustPolicyExternalID fetches the current trust policy for the named IAM role,
+// injects an sts:ExternalId condition into every sts:AssumeRole Allow statement,
+// and updates the role if a change was made.
+func ApplyTrustPolicyExternalID(ctx context.Context, iamClient *iam.Client, roleName, externalID string) error {
+	roleOutput, err := iamClient.GetRole(ctx, &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get role %q: %w", roleName, err)
+	}
+
+	rawPolicy := aws.ToString(roleOutput.Role.AssumeRolePolicyDocument)
+	if rawPolicy == "" {
+		return fmt.Errorf("role %q has no assume role policy document", roleName)
+	}
+
+	decoded, err := url.QueryUnescape(rawPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to URL-decode trust policy for role %q: %w", roleName, err)
+	}
+
+	updated, changed, err := InjectExternalIDIntoTrustPolicy(decoded, externalID)
+	if err != nil {
+		return fmt.Errorf("failed to inject external ID into trust policy for role %q: %w", roleName, err)
+	}
+	if !changed {
+		return nil
+	}
+
+	_, err = iamClient.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyDocument: aws.String(updated),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update assume role policy for role %q: %w", roleName, err)
+	}
+	return nil
+}
+
+// InjectExternalIDIntoTrustPolicy parses a trust policy JSON document and adds
+// an sts:ExternalId condition to every sts:AssumeRole Allow statement.
+// Returns the modified JSON and whether any change was made.
+func InjectExternalIDIntoTrustPolicy(policyJSON, externalID string) (string, bool, error) {
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(policyJSON), &doc); err != nil {
+		return "", false, fmt.Errorf("failed to parse trust policy: %w", err)
+	}
+
+	statements, ok := doc["Statement"].([]interface{})
+	if !ok {
+		return policyJSON, false, nil
+	}
+
+	changed := false
+	for _, raw := range statements {
+		stmt, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if !isAssumeRoleAllowStatement(stmt) {
+			continue
+		}
+		if setExternalIDCondition(stmt, externalID) {
+			changed = true
+		}
+	}
+
+	if !changed {
+		return policyJSON, false, nil
+	}
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to marshal updated trust policy: %w", err)
+	}
+	return string(out), true, nil
+}
+
+func isAssumeRoleAllowStatement(stmt map[string]interface{}) bool {
+	effect, _ := stmt["Effect"].(string)
+	if effect != "Allow" {
+		return false
+	}
+	switch action := stmt["Action"].(type) {
+	case string:
+		return action == "sts:AssumeRole"
+	case []interface{}:
+		for _, a := range action {
+			if s, ok := a.(string); ok && s == "sts:AssumeRole" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// setExternalIDCondition adds or updates sts:ExternalId in the StringEquals condition.
+// Returns true if the statement was modified.
+func setExternalIDCondition(stmt map[string]interface{}, externalID string) bool {
+	condition, _ := stmt["Condition"].(map[string]interface{})
+	if condition == nil {
+		stmt["Condition"] = map[string]interface{}{
+			"StringEquals": map[string]interface{}{
+				"sts:ExternalId": externalID,
+			},
+		}
+		return true
+	}
+
+	stringEquals, _ := condition["StringEquals"].(map[string]interface{})
+	if stringEquals == nil {
+		condition["StringEquals"] = map[string]interface{}{
+			"sts:ExternalId": externalID,
+		}
+		return true
+	}
+
+	existing, _ := stringEquals["sts:ExternalId"].(string)
+	if existing == externalID {
+		return false
+	}
+
+	stringEquals["sts:ExternalId"] = externalID
+	return true
+}

--- a/pkg/rosa/trust_policy_test.go
+++ b/pkg/rosa/trust_policy_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rosa
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestInjectExternalIDIntoTrustPolicy(t *testing.T) {
+	t.Run("injects external ID into policy with no condition", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+				"Action": "sts:AssumeRole"
+			}]
+		}`
+
+		result, changed, err := InjectExternalIDIntoTrustPolicy(policy, "my-external-id")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeTrue())
+
+		var doc map[string]interface{}
+		g.Expect(json.Unmarshal([]byte(result), &doc)).To(Succeed())
+
+		statements := doc["Statement"].([]interface{})
+		stmt := statements[0].(map[string]interface{})
+		condition := stmt["Condition"].(map[string]interface{})
+		stringEquals := condition["StringEquals"].(map[string]interface{})
+		g.Expect(stringEquals["sts:ExternalId"]).To(Equal("my-external-id"))
+	})
+
+	t.Run("injects external ID into policy with existing condition but no StringEquals", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+				"Action": "sts:AssumeRole",
+				"Condition": {
+					"Bool": {"aws:MultiFactorAuthPresent": "true"}
+				}
+			}]
+		}`
+
+		result, changed, err := InjectExternalIDIntoTrustPolicy(policy, "ext-123")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeTrue())
+
+		var doc map[string]interface{}
+		g.Expect(json.Unmarshal([]byte(result), &doc)).To(Succeed())
+
+		statements := doc["Statement"].([]interface{})
+		stmt := statements[0].(map[string]interface{})
+		condition := stmt["Condition"].(map[string]interface{})
+		g.Expect(condition["Bool"]).ToNot(BeNil())
+		stringEquals := condition["StringEquals"].(map[string]interface{})
+		g.Expect(stringEquals["sts:ExternalId"]).To(Equal("ext-123"))
+	})
+
+	t.Run("injects external ID into policy with existing StringEquals condition", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+				"Action": "sts:AssumeRole",
+				"Condition": {
+					"StringEquals": {"aws:PrincipalTag/Environment": "production"}
+				}
+			}]
+		}`
+
+		result, changed, err := InjectExternalIDIntoTrustPolicy(policy, "ext-456")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeTrue())
+
+		var doc map[string]interface{}
+		g.Expect(json.Unmarshal([]byte(result), &doc)).To(Succeed())
+
+		statements := doc["Statement"].([]interface{})
+		stmt := statements[0].(map[string]interface{})
+		condition := stmt["Condition"].(map[string]interface{})
+		stringEquals := condition["StringEquals"].(map[string]interface{})
+		g.Expect(stringEquals["aws:PrincipalTag/Environment"]).To(Equal("production"))
+		g.Expect(stringEquals["sts:ExternalId"]).To(Equal("ext-456"))
+	})
+
+	t.Run("skips injection when correct external ID already present", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+				"Action": "sts:AssumeRole",
+				"Condition": {
+					"StringEquals": {"sts:ExternalId": "my-id"}
+				}
+			}]
+		}`
+
+		_, changed, err := InjectExternalIDIntoTrustPolicy(policy, "my-id")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeFalse())
+	})
+
+	t.Run("updates external ID when different value present", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+				"Action": "sts:AssumeRole",
+				"Condition": {
+					"StringEquals": {"sts:ExternalId": "old-id"}
+				}
+			}]
+		}`
+
+		result, changed, err := InjectExternalIDIntoTrustPolicy(policy, "new-id")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeTrue())
+
+		var doc map[string]interface{}
+		g.Expect(json.Unmarshal([]byte(result), &doc)).To(Succeed())
+
+		statements := doc["Statement"].([]interface{})
+		stmt := statements[0].(map[string]interface{})
+		condition := stmt["Condition"].(map[string]interface{})
+		stringEquals := condition["StringEquals"].(map[string]interface{})
+		g.Expect(stringEquals["sts:ExternalId"]).To(Equal("new-id"))
+	})
+
+	t.Run("does not modify non-AssumeRole statements", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [
+				{
+					"Effect": "Allow",
+					"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+					"Action": "sts:AssumeRole"
+				},
+				{
+					"Effect": "Allow",
+					"Principal": {"Service": "lambda.amazonaws.com"},
+					"Action": "sts:AssumeRoleWithWebIdentity"
+				}
+			]
+		}`
+
+		result, changed, err := InjectExternalIDIntoTrustPolicy(policy, "ext-id")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeTrue())
+
+		var doc map[string]interface{}
+		g.Expect(json.Unmarshal([]byte(result), &doc)).To(Succeed())
+
+		statements := doc["Statement"].([]interface{})
+		stmt0 := statements[0].(map[string]interface{})
+		g.Expect(stmt0["Condition"]).ToNot(BeNil())
+		stmt1 := statements[1].(map[string]interface{})
+		g.Expect(stmt1["Condition"]).To(BeNil())
+	})
+
+	t.Run("handles Action as array containing sts:AssumeRole", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+				"Action": ["sts:AssumeRole", "sts:TagSession"]
+			}]
+		}`
+
+		result, changed, err := InjectExternalIDIntoTrustPolicy(policy, "array-ext-id")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeTrue())
+
+		var doc map[string]interface{}
+		g.Expect(json.Unmarshal([]byte(result), &doc)).To(Succeed())
+
+		statements := doc["Statement"].([]interface{})
+		stmt := statements[0].(map[string]interface{})
+		condition := stmt["Condition"].(map[string]interface{})
+		stringEquals := condition["StringEquals"].(map[string]interface{})
+		g.Expect(stringEquals["sts:ExternalId"]).To(Equal("array-ext-id"))
+	})
+
+	t.Run("no change when no AssumeRole statements exist", func(t *testing.T) {
+		g := NewWithT(t)
+
+		policy := `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"Service": "lambda.amazonaws.com"},
+				"Action": "sts:AssumeRoleWithWebIdentity"
+			}]
+		}`
+
+		_, changed, err := InjectExternalIDIntoTrustPolicy(policy, "ext-id")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(changed).To(BeFalse())
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, _, err := InjectExternalIDIntoTrustPolicy("not json", "ext-id")
+		g.Expect(err).To(HaveOccurred())
+	})
+}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind feature
/kind api-change
/kind documentation
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Adds an optional `trustPolicyExternalID` field to `ROSARoleConfig` and `ROSAControlPlane` CRDs. When set on `ROSARoleConfig`, the controller embeds an `sts:ExternalId` condition in installer and support role trust policies after role creation, and the value is automatically propagated to OCM during cluster creation. When set directly on `ROSAControlPlane` (without `rosaRoleConfigRef`), the value is passed to OCM but trust policies are not modified and the user is responsible for configuring their pre-existing roles.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**:
Fixes #6048

**Special notes for your reviewer**:

- Trust policy injection is implemented directly via the IAM API (`GetRole` + `UpdateAssumeRolePolicy`) rather than relying on upstream `openshift/rosa` library support, which would have required bumping the Go version from 1.24.0 to 1.25.8. This means that no dependency changes are needed to support this feature. There is a small downside to this: between role creation and the trust policy update, there is a brief window where the role exists without the `sts:ExternalId` condition. This is less than a second and, as the role was just created, I believe the exposure is minimal.
- When using `rosaRoleConfigRef`, the external ID is automatically read from the `ROSARoleConfig` and passed to OCM, so users only need to declare it once.
- When providing role ARNs directly on `ROSAControlPlane` (no `rosaRoleConfigRef`), CAPA only passes the value to OCM; it does not modify externally-created roles' trust policies.
- The field is immutable once set, enforced via CEL validation.
- The worker and Shared VPC account roles are intentionally excluded from the external ID condition.

**AI Usage**:

Cursor with Claude was used to assist with test authoring, implementation of the trust policy injection helper, and evaluating approaches to avoid the Go version bump.

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [x] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Add optional `trustPolicyExternalID` field to ROSARoleConfig and ROSAControlPlane for embedding sts:ExternalId conditions in ROSA HCP account role trust policies. When using ROSARoleConfig, the controller manages the trust policies automatically. When providing role ARNs directly, the value is passed to OCM and users are responsible for properly configuring their pre-existing roles.
```