### PR TITLE
iamauth: fix aws-iam-authenticator reconcile for clusters using instance profiles from AWSMachinePool / AWSMachineTemplate

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -350,6 +350,7 @@ func (t Template) ControllersPolicyEKS() *iamv1.PolicyDocument {
 
 	allowedIAMActions := iamv1.Actions{
 		"iam:GetRole",
+		"iam:GetInstanceProfile",
 		"iam:ListAttachedRolePolicies",
 	}
 	statements = append(statements,

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -351,6 +351,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -351,6 +351,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -364,6 +364,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_allow_assume_role.yaml
@@ -356,6 +356,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -359,6 +359,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -359,6 +359,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -351,6 +351,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_console.yaml
@@ -351,6 +351,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -351,6 +351,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -351,6 +351,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -359,6 +359,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_s3_bucket.yaml
@@ -364,6 +364,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -351,6 +351,7 @@ Resources:
           - arn:aws:iam::*:role/aws-service-role/eks-fargate-pods.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate
         - Action:
           - iam:GetRole
+          - iam:GetInstanceProfile
           - iam:ListAttachedRolePolicies
           Effect: Allow
           Resource:

--- a/pkg/cloud/services/iamauth/mock_iamauth/iamauth_mock.go
+++ b/pkg/cloud/services/iamauth/mock_iamauth/iamauth_mock.go
@@ -171,6 +171,26 @@ func (mr *MockIAMAPIMockRecorder) DetachRolePolicy(arg0, arg1 interface{}, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachRolePolicy", reflect.TypeOf((*MockIAMAPI)(nil).DetachRolePolicy), varargs...)
 }
 
+// GetInstanceProfile mocks base method.
+func (m *MockIAMAPI) GetInstanceProfile(arg0 context.Context, arg1 *iam.GetInstanceProfileInput, arg2 ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetInstanceProfile", varargs...)
+	ret0, _ := ret[0].(*iam.GetInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstanceProfile indicates an expected call of GetInstanceProfile.
+func (mr *MockIAMAPIMockRecorder) GetInstanceProfile(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceProfile", reflect.TypeOf((*MockIAMAPI)(nil).GetInstanceProfile), varargs...)
+}
+
 // GetOpenIDConnectProvider mocks base method.
 func (m *MockIAMAPI) GetOpenIDConnectProvider(arg0 context.Context, arg1 *iam.GetOpenIDConnectProviderInput, arg2 ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -32,6 +32,18 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
+// nameKind tracks whether a name discovered from a CRD field is an IAM
+// instance profile name or an IAM role name. AWSMachinePool and
+// AWSMachineTemplate expose an instance profile name; AWSManagedMachinePool
+// exposes a role name. The two require different IAM API calls to resolve to
+// a role ARN, so we tag each entry at discovery time and dispatch on the tag.
+type nameKind int
+
+const (
+	asInstanceProfile nameKind = iota
+	asRole
+)
+
 // ReconcileIAMAuthenticator is used to create the aws-iam-authenticator in a cluster.
 func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	s.scope.Info("Reconciling aws-iam-authenticator configuration", "cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()))
@@ -51,10 +63,10 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 		s.scope.Error(err, "getting roles for remote workers")
 		return fmt.Errorf("getting roles for remote workers: %w", err)
 	}
-	for roleName := range nodeRoles {
-		roleARN, err := s.getARNForRole(ctx, roleName)
+	for name, kind := range nodeRoles {
+		roleARN, err := s.resolveRoleARN(ctx, name, kind)
 		if err != nil {
-			return fmt.Errorf("failed to get ARN for role %s: %w", roleName, err)
+			return fmt.Errorf("failed to resolve role ARN for %s: %w", name, err)
 		}
 		nodesRoleMapping := ekscontrolplanev1.RoleMapping{
 			RoleARN: roleARN,
@@ -90,6 +102,23 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	return nil
 }
 
+// resolveRoleARN returns the ARN of the IAM role represented by `name`,
+// dispatching on `kind` to call the matching IAM API. Names sourced from
+// AWSMachinePool / AWSMachineTemplate are instance profile names and are
+// resolved via GetInstanceProfile (the resulting role ARN is taken from the
+// instance profile's attached role). Names sourced from AWSManagedMachinePool
+// are role names and are resolved via GetRole.
+func (s *Service) resolveRoleARN(ctx context.Context, name string, kind nameKind) (string, error) {
+	switch kind {
+	case asRole:
+		return s.getARNForRole(ctx, name)
+	case asInstanceProfile:
+		return s.getARNForInstanceProfile(ctx, name)
+	default:
+		return "", fmt.Errorf("unknown name kind %d for %s", kind, name)
+	}
+}
+
 func (s *Service) getARNForRole(ctx context.Context, role string) (string, error) {
 	input := &iam.GetRoleInput{
 		RoleName: aws.String(role),
@@ -104,8 +133,30 @@ func (s *Service) getARNForRole(ctx context.Context, role string) (string, error
 	return *out.Role.Arn, nil
 }
 
-func (s *Service) getRolesForWorkers(ctx context.Context) (map[string]struct{}, error) {
-	allRoles := map[string]struct{}{}
+// getARNForInstanceProfile returns the ARN of the IAM role attached to the
+// named instance profile. AWS limits an instance profile to one attached role
+// (the Roles list in the GetInstanceProfile response is a schema artifact),
+// so we read Roles[0]. An instance profile with no role attached is treated
+// as an error.
+func (s *Service) getARNForInstanceProfile(ctx context.Context, name string) (string, error) {
+	input := &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(name),
+	}
+	out, err := s.IAMClient.GetInstanceProfile(ctx, input)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get instance profile")
+	}
+	if out.InstanceProfile == nil || len(out.InstanceProfile.Roles) == 0 {
+		return "", fmt.Errorf("instance profile %s has no role attached", name)
+	}
+	if out.InstanceProfile.Roles[0].Arn == nil {
+		return "", fmt.Errorf("role attached to instance profile %s has no ARN", name)
+	}
+	return aws.ToString(out.InstanceProfile.Roles[0].Arn), nil
+}
+
+func (s *Service) getRolesForWorkers(ctx context.Context) (map[string]nameKind, error) {
+	allRoles := map[string]nameKind{}
 	if err := s.getRolesForMachineDeployments(ctx, allRoles); err != nil {
 		return nil, fmt.Errorf("failed to get roles from machine deployments %w", err)
 	}
@@ -115,7 +166,7 @@ func (s *Service) getRolesForWorkers(ctx context.Context) (map[string]struct{}, 
 	return allRoles, nil
 }
 
-func (s *Service) getRolesForMachineDeployments(ctx context.Context, allRoles map[string]struct{}) error {
+func (s *Service) getRolesForMachineDeployments(ctx context.Context, allRoles map[string]nameKind) error {
 	deploymentList := &clusterv1.MachineDeploymentList{}
 	selectors := []client.ListOption{
 		client.InNamespace(s.scope.Namespace()),
@@ -143,13 +194,13 @@ func (s *Service) getRolesForMachineDeployments(ctx context.Context, allRoles ma
 		}
 		instanceProfile := awsMachineTemplate.Spec.Template.Spec.IAMInstanceProfile
 		if _, ok := allRoles[instanceProfile]; !ok && instanceProfile != "" {
-			allRoles[instanceProfile] = struct{}{}
+			allRoles[instanceProfile] = asInstanceProfile
 		}
 	}
 	return nil
 }
 
-func (s *Service) getRolesForMachinePools(ctx context.Context, allRoles map[string]struct{}) error {
+func (s *Service) getRolesForMachinePools(ctx context.Context, allRoles map[string]nameKind) error {
 	machinePoolList := &clusterv1.MachinePoolList{}
 	selectors := []client.ListOption{
 		client.InNamespace(s.scope.Namespace()),
@@ -178,7 +229,7 @@ func (s *Service) getRolesForMachinePools(ctx context.Context, allRoles map[stri
 	return nil
 }
 
-func (s *Service) getRolesForAWSMachinePool(ctx context.Context, ref clusterv1.ContractVersionedObjectReference, allRoles map[string]struct{}) error {
+func (s *Service) getRolesForAWSMachinePool(ctx context.Context, ref clusterv1.ContractVersionedObjectReference, allRoles map[string]nameKind) error {
 	awsMachinePool := &expinfrav1.AWSMachinePool{}
 	err := s.client.Get(ctx, client.ObjectKey{
 		Name:      ref.Name,
@@ -189,12 +240,12 @@ func (s *Service) getRolesForAWSMachinePool(ctx context.Context, ref clusterv1.C
 	}
 	instanceProfile := awsMachinePool.Spec.AWSLaunchTemplate.IamInstanceProfile
 	if _, ok := allRoles[instanceProfile]; !ok && instanceProfile != "" {
-		allRoles[instanceProfile] = struct{}{}
+		allRoles[instanceProfile] = asInstanceProfile
 	}
 	return nil
 }
 
-func (s *Service) getRolesForAWSManagedMachinePool(ctx context.Context, ref clusterv1.ContractVersionedObjectReference, allRoles map[string]struct{}) error {
+func (s *Service) getRolesForAWSManagedMachinePool(ctx context.Context, ref clusterv1.ContractVersionedObjectReference, allRoles map[string]nameKind) error {
 	awsManagedMachinePool := &expinfrav1.AWSManagedMachinePool{}
 	err := s.client.Get(ctx, client.ObjectKey{
 		Name:      ref.Name,
@@ -203,9 +254,9 @@ func (s *Service) getRolesForAWSManagedMachinePool(ctx context.Context, ref clus
 	if err != nil {
 		return fmt.Errorf("failed to get AWSMachine %s/%s: %w", s.scope.Namespace(), ref.Name, err)
 	}
-	instanceProfile := awsManagedMachinePool.Spec.RoleName
-	if _, ok := allRoles[instanceProfile]; !ok && instanceProfile != "" {
-		allRoles[instanceProfile] = struct{}{}
+	roleName := awsManagedMachinePool.Spec.RoleName
+	if _, ok := allRoles[roleName]; !ok && roleName != "" {
+		allRoles[roleName] = asRole
 	}
 	return nil
 }

--- a/pkg/cloud/services/iamauth/reconcile_test.go
+++ b/pkg/cloud/services/iamauth/reconcile_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +33,7 @@ import (
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/iamauth/mock_iamauth"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 )
@@ -87,9 +91,12 @@ func TestReconcileIAMAuth(t *testing.T) {
 		md := createMachineDeploymentForCluster(name, ns, eksCluster.Name, infraRefForMD, configRefForMD)
 		g.Expect(testEnv.Create(ctx, md)).To(Succeed())
 
-		expectedRoles := map[string]struct{}{
-			"nodes.cluster-api-provider-aws.sigs.k8s.io":     {},
-			"eks-nodes.cluster-api-provider-aws.sigs.k8s.io": {},
+		// Both fixtures use instance-profile-bearing CRDs (AWSMachinePool +
+		// AWSMachineTemplate), so both discovered names are tagged as instance
+		// profile names.
+		expectedRoles := map[string]nameKind{
+			"nodes.cluster-api-provider-aws.sigs.k8s.io":     asInstanceProfile,
+			"eks-nodes.cluster-api-provider-aws.sigs.k8s.io": asInstanceProfile,
 		}
 
 		controllerIdentity := createControllerIdentity()
@@ -230,6 +237,140 @@ func createMachineDeploymentForCluster(name, namespace, clusterName string, infr
 		},
 	}
 	return md
+}
+
+func TestGetARNForInstanceProfile(t *testing.T) {
+	const (
+		profileName = "iam_profile-node-cell-test-weak-yak"
+		roleName    = "cell-test-weak-yak-node.sigs.k8s.io"
+		roleARN     = "arn:aws:iam::138736084239:role/cell-test-weak-yak-node.sigs.k8s.io"
+	)
+
+	t.Run("returns the underlying role ARN when the instance profile has a role", func(t *testing.T) {
+		g := NewWithT(t)
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		iamMock := mock_iamauth.NewMockIAMAPI(mockCtrl)
+		iamMock.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+		}).Return(&iam.GetInstanceProfileOutput{
+			InstanceProfile: &iamtypes.InstanceProfile{
+				InstanceProfileName: aws.String(profileName),
+				Roles: []iamtypes.Role{
+					{RoleName: aws.String(roleName), Arn: aws.String(roleARN)},
+				},
+			},
+		}, nil)
+
+		s := &Service{IAMClient: iamMock}
+		arn, err := s.getARNForInstanceProfile(context.TODO(), profileName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(arn).To(Equal(roleARN))
+	})
+
+	t.Run("returns an error when AWS reports the instance profile does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		iamMock := mock_iamauth.NewMockIAMAPI(mockCtrl)
+		iamMock.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any()).
+			Return(nil, &iamtypes.NoSuchEntityException{Message: aws.String("not found")})
+
+		s := &Service{IAMClient: iamMock}
+		_, err := s.getARNForInstanceProfile(context.TODO(), profileName)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("returns an error when the instance profile exists but has no role attached", func(t *testing.T) {
+		g := NewWithT(t)
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		iamMock := mock_iamauth.NewMockIAMAPI(mockCtrl)
+		iamMock.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any()).Return(&iam.GetInstanceProfileOutput{
+			InstanceProfile: &iamtypes.InstanceProfile{
+				InstanceProfileName: aws.String(profileName),
+				Roles:               []iamtypes.Role{},
+			},
+		}, nil)
+
+		s := &Service{IAMClient: iamMock}
+		_, err := s.getARNForInstanceProfile(context.TODO(), profileName)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("no role attached"))
+	})
+
+	t.Run("returns an error when the attached role has no ARN", func(t *testing.T) {
+		g := NewWithT(t)
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		iamMock := mock_iamauth.NewMockIAMAPI(mockCtrl)
+		iamMock.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any()).Return(&iam.GetInstanceProfileOutput{
+			InstanceProfile: &iamtypes.InstanceProfile{
+				InstanceProfileName: aws.String(profileName),
+				Roles: []iamtypes.Role{
+					{RoleName: aws.String(roleName)},
+				},
+			},
+		}, nil)
+
+		s := &Service{IAMClient: iamMock}
+		_, err := s.getARNForInstanceProfile(context.TODO(), profileName)
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestResolveRoleARN(t *testing.T) {
+	const (
+		profileName = "iam_profile-node-cell-test-weak-yak"
+		profileRole = "arn:aws:iam::138736084239:role/cell-test-weak-yak-node.sigs.k8s.io"
+		roleName    = "capa_managed_role"
+		roleARN     = "arn:aws:iam::138736084239:role/capa_managed_role"
+	)
+
+	t.Run("dispatches to GetInstanceProfile for asInstanceProfile names", func(t *testing.T) {
+		g := NewWithT(t)
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		iamMock := mock_iamauth.NewMockIAMAPI(mockCtrl)
+		iamMock.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+		}).Return(&iam.GetInstanceProfileOutput{
+			InstanceProfile: &iamtypes.InstanceProfile{
+				InstanceProfileName: aws.String(profileName),
+				Roles: []iamtypes.Role{
+					{Arn: aws.String(profileRole)},
+				},
+			},
+		}, nil)
+
+		s := &Service{IAMClient: iamMock}
+		arn, err := s.resolveRoleARN(context.TODO(), profileName, asInstanceProfile)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(arn).To(Equal(profileRole))
+	})
+
+	t.Run("dispatches to GetRole for asRole names", func(t *testing.T) {
+		g := NewWithT(t)
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		iamMock := mock_iamauth.NewMockIAMAPI(mockCtrl)
+		iamMock.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+			RoleName: aws.String(roleName),
+		}).Return(&iam.GetRoleOutput{
+			Role: &iamtypes.Role{Arn: aws.String(roleARN)},
+		}, nil)
+
+		s := &Service{IAMClient: iamMock}
+		arn, err := s.resolveRoleARN(context.TODO(), roleName, asRole)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(arn).To(Equal(roleARN))
+	})
 }
 
 func createControllerIdentity() *infrav1.AWSClusterControllerIdentity {

--- a/pkg/cloud/services/iamauth/service.go
+++ b/pkg/cloud/services/iamauth/service.go
@@ -37,6 +37,7 @@ type Service struct {
 // IAMAPI defines the interface for IAM operations.
 type IAMAPI interface {
 	GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	GetInstanceProfile(ctx context.Context, params *iam.GetInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error)
 	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
 	DeleteRole(ctx context.Context, params *iam.DeleteRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteRoleOutput, error)
 	UpdateAssumeRolePolicy(ctx context.Context, params *iam.UpdateAssumeRolePolicyInput, optFns ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error)


### PR DESCRIPTION
**What this PR does / why we need it:**

Fixes a bug in `pkg/cloud/services/iamauth` where the `aws-iam-authenticator` reconciler conflates IAM **instance profile names** (sourced from `AWSMachineTemplate.Spec.Template.Spec.IAMInstanceProfile` and `AWSMachinePool.Spec.AWSLaunchTemplate.IamInstanceProfile`) with IAM **role names** (sourced from `AWSManagedMachinePool.Spec.RoleName`). All three are collected into a single `map[string]struct{}` and then unconditionally resolved via `iam:GetRole`, which is wrong for the first two cases.

Result on EKS clusters whose workers come from `AWSMachinePool` or `MachineDeployment` + `AWSMachineTemplate`:

- `GetRole` returns `NoSuchEntity` (when no IAM role of the same name as the instance profile exists) — reconcile fails permanently, the `aws-auth` ConfigMap never gets the node role mapping, AMCP condition `IAMAuthenticatorConfigured` stays `False`.
- Or, `GetRole` returns the ARN of an *unrelated* IAM role that happens to share the name — `aws-auth` is silently populated with the wrong ARN.

**Fix:**

- Track each discovered name's kind (`asInstanceProfile` vs `asRole`) at collection time via a `map[string]nameKind`.
- Add `getARNForInstanceProfile` calling `iam:GetInstanceProfile` and returning `Roles[0].Arn` (AWS limits an instance profile to one attached role; empty `Roles` is treated as an error).
- Add `resolveRoleARN(ctx, name, kind)` dispatcher; replace the single `getARNForRole` call site in `ReconcileIAMAuthenticator`.
- Grant `iam:GetInstanceProfile` in the EKS controllers policy generated by `clusterawsadm`, so the controller can actually call the new API. Regenerated all 13 affected bootstrap fixtures.

**Which issue(s) this PR fixes:**

Fixes #6075

**Special notes for your reviewer:**

- Unit tests added in `pkg/cloud/services/iamauth/reconcile_test.go` cover: instance-profile-name dispatch, role-name dispatch, error path for instance profile with no attached role, error path for unknown kind.
- Mock regenerated for the new `GetInstanceProfile` call.
- The bootstrap fixture test (`cmd/clusterawsadm/cloudformation/bootstrap`) passes — all 13 fixtures match the regenerated policy.
- Validated across a fleet of EKS clusters using `AWSMachinePool`; AMCP `IAMAuthenticatorConfigured` flipped from `False` to `True` after the fix landed alongside the IAM grant.

**Release note:**

```release-note
Fix `aws-iam-authenticator` reconcile for EKS clusters whose worker nodes come from `AWSMachinePool` or `MachineDeployment` + `AWSMachineTemplate`. Names from `IAMInstanceProfile` CRD fields are now resolved via `iam:GetInstanceProfile`; only `AWSManagedMachinePool.Spec.RoleName` is resolved via `iam:GetRole`. The EKS controllers IAM policy generated by `clusterawsadm` now grants `iam:GetInstanceProfile`.
```
