### PR TITLE
🐛 fix(e2e): increase multitenancy STS role session duration to 1 hour

### DIFF
--- a/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-nested-multitenancy-clusterclass.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/e2e_test_templates/cluster-template-nested-multitenancy-clusterclass.yaml
@@ -90,7 +90,7 @@ metadata:
   name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
-  durationSeconds: 900
+  durationSeconds: 3600
   roleARN: ${MULTI_TENANCY_JUMP_ROLE_ARN}
   sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:

--- a/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/role.yaml
+++ b/test/e2e/data/infrastructure-aws/withclusterclass/kustomize_sources/nested-multitenancy-clusterclass/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
 spec:
   roleARN: "${MULTI_TENANCY_JUMP_ROLE_ARN}"
-  durationSeconds: 900
+  durationSeconds: 3600
   sessionName: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-nested-multitenancy.yaml
@@ -1177,7 +1177,7 @@ metadata:
   name: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
 spec:
   allowedNamespaces: {}
-  durationSeconds: 900
+  durationSeconds: 3600
   roleARN: ${MULTI_TENANCY_JUMP_ROLE_ARN}
   sessionName: ${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}
   sourceIdentityRef:

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/e2e_test_templates/cluster-template-simple-multitenancy.yaml
@@ -1167,7 +1167,7 @@ metadata:
   name: ${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}
 spec:
   allowedNamespaces: {}
-  durationSeconds: 900
+  durationSeconds: 3600
   roleARN: ${MULTI_TENANCY_SIMPLE_ROLE_ARN}
   sessionName: ${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}
   sourceIdentityRef:

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/nested-multitenancy/role.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/nested-multitenancy/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
 spec:
   roleARN: "${MULTI_TENANCY_JUMP_ROLE_ARN}"
-  durationSeconds: 900
+  durationSeconds: 3600
   sessionName: "${MULTI_TENANCY_JUMP_IDENTITY_NAME}-${CLUSTER_NAME}"
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity

--- a/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/simple-multitenancy/role.yaml
+++ b/test/e2e/data/infrastructure-aws/withoutclusterclass/kustomize_sources/simple-multitenancy/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}"
 spec:
   roleARN: "${MULTI_TENANCY_SIMPLE_ROLE_ARN}"
-  durationSeconds: 900
+  durationSeconds: 3600
   sessionName: "${MULTI_TENANCY_SIMPLE_IDENTITY_NAME}"
   sourceIdentityRef:
     kind: AWSClusterControllerIdentity


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

The multitenancy e2e tests configure `durationSeconds: 900` (15 minutes) for assumed STS roles. Cluster lifecycle (create + test + delete) regularly exceeds this window, causing STS token expiry mid-deletion. This manifests as deletion timeouts and test flakes.

In a recent CI run, the STS token expired during AWSMachine deletion, causing 6,538 retries over ~19.5 minutes on Secrets Manager `DeleteSecret` calls. The 20-minute test timeout was exceeded by just 25 seconds.

This PR increases `durationSeconds` from `900` to `3600` (1 hour, which is the AWS default when the field is omitted) across all multitenancy e2e templates, providing sufficient headroom for the full cluster lifecycle.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #6066

**Special notes for your reviewer**:

The `durationSeconds: 900` was unnecessarily restrictive. When `durationSeconds` is omitted, the AWS default is 3600 seconds (1 hour), governed by the IAM role's `MaxSessionDuration` setting. The explicit 900-second value was lowering the session duration well below what the tests need.

Note: there is also a deeper issue in `pkg/cloud/identity/identity.go` where chained role credential refresh is broken (source credentials are snapshotted into a `StaticCredentialsProvider` instead of being refreshed dynamically). That is tracked separately in the issue description but not addressed here.

**AI Usage**:

Claude Code (claude-opus-4-6) was used to investigate the CI failure logs, trace the STS credential lifecycle through the codebase, identify the root cause, and prepare this PR. All changes were reviewed and approved by a human.

**Checklist**:

- [X] squashed commits
- [ ] includes documentation
- [X] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [X] adds or updates e2e tests

**Release note**:

```release-note
NONE
```