### PR TITLE
✨ feat(ROSA): add delete protection support to ROSA

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_rosacontrolplanes.yaml
@@ -279,6 +279,16 @@ spec:
                     minimum: 75
                     type: integer
                 type: object
+              deleteProtection:
+                default: Disabled
+                description: |-
+                  DeleteProtection prevents accidental ROSA cluster deletion.
+                  When set to "Enabled", the ROSA cluster cannot be deleted through OCM.
+                  Defaults to "Disabled".
+                enum:
+                - Enabled
+                - Disabled
+                type: string
               domainPrefix:
                 description: |-
                   DomainPrefix is an optional prefix added to the cluster's domain name. It will be used

--- a/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
+++ b/controlplane/rosa/api/v1beta2/rosacontrolplane_types.go
@@ -82,6 +82,17 @@ const (
 	FIPSDisabled FIPSState = "Disabled"
 )
 
+// DeleteProtectionState represents whether delete protection is enabled for the ROSA cluster.
+type DeleteProtectionState string
+
+const (
+	// DeleteProtectionEnabled indicates delete protection is enabled.
+	DeleteProtectionEnabled DeleteProtectionState = "Enabled"
+
+	// DeleteProtectionDisabled indicates delete protection is disabled.
+	DeleteProtectionDisabled DeleteProtectionState = "Disabled"
+)
+
 // AutoNodeMode specifies the AutoNode mode for the ROSA Control Plane.
 type AutoNodeMode string
 
@@ -201,6 +212,15 @@ type RosaControlPlaneSpec struct { //nolint: maligned
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="enableExternalAuthProviders is immutable"
 	// +optional
 	EnableExternalAuthProviders bool `json:"enableExternalAuthProviders,omitempty"`
+
+	// DeleteProtection prevents accidental ROSA cluster deletion.
+	// When set to "Enabled", the ROSA cluster cannot be deleted through OCM.
+	// Defaults to "Disabled".
+	//
+	// +kubebuilder:default=Disabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	DeleteProtection DeleteProtectionState `json:"deleteProtection,omitempty"`
 
 	// ExternalAuthProviders are external OIDC identity providers that can issue tokens for this cluster.
 	// Can only be set if "enableExternalAuthProviders" is set to "True".

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -286,6 +286,11 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 		rosaScope.ControlPlane.Status.Ready = false
 		rosaScope.ControlPlane.Status.Version = rosa.RawVersionID(cluster.Version())
 
+		if err := rosa.ReconcileDeleteProtection(rosaScope, ocmClient, cluster); err != nil {
+			rosaScope.Error(err, "failed to reconcile delete protection")
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
+		}
+
 		switch cluster.Status().State() {
 		case cmv1.ClusterStateReady:
 			v1beta1conditions.MarkTrue(rosaScope.ControlPlane, rosacontrolplanev1.ROSAControlPlaneReadyCondition)
@@ -386,6 +391,19 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 	rosaScope.Info("cluster created", "state", cluster.Status().State())
 	rosaScope.ControlPlane.Status.ID = cluster.ID()
 
+	if rosaScope.ControlPlane.Spec.DeleteProtection == rosacontrolplanev1.DeleteProtectionEnabled {
+		if err := rosa.UpdateClusterDeletionProtection(ocmClient, cluster.ID(), true); err != nil {
+			v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
+				rosacontrolplanev1.ROSAControlPlaneReadyCondition,
+				rosacontrolplanev1.ReconciliationFailedReason,
+				clusterv1beta1.ConditionSeverityError,
+				"cluster '%s' was created but delete protection could not be enabled: %s",
+				cluster.ID(),
+				err.Error())
+			return ctrl.Result{}, fmt.Errorf("failed to enable delete protection for cluster '%s': %w", cluster.ID(), err)
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -457,6 +475,13 @@ func (r *ROSAControlPlaneReconciler) reconcileDelete(ctx context.Context, rosaSc
 	}
 	if cluster == nil {
 		// cluster and machinepools are deleted, removing finalizer.
+		controllerutil.RemoveFinalizer(rosaScope.ControlPlane, ROSAControlPlaneFinalizer)
+
+		return ctrl.Result{}, nil
+	}
+
+	if rosa.IsDeleteProtectionBlocking(rosaScope, cluster) {
+		rosaScope.Info("Delete protection is enabled, removing finalizer without deleting the ROSA cluster")
 		controllerutil.RemoveFinalizer(rosaScope.ControlPlane, ROSAControlPlaneFinalizer)
 
 		return ctrl.Result{}, nil

--- a/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
@@ -573,6 +573,7 @@ func TestRosaControlPlaneReconcileStatusVersion(t *testing.T) {
 			api := (&v1.ClusterAPIBuilder{}).URL("https://url.com:5000")
 			version := (&v1.VersionBuilder{}).RawID(rosaControlPlane.Spec.Version)
 			mockCluster, _ := v1.NewCluster().AWS(aws).ID("cluster-1").Version(version).Status(status).Console(console).API(api).
+				DeleteProtection(v1.NewDeleteProtection().Enabled(false)).
 				RegistryConfig(v1.NewClusterRegistryConfig().
 					AdditionalTrustedCa(map[string]string{"trusted-ca": "-----BEGIN CERTIFICATE----- testcert -----END CERTIFICATE-----"}).
 					AllowedRegistriesForImport(v1.NewRegistryLocation().

--- a/docs/book/src/topics/rosa/creating-a-cluster.md
+++ b/docs/book/src/topics/rosa/creating-a-cluster.md
@@ -345,6 +345,12 @@ The CAPA controller requires service account credentials to provision ROSA HCP c
 
 ## Deleting a ROSA HCP cluster
 
+When `spec.deleteProtection` is set to `Enabled` on the `ROSAControlPlane`, deleting the `ROSAControlPlane` CR will remove the Kubernetes resource but leave the ROSA cluster intact in OCM. No cascade deletion of NodePools or the cluster itself will occur. To fully delete a protected cluster:
+
+1. Set `spec.deleteProtection` to `Disabled` on the `ROSAControlPlane`.
+2. Wait for reconciliation to complete.
+3. Delete the `Cluster` and `ROSAControlPlane` resources.
+
 To delete a ROSA HCP cluster, delete the `Cluster` and `ROSAControlPlane` resources. This will also clean up the associated `ROSACluster`, `MachinePool`, and `ROSAMachinePool` resources:
 
 ```shell

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -317,6 +317,12 @@ func (r *ROSAMachinePoolReconciler) reconcileDelete(
 ) error {
 	machinePoolScope.Info("Reconciling deletion of RosaMachinePool")
 
+	if machinePoolScope.ControlPlane.Spec.DeleteProtection == rosacontrolplanev1.DeleteProtectionEnabled {
+		machinePoolScope.Info("Delete protection is enabled on ROSAControlPlane, skipping NodePool deletion in OCM")
+		controllerutil.RemoveFinalizer(machinePoolScope.RosaMachinePool, expinfrav1.RosaMachinePoolFinalizer)
+		return nil
+	}
+
 	ocmClient, err := r.NewOCMClient(ctx, rosaControlPlaneScope)
 	if err != nil || ocmClient == nil {
 		// TODO: need to expose in status, as likely the credentials are invalid

--- a/exp/controllers/rosaocmroleconfig_controller_test.go
+++ b/exp/controllers/rosaocmroleconfig_controller_test.go
@@ -520,7 +520,7 @@ func TestROSAOCMRoleConfigSetUpRuntimeWithExpiredAWSCredentials(t *testing.T) {
 		Client: testEnv.Client,
 		NewOCMClient: func(ctx context.Context, scope caparosa.OCMSecretsRetriever) (caparosa.OCMClient, error) {
 			ocmClientCallCount++
-			return ocmClient, nil
+			return caparosa.NewOCMClientFromRosaClient(ocmClient), nil
 		},
 		runtimeFactory: nil, // Use default setUpRuntime (not the mock factory)
 	}

--- a/pkg/rosa/delete_protection.go
+++ b/pkg/rosa/delete_protection.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rosa
+
+import (
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+)
+
+// DeleteProtectionEnabledFromCluster reads delete protection from the inline cluster field.
+func DeleteProtectionEnabledFromCluster(cluster *cmv1.Cluster) (enabled bool, ok bool) {
+	if cluster == nil {
+		return false, false
+	}
+	if dp, present := cluster.GetDeleteProtection(); present && dp != nil {
+		return dp.Enabled(), true
+	}
+	return false, false
+}
+
+// UpdateClusterDeletionProtection patches the cluster delete protection sub-resource.
+func UpdateClusterDeletionProtection(ocmClient OCMClient, clusterID string, enabled bool) error {
+	return ocmClient.UpdateClusterDeletionProtection(clusterID, enabled)
+}
+
+// ReconcileDeleteProtection syncs spec.deleteProtection to OCM.
+func ReconcileDeleteProtection(
+	rosaScope *scope.ROSAControlPlaneScope,
+	ocmClient OCMClient,
+	cluster *cmv1.Cluster,
+) error {
+	liveEnabled, ok := DeleteProtectionEnabledFromCluster(cluster)
+	if !ok {
+		return fmt.Errorf("failed to read delete protection for cluster '%s'", cluster.ID())
+	}
+
+	specEnabled := rosaScope.ControlPlane.Spec.DeleteProtection == rosacontrolplanev1.DeleteProtectionEnabled
+	if specEnabled == liveEnabled {
+		return nil
+	}
+
+	if err := UpdateClusterDeletionProtection(ocmClient, cluster.ID(), specEnabled); err != nil {
+		return fmt.Errorf("failed to update delete protection for cluster '%s': %w", cluster.ID(), err)
+	}
+
+	return nil
+}
+
+// IsDeleteProtectionBlocking reports whether cluster deletion should be blocked.
+func IsDeleteProtectionBlocking(
+	rosaScope *scope.ROSAControlPlaneScope,
+	cluster *cmv1.Cluster,
+) bool {
+	if rosaScope.ControlPlane.Spec.DeleteProtection == rosacontrolplanev1.DeleteProtectionEnabled {
+		return true
+	}
+
+	enabled, ok := DeleteProtectionEnabledFromCluster(cluster)
+	if !ok {
+		return false
+	}
+
+	return enabled
+}

--- a/pkg/rosa/delete_protection_test.go
+++ b/pkg/rosa/delete_protection_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rosa_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/rosa"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
+)
+
+func TestDeleteProtectionEnabledFromCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("returns false when cluster is nil", func(t *testing.T) {
+		enabled, ok := rosa.DeleteProtectionEnabledFromCluster(nil)
+		g.Expect(ok).To(BeFalse())
+		g.Expect(enabled).To(BeFalse())
+	})
+
+	t.Run("returns enabled value when inline field is present", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			DeleteProtection(cmv1.NewDeleteProtection().Enabled(true)).
+			Build()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		enabled, ok := rosa.DeleteProtectionEnabledFromCluster(cluster)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(enabled).To(BeTrue())
+	})
+
+	t.Run("returns false when inline field reports disabled", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			DeleteProtection(cmv1.NewDeleteProtection().Enabled(false)).
+			Build()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		enabled, ok := rosa.DeleteProtectionEnabledFromCluster(cluster)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(enabled).To(BeFalse())
+	})
+}
+
+func TestReconcileDeleteProtection(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster, err := cmv1.NewCluster().
+		ID("cluster-1").
+		DeleteProtection(cmv1.NewDeleteProtection().Enabled(false)).
+		Build()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	rosaControlPlane := &rosacontrolplanev1.ROSAControlPlane{
+		Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+			DeleteProtection: rosacontrolplanev1.DeleteProtectionEnabled,
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	ocmMock := mocks.NewMockOCMClient(mockCtrl)
+	ocmMock.EXPECT().
+		UpdateClusterDeletionProtection("cluster-1", true).
+		Return(nil).
+		Times(1)
+
+	rosaScope := &scope.ROSAControlPlaneScope{
+		ControlPlane: rosaControlPlane,
+	}
+
+	g.Expect(rosa.ReconcileDeleteProtection(rosaScope, ocmMock, cluster)).To(Succeed())
+}
+
+func TestIsDeleteProtectionBlocking(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster, err := cmv1.NewCluster().
+		ID("cluster-1").
+		DeleteProtection(cmv1.NewDeleteProtection().Enabled(true)).
+		Build()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Run("blocks when spec requests protection", func(t *testing.T) {
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					DeleteProtection: rosacontrolplanev1.DeleteProtectionEnabled,
+				},
+			},
+		}
+
+		blocking := rosa.IsDeleteProtectionBlocking(rosaScope, cluster)
+		g.Expect(blocking).To(BeTrue())
+	})
+
+	t.Run("blocks when live protection is enabled", func(t *testing.T) {
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					DeleteProtection: rosacontrolplanev1.DeleteProtectionDisabled,
+				},
+			},
+		}
+
+		blocking := rosa.IsDeleteProtectionBlocking(rosaScope, cluster)
+		g.Expect(blocking).To(BeTrue())
+	})
+
+	t.Run("allows delete when protection is disabled", func(t *testing.T) {
+		disabledCluster, err := cmv1.NewCluster().
+			ID("cluster-1").
+			DeleteProtection(cmv1.NewDeleteProtection().Enabled(false)).
+			Build()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		rosaScope := &scope.ROSAControlPlaneScope{
+			ControlPlane: &rosacontrolplanev1.ROSAControlPlane{
+				Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+					DeleteProtection: rosacontrolplanev1.DeleteProtectionDisabled,
+				},
+			},
+		}
+
+		blocking := rosa.IsDeleteProtectionBlocking(rosaScope, disabledCluster)
+		g.Expect(blocking).To(BeFalse())
+	})
+}

--- a/pkg/rosa/ocmclient.go
+++ b/pkg/rosa/ocmclient.go
@@ -64,6 +64,7 @@ type OCMClient interface {
 	UpdateLogForwarder(logForwarder *v1.LogForwarder, logForwarderID string, clusterID string) error
 	DeleteLogForwarder(clusterID string, logForwarderID string) error
 	GetLogForwarders(clusterID string) ([]*v1.LogForwarder, error)
+	UpdateClusterDeletionProtection(clusterID string, enabled bool) error
 }
 
 func (c *ocmclient) AckVersionGate(clusterID string, gateID string) error {
@@ -182,6 +183,19 @@ func (c *ocmclient) GetLogForwarders(clusterID string) ([]*v1.LogForwarder, erro
 	return c.ocmClient.GetLogForwarders(clusterID)
 }
 
+func (c *ocmclient) UpdateClusterDeletionProtection(clusterID string, enabled bool) error {
+	body, err := v1.NewDeleteProtection().Enabled(enabled).Build()
+	if err != nil {
+		return fmt.Errorf("failed to build delete protection: %w", err)
+	}
+	return c.ocmClient.UpdateClusterDeletionProtection(clusterID, body)
+}
+
+// NewOCMClientFromRosaClient wraps a rosa ocm.Client as an OCMClient.
+func NewOCMClientFromRosaClient(client *ocm.Client) OCMClient {
+	return &ocmclient{ocmClient: client}
+}
+
 // NewMockOCMClient creates a new empty ocm.Client without any real connection.
 func NewMockOCMClient(ctx context.Context, rosaScope *scope.ROSAControlPlaneScope) (OCMClient, error) {
 	return &ocmclient{ocmClient: &ocm.Client{}}, nil
@@ -191,11 +205,7 @@ func NewMockOCMClient(ctx context.Context, rosaScope *scope.ROSAControlPlaneScop
 func ConvertToRosaOcmClient(i OCMClient) (*ocm.Client, error) {
 	c, ok := i.(*ocmclient)
 	if !ok {
-		c, ok := i.(*ocm.Client)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert to Rosa OCM Client")
-		}
-		return c, nil
+		return nil, fmt.Errorf("failed to convert to Rosa OCM Client")
 	}
 	return c.ocmClient, nil
 }

--- a/templates/cluster-template-rosa.yaml
+++ b/templates/cluster-template-rosa.yaml
@@ -50,3 +50,4 @@ spec:
   installerRoleARN: "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role"
   supportRoleARN: "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Support-Role"
   workerRoleARN: "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Worker-Role"
+  # deleteProtection: Enabled

--- a/test/mocks/ocm_client_mock.go
+++ b/test/mocks/ocm_client_mock.go
@@ -438,6 +438,20 @@ func (mr *MockOCMClientMockRecorder) UpdateCluster(arg0, arg1, arg2 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOCMClient)(nil).UpdateCluster), arg0, arg1, arg2)
 }
 
+// UpdateClusterDeletionProtection mocks base method.
+func (m *MockOCMClient) UpdateClusterDeletionProtection(arg0 string, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterDeletionProtection", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateClusterDeletionProtection indicates an expected call of UpdateClusterDeletionProtection.
+func (mr *MockOCMClientMockRecorder) UpdateClusterDeletionProtection(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterDeletionProtection", reflect.TypeOf((*MockOCMClient)(nil).UpdateClusterDeletionProtection), arg0, arg1)
+}
+
 // UpdateLogForwarder mocks base method.
 func (m *MockOCMClient) UpdateLogForwarder(arg0 *v1.LogForwarder, arg1, arg2 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:

ROSA provides support for deletion protection, but CAPA did not expose or reconcile that setting on `ROSAControlPlane`. This PR adds optional `spec.deleteProtection` and `status.deleteProtection` fields and wires them through the controller.

Changes include:

- Add `spec.deleteProtection` and `status.deleteProtection` to `ROSAControlPlane` (`v1beta2`) and regenerate CRDs/deepcopy.
- Reconcile delete protection during normal reconciliation via `pkg/rosa/delete_protection.go`, including syncing spec to OCM and updating status from the cluster object or OCM sub-resource.
- Enable delete protection immediately after cluster creation when requested in spec.
- When a `ROSAControlPlane` is deleted while protection is enabled, remove the finalizer and allow the CR to be deleted without cascading deletion to the ROSA cluster in OCM.
- Extend `OCMClient` with `UpdateClusterDeletionProtection` and add `NewOCMClientFromRosaClient` for tests that use a real `*ocm.Client`.
- Document the disable-before-delete workflow in the ROSA cluster creation guide and add a commented example to `templates/cluster-template-rosa.yaml`.
- Add unit tests in `pkg/rosa/` and update controller tests for the new reconcile path.

Transient OCM failures during delete-protection reconciliation log the error and requeue after one minute instead of returning a reconcile error alongside `RequeueAfter`.

**Which issue(s) this PR fixes**:

Fixes #6121 

**Special notes for your reviewer**:

- When delete protection is enabled and the CR is deleted, the finalizer is removed and the CR is garbage-collected, but the ROSA cluster in OCM is left intact. No machine pool cascade or OCM delete call occurs.
- No ROSA-specific e2e coverage exists today; validation is unit/controller tests plus manual checks below.

**AI Usage**:

Cursor was used to assist with test authoring. CodeRabbit was used to review the change before opening the PR. All changes have been reviewed and validated locally before submission.

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**How to test**:

- [x] `make generate`
- [x] `make lint`
- [x] `make lint-api`
- [x] `make test`
- [x] `make binaries`
- [x] `make compile-e2e`
- [x] `go test ./pkg/rosa/... -run 'DeleteProtection|ReconcileDeleteProtection|IsDeleteProtectionBlocking' -v`
- [x] Manual: set `spec.deleteProtection: true`, confirm `status.deleteProtection` becomes `true`
- [x] Manual: set `spec.deleteProtection: false`, confirm status follows and OCM protection is cleared
- [x] Manual: attempt delete while protected and confirm deletion is blocked with the documented message
- [x] Manual: disable protection, wait for reconcile, then delete successfully

**Release note**:

```release-note
ROSAControlPlane now supports optional `spec.deleteProtection` and reports live protection state in `status.deleteProtection`. When enabled, CAPA syncs the setting to OCM. Deleting the ROSAControlPlane CR while protection is enabled removes the CR without cascading deletion to the ROSA cluster in OCM.
```