### PR TITLE
🌱 build(ami): bump image-builder default to v0.1.52

### DIFF
--- a/.github/workflows/build-ami-varsfile.yml
+++ b/.github/workflows/build-ami-varsfile.yml
@@ -10,7 +10,7 @@ on:
       image_builder_version:
         description: "Image builder version"
         required: true
-        default: '990737c79abb37fd56faca64f46e5a385dd1a982' # post-v0.1.48, includes fix https://github.com/kubernetes-sigs/image-builder/pull/1919
+        default: 'v0.1.52'
       target:
         description: "target os"
         required: true

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -10,7 +10,7 @@ on:
       image_builder_version:
         description: "Image builder version"
         required: true
-        default: '990737c79abb37fd56faca64f46e5a385dd1a982' # post-v0.1.48, includes fix https://github.com/kubernetes-sigs/image-builder/pull/1919
+        default: 'v0.1.52'
       regions:
         description: 'Publication regions'
         required: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps the default `image_builder_version` in both `build-ami.yml` and `build-ami-varsfile.yml` workflows from `990737c79a` (post-v0.1.48) to `v0.1.52`.

Flatcar Stable 4593.2.0 increased its root partition sizes (`/boot` to 1 GB, both `/usr` partitions to 2 GB, `/oem` to 1 GB), pushing the source AMI snapshot above the old 8 GB `volume_size` default. This causes Flatcar AMI builds to fail with:

```
InvalidBlockDeviceMapping: Volume of size 8GB is smaller than snapshot, expect size >= 13GB
```

image-builder v0.1.52 includes the fix (kubernetes-sigs/image-builder#1992) that bumps the Flatcar `volume_size` to 15 GB.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

None

**AI Usage**:

Claude Code was used to investigate the CI failure, identify the upstream fix, and prepare this PR.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
NONE
```