### PR TITLE
🐛 fix(e2e): use targeted patch for EKS upgrade policy test

### DIFF
--- a/test/e2e/suites/managed/eks_upgrade_policy_test.go
+++ b/test/e2e/suites/managed/eks_upgrade_policy_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/test/e2e/shared"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/patch"
 )
 
 // EKS upgrade policy test.
@@ -92,10 +94,28 @@ var _ = ginkgo.Describe("EKS upgrade policy test", func() {
 
 		changedUpgradePolicy := ekscontrolplanev1.UpgradePolicyExtended
 		ginkgo.By(fmt.Sprintf("Changing the UpgradePolicy from %s to %s", upgradePolicy, changedUpgradePolicy))
-		shared.SetEnvVar(shared.UpgradePolicy, changedUpgradePolicy.String(), false)
-		ManagedClusterSpec(ctx, getManagedClusterSpec)
+
+		mgmtClient := e2eCtx.Environment.BootstrapClusterProxy.GetClient()
+		controlPlane := &ekscontrolplanev1.AWSManagedControlPlane{}
+
+		// Get the AWSManagedControlPlane.
+		Eventually(func() error {
+			return mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: namespace.Name, Name: getControlPlaneName(clusterName)}, controlPlane)
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-client-request")...).Should(Succeed(), "eventually failed trying to get the AWSManagedControlPlane")
+
+		// Patch the AWSManagedControlPlane with the new upgrade policy.
+		patchHelper, err := patch.NewHelper(controlPlane, mgmtClient)
+		Expect(err).ToNot(HaveOccurred())
+		controlPlane.Spec.UpgradePolicy = changedUpgradePolicy
+
+		Eventually(func() error {
+			return patchHelper.Patch(ctx, controlPlane)
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-client-request")...).Should(Succeed(), "eventually failed patching the AWSManagedControlPlane")
+
+		// Wait for the upgrade policy to be reflected in AWS EKS.
 		WaitForEKSClusterUpgradePolicy(ctx, e2eCtx.BootstrapUserAWSSession, eksClusterName, changedUpgradePolicy)
 
+		// Clean up the cluster.
 		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
 			Deleter: e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
 			Cluster: cluster,
@@ -109,6 +129,8 @@ var _ = ginkgo.Describe("EKS upgrade policy test", func() {
 	})
 })
 
+// WaitForEKSClusterUpgradePolicy polls the AWS EKS API until the cluster's upgrade policy
+// matches the expected value, failing early if the cluster is not found.
 func WaitForEKSClusterUpgradePolicy(ctx context.Context, sess *aws.Config, eksClusterName string, upgradePolicy ekscontrolplanev1.UpgradePolicy) {
 	ginkgo.By(fmt.Sprintf("Checking EKS control plane upgrade policy matches %s", upgradePolicy))
 	Eventually(func() error {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake

**What this PR does / why we need it**:

The `[managed] [upgrade-policy]` EKS e2e test flakes because it re-applies the entire cluster template (via `ManagedClusterSpec()`) to change a single field (`upgradePolicy`). The CAPI framework's `CreateOrUpdate` performs a full object `Update()`, which wipes `ownerReferences`, finalizers, and status from the existing `AWSManagedControlPlane`. This creates a race where the controller may never reconcile within the 5-minute timeout.

This PR replaces the second `ManagedClusterSpec()` call with a targeted patch using the CAPI `patch.NewHelper`, matching the pattern already used by `UpgradeControlPlaneVersionSpec()`. This preserves all controller-managed metadata and triggers a reliable reconciliation. The `Get` and `Patch` calls are wrapped in `Eventually` blocks for resilience against transient API errors.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

Confirmed from Prow CI logs that in failing runs, after the second `ManagedClusterSpec()` call the webhook accepts the update but the `awsmanagedcontrolplane` controller never reconciles the resource again (ownerRef wiped). The test passed in ~4/19 runs on PR #5857 (timing-dependent).

**AI Usage**:

Claude Code (Opus) was used to investigate the root cause of the flake via Prow CI artifact analysis, and to draft the initial fix. The final code was reviewed and adjusted by the author.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [x] adds or updates e2e tests

**Release note**:

```release-note
NONE
```