### PR TITLE
:bug: fix: Clear credential cache on InvalidClientTokenId to allow retry on next reconcile

### DIFF
--- a/pkg/cloud/identity/identity.go
+++ b/pkg/cloud/identity/identity.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/gob"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -29,12 +31,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 	corev1 "k8s.io/api/core/v1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	awsmetrics "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/metrics"
 	stsservice "sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
+)
+
+const (
+	// invalidClientTokenIDCode is the AWS error code returned when an access key
+	// has not yet propagated through IAM's eventual consistency.
+	invalidClientTokenIDCode = "InvalidClientTokenId"
 )
 
 // AWSPrincipalTypeProvider defines the interface for AWS Principal Type Provider.
@@ -180,5 +189,30 @@ func (p *AWSRolePrincipalTypeProvider) Retrieve(ctx context.Context) (aws.Creden
 		// Update credentials
 		p.credentials = creds
 	}
-	return p.credentials.Retrieve(ctx)
+	result, err := p.credentials.Retrieve(ctx)
+	if err != nil && IsInvalidClientTokenIDError(err) {
+		// Clear the cached credentials so the next reconcile creates a fresh
+		// cache and retries AssumeRole. This handles AWS IAM eventual
+		// consistency for freshly-created access keys, where the first
+		// AssumeRole call may fail with InvalidClientTokenId before the key
+		// has propagated. Without this, the CredentialsCache retains the
+		// failed result and subsequent reconciles never recover.
+		p.log.Info("Transient InvalidClientTokenId error from AssumeRole, clearing credential cache to allow retry on next reconcile")
+		p.credentials = nil
+	}
+	return result, err
+}
+
+// IsInvalidClientTokenIDError reports whether err is an AWS STS
+// InvalidClientTokenId error, which is raised when an access key has not yet
+// propagated through IAM's eventual consistency.
+func IsInvalidClientTokenIDError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == invalidClientTokenIDCode {
+		return true
+	}
+	return strings.Contains(err.Error(), invalidClientTokenIDCode)
 }

--- a/pkg/cloud/identity/identity_test.go
+++ b/pkg/cloud/identity/identity_test.go
@@ -18,19 +18,23 @@ package identity
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/aws/smithy-go"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/sts/mock_stsiface"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
 )
 
 func TestAWSStaticPrincipalTypeProvider(t *testing.T) {
@@ -190,6 +194,115 @@ func TestAWSStaticPrincipalTypeProvider(t *testing.T) {
 			if !cmp.Equal(tc.value, value) {
 				t.Fatal("Did not get expected result")
 			}
+		})
+	}
+}
+
+func TestAWSRolePrincipalTypeProvider_ClearsCredentialCacheOnInvalidClientTokenId(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	g := NewWithT(t)
+
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			"AccessKeyID":     []byte("test-key"),
+			"SecretAccessKey": []byte("test-secret"),
+		},
+	}
+	staticProvider := NewAWSStaticPrincipalTypeProvider(&infrav1.AWSClusterStaticIdentity{}, secret)
+
+	stsMock := mock_stsiface.NewMockSTSClient(mockCtrl)
+	roleIdentity := &infrav1.AWSClusterRoleIdentity{
+		Spec: infrav1.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: infrav1.AWSRoleSpec{
+				RoleArn:         "arn:aws:iam::123456789012:role/test-role",
+				SessionName:     "test-session",
+				DurationSeconds: 900,
+			},
+		},
+	}
+
+	testLog := logger.NewLogger(klog.NewKlogr())
+	roleProvider := &AWSRolePrincipalTypeProvider{
+		credentials:    nil,
+		Principal:      roleIdentity,
+		region:         "us-east-1",
+		sourceProvider: staticProvider,
+		stsClient:      stsMock,
+		log:            testLog.WithName("test"),
+	}
+
+	// First call: return InvalidClientTokenId error
+	invalidTokenErr := &smithy.GenericAPIError{
+		Code:    "InvalidClientTokenId",
+		Message: "The security token included in the request is invalid",
+	}
+	stsMock.EXPECT().AssumeRole(gomock.Any(), gomock.Any()).Return(nil, invalidTokenErr)
+
+	_, err := roleProvider.Retrieve(context.TODO())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("InvalidClientTokenId"))
+	// Credentials cache should be cleared
+	g.Expect(roleProvider.credentials).To(BeNil())
+
+	// Second call: succeed — proves the cache was cleared and a fresh attempt is made
+	stsMock.EXPECT().AssumeRole(gomock.Any(), gomock.Any()).Return(&sts.AssumeRoleOutput{
+		Credentials: &ststypes.Credentials{
+			AccessKeyId:     aws.String("new-key"),
+			SecretAccessKey: aws.String("new-secret"),
+			SessionToken:    aws.String("new-token"),
+			Expiration:      aws.Time(time.Now().Add(1 * time.Hour)),
+		},
+	}, nil)
+
+	creds, err := roleProvider.Retrieve(context.TODO())
+	g.Expect(err).To(BeNil())
+	g.Expect(creds.AccessKeyID).To(Equal("new-key"))
+}
+
+func TestIsInvalidClientTokenIDError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		expect bool
+	}{
+		{
+			name:   "nil error",
+			err:    nil,
+			expect: false,
+		},
+		{
+			name: "typed smithy APIError with InvalidClientTokenId",
+			err: &smithy.GenericAPIError{
+				Code:    "InvalidClientTokenId",
+				Message: "The security token included in the request is invalid",
+			},
+			expect: true,
+		},
+		{
+			name:   "error containing InvalidClientTokenId in message",
+			err:    fmt.Errorf("operation failed: InvalidClientTokenId: token not valid"),
+			expect: true,
+		},
+		{
+			name:   "unrelated error",
+			err:    fmt.Errorf("connection timeout"),
+			expect: false,
+		},
+		{
+			name: "different API error code",
+			err: &smithy.GenericAPIError{
+				Code:    "AccessDenied",
+				Message: "not authorized",
+			},
+			expect: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(IsInvalidClientTokenIDError(tt.err)).To(Equal(tt.expect))
 		})
 	}
 }

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -937,6 +937,12 @@ func newUserAccessKey(ctx context.Context, cfg *aws.Config, userName string) *ia
 // key may not be immediately usable across all AWS services. STS GetCallerIdentity
 // is a lightweight call that validates the credential without requiring any IAM
 // permissions.
+//
+// Note: the controller itself also handles this scenario gracefully by clearing
+// the credential cache when AssumeRole returns InvalidClientTokenId (see
+// AWSRolePrincipalTypeProvider.Retrieve in pkg/cloud/identity/identity.go).
+// This e2e wait is kept as defense-in-depth to avoid unnecessary reconcile
+// churn during tests.
 func waitForAccessKeyPropagation(cfg *aws.Config) {
 	By("Waiting for access key to propagate via STS GetCallerIdentity...")
 	stsSvc := sts.NewFromConfig(*cfg)


### PR DESCRIPTION
Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/6123


## What this PR does

Clears the cached `*aws.CredentialsCache` in `AWSRolePrincipalTypeProvider.Retrieve()` when the error is `InvalidClientTokenId`, allowing the next controller-runtime reconcile loop to create a fresh credentials cache and retry the `AssumeRole` call.

## Why this is needed

After the AWS SDK v1→v2 migration, `aws.NewCredentialsCache` caches failed `AssumeRole` results. When a freshly-created IAM access key has not yet propagated through AWS IAM eventual consistency, the first `AssumeRole` call fails with `InvalidClientTokenId`. Unlike SDK v1 where `IsExpired()` returned true after failure (triggering a fresh attempt on the next reconcile), SDK v2's `CredentialsCache` retains the error.

This causes the CAPA controller to be unable to recover from a transient IAM propagation delay for the lifetime of the provider instance (~50 minutes observed in production until KubeadmControlPlane timeout).

## How it works

```go
result, err := p.credentials.Retrieve(ctx)
if err != nil && IsInvalidClientTokenIDError(err) {
    p.credentials = nil  // next reconcile will recreate the cache
}
return result, err
```

This restores the pre-SDK-migration behavior with minimal change.

## Testing

- Unit test added verifying cache is cleared on `InvalidClientTokenId` and subsequent `Retrieve()` succeeds
- Unit test for `IsInvalidClientTokenIDError` helper with typed and string-match cases



/kind bug



AI Usage:

1. Research & Analysis — Investigated CAPA source code (<v2.9 vs v2.11.1), identified the AWS SDK v1→v2 credential caching regression as root cause of the IAM key propagation issue
2. Code — Implemented the fix in pkg/cloud/identity/identity.go (added IsInvalidClientTokenIDError helper, modified Retrieve() to clear cache on transient error) and wrote unit tests in identity_test.go

Checklist:

- [x]  squashed commits
- [x]  includes documentation
- [x]  includes AI generated content
- [x]  includes emoji in title
- [x]  adds unit tests
- [ ]  adds or updates e2e tests

```release-note
Fix credential cache poisoning in AWSRolePrincipalTypeProvider when AssumeRole fails with InvalidClientTokenId due to IAM eventual consistency. The credential cache is now cleared on this transient error, allowing the controller to retry on the next reconcile instead of remaining stuck until restart.
```