### PR TITLE
🐛 fix: create CAPI-contract kubeconfig for external auth ROSA clusters

### DIFF
--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
 	"reflect"
@@ -85,6 +86,12 @@ const (
 
 	// ExternalAuthProviderLastAppliedAnnotation annotation tracks the last applied external auth configuration to inform if an update is required.
 	ExternalAuthProviderLastAppliedAnnotation = "controlplane.cluster.x-k8s.io/rosacontrolplane-last-applied-external-auth-provider"
+
+	// ROSAControlPlaneCredentialExpiryAnnotation tracks when the break-glass credential in a kubeconfig secret expires.
+	ROSAControlPlaneCredentialExpiryAnnotation = "controlplane.cluster.x-k8s.io/rosacontrolplane-credential-expiry"
+
+	// credentialRefreshThreshold is how long before expiry a break-glass credential should be refreshed.
+	credentialRefreshThreshold = 1 * time.Hour
 )
 
 // ROSAControlPlaneReconciler reconciles a ROSAControlPlane object.
@@ -969,23 +976,31 @@ func (r *ROSAControlPlaneReconciler) reconcileExternalAuthProviders(ctx context.
 	return nil
 }
 
-// Generates a temporarily admin kubeconfig using break-glass credentials for the user to bootstreap their environment like setting up RBAC for oidc users/groups.
-// This Kubeonconfig will be created only once initially and be valid for only 24h.
-// The kubeconfig secret will not be autoamticallty rotated and will be invalid after the 24h. However, users can opt to manually delete the secret to trigger the generation of a new one which will be valid for another 24h.
+// reconcileExternalAuthBootstrapKubeconfig ensures both the bootstrap kubeconfig (for user RBAC setup)
+// and the CAPI-contract kubeconfig (for RemoteConnectionProbe) exist and are refreshed before expiry.
 func (r *ROSAControlPlaneReconciler) reconcileExternalAuthBootstrapKubeconfig(ctx context.Context, externalAuthClient *rosa.ExternalAuthClient, rosaScope *scope.ROSAControlPlaneScope, cluster *cmv1.Cluster) error {
-	kubeconfigSecret := rosaScope.ExternalAuthBootstrapKubeconfigSecret()
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(kubeconfigSecret), kubeconfigSecret)
-	if err == nil {
-		// already exist.
-		return nil
-	} else if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get bootstrap kubeconfig secret: %w", err)
+	bootstrapSecret := rosaScope.ExternalAuthBootstrapKubeconfigSecret()
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(bootstrapSecret), bootstrapSecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get bootstrap kubeconfig secret: %w", err)
+		}
+		bootstrapSecret = nil
 	}
 
-	// kubeconfig doesn't exist, generate a new one.
+	clusterRef := client.ObjectKeyFromObject(rosaScope.Cluster)
+	capiSecret, err := secret.GetFromNamespacedName(ctx, r.Client, clusterRef, secret.Kubeconfig)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get kubeconfig secret: %w", err)
+	}
+
+	if !needsCredentialRefresh(bootstrapSecret) && !needsCredentialRefresh(capiSecret) {
+		return nil
+	}
+
+	expiration := time.Now().Add(time.Hour * 24)
 	breakGlassConfig, err := cmv1.NewBreakGlassCredential().
 		Username(names.SimpleNameGenerator.GenerateName("capi-admin-")). // OCM requires unique usernames
-		ExpirationTimestamp(time.Now().Add(time.Hour * 24)).
+		ExpirationTimestamp(expiration).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to build break glass config: %v", err)
@@ -1001,14 +1016,56 @@ func (r *ROSAControlPlaneReconciler) reconcileExternalAuthBootstrapKubeconfig(ct
 		return fmt.Errorf("failed to poll break glass kubeconfig: %v", err)
 	}
 
-	kubeconfigSecret.Data = map[string][]byte{
-		"value": []byte(kubeconfigData),
-	}
-	if err := r.Client.Create(ctx, kubeconfigSecret); err != nil {
-		return fmt.Errorf("failed to create external auth bootstrap kubeconfig: %v", err)
+	expiryAnnotation := map[string]string{
+		ROSAControlPlaneCredentialExpiryAnnotation: expiration.Format(time.RFC3339),
 	}
 
-	return nil
+	bootstrapNewSecret := rosaScope.ExternalAuthBootstrapKubeconfigSecret()
+	if err := r.reconcileKubeconfigSecret(ctx, kubeconfigData, expiryAnnotation, bootstrapSecret, bootstrapNewSecret); err != nil {
+		return err
+	}
+
+	controllerOwnerRef := *metav1.NewControllerRef(rosaScope.ControlPlane, rosacontrolplanev1.GroupVersion.WithKind("ROSAControlPlane"))
+	capiNewSecret := kubeconfig.GenerateSecretWithOwner(clusterRef, []byte(kubeconfigData), controllerOwnerRef)
+	return r.reconcileKubeconfigSecret(ctx, kubeconfigData, expiryAnnotation, capiSecret, capiNewSecret)
+}
+
+func (r *ROSAControlPlaneReconciler) reconcileKubeconfigSecret(ctx context.Context, kubeconfigData string, annotations map[string]string, existing *corev1.Secret, newSecret *corev1.Secret) error {
+	if existing != nil {
+		existing.Data = map[string][]byte{secret.KubeconfigDataName: []byte(kubeconfigData)}
+		if existing.Annotations == nil {
+			existing.Annotations = make(map[string]string)
+		}
+		maps.Copy(existing.Annotations, annotations)
+		return r.Client.Update(ctx, existing)
+	}
+
+	newSecret.Data = map[string][]byte{secret.KubeconfigDataName: []byte(kubeconfigData)}
+	if newSecret.Annotations == nil {
+		newSecret.Annotations = make(map[string]string)
+	}
+	maps.Copy(newSecret.Annotations, annotations)
+	return r.Client.Create(ctx, newSecret)
+}
+
+// needsCredentialRefresh returns true if the break-glass credential in the secret
+// is missing, has no expiry annotation, or is within the refresh threshold of expiring.
+func needsCredentialRefresh(s *corev1.Secret) bool {
+	if s == nil {
+		return true
+	}
+
+	expiryStr, ok := s.Annotations[ROSAControlPlaneCredentialExpiryAnnotation]
+	if !ok {
+		return true
+	}
+
+	expiry, err := time.Parse(time.RFC3339, expiryStr)
+	if err != nil {
+		return true
+	}
+
+	return time.Until(expiry) < credentialRefreshThreshold
 }
 
 func (r *ROSAControlPlaneReconciler) reconcileKubeconfig(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope, ocmClient rosa.OCMClient, cluster *cmv1.Cluster) error {

--- a/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
@@ -55,7 +55,9 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 // fakeStsAPIClient is a minimal implementation of rosaaws.StsApiClient for use in tests.
@@ -1685,4 +1687,278 @@ func TestBuildOCMClusterSpec(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(ocmSpec.ExternalID).To(Equal("direct-external-id"))
 	})
+}
+
+func TestReconcileExternalAuthKubeconfigSecrets(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, "test-ext-auth-kubeconfig")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	rosaControlPlane := &rosacontrolplanev1.ROSAControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rosa-cp",
+			Namespace: ns.Name,
+			UID:       types.UID("test-rosa-cp-uid"),
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ROSAControlPlane",
+			APIVersion: rosacontrolplanev1.GroupVersion.String(),
+		},
+		Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+			RosaClusterName:             "test-rosa-cp",
+			EnableExternalAuthProviders: true,
+			Subnets:                     []string{"subnet-1"},
+			AvailabilityZones:           []string{"us-east-1a"},
+			Region:                      "us-east-1",
+			Version:                     "4.16.0",
+			RolesRef: rosacontrolplanev1.AWSRolesRef{
+				IngressARN:              "arn1",
+				ImageRegistryARN:        "arn2",
+				StorageARN:              "arn3",
+				NetworkARN:              "arn4",
+				KubeCloudControllerARN:  "arn5",
+				NodePoolManagementARN:   "arn6",
+				ControlPlaneOperatorARN: "arn7",
+				KMSProviderARN:          "arn8",
+			},
+			OIDCID:           "oidc1",
+			InstallerRoleARN: "arn:aws:iam::123456789012:role/installer",
+			WorkerRoleARN:    "arn:aws:iam::123456789012:role/worker",
+			SupportRoleARN:   "arn:aws:iam::123456789012:role/support",
+			IdentityRef: &infrav1.AWSIdentityReference{
+				Name: "default",
+				Kind: infrav1.ControllerIdentityKind,
+			},
+			VersionGate: "Acknowledge",
+			CredentialsSecretRef: &corev1.LocalObjectReference{
+				Name: "test-ocm-secret",
+			},
+		},
+	}
+
+	ocmSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ocm-secret",
+			Namespace: ns.Name,
+		},
+		Data: map[string][]byte{
+			"ocmToken": []byte("test-token"),
+		},
+	}
+	g.Expect(testEnv.Create(ctx, ocmSecret)).To(Succeed())
+
+	ownerCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-owner-cluster",
+			Namespace: ns.Name,
+			UID:       types.UID("test-owner-cluster-uid"),
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: clusterv1.ContractVersionedObjectReference{
+				Name:     rosaControlPlane.Name,
+				Kind:     "ROSAControlPlane",
+				APIGroup: rosacontrolplanev1.GroupVersion.Group,
+			},
+		},
+	}
+
+	identity := &infrav1.AWSClusterControllerIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: infrav1.AWSClusterControllerIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+		},
+	}
+	identity.SetGroupVersionKind(infrav1.GroupVersion.WithKind("AWSClusterControllerIdentity"))
+
+	g.Expect(testEnv.Create(ctx, identity)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, ownerCluster)).To(Succeed())
+
+	rosaControlPlane.OwnerReferences = []metav1.OwnerReference{
+		{
+			Name:       ownerCluster.Name,
+			UID:        ownerCluster.UID,
+			Kind:       "Cluster",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+	}
+	g.Expect(testEnv.Create(ctx, rosaControlPlane)).To(Succeed())
+
+	defer func() {
+		g.Expect(testEnv.Cleanup(ctx, rosaControlPlane, ownerCluster, identity, ocmSecret)).To(Succeed())
+	}()
+
+	rosaScope := &scope.ROSAControlPlaneScope{
+		Cluster:      ownerCluster,
+		ControlPlane: rosaControlPlane,
+	}
+
+	reconciler := &ROSAControlPlaneReconciler{
+		Client: testEnv.Client,
+	}
+
+	kubeconfigData := "apiVersion: v1\nkind: Config\nclusters: []\n"
+	expiration := time.Now().Add(24 * time.Hour)
+	annotations := map[string]string{
+		ROSAControlPlaneCredentialExpiryAnnotation: expiration.Format(time.RFC3339),
+	}
+
+	t.Run("creates both secrets on first reconcile", func(t *testing.T) {
+		g := NewWithT(t)
+
+		bootstrapNewSecret := rosaScope.ExternalAuthBootstrapKubeconfigSecret()
+		err := reconciler.reconcileKubeconfigSecret(ctx, kubeconfigData, annotations, nil, bootstrapNewSecret)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		clusterRef := client.ObjectKeyFromObject(ownerCluster)
+		controllerOwnerRef := *metav1.NewControllerRef(rosaControlPlane, rosacontrolplanev1.GroupVersion.WithKind("ROSAControlPlane"))
+		capiNewSecret := kubeconfig.GenerateSecretWithOwner(clusterRef, []byte(kubeconfigData), controllerOwnerRef)
+		err = reconciler.reconcileKubeconfigSecret(ctx, kubeconfigData, annotations, nil, capiNewSecret)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify bootstrap secret
+		bootstrapSecret := &corev1.Secret{}
+		err = testEnv.Get(ctx, client.ObjectKey{
+			Name:      fmt.Sprintf("%s-bootstrap-kubeconfig", ownerCluster.Name),
+			Namespace: ns.Name,
+		}, bootstrapSecret)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(bootstrapSecret.Data).To(HaveKey(secret.KubeconfigDataName))
+		g.Expect(string(bootstrapSecret.Data[secret.KubeconfigDataName])).To(Equal(kubeconfigData))
+		g.Expect(bootstrapSecret.Annotations).To(HaveKey(ROSAControlPlaneCredentialExpiryAnnotation))
+
+		// Verify CAPI contract secret
+		capiSecret := &corev1.Secret{}
+		err = testEnv.Get(ctx, client.ObjectKey{
+			Name:      fmt.Sprintf("%s-kubeconfig", ownerCluster.Name),
+			Namespace: ns.Name,
+		}, capiSecret)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(capiSecret.Data).To(HaveKey(secret.KubeconfigDataName))
+		g.Expect(string(capiSecret.Data[secret.KubeconfigDataName])).To(Equal(kubeconfigData))
+		g.Expect(capiSecret.Annotations).To(HaveKey(ROSAControlPlaneCredentialExpiryAnnotation))
+		g.Expect(capiSecret.Labels).To(HaveKeyWithValue("cluster.x-k8s.io/cluster-name", ownerCluster.Name))
+	})
+
+	t.Run("updates both secrets on refresh", func(t *testing.T) {
+		g := NewWithT(t)
+
+		newKubeconfigData := "apiVersion: v1\nkind: Config\nclusters: []\nrefreshed: true\n"
+		newExpiration := time.Now().Add(24 * time.Hour)
+		newAnnotations := map[string]string{
+			ROSAControlPlaneCredentialExpiryAnnotation: newExpiration.Format(time.RFC3339),
+		}
+
+		// Fetch existing secrets
+		existingBootstrap := &corev1.Secret{}
+		err := testEnv.Get(ctx, client.ObjectKey{
+			Name:      fmt.Sprintf("%s-bootstrap-kubeconfig", ownerCluster.Name),
+			Namespace: ns.Name,
+		}, existingBootstrap)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		existingCAPI := &corev1.Secret{}
+		err = testEnv.Get(ctx, client.ObjectKey{
+			Name:      fmt.Sprintf("%s-kubeconfig", ownerCluster.Name),
+			Namespace: ns.Name,
+		}, existingCAPI)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = reconciler.reconcileKubeconfigSecret(ctx, newKubeconfigData, newAnnotations, existingBootstrap, nil)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = reconciler.reconcileKubeconfigSecret(ctx, newKubeconfigData, newAnnotations, existingCAPI, nil)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify updated bootstrap secret
+		g.Eventually(func(g Gomega) {
+			updated := &corev1.Secret{}
+			g.Expect(testEnv.Get(ctx, client.ObjectKey{
+				Name:      fmt.Sprintf("%s-bootstrap-kubeconfig", ownerCluster.Name),
+				Namespace: ns.Name,
+			}, updated)).To(Succeed())
+			g.Expect(string(updated.Data[secret.KubeconfigDataName])).To(Equal(newKubeconfigData))
+			g.Expect(updated.Annotations[ROSAControlPlaneCredentialExpiryAnnotation]).To(Equal(newAnnotations[ROSAControlPlaneCredentialExpiryAnnotation]))
+		}).Should(Succeed())
+
+		// Verify updated CAPI secret
+		g.Eventually(func(g Gomega) {
+			updatedCAPI := &corev1.Secret{}
+			g.Expect(testEnv.Get(ctx, client.ObjectKey{
+				Name:      fmt.Sprintf("%s-kubeconfig", ownerCluster.Name),
+				Namespace: ns.Name,
+			}, updatedCAPI)).To(Succeed())
+			g.Expect(string(updatedCAPI.Data[secret.KubeconfigDataName])).To(Equal(newKubeconfigData))
+			g.Expect(updatedCAPI.Annotations[ROSAControlPlaneCredentialExpiryAnnotation]).To(Equal(newAnnotations[ROSAControlPlaneCredentialExpiryAnnotation]))
+		}).Should(Succeed())
+	})
+}
+
+func TestNeedsCredentialRefresh(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+		want   bool
+	}{
+		{
+			name:   "nil secret needs refresh",
+			secret: nil,
+			want:   true,
+		},
+		{
+			name: "missing annotation needs refresh",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-kubeconfig",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "expired credential needs refresh",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-kubeconfig",
+					Annotations: map[string]string{
+						ROSAControlPlaneCredentialExpiryAnnotation: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "credential expiring within threshold needs refresh",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-kubeconfig",
+					Annotations: map[string]string{
+						ROSAControlPlaneCredentialExpiryAnnotation: time.Now().Add(30 * time.Minute).Format(time.RFC3339),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "valid credential does not need refresh",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-kubeconfig",
+					Annotations: map[string]string{
+						ROSAControlPlaneCredentialExpiryAnnotation: time.Now().Add(12 * time.Hour).Format(time.RFC3339),
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(needsCredentialRefresh(tt.secret)).To(Equal(tt.want))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

When `EnableExternalAuthProviders: true` is set on a ROSAControlPlane, CAPA only created a `<cluster>-bootstrap-kubeconfig` secret (24h TTL, no refresh) but never the CAPI-contract `<cluster>-kubeconfig` secret. In CAPI v1.11, `RemoteConnectionProbe` became load-bearing — it gates `ClusterAvailableV1Beta2Condition`. Without a valid `<cluster>-kubeconfig`, all external-auth ROSA clusters report `Available=False`, and CAPI loses MachinePool status reporting.

### Root Cause

In `rosacontrolplane_controller.go`, the reconcile logic splits on `EnableExternalAuthProviders`:
- Standard path → `reconcileKubeconfig()` creates `<cluster>-kubeconfig` (CAPI contract) via OAuth token
- External auth path → `reconcileExternalAuthBootstrapKubeconfig()` creates only `<cluster>-bootstrap-kubeconfig` via break-glass credential

The standard path can't work for external OIDC because there is no OpenShift OAuth server.

### Fix

- Create **both** `<cluster>-bootstrap-kubeconfig` (for user RBAC setup) and `<cluster>-kubeconfig` (for CAPI/RemoteConnectionProbe) from the same break-glass credential
- Track credential expiry via `controlplane.cluster.x-k8s.io/rosacontrolplane-credential-expiry` annotation
- Auto-refresh break-glass credential before the 24h TTL expires (1h threshold)
- Use `kubeconfig.GenerateSecretWithOwner()` for the CAPI secret to ensure contract compliance (labels, owner refs, secret type)

### Changes

- **`rosacontrolplane_controller.go`**: New annotation constant, modified `reconcileExternalAuthBootstrapKubeconfig` to check expiry and write dual secrets, new `needsCredentialRefresh` helper
- **`rosacontrolplane_controller_test.go`**: Table-driven tests for `needsCredentialRefresh` (5 cases) + envtest integration tests for dual secret create/update

## Test plan

- [x] `make generate` — no generated file changes
- [x] `make lint` — 0 issues
- [x] `make test` — 49/49 passed (full controller package)
- [ ] E2E validation on a ROSA cluster with `EnableExternalAuthProviders: true` (requires OCM credentials)


```release-note
fix(rosa): RemoteConnectionProbe failure for external auth clusters by creating and auto-refreshing the CAPI-contract kubeconfig secret
```