### PR TITLE
🐛 fix: Prevent capacityReservationID updates in ROSAMachinePool

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
@@ -93,6 +93,9 @@ spec:
                   CapacityReservationID specifies the ID of an AWS On-Demand Capacity Reservation and Capacity Blocks for ML.
                   The CapacityReservationID must be pre-created in advance, before creating a NodePool.
                 type: string
+                x-kubernetes-validations:
+                - message: capacityReservationID is immutable
+                  rule: self == oldSelf
               imageType:
                 description: ImageType is the AMI (Amazon Machine Image) to use for
                   running the associated NodePool (i.e. Windows or Default/Linux).

--- a/exp/api/v1beta2/rosamachinepool_types.go
+++ b/exp/api/v1beta2/rosamachinepool_types.go
@@ -130,6 +130,8 @@ type RosaMachinePoolSpec struct {
 	// CapacityReservationID specifies the ID of an AWS On-Demand Capacity Reservation and Capacity Blocks for ML.
 	// The CapacityReservationID must be pre-created in advance, before creating a NodePool.
 	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="capacityReservationID is immutable"
+	// +immutable
 	// +optional
 	CapacityReservationID string `json:"capacityReservationID,omitempty"`
 }

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -403,6 +403,7 @@ func (r *ROSAMachinePoolReconciler) updateNodePool(machinePoolScope *scope.RosaM
 	desiredSpec.AdditionalSecurityGroups = nil
 	desiredSpec.AdditionalTags = nil
 	desiredSpec.VolumeSize = 0
+	desiredSpec.CapacityReservationID = ""
 
 	npBuilder := nodePoolBuilder(desiredSpec, machinePoolScope.MachinePool.Spec, machinePoolScope.ControlPlane.Spec.ChannelGroup, machinePoolScope.ControlPlane.Spec.Channel)
 	nodePoolSpec, err := npBuilder.Build()
@@ -432,6 +433,7 @@ func computeSpecDiff(desiredSpec expinfrav1.RosaMachinePoolSpec, nodePool *cmv1.
 		"AdditionalTags",           // AdditionalTags day2 changes not supported.
 		"AdditionalSecurityGroups", // AdditionalSecurityGroups day2 changes not supported.
 		"VolumeSize",               // VolumeSize is immutable after creation.
+		"CapacityReservationID",    // CapacityReservationID is immutable after creation.
 	}
 
 	return cmp.Diff(desiredSpec, currentSpec,

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -756,6 +756,54 @@ func TestVolumeSizeZeroedBeforeUpdate(t *testing.T) {
 	g.Expect(nodePoolSpec.AWSNodePool().RootVolume()).To(BeNil(), "RootVolume should not be set when volumeSize is 0")
 }
 
+func TestCapacityReservationIDIgnoredInDiff(t *testing.T) {
+	g := NewWithT(t)
+
+	rosaMachinePoolSpec := expinfrav1.RosaMachinePoolSpec{
+		NodePoolName:          "test-nodepool",
+		Version:               "4.14.5",
+		Subnet:                "subnet-id",
+		AutoRepair:            true,
+		InstanceType:          "m5.large",
+		CapacityReservationID: "cr-12345",
+	}
+
+	// Create a NodePool with different capacityReservationID
+	nodePool, err := cmv1.NewNodePool().
+		ID("test-nodepool").
+		Version(cmv1.NewVersion().ID("openshift-v4.14.5")).
+		Subnet("subnet-id").
+		AutoRepair(true).
+		AWSNodePool(cmv1.NewAWSNodePool().
+			InstanceType("m5.large").
+			CapacityReservation(cmv1.NewAWSCapacityReservation().Id("cr-67890"))).
+		Build()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	diff := computeSpecDiff(rosaMachinePoolSpec, nodePool)
+	g.Expect(diff).To(BeEmpty(), "capacityReservationID should be ignored in diff computation")
+}
+
+func TestCapacityReservationIDZeroedBeforeUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	desiredSpec := expinfrav1.RosaMachinePoolSpec{
+		NodePoolName:          "test-nodepool",
+		InstanceType:          "m5.large",
+		CapacityReservationID: "",
+	}
+
+	machinePoolSpec := clusterv1.MachinePoolSpec{
+		Replicas: ptr.To[int32](2),
+	}
+	nodePoolBuilder := nodePoolBuilder(desiredSpec, machinePoolSpec, rosacontrolplanev1.Stable, "")
+	nodePoolSpec, err := nodePoolBuilder.Build()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(nodePoolSpec.AWSNodePool()).ToNot(BeNil())
+	g.Expect(nodePoolSpec.AWSNodePool().CapacityReservation()).To(BeNil(), "CapacityReservation should not be set when capacityReservationID is empty")
+}
+
 func createObject(g *WithT, obj client.Object, namespace string) {
 	if obj.DeepCopyObject() != nil {
 		obj.SetNamespace(namespace)


### PR DESCRIPTION
 **What type of PR is this?**

 /kind bug

 **What this PR does / why we need it**:

This PR fixes `capacityReservationID` immutability for `ROSAMachinePool` resources. Currently, when updating other fields (like labels, scaling) on a `ROSAMachinePool` that has `capacityReservationID` set, the controller sends the entire spec including `capacityReservationID` to the OCM API, which rejects it with the error: `"Attribute 'aws_node_pool.capacity_reservation' is not allowed"` because `capacityReservationID` is immutable after nodepool creation.

  **Changes:**
  - Adds CEL validation to enforce `capacityReservationID` immutability at the CRD level
  - Adds `CapacityReservationID` to `ignoredFields` in `computeSpecDiff` to prevent diff detection on `capacityReservationID` mismatches
  - Zeros out `desiredSpec.CapacityReservationID` before UPDATE requests to ensure it's never sent to OCM.

  **Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
  Fixes #

  **Special notes for your reviewer**:

  This follows the same pattern as the volumeSize fix (PR #6086).

  **AI Usage**:

  Claude assisted with test generation and implementation following the volumeSize pattern

  **Checklist**:

  - [x] squashed commits
  - [ ] includes documentation
  - [x] includes AI generated content
  - [x] includes emoji in title
  - [x] adds unit tests
  - [ ] adds or updates e2e tests

  **Release note**:

  ```release-note
  Fix capacityReservationID immutability for ROSAMachinePool to prevent OCM API errors when updating other fields. capacityReservationID is now enforced as immutable via CEL validation and is no longer sent in UPDATE requests.