### PR TITLE
🐛 fix(eks): add ObservedGeneration to AWSManagedControlPlane to prevent missed spec changes

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2295,6 +2295,11 @@ spec:
                       security group to its unique name, if any.
                     type: object
                 type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               oidcProvider:
                 description: OIDCProvider holds the status of the identity provider
                   for this cluster
@@ -4751,6 +4756,11 @@ spec:
                       security group to its unique name, if any.
                     type: object
                 type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               oidcProvider:
                 description: OIDCProvider holds the status of the identity provider
                   for this cluster

--- a/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta1/awsmanagedcontrolplane_types.go
@@ -276,6 +276,9 @@ type AWSManagedControlPlaneStatus struct {
 	// associated identity provider
 	// +optional
 	IdentityProviderStatus IdentityProviderStatus `json:"identityProviderStatus,omitempty"`
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/controlplane/eks/api/v1beta1/zz_generated.conversion.go
+++ b/controlplane/eks/api/v1beta1/zz_generated.conversion.go
@@ -401,6 +401,7 @@ func autoConvert_v1beta1_AWSManagedControlPlaneStatus_To_v1beta2_AWSManagedContr
 	if err := Convert_v1beta1_IdentityProviderStatus_To_v1beta2_IdentityProviderStatus(&in.IdentityProviderStatus, &out.IdentityProviderStatus, s); err != nil {
 		return err
 	}
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -426,6 +427,7 @@ func autoConvert_v1beta2_AWSManagedControlPlaneStatus_To_v1beta1_AWSManagedContr
 		return err
 	}
 	// WARNING: in.Version requires manual conversion: does not exist in peer-type
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
@@ -402,6 +402,9 @@ type AWSManagedControlPlaneStatus struct {
 	// in the cluster.
 	// +optional
 	Version *string `json:"version,omitempty"`
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -57,6 +57,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
@@ -287,7 +288,11 @@ func (r *AWSManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 
 		v1beta1conditions.SetSummary(managedScope.ControlPlane, v1beta1conditions.WithConditions(applicableConditions...), v1beta1conditions.WithStepCounter())
 
-		if err := managedScope.Close(); err != nil && reterr == nil {
+		patchOpts := []v1beta1patch.Option{}
+		if reterr == nil {
+			patchOpts = append(patchOpts, v1beta1patch.WithStatusObservedGeneration{})
+		}
+		if err := managedScope.PatchObjectWithOptions(patchOpts...); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -387,6 +387,13 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 		})
 	}
 
+	if awsManagedControlPlane.Status.ObservedGeneration < awsManagedControlPlane.Generation {
+		managedScope.Info("Observed generation behind current generation, requeueing",
+			"observedGeneration", awsManagedControlPlane.Status.ObservedGeneration,
+			"generation", awsManagedControlPlane.Generation)
+		return reconcile.Result{RequeueAfter: r.WaitInfraPeriod}, nil
+	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
@@ -87,9 +87,10 @@ func TestAWSManagedControlPlaneReconcilerIntegrationTests(t *testing.T) {
 		mockCtrl = gomock.NewController(t)
 		recorder = record.NewFakeRecorder(10)
 		reconciler = AWSManagedControlPlaneReconciler{
-			Client:    testEnv.Client,
-			Recorder:  recorder,
-			EnableIAM: true,
+			Client:          testEnv.Client,
+			Recorder:        recorder,
+			EnableIAM:       true,
+			WaitInfraPeriod: 1 * time.Minute,
 		}
 		ctx = context.TODO()
 
@@ -218,13 +219,14 @@ func TestAWSManagedControlPlaneReconcilerIntegrationTests(t *testing.T) {
 			return sgSvc
 		}
 
-		_, err = reconciler.Reconcile(ctx, ctrl.Request{
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
 			NamespacedName: client.ObjectKey{
 				Namespace: awsManagedControlPlane.Namespace,
 				Name:      awsManagedControlPlane.Name,
 			},
 		})
 		g.Expect(err).To(BeNil())
+		g.Expect(result.RequeueAfter).To(Equal(reconciler.WaitInfraPeriod))
 
 		g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(&awsManagedControlPlane), &awsManagedControlPlane)).To(Succeed())
 		g.Expect(awsManagedControlPlane.Finalizers).To(ContainElement(ekscontrolplanev1.ManagedControlPlaneFinalizer))

--- a/pkg/cloud/scope/managedcontrolplane.go
+++ b/pkg/cloud/scope/managedcontrolplane.go
@@ -265,10 +265,16 @@ func (s *ManagedControlPlaneScope) ListOptionsLabelSelector() client.ListOption 
 
 // PatchObject persists the control plane configuration and status.
 func (s *ManagedControlPlaneScope) PatchObject() error {
-	return s.patchHelper.Patch(
-		context.TODO(),
-		s.ControlPlane,
+	return s.PatchObjectWithOptions()
+}
+
+// PatchObjectWithOptions persists the control plane configuration and status
+// with additional patch options.
+func (s *ManagedControlPlaneScope) PatchObjectWithOptions(opts ...v1beta1patch.Option) error {
+	allOpts := append([]v1beta1patch.Option{
 		v1beta1patch.WithOwnedConditions{Conditions: []clusterv1beta1.ConditionType{
+			infrav1.PrincipalUsageAllowedCondition,
+			infrav1.PrincipalCredentialRetrievedCondition,
 			infrav1.VpcReadyCondition,
 			infrav1.SubnetsReadyCondition,
 			infrav1.ClusterSecurityGroupsReadyCondition,
@@ -282,7 +288,12 @@ func (s *ManagedControlPlaneScope) PatchObject() error {
 			ekscontrolplanev1.EKSControlPlaneReadyCondition,
 			ekscontrolplanev1.EKSControlPlaneUpdatingCondition,
 			ekscontrolplanev1.IAMControlPlaneRolesReadyCondition,
-		}})
+		}},
+	}, opts...)
+	return s.patchHelper.Patch(
+		context.TODO(),
+		s.ControlPlane,
+		allOpts...)
 }
 
 // Close closes the current scope persisting the control plane configuration and status.

--- a/test/e2e/suites/managed/eks_upgrade_policy_test.go
+++ b/test/e2e/suites/managed/eks_upgrade_policy_test.go
@@ -112,6 +112,17 @@ var _ = ginkgo.Describe("EKS upgrade policy test", func() {
 			return patchHelper.Patch(ctx, controlPlane)
 		}, e2eCtx.E2EConfig.GetIntervals("", "wait-client-request")...).Should(Succeed(), "eventually failed patching the AWSManagedControlPlane")
 
+		// Verify the spec change was persisted before polling EKS.
+		ginkgo.By("Verifying the upgrade policy spec change was persisted")
+		Eventually(func() ekscontrolplanev1.UpgradePolicy {
+			updatedCP := &ekscontrolplanev1.AWSManagedControlPlane{}
+			if err := mgmtClient.Get(ctx, crclient.ObjectKey{Namespace: namespace.Name, Name: getControlPlaneName(clusterName)}, updatedCP); err != nil {
+				return ""
+			}
+			return updatedCP.Spec.UpgradePolicy
+		}, e2eCtx.E2EConfig.GetIntervals("", "wait-client-request")...).Should(Equal(changedUpgradePolicy),
+			"upgrade policy spec change should be persisted")
+
 		// Wait for the upgrade policy to be reflected in AWS EKS.
 		WaitForEKSClusterUpgradePolicy(ctx, e2eCtx.BootstrapUserAWSSession, eksClusterName, changedUpgradePolicy)
 
@@ -155,5 +166,5 @@ func WaitForEKSClusterUpgradePolicy(ctx context.Context, sess *aws.Config, eksCl
 
 		// Success in finding the change has been reflected in EKS.
 		return nil
-	}, 5*time.Minute, 10*time.Second).Should(Succeed(), fmt.Sprintf("eventually failed checking EKS Cluster %q upgrade policy is %s", eksClusterName, upgradePolicy))
+	}, 10*time.Minute, 10*time.Second).Should(Succeed(), fmt.Sprintf("eventually failed checking EKS Cluster %q upgrade policy is %s", eksClusterName, upgradePolicy))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The AWSManagedControlPlane controller could miss spec changes due to controller-runtime event coalescing. When multiple EKS clusters are reconciling concurrently, all 5 worker slots can be occupied for 12+ minutes. If a spec change arrives during this window, its watch event gets coalesced with an earlier status-patch event in the work queue. Since `reconcileNormal` returns `ctrl.Result{}` (no `RequeueAfter`), the controller never re-examines the object and the spec change is never reconciled.

Root cause confirmed from CI logs: the spec change watch event was not lost — it was deduplicated in the work queue because all workers were busy with long-running EKS cluster creation reconciles. By the time a worker picked up the item, the test had already issued a delete.

This PR:
- Adds `status.observedGeneration` to `AWSManagedControlPlaneStatus` (both v1beta2 and v1beta1) and wires `WithStatusObservedGeneration` into the controller's defer block on successful reconciliation. This is the idiomatic CAPI pattern already used by `EKSConfigReconciler` and `NodeadmConfigReconciler` in this repo.
- Adds a conditional `RequeueAfter` at the end of `reconcileNormal`: when `observedGeneration < generation`, the controller requeues to catch any coalesced spec changes. Once caught up, it returns `nil` and goes quiescent — no unnecessary periodic reconciling.
- Adds `PrincipalUsageAllowedCondition` and `PrincipalCredentialRetrievedCondition` to the `ManagedControlPlaneScope`'s owned conditions list — they were set during scope creation but not declared as owned, which caused patch conflicts when `WithStatusObservedGeneration` was added.
- Hardens the `[upgrade-policy]` e2e test by verifying the spec patch is persisted before polling EKS, and increases the EKS API polling timeout from 5 to 10 minutes.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #6085

**Special notes for your reviewer**:

The `ObservedGeneration` + conditional requeue mechanism works as follows:
1. On successful reconciliation, the deferred `scope.Close()` sets `status.observedGeneration = metadata.generation` via the CAPI patch helper's `WithStatusObservedGeneration` option.
2. At the end of `reconcileNormal`, if `observedGeneration < generation` (values read at reconcile start), the controller requeues after `WaitInfraPeriod` (default 1 minute). This catches spec changes that were coalesced during a long reconcile.
3. The follow-up reconcile sees `observedGeneration == generation` (set by the previous `scope.Close()`) and returns `nil` — the controller goes quiescent.

The v1beta1 conversion is auto-generated — `ObservedGeneration` is a simple `int64` field present in both versions, so `conversion-gen` handles it automatically.

**AI Usage**:

Claude Code was used to investigate the root cause via Prow CI artifacts, research the CAPI `WithStatusObservedGeneration` pattern, implement the fix, and create this PR.

**Checklist**:

- [X] squashed commits
- [X] includes documentation
- [X] includes AI generated content
- [X] includes emoji in title
- [X] adds unit tests
- [X] adds or updates e2e tests

**Release note**:

```release-note
fix(eks): race condition where AWSManagedControlPlane controller could miss spec changes due to controller-runtime event coalescing by adding status.observedGeneration tracking and conditional requeue.
```