### PR TITLE
📖 docs(api): clarify DNSResolutionCheck default behavior

### DIFF
--- a/api/v1beta2/awscluster_types.go
+++ b/api/v1beta2/awscluster_types.go
@@ -278,7 +278,7 @@ type AWSLoadBalancerSpec struct {
 
 	// DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
 	// Set to "None" to disable the check.
-	// If omitted, the provider will pick a reasonable default which may change over time.
+	// If omitted, the DNS resolution check is enabled.
 	// +kubebuilder:validation:Enum=None;Enabled
 	// +optional
 	DNSResolutionCheck *AWSLoadBalancerDNSResolutionCheck `json:"dnsResolutionCheck,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1111,7 +1111,7 @@ spec:
                     description: |-
                       DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
                       Set to "None" to disable the check.
-                      If omitted, the provider will pick a reasonable default which may change over time.
+                      If omitted, the DNS resolution check is enabled.
                     enum:
                     - None
                     - Enabled
@@ -2024,7 +2024,7 @@ spec:
                     description: |-
                       DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
                       Set to "None" to disable the check.
-                      If omitted, the provider will pick a reasonable default which may change over time.
+                      If omitted, the DNS resolution check is enabled.
                     enum:
                     - None
                     - Enabled

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclustertemplates.yaml
@@ -689,7 +689,7 @@ spec:
                             description: |-
                               DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
                               Set to "None" to disable the check.
-                              If omitted, the provider will pick a reasonable default which may change over time.
+                              If omitted, the DNS resolution check is enabled.
                             enum:
                             - None
                             - Enabled
@@ -1613,7 +1613,7 @@ spec:
                             description: |-
                               DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
                               Set to "None" to disable the check.
-                              If omitted, the provider will pick a reasonable default which may change over time.
+                              If omitted, the DNS resolution check is enabled.
                             enum:
                             - None
                             - Enabled


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The `DNSResolutionCheck` field's doc comment was vague: "the provider will pick a reasonable default which may change over time." This doesn't tell users what actually happens when the field is omitted.

The controller code (`controllers/awscluster_controller.go:308`) shows the check is enabled when the field is `nil`:
```go
if lbSpec.DNSResolutionCheck == nil || *lbSpec.DNSResolutionCheck != infrav1.AWSLoadBalancerDNSResolutionCheckNone
```

This PR replaces the vague doc comment with an explicit statement: "If omitted, the DNS resolution check is enabled." CRD descriptions are regenerated via `make generate` to reflect the updated comment.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

Addresses review comment: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5857#discussion_r3480861523

Doc-only change. No behavioral changes.

**AI Usage**:

Claude Code was used to investigate the controller's default behavior, make the doc comment change, regenerate CRDs, and create this PR.

**Checklist**:

- [X] squashed commits
- [X] includes documentation
- [X] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
NONE
```