### PR TITLE
🐛 fix: clean up orphaned ENIs before subnet deletion at teardown

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -266,7 +266,7 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 		}
 	}
 
-	if err := networkSvc.DeleteNetwork(); err != nil {
+	if err := networkSvc.DeleteNetwork(ctx); err != nil {
 		allErrs = append(allErrs, errors.Wrap(err, "error deleting network"))
 	}
 

--- a/controllers/awscluster_controller_unit_test.go
+++ b/controllers/awscluster_controller_unit_test.go
@@ -400,7 +400,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 			deleteCluster := func() {
 				ec2Svc.EXPECT().DeleteBastion().Return(nil)
 				elbSvc.EXPECT().DeleteLoadbalancers(gomock.Any()).Return(nil)
-				networkSvc.EXPECT().DeleteNetwork().Return(nil)
+				networkSvc.EXPECT().DeleteNetwork(gomock.Any()).Return(nil)
 				sgSvc.EXPECT().DeleteSecurityGroups().Return(nil)
 			}
 			t.Run("Should successfully delete AWSCluster with Cluster Finalizer removed", func(t *testing.T) {
@@ -431,7 +431,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					t.Helper()
 					elbSvc.EXPECT().DeleteLoadbalancers(gomock.Any()).Return(expectedErr)
 					ec2Svc.EXPECT().DeleteBastion().Return(nil)
-					networkSvc.EXPECT().DeleteNetwork().Return(nil)
+					networkSvc.EXPECT().DeleteNetwork(gomock.Any()).Return(nil)
 					sgSvc.EXPECT().DeleteSecurityGroups().Return(nil)
 				}
 				awsCluster := getAWSCluster("test", "test")
@@ -456,7 +456,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 				deleteCluster := func() {
 					ec2Svc.EXPECT().DeleteBastion().Return(expectedErr)
 					elbSvc.EXPECT().DeleteLoadbalancers(gomock.Any()).Return(nil)
-					networkSvc.EXPECT().DeleteNetwork().Return(nil)
+					networkSvc.EXPECT().DeleteNetwork(gomock.Any()).Return(nil)
 					sgSvc.EXPECT().DeleteSecurityGroups().Return(nil)
 				}
 				awsCluster := getAWSCluster("test", "test")
@@ -482,7 +482,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					ec2Svc.EXPECT().DeleteBastion().Return(nil)
 					elbSvc.EXPECT().DeleteLoadbalancers(gomock.Any()).Return(nil)
 					sgSvc.EXPECT().DeleteSecurityGroups().Return(expectedErr)
-					networkSvc.EXPECT().DeleteNetwork().Return(nil)
+					networkSvc.EXPECT().DeleteNetwork(gomock.Any()).Return(nil)
 				}
 				awsCluster := getAWSCluster("test", "test")
 				awsCluster.Finalizers = []string{infrav1.ClusterFinalizer}
@@ -507,7 +507,7 @@ func TestAWSClusterReconcileOperations(t *testing.T) {
 					ec2Svc.EXPECT().DeleteBastion().Return(nil)
 					elbSvc.EXPECT().DeleteLoadbalancers(gomock.Any()).Return(nil)
 					sgSvc.EXPECT().DeleteSecurityGroups().Return(nil)
-					networkSvc.EXPECT().DeleteNetwork().Return(expectedErr)
+					networkSvc.EXPECT().DeleteNetwork(gomock.Any()).Return(expectedErr)
 				}
 				awsCluster := getAWSCluster("test", "test")
 				awsCluster.Finalizers = []string{infrav1.ClusterFinalizer}

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -428,7 +428,7 @@ func (r *AWSManagedControlPlaneReconciler) reconcileDelete(ctx context.Context, 
 		}
 	}
 
-	if err := networkSvc.DeleteNetwork(); err != nil {
+	if err := networkSvc.DeleteNetwork(ctx); err != nil {
 		log.Error(err, "error deleting network for AWSManagedControlPlane", "namespace", controlPlane.Namespace, "name", controlPlane.Name)
 		return reconcile.Result{}, err
 	}

--- a/pkg/cloud/services/common/common.go
+++ b/pkg/cloud/services/common/common.go
@@ -50,6 +50,7 @@ type EC2API interface {
 	DeleteLaunchTemplate(ctx context.Context, params *ec2.DeleteLaunchTemplateInput, optFns ...func(*ec2.Options)) (*ec2.DeleteLaunchTemplateOutput, error)
 	DeleteLaunchTemplateVersions(ctx context.Context, params *ec2.DeleteLaunchTemplateVersionsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteLaunchTemplateVersionsOutput, error)
 	DeleteNatGateway(ctx context.Context, params *ec2.DeleteNatGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNatGatewayOutput, error)
+	DeleteNetworkInterface(ctx context.Context, params *ec2.DeleteNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error)
 	DeleteRouteTable(ctx context.Context, params *ec2.DeleteRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error)
 	DeleteSecurityGroup(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
 	DeleteSubnet(ctx context.Context, params *ec2.DeleteSubnetInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error)

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -125,7 +125,7 @@ type ELBInterface interface {
 // NetworkInterface encapsulates the methods exposed to the cluster
 // controller.
 type NetworkInterface interface {
-	DeleteNetwork() error
+	DeleteNetwork(ctx context.Context) error
 	ReconcileNetwork() error
 }
 

--- a/pkg/cloud/services/mock_services/network_interface_mock.go
+++ b/pkg/cloud/services/mock_services/network_interface_mock.go
@@ -21,6 +21,7 @@ limitations under the License.
 package mock_services
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -50,17 +51,17 @@ func (m *MockNetworkInterface) EXPECT() *MockNetworkInterfaceMockRecorder {
 }
 
 // DeleteNetwork mocks base method.
-func (m *MockNetworkInterface) DeleteNetwork() error {
+func (m *MockNetworkInterface) DeleteNetwork(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNetwork")
+	ret := m.ctrl.Call(m, "DeleteNetwork", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNetwork indicates an expected call of DeleteNetwork.
-func (mr *MockNetworkInterfaceMockRecorder) DeleteNetwork() *gomock.Call {
+func (mr *MockNetworkInterfaceMockRecorder) DeleteNetwork(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetwork", reflect.TypeOf((*MockNetworkInterface)(nil).DeleteNetwork))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetwork", reflect.TypeOf((*MockNetworkInterface)(nil).DeleteNetwork), arg0)
 }
 
 // ReconcileNetwork mocks base method.

--- a/pkg/cloud/services/network/enis.go
+++ b/pkg/cloud/services/network/enis.go
@@ -30,7 +30,7 @@ import (
 // in "available" state (not attached to any instance or service) and reference
 // one of the cluster's security groups. These are typically left behind by NLBs
 // whose cross-AZ ENIs are cleaned up asynchronously by AWS after LB deletion.
-func (s *Service) deleteOrphanedENIs() error {
+func (s *Service) deleteOrphanedENIs(ctx context.Context) error {
 	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
 		s.scope.Trace("Skipping orphaned ENI cleanup in unmanaged mode")
 		return nil
@@ -59,7 +59,7 @@ func (s *Service) deleteOrphanedENIs() error {
 		},
 	}
 
-	out, err := s.EC2Client.DescribeNetworkInterfaces(context.TODO(), input)
+	out, err := s.EC2Client.DescribeNetworkInterfaces(ctx, input)
 	if err != nil {
 		return fmt.Errorf("describing orphaned network interfaces: %w", err)
 	}

--- a/pkg/cloud/services/network/enis.go
+++ b/pkg/cloud/services/network/enis.go
@@ -75,7 +75,7 @@ func (s *Service) deleteOrphanedENIs(ctx context.Context) error {
 		eniID := aws.ToString(eni.NetworkInterfaceId)
 		s.scope.Debug("Deleting orphaned network interface", "eni-id", eniID)
 
-		if _, err := s.EC2Client.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+		if _, err := s.EC2Client.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
 			NetworkInterfaceId: eni.NetworkInterfaceId,
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("deleting network interface %q: %w", eniID, err))

--- a/pkg/cloud/services/network/enis.go
+++ b/pkg/cloud/services/network/enis.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// deleteOrphanedENIs deletes network interfaces in the cluster's VPC that are
+// in "available" state (not attached to any instance or service) and reference
+// one of the cluster's security groups. These are typically left behind by NLBs
+// whose cross-AZ ENIs are cleaned up asynchronously by AWS after LB deletion.
+func (s *Service) deleteOrphanedENIs() error {
+	if s.scope.VPC().IsUnmanaged(s.scope.Name()) {
+		s.scope.Trace("Skipping orphaned ENI cleanup in unmanaged mode")
+		return nil
+	}
+
+	sgIDs := s.clusterSecurityGroupIDs()
+	if len(sgIDs) == 0 {
+		s.scope.Debug("No cluster security groups found, skipping orphaned ENI cleanup")
+		return nil
+	}
+
+	input := &ec2.DescribeNetworkInterfacesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []string{s.scope.VPC().ID},
+			},
+			{
+				Name:   aws.String("group-id"),
+				Values: sgIDs,
+			},
+			{
+				Name:   aws.String("status"),
+				Values: []string{"available"},
+			},
+		},
+	}
+
+	out, err := s.EC2Client.DescribeNetworkInterfaces(context.TODO(), input)
+	if err != nil {
+		return fmt.Errorf("describing orphaned network interfaces: %w", err)
+	}
+
+	if len(out.NetworkInterfaces) == 0 {
+		return nil
+	}
+
+	s.scope.Info("Deleting orphaned network interfaces", "count", len(out.NetworkInterfaces))
+
+	var errs []error
+	for _, eni := range out.NetworkInterfaces {
+		eniID := aws.ToString(eni.NetworkInterfaceId)
+		s.scope.Debug("Deleting orphaned network interface", "eni-id", eniID)
+
+		if _, err := s.EC2Client.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: eni.NetworkInterfaceId,
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("deleting network interface %q: %w", eniID, err))
+			continue
+		}
+
+		s.scope.Info("Deleted orphaned network interface", "eni-id", eniID)
+	}
+
+	return kerrors.NewAggregate(errs)
+}
+
+func (s *Service) clusterSecurityGroupIDs() []string {
+	sgs := s.scope.SecurityGroups()
+	ids := make([]string, 0, len(sgs))
+	for _, sg := range sgs {
+		if sg.ID != "" {
+			ids = append(ids, sg.ID)
+		}
+	}
+	return ids
+}

--- a/pkg/cloud/services/network/enis_test.go
+++ b/pkg/cloud/services/network/enis_test.go
@@ -54,7 +54,7 @@ func TestDeleteOrphanedENIs(t *testing.T) {
 					infrav1.SecurityGroupNode: {ID: "sg-node"},
 				}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+				m.DescribeNetworkInterfaces(gomock.Any(), gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
 						NetworkInterfaces: []types.NetworkInterface{},
 					}, nil)
@@ -77,17 +77,17 @@ func TestDeleteOrphanedENIs(t *testing.T) {
 					infrav1.SecurityGroupNode: {ID: "sg-node"},
 				}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+				m.DescribeNetworkInterfaces(gomock.Any(), gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
 						NetworkInterfaces: []types.NetworkInterface{
 							{NetworkInterfaceId: aws.String("eni-111")},
 							{NetworkInterfaceId: aws.String("eni-222")},
 						},
 					}, nil)
-				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+				m.DeleteNetworkInterface(gomock.Any(), &ec2.DeleteNetworkInterfaceInput{
 					NetworkInterfaceId: aws.String("eni-111"),
 				}).Return(&ec2.DeleteNetworkInterfaceOutput{}, nil)
-				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+				m.DeleteNetworkInterface(gomock.Any(), &ec2.DeleteNetworkInterfaceInput{
 					NetworkInterfaceId: aws.String("eni-222"),
 				}).Return(&ec2.DeleteNetworkInterfaceOutput{}, nil)
 			},
@@ -108,17 +108,17 @@ func TestDeleteOrphanedENIs(t *testing.T) {
 					infrav1.SecurityGroupLB: {ID: "sg-lb"},
 				}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+				m.DescribeNetworkInterfaces(gomock.Any(), gomock.Any()).
 					Return(&ec2.DescribeNetworkInterfacesOutput{
 						NetworkInterfaces: []types.NetworkInterface{
 							{NetworkInterfaceId: aws.String("eni-111")},
 							{NetworkInterfaceId: aws.String("eni-222")},
 						},
 					}, nil)
-				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+				m.DeleteNetworkInterface(gomock.Any(), &ec2.DeleteNetworkInterfaceInput{
 					NetworkInterfaceId: aws.String("eni-111"),
 				}).Return(nil, fmt.Errorf("InvalidNetworkInterfaceID.NotFound"))
-				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+				m.DeleteNetworkInterface(gomock.Any(), &ec2.DeleteNetworkInterfaceInput{
 					NetworkInterfaceId: aws.String("eni-222"),
 				}).Return(&ec2.DeleteNetworkInterfaceOutput{}, nil)
 			},
@@ -167,7 +167,7 @@ func TestDeleteOrphanedENIs(t *testing.T) {
 					infrav1.SecurityGroupLB: {ID: "sg-lb"},
 				}),
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
-				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+				m.DescribeNetworkInterfaces(gomock.Any(), gomock.Any()).
 					Return(nil, fmt.Errorf("aws api error"))
 			},
 			errorExpected: true,
@@ -189,7 +189,7 @@ func TestDeleteOrphanedENIs(t *testing.T) {
 			s.EC2Client = ec2Mock
 
 			tc.expect(ec2Mock.EXPECT())
-			err = s.deleteOrphanedENIs()
+			err = s.deleteOrphanedENIs(context.Background())
 
 			if tc.errorExpected {
 				g.Expect(err).To(HaveOccurred())

--- a/pkg/cloud/services/network/enis_test.go
+++ b/pkg/cloud/services/network/enis_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
+)
+
+func TestDeleteOrphanedENIs(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         ScopeBuilder
+		expect        func(m *mocks.MockEC2APIMockRecorder)
+		errorExpected bool
+	}{
+		{
+			name: "No orphaned ENIs found",
+			input: NewClusterScope().
+				WithNetwork(&infrav1.NetworkSpec{
+					VPC: infrav1.VPCSpec{
+						ID: subnetsVPCID,
+						Tags: infrav1.Tags{
+							infrav1.ClusterTagKey("test-cluster"): "owned",
+						},
+					},
+				}).
+				WithSecurityGroups(map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+					infrav1.SecurityGroupLB:   {ID: "sg-lb"},
+					infrav1.SecurityGroupNode: {ID: "sg-node"},
+				}),
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+					Return(&ec2.DescribeNetworkInterfacesOutput{
+						NetworkInterfaces: []types.NetworkInterface{},
+					}, nil)
+			},
+			errorExpected: false,
+		},
+		{
+			name: "Available ENIs found and deleted",
+			input: NewClusterScope().
+				WithNetwork(&infrav1.NetworkSpec{
+					VPC: infrav1.VPCSpec{
+						ID: subnetsVPCID,
+						Tags: infrav1.Tags{
+							infrav1.ClusterTagKey("test-cluster"): "owned",
+						},
+					},
+				}).
+				WithSecurityGroups(map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+					infrav1.SecurityGroupLB:   {ID: "sg-lb"},
+					infrav1.SecurityGroupNode: {ID: "sg-node"},
+				}),
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+					Return(&ec2.DescribeNetworkInterfacesOutput{
+						NetworkInterfaces: []types.NetworkInterface{
+							{NetworkInterfaceId: aws.String("eni-111")},
+							{NetworkInterfaceId: aws.String("eni-222")},
+						},
+					}, nil)
+				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+					NetworkInterfaceId: aws.String("eni-111"),
+				}).Return(&ec2.DeleteNetworkInterfaceOutput{}, nil)
+				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+					NetworkInterfaceId: aws.String("eni-222"),
+				}).Return(&ec2.DeleteNetworkInterfaceOutput{}, nil)
+			},
+			errorExpected: false,
+		},
+		{
+			name: "One deletion fails, other still attempted",
+			input: NewClusterScope().
+				WithNetwork(&infrav1.NetworkSpec{
+					VPC: infrav1.VPCSpec{
+						ID: subnetsVPCID,
+						Tags: infrav1.Tags{
+							infrav1.ClusterTagKey("test-cluster"): "owned",
+						},
+					},
+				}).
+				WithSecurityGroups(map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+					infrav1.SecurityGroupLB: {ID: "sg-lb"},
+				}),
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+					Return(&ec2.DescribeNetworkInterfacesOutput{
+						NetworkInterfaces: []types.NetworkInterface{
+							{NetworkInterfaceId: aws.String("eni-111")},
+							{NetworkInterfaceId: aws.String("eni-222")},
+						},
+					}, nil)
+				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+					NetworkInterfaceId: aws.String("eni-111"),
+				}).Return(nil, fmt.Errorf("InvalidNetworkInterfaceID.NotFound"))
+				m.DeleteNetworkInterface(context.TODO(), &ec2.DeleteNetworkInterfaceInput{
+					NetworkInterfaceId: aws.String("eni-222"),
+				}).Return(&ec2.DeleteNetworkInterfaceOutput{}, nil)
+			},
+			errorExpected: true,
+		},
+		{
+			name: "No security groups, skip entirely",
+			input: NewClusterScope().
+				WithNetwork(&infrav1.NetworkSpec{
+					VPC: infrav1.VPCSpec{
+						ID: subnetsVPCID,
+						Tags: infrav1.Tags{
+							infrav1.ClusterTagKey("test-cluster"): "owned",
+						},
+					},
+				}),
+			expect:        func(m *mocks.MockEC2APIMockRecorder) {},
+			errorExpected: false,
+		},
+		{
+			name: "Unmanaged VPC, skip entirely",
+			input: NewClusterScope().
+				WithNetwork(&infrav1.NetworkSpec{
+					VPC: infrav1.VPCSpec{
+						ID: subnetsVPCID,
+					},
+				}).
+				WithSecurityGroups(map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+					infrav1.SecurityGroupLB: {ID: "sg-lb"},
+				}),
+			expect:        func(m *mocks.MockEC2APIMockRecorder) {},
+			errorExpected: false,
+		},
+		{
+			name: "DescribeNetworkInterfaces fails",
+			input: NewClusterScope().
+				WithNetwork(&infrav1.NetworkSpec{
+					VPC: infrav1.VPCSpec{
+						ID: subnetsVPCID,
+						Tags: infrav1.Tags{
+							infrav1.ClusterTagKey("test-cluster"): "owned",
+						},
+					},
+				}).
+				WithSecurityGroups(map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+					infrav1.SecurityGroupLB: {ID: "sg-lb"},
+				}),
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.DescribeNetworkInterfaces(context.TODO(), gomock.Any()).
+					Return(nil, fmt.Errorf("aws api error"))
+			},
+			errorExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			ec2Mock := mocks.NewMockEC2API(mockCtrl)
+
+			scope, err := tc.input.Build()
+			g.Expect(err).NotTo(HaveOccurred())
+
+			s := NewService(scope)
+			s.EC2Client = ec2Mock
+
+			tc.expect(ec2Mock.EXPECT())
+			err = s.deleteOrphanedENIs()
+
+			if tc.errorExpected {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/pkg/cloud/services/network/network.go
+++ b/pkg/cloud/services/network/network.go
@@ -17,6 +17,8 @@ limitations under the License.
 package network
 
 import (
+	"context"
+
 	"k8s.io/klog/v2"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -98,7 +100,7 @@ func (s *Service) ReconcileNetwork() (err error) {
 }
 
 // DeleteNetwork deletes the network of the given cluster.
-func (s *Service) DeleteNetwork() (err error) {
+func (s *Service) DeleteNetwork(ctx context.Context) (err error) {
 	s.scope.Debug("Deleting network")
 
 	vpc := &infrav1.VPCSpec{}
@@ -195,7 +197,7 @@ func (s *Service) DeleteNetwork() (err error) {
 
 	// Orphaned ENIs — clean up detached network interfaces that reference
 	// cluster security groups before attempting subnet deletion.
-	if err := s.deleteOrphanedENIs(); err != nil {
+	if err := s.deleteOrphanedENIs(ctx); err != nil {
 		s.scope.Debug("Non-fatal: failed to delete orphaned ENIs", "error", err)
 	}
 

--- a/pkg/cloud/services/network/network.go
+++ b/pkg/cloud/services/network/network.go
@@ -193,6 +193,12 @@ func (s *Service) DeleteNetwork() (err error) {
 	}
 	conditions.MarkFalse(s.scope.InfraCluster(), infrav1.EgressOnlyInternetGatewayReadyCondition, clusterv1.DeletedReason, clusterv1.ConditionSeverityInfo, "")
 
+	// Orphaned ENIs — clean up detached network interfaces that reference
+	// cluster security groups before attempting subnet deletion.
+	if err := s.deleteOrphanedENIs(); err != nil {
+		s.scope.Debug("Non-fatal: failed to delete orphaned ENIs", "error", err)
+	}
+
 	// Subnets.
 	conditions.MarkFalse(s.scope.InfraCluster(), infrav1.SubnetsReadyCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
 	if err := s.scope.PatchObject(); err != nil {

--- a/pkg/cloud/services/network/subnets_test.go
+++ b/pkg/cloud/services/network/subnets_test.go
@@ -4570,6 +4570,14 @@ func (b *ClusterScopeBuilder) WithNetwork(n *infrav1.NetworkSpec) *ClusterScopeB
 	return b
 }
 
+func (b *ClusterScopeBuilder) WithSecurityGroups(sgs map[infrav1.SecurityGroupRole]infrav1.SecurityGroup) *ClusterScopeBuilder {
+	b.customizers = append(b.customizers, func(p *scope.ClusterScopeParams) {
+		p.AWSCluster.Status.Network.SecurityGroups = sgs
+	})
+
+	return b
+}
+
 func (b *ClusterScopeBuilder) WithTagUnmanagedNetworkResources(value bool) *ClusterScopeBuilder {
 	b.customizers = append(b.customizers, func(p *scope.ClusterScopeParams) {
 		p.TagUnmanagedNetworkResources = value

--- a/test/mocks/aws_ec2api_mock.go
+++ b/test/mocks/aws_ec2api_mock.go
@@ -551,6 +551,26 @@ func (mr *MockEC2APIMockRecorder) DeleteNatGateway(arg0, arg1 interface{}, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNatGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteNatGateway), varargs...)
 }
 
+// DeleteNetworkInterface mocks base method.
+func (m *MockEC2API) DeleteNetworkInterface(arg0 context.Context, arg1 *ec2.DeleteNetworkInterfaceInput, arg2 ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteNetworkInterface", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkInterfaceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNetworkInterface indicates an expected call of DeleteNetworkInterface.
+func (mr *MockEC2APIMockRecorder) DeleteNetworkInterface(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterface", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInterface), varargs...)
+}
+
 // DeleteRouteTable mocks base method.
 func (m *MockEC2API) DeleteRouteTable(arg0 context.Context, arg1 *ec2.DeleteRouteTableInput, arg2 ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After NLB deletion during cluster teardown, AWS asynchronously cleans up the NLB's cross-AZ ENIs, a process that can take up to 1 hour. CAPA proceeds immediately to security group and subnet deletion with no ENI cleanup step, causing `DependencyViolation` errors that block cluster deletion until the e2e test times out.

This PR adds a `deleteOrphanedENIs()` step in `DeleteNetwork()`, right before subnet deletion. It discovers ENIs in the VPC that are:
- in `available` state (not attached to any instance or service)
- referencing one of the cluster's security groups (scoped to only this cluster's ENIs)

This targets exactly the ENIs blocking SG/subnet deletion without touching other clusters' ENIs sharing the same VPC.

**Which issue(s) this PR fixes**:
Fixes #6067

**Special notes for your reviewer**:

The ENI cleanup is non-fatal: if it fails, the error is logged and subnet deletion proceeds (which will fail with `DependencyViolation` and trigger a requeue, as before). On the next reconcile, the ENIs that have since become `available` are cleaned up, unblocking both SG and subnet deletion.

No new service factory, interface, or controller wiring is needed, the implementation lives entirely in the existing network service's `DeleteNetwork()` flow.

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [x] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```release-note
fix: clean up orphaned network interfaces (ENIs) before subnet deletion during cluster teardown, preventing DependencyViolation errors caused by NLB ENIs that AWS cleans up asynchronously after load balancer deletion.
```