### PR TITLE
🐛 Reject removal of a secondary control plane load balancer instead of panicking

### DIFF
--- a/webhooks/awscluster_webhook.go
+++ b/webhooks/awscluster_webhook.go
@@ -114,18 +114,24 @@ func (w *AWSCluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Ob
 		)
 	}
 
-	// Validate the control plane load balancers.
-	lbs := map[*infrav1.AWSLoadBalancerSpec]*infrav1.AWSLoadBalancerSpec{
-		oldC.Spec.ControlPlaneLoadBalancer:          r.Spec.ControlPlaneLoadBalancer,
-		oldC.Spec.SecondaryControlPlaneLoadBalancer: r.Spec.SecondaryControlPlaneLoadBalancer,
+	// Validate the control plane load balancers. Each entry carries its own field
+	// path so validation errors (including the immutability checks below) are
+	// attributed to the correct load balancer instead of always to the primary.
+	lbs := []struct {
+		old  *infrav1.AWSLoadBalancerSpec
+		new  *infrav1.AWSLoadBalancerSpec
+		path *field.Path
+	}{
+		{oldC.Spec.ControlPlaneLoadBalancer, r.Spec.ControlPlaneLoadBalancer, field.NewPath("spec", "controlPlaneLoadBalancer")},
+		{oldC.Spec.SecondaryControlPlaneLoadBalancer, r.Spec.SecondaryControlPlaneLoadBalancer, field.NewPath("spec", "secondaryControlPlaneLoadBalancer")},
 	}
 
-	for oldLB, newLB := range lbs {
-		if oldLB == nil && newLB == nil {
+	for _, lb := range lbs {
+		if lb.old == nil && lb.new == nil {
 			continue
 		}
 
-		allErrs = append(allErrs, w.validateControlPlaneLoadBalancerUpdate(oldLB, newLB)...)
+		allErrs = append(allErrs, w.validateControlPlaneLoadBalancerUpdate(lb.old, lb.new, lb.path)...)
 	}
 
 	if !cmp.Equal(oldC.Spec.ControlPlaneEndpoint, clusterv1beta1.APIEndpoint{}) &&
@@ -186,14 +192,25 @@ func (w *AWSCluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Ob
 	return allWarnings, aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 
-func (w *AWSCluster) validateControlPlaneLoadBalancerUpdate(oldlb, newlb *infrav1.AWSLoadBalancerSpec) field.ErrorList {
+func (w *AWSCluster) validateControlPlaneLoadBalancerUpdate(oldlb, newlb *infrav1.AWSLoadBalancerSpec, lbPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
+
+	// A previously-set control plane load balancer cannot be removed: the
+	// underlying AWS load balancer is not deleted by reconciliation, so allowing
+	// the removal would leak it. Reject the change with a clear, field-scoped
+	// error instead of dereferencing newlb below, which would panic when it is
+	// nil.
+	if oldlb != nil && newlb == nil {
+		allErrs = append(allErrs, field.Invalid(lbPath, newlb,
+			"control plane load balancer cannot be removed once set"))
+		return allErrs
+	}
 
 	if oldlb == nil {
 		// If old scheme was nil, the only value accepted here is the default value: internet-facing
 		if newlb.Scheme != nil && newlb.Scheme.String() != infrav1.ELBSchemeInternetFacing.String() {
 			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "scheme"),
+				field.Invalid(lbPath.Child("scheme"),
 					newlb.Scheme, "field is immutable, default value was set to internet-facing"),
 			)
 		}
@@ -204,14 +221,14 @@ func (w *AWSCluster) validateControlPlaneLoadBalancerUpdate(oldlb, newlb *infrav
 		if (oldlb.LoadBalancerType == infrav1.LoadBalancerTypeDisabled && newlb.LoadBalancerType != infrav1.LoadBalancerTypeDisabled) ||
 			(newlb.LoadBalancerType == infrav1.LoadBalancerTypeDisabled && oldlb.LoadBalancerType != infrav1.LoadBalancerTypeDisabled) {
 			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "type"),
+				field.Invalid(lbPath.Child("type"),
 					newlb.Scheme, "field is immutable when created of disabled type"),
 			)
 		}
 		// If old scheme was not nil, the new scheme should be the same.
 		if !cmp.Equal(oldlb.Scheme, newlb.Scheme) {
 			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "scheme"),
+				field.Invalid(lbPath.Child("scheme"),
 					newlb.Scheme, "field is immutable"),
 			)
 		}
@@ -220,7 +237,7 @@ func (w *AWSCluster) validateControlPlaneLoadBalancerUpdate(oldlb, newlb *infrav
 		// so the name remains nil. In either case, the name cannot be changed.
 		if !cmp.Equal(oldlb.Name, newlb.Name) {
 			allErrs = append(allErrs,
-				field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "name"),
+				field.Invalid(lbPath.Child("name"),
 					newlb.Name, "field is immutable"),
 			)
 		}
@@ -231,7 +248,7 @@ func (w *AWSCluster) validateControlPlaneLoadBalancerUpdate(oldlb, newlb *infrav
 		if oldlb.LoadBalancerType != infrav1.LoadBalancerTypeClassic {
 			if !cmp.Equal(newlb.HealthCheckProtocol, oldlb.HealthCheckProtocol) {
 				allErrs = append(allErrs,
-					field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "healthCheckProtocol"),
+					field.Invalid(lbPath.Child("healthCheckProtocol"),
 						newlb.HealthCheckProtocol, "field is immutable once set"),
 				)
 			}
@@ -240,7 +257,7 @@ func (w *AWSCluster) validateControlPlaneLoadBalancerUpdate(oldlb, newlb *infrav
 		// TargetGroupIPType is immutable after creation.
 		if !cmp.Equal(oldlb.TargetGroupIPType, newlb.TargetGroupIPType) {
 			allErrs = append(allErrs,
-				field.Forbidden(field.NewPath("spec", "controlPlaneLoadBalancer", "targetGroupIPType"),
+				field.Forbidden(lbPath.Child("targetGroupIPType"),
 					"field is immutable and cannot be changed after target group creation"),
 			)
 		}

--- a/webhooks/awscluster_webhook_test.go
+++ b/webhooks/awscluster_webhook_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/component-base/featuregate/testing"
@@ -1519,6 +1520,31 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Should fail if the secondary control plane load balancer is removed",
+			oldCluster: &infrav1.AWSCluster{
+				Spec: infrav1.AWSClusterSpec{
+					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+						Name:   ptr.To("primary-lb"),
+						Scheme: &infrav1.ELBSchemeInternetFacing,
+					},
+					SecondaryControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+						Name:             ptr.To("secondary-lb"),
+						Scheme:           &infrav1.ELBSchemeInternal,
+						LoadBalancerType: infrav1.LoadBalancerTypeNLB,
+					},
+				},
+			},
+			newCluster: &infrav1.AWSCluster{
+				Spec: infrav1.AWSClusterSpec{
+					ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+						Name:   ptr.To("primary-lb"),
+						Scheme: &infrav1.ELBSchemeInternetFacing,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "Should pass if controlPlaneLoadBalancer healthcheckprotocol is same after update",
 			oldCluster: &infrav1.AWSCluster{
 				Spec: infrav1.AWSClusterSpec{
@@ -1682,6 +1708,45 @@ func TestAWSClusterValidateUpdate(t *testing.T) {
 		},
 		)
 	}
+}
+
+func TestAWSClusterValidateUpdateSecondaryControlPlaneLoadBalancerRemovalIsRejected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	primaryScheme := infrav1.ELBSchemeInternetFacing
+	secondaryScheme := infrav1.ELBSchemeInternal
+
+	oldCluster := &infrav1.AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: infrav1.AWSClusterSpec{
+			ControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+				Name:   ptr.To("primary-lb"),
+				Scheme: &primaryScheme,
+			},
+			SecondaryControlPlaneLoadBalancer: &infrav1.AWSLoadBalancerSpec{
+				Name:             ptr.To("secondary-lb"),
+				Scheme:           &secondaryScheme,
+				LoadBalancerType: infrav1.LoadBalancerTypeNLB,
+			},
+		},
+	}
+	newCluster := oldCluster.DeepCopy()
+	newCluster.Spec.SecondaryControlPlaneLoadBalancer = nil
+
+	var err error
+	g.Expect(func() {
+		_, err = (&AWSCluster{}).ValidateUpdate(ctx, oldCluster, newCluster)
+	}).ToNot(Panic())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	statusErr, ok := err.(apierrors.APIStatus)
+	g.Expect(ok).To(BeTrue())
+	invalidFields := make([]string, 0)
+	for _, cause := range statusErr.Status().Details.Causes {
+		invalidFields = append(invalidFields, cause.Field)
+	}
+	g.Expect(invalidFields).To(ContainElement("spec.secondaryControlPlaneLoadBalancer"))
 }
 
 func TestAWSClusterDefaultCNIIngressRules(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR prevents the `AWSCluster` validating webhook from panicking when an update attempts to remove a previously configured `spec.secondaryControlPlaneLoadBalancer`.

`ValidateUpdate` validates old/new pairs for the primary and secondary control plane load balancer specifications. It skips a pair only when both values are nil.

Before this change, when an existing secondary load balancer configuration was removed, the validation helper received:

```text
oldlb != nil
newlb == nil
```

The helper entered the existing-load-balancer branch and dereferenced `newlb`, for example through `newlb.LoadBalancerType`, causing a nil pointer panic. The HTTP server recovered the individual request, but the admission request failed with an internal webhook error instead of returning a normal validation response.

This change:

* detects an attempted removal before dereferencing `newlb`;
* returns a clear, field-scoped validation error instead of panicking;
* passes the field path for each load balancer into the validation helper, so validation errors are attributed to the correct primary or secondary load balancer field instead of always being reported under `controlPlaneLoadBalancer`; this also corrects the existing behavior where immutable-field errors for the secondary load balancer were incorrectly reported against the primary load balancer path; and
* adds a regression test covering the `oldlb != nil, newlb == nil` case.

This is the mirror of #5247, fixed by #5248, which covered adding a secondary control plane load balancer where `oldlb == nil` and `newlb != nil`.

This PR intentionally does not add support for deleting an existing secondary control plane load balancer. Supporting removal would also require controller-side reconciliation and cleanup of the corresponding AWS resources, which is outside the scope of this webhook robustness fix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6129

**Special notes for your reviewer**:

The change is limited to update validation and its regression coverage. It does not modify the API schema, defaulting behavior, or AWS resource reconciliation.

The regression test verifies that attempting to remove an existing secondary control plane load balancer:

* does not panic;
* returns a structured `apierrors.Invalid` error; and
* includes a status cause whose `Field` is exactly `spec.secondaryControlPlaneLoadBalancer`, rather than relying only on substring matching of the rendered error message.

No e2e test is added because the failure is fully reproducible in webhook validation and does not require an AWS environment.

Testing performed:

```text
make test
```

**AI Usage**:

Claude Code was used to help analyze the failure mode, adversarially review the proposed behavior, and refine the issue and pull request descriptions. All code changes and tests were manually reviewed and validated by the author.

**Checklist**:

* [x] squashed commits
* [ ] includes documentation
* [x] includes AI generated content
* [x] includes emoji in title
* [x] adds unit tests
* [ ] adds or updates e2e tests

**Release note**:

```release-note
Prevented the AWSCluster validating webhook from panicking when removal of an existing secondary control plane load balancer is attempted. The update now returns a clear validation error.
```