### PR TITLE
🐛 fix: allow cluster-scoped resources to bypass allowedNamepsaces checks

### DIFF
--- a/pkg/cloud/scope/rosanetwork_test.go
+++ b/pkg/cloud/scope/rosanetwork_test.go
@@ -77,7 +77,11 @@ func TestNewROSANetworkScope(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(clusterControllerIdentity, staticSecret, clusterStaticIdentity).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(clusterControllerIdentity, staticSecret, clusterStaticIdentity).
+		Build()
 
 	rosaNetwork := expinfrav1.ROSANetwork{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/cloud/scope/session.go
+++ b/pkg/cloud/scope/session.go
@@ -31,8 +31,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
@@ -260,7 +262,7 @@ func buildProvidersForRef(
 			return providers, err
 		}
 		log.Trace("Principal retrieved")
-		canUse, err := isClusterPermittedToUsePrincipal(k8sClient, roleIdentity.Spec.AllowedNamespaces, clusterScoper.Namespace())
+		canUse, err := isClusterPermittedToUsePrincipal(k8sClient, roleIdentity.Spec.AllowedNamespaces, clusterScoper.Namespace(), clusterScoper.InfraCluster())
 		if err != nil {
 			return providers, err
 		}
@@ -337,7 +339,7 @@ func buildAWSClusterStaticIdentity(ctx context.Context, identityObjectKey client
 		return nil, errors.Wrapf(err, "failed to patch secret name:%s namespace:%s", secret.Name, secret.Namespace)
 	}
 
-	canUse, err := isClusterPermittedToUsePrincipal(k8sClient, staticPrincipal.Spec.AllowedNamespaces, clusterScoper.Namespace())
+	canUse, err := isClusterPermittedToUsePrincipal(k8sClient, staticPrincipal.Spec.AllowedNamespaces, clusterScoper.Namespace(), clusterScoper.InfraCluster())
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +366,7 @@ func buildAWSClusterControllerIdentity(ctx context.Context, identityObjectKey cl
 		return err
 	}
 
-	canUse, err := isClusterPermittedToUsePrincipal(k8sClient, controllerIdentity.Spec.AllowedNamespaces, clusterScoper.Namespace())
+	canUse, err := isClusterPermittedToUsePrincipal(k8sClient, controllerIdentity.Spec.AllowedNamespaces, clusterScoper.Namespace(), clusterScoper.InfraCluster())
 	if err != nil {
 		return err
 	}
@@ -386,7 +388,34 @@ func getProvidersForCluster(ctx context.Context, k8sClient client.Client, cluste
 	return providers, nil
 }
 
-func isClusterPermittedToUsePrincipal(k8sClient client.Client, allowedNs *infrav1.AllowedNamespaces, clusterNamespace string) (bool, error) {
+func isClusterScopedResource(k8sClient client.Client, obj client.Object) (bool, error) {
+	gvk, err := apiutil.GVKForObject(obj, k8sClient.Scheme())
+	if err != nil {
+		return false, fmt.Errorf("unable to determine resource type for %T: %w", obj, err)
+	}
+
+	restMapper := k8sClient.RESTMapper()
+	mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return false, fmt.Errorf("resource type %s is not registered in the cluster, ensure the CRD is installed: %w", gvk.String(), err)
+	}
+	if mapping == nil || mapping.Scope == nil {
+		return false, fmt.Errorf("unable to determine scope for %s: mapping returned nil (this should not happen)", gvk.String())
+	}
+
+	return mapping.Scope.Name() == meta.RESTScopeNameRoot, nil
+}
+
+func isClusterPermittedToUsePrincipal(k8sClient client.Client, allowedNs *infrav1.AllowedNamespaces, clusterNamespace string, obj client.Object) (bool, error) {
+	// Cluster-scoped resources bypass allowedNamespaces checks.
+	isClusterScoped, err := isClusterScopedResource(k8sClient, obj)
+	if err != nil {
+		return false, fmt.Errorf("failed to determine resource scope: %w", err)
+	}
+	if isClusterScoped {
+		return true, nil
+	}
+
 	// nil value does not match with any namespaces
 	if allowedNs == nil {
 		return false, nil

--- a/pkg/cloud/scope/session_test.go
+++ b/pkg/cloud/scope/session_test.go
@@ -43,6 +43,7 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 		clusterNamespace string
 		allowedNs        *infrav1.AllowedNamespaces
 		setup            func(*testing.T, client.Client)
+		obj              client.Object
 		expectedResult   bool
 		expectErr        bool
 	}{
@@ -187,6 +188,64 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 			expectedResult: true,
 			expectErr:      false,
 		},
+		{
+			name:             "Cluster-scoped resources bypass allowedNamespaces check even with restricted allowedNamespaces",
+			clusterNamespace: "default",
+			allowedNs: &infrav1.AllowedNamespaces{
+				NamespaceList: []string{"team-a", "team-b"},
+			},
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+			},
+			obj: func() client.Object {
+				obj := &infrav1.AWSClusterRoleIdentity{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-scoped-identity",
+					},
+					Spec: infrav1.AWSClusterRoleIdentitySpec{
+						AWSRoleSpec: infrav1.AWSRoleSpec{
+							RoleArn: "arn:aws:iam::123456789012:role/test-role",
+						},
+					},
+				}
+				obj.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   infrav1.GroupVersion.Group,
+					Version: infrav1.GroupVersion.Version,
+					Kind:    "AWSClusterRoleIdentity",
+				})
+				return obj
+			}(),
+			expectedResult: true,
+			expectErr:      false,
+		},
+		{
+			name:             "Cluster-scoped resources bypass allowedNamespaces check even with nil allowedNamespaces",
+			clusterNamespace: "default",
+			allowedNs:        nil,
+			setup: func(t *testing.T, c client.Client) {
+				t.Helper()
+			},
+			obj: func() client.Object {
+				obj := &infrav1.AWSClusterRoleIdentity{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-scoped-identity-2",
+					},
+					Spec: infrav1.AWSClusterRoleIdentitySpec{
+						AWSRoleSpec: infrav1.AWSRoleSpec{
+							RoleArn: "arn:aws:iam::123456789012:role/test-role",
+						},
+					},
+				}
+				obj.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   infrav1.GroupVersion.Group,
+					Version: infrav1.GroupVersion.Version,
+					Kind:    "AWSClusterRoleIdentity",
+				})
+				return obj
+			}(),
+			expectedResult: true,
+			expectErr:      false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -197,11 +256,26 @@ func TestIsClusterPermittedToUsePrincipal(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRESTMapper(newTestRESTMapper()).
+				Build()
 			if tc.setup != nil {
 				tc.setup(t, k8sClient)
 			}
-			result, err := isClusterPermittedToUsePrincipal(k8sClient, tc.allowedNs, tc.clusterNamespace)
+
+			// Create a test object (namespace-scoped AWSCluster) if not provided
+			testObj := tc.obj
+			if testObj == nil {
+				testObj = &infrav1.AWSCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster",
+						Namespace: tc.clusterNamespace,
+					},
+				}
+			}
+
+			result, err := isClusterPermittedToUsePrincipal(k8sClient, tc.allowedNs, tc.clusterNamespace, testObj)
 			if tc.expectErr {
 				g.Expect(err).ToNot(BeNil())
 			} else {
@@ -219,7 +293,10 @@ func TestPrincipalParsing(t *testing.T) {
 	// Create the scope.
 	scheme := runtime.NewScheme()
 	_ = infrav1.AddToScheme(scheme)
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(newTestRESTMapper()).
+		Build()
 	clusterScope, _ := NewClusterScope(ClusterScopeParams{
 		Client: cl,
 		Cluster: &clusterv1.Cluster{
@@ -485,7 +562,10 @@ func TestPrincipalParsing(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRESTMapper(newTestRESTMapper()).
+				Build()
 			tc.setup(t, k8sClient)
 			clusterScope.AWSCluster = &tc.awsCluster
 			providers, err := getProvidersForCluster(context.Background(), k8sClient, clusterScope, clusterScope.Region(), logger.NewLogger(klog.Background()))

--- a/pkg/cloud/scope/test_helpers.go
+++ b/pkg/cloud/scope/test_helpers.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// newTestRESTMapper creates a RESTMapper for tests that knows about CAPA resource types.
+func newTestRESTMapper() meta.RESTMapper {
+	rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2"},
+		{Group: "", Version: "v1"},
+	})
+
+	rm.Add(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSCluster",
+	}, meta.RESTScopeNamespace)
+
+	rm.Add(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "ROSANetwork",
+	}, meta.RESTScopeNamespace)
+
+	rm.Add(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSClusterRoleIdentity",
+	}, meta.RESTScopeRoot)
+
+	rm.Add(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSClusterStaticIdentity",
+	}, meta.RESTScopeRoot)
+
+	rm.Add(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSClusterControllerIdentity",
+	}, meta.RESTScopeRoot)
+
+	rm.Add(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "ROSAOCMRoleConfig",
+	}, meta.RESTScopeRoot)
+
+	rm.Add(schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Namespace",
+	}, meta.RESTScopeRoot)
+
+	return rm
+}


### PR DESCRIPTION
**What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:

 This PR fixes a bug where cluster-scoped resources cannot use AWS identities that have `allowedNamespaces` restrictions.

  The permission check in `isClusterPermittedToUsePrincipal()` assumes all resources have a namespace, but cluster-scoped resources return an empty namespace (`""`), causing them to fail
  `allowedNamespaces` validation even when they should be allowed.

  This fix allows cluster-scoped resources to bypass `allowedNamespaces` checks since:
  1. Cluster-scoped resources don't belong to a namespace
  2. The `allowedNamespaces` field is designed for namespace-scoped resources to enforce multi-tenancy
  3. Cluster-scoped resources are already protected by cluster-level RBAC (only cluster admins can create them)

  Changes:
  - Added `isClusterScopedResource()` helper that uses `RESTMapper` to query resource scope metadata from CRD definitions.
  - Cluster-scoped resources bypass `allowedNamespaces` validation

  **Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
  Fixes #6087
https://redhat.atlassian.net/browse/ROSAENG-60948

  **Special notes for your reviewer**:

  **AI Usage**:

 None

  **Checklist**:

  - [x] squashed commits
  - [x] includes documentation
  - [ ] includes AI generated content
  - [x] includes emoji in title
  - [x] adds unit tests
  - [x] adds or updates e2e tests

  **Release note**:

```release-note
fix: allow cluster-scoped resources to bypass allowedNamepsaces checks
```