### PR TITLE
🐛 fix: Prevent volumeSize updates in ROSAMachinePool

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
@@ -233,6 +233,9 @@ spec:
                 maximum: 16384
                 minimum: 75
                 type: integer
+                x-kubernetes-validations:
+                - message: volumeSize is immutable
+                  rule: self == oldSelf
             required:
             - instanceType
             - nodePoolName

--- a/exp/api/v1beta2/rosamachinepool_types.go
+++ b/exp/api/v1beta2/rosamachinepool_types.go
@@ -103,6 +103,7 @@ type RosaMachinePoolSpec struct {
 	// VolumeSize set the disk volume size for the machine pool, in Gib. The default is 300 GiB.
 	// +kubebuilder:validation:Minimum=75
 	// +kubebuilder:validation:Maximum=16384
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="volumeSize is immutable"
 	// +immutable
 	// +optional
 	VolumeSize int `json:"volumeSize,omitempty"`

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -402,6 +402,7 @@ func (r *ROSAMachinePoolReconciler) updateNodePool(machinePoolScope *scope.RosaM
 	desiredSpec.Version = ""
 	desiredSpec.AdditionalSecurityGroups = nil
 	desiredSpec.AdditionalTags = nil
+	desiredSpec.VolumeSize = 0
 
 	npBuilder := nodePoolBuilder(desiredSpec, machinePoolScope.MachinePool.Spec, machinePoolScope.ControlPlane.Spec.ChannelGroup, machinePoolScope.ControlPlane.Spec.Channel)
 	nodePoolSpec, err := npBuilder.Build()
@@ -430,6 +431,7 @@ func computeSpecDiff(desiredSpec expinfrav1.RosaMachinePoolSpec, nodePool *cmv1.
 		"Version",                  // Version changes are reconciled separately.
 		"AdditionalTags",           // AdditionalTags day2 changes not supported.
 		"AdditionalSecurityGroups", // AdditionalSecurityGroups day2 changes not supported.
+		"VolumeSize",               // VolumeSize is immutable after creation.
 	}
 
 	return cmp.Diff(desiredSpec, currentSpec,

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -708,6 +708,54 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 	})
 }
 
+func TestVolumeSizeIgnoredInDiff(t *testing.T) {
+	g := NewWithT(t)
+
+	rosaMachinePoolSpec := expinfrav1.RosaMachinePoolSpec{
+		NodePoolName: "test-nodepool",
+		Version:      "4.14.5",
+		Subnet:       "subnet-id",
+		AutoRepair:   true,
+		InstanceType: "m5.large",
+		VolumeSize:   300,
+	}
+
+	// Create a NodePool with different volumeSize
+	nodePool, err := cmv1.NewNodePool().
+		ID("test-nodepool").
+		Version(cmv1.NewVersion().ID("openshift-v4.14.5")).
+		Subnet("subnet-id").
+		AutoRepair(true).
+		AWSNodePool(cmv1.NewAWSNodePool().
+			InstanceType("m5.large").
+			RootVolume(cmv1.NewAWSVolume().Size(400))).
+		Build()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	diff := computeSpecDiff(rosaMachinePoolSpec, nodePool)
+	g.Expect(diff).To(BeEmpty(), "volumeSize should be ignored in diff computation")
+}
+
+func TestVolumeSizeZeroedBeforeUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	desiredSpec := expinfrav1.RosaMachinePoolSpec{
+		NodePoolName: "test-nodepool",
+		InstanceType: "m5.large",
+		VolumeSize:   0,
+	}
+
+	machinePoolSpec := clusterv1.MachinePoolSpec{
+		Replicas: ptr.To[int32](2),
+	}
+	nodePoolBuilder := nodePoolBuilder(desiredSpec, machinePoolSpec, rosacontrolplanev1.Stable, "")
+	nodePoolSpec, err := nodePoolBuilder.Build()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(nodePoolSpec.AWSNodePool()).ToNot(BeNil())
+	g.Expect(nodePoolSpec.AWSNodePool().RootVolume()).To(BeNil(), "RootVolume should not be set when volumeSize is 0")
+}
+
 func createObject(g *WithT, obj client.Object, namespace string) {
 	if obj.DeepCopyObject() != nil {
 		obj.SetNamespace(namespace)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

This PR fixes `volumeSize` immutability for `ROSAMachinePool` resources. Currently, when updating other fields (like labels) on a `ROSAMachinePool`, the controller sends the entire spec including `volumeSize` to the OCM API, which rejects it with the error: `"Attribute 'aws_node_pool.root_volume.size' is not allowed"` because `volumeSize` is immutable after `nodepool` creation.

*Changes*:
- Adds CEL validation to enforce `volumeSize` immutability at the CRD level
- Adds `VolumeSize` to `ignoredFields` in `computeSpecDiff` to prevent diff detection on `volumeSize` mismatches
- Zeros out `desiredSpec.VolumeSize` before UPDATE requests to ensure it's never sent to OCM

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes https://redhat.atlassian.net/browse/ROSAENG-8325

**Special notes for your reviewer**:

Tested these scenarios manually in a ROSA HCP cluster

**AI Usage**:

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".



-->

Claude assisted for test generation

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fix volumeSize immutability for ROSAMachinePool to prevent OCM API errors when updating other fields. volumeSize is now enforced as immutable via CEL validation and is no longer sent in UPDATE requests.
```
