### PR TITLE
🐛 Persist ProviderID immediately after instance creation

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -580,6 +580,11 @@ func (r *AWSMachineReconciler) reconcileNormal(ctx context.Context, machineScope
 			v1beta1conditions.MarkFalse(machineScope.AWSMachine, infrav1.InstanceReadyCondition, infrav1.InstanceProvisionFailedReason, clusterv1beta1.ConditionSeverityError, "%s", err.Error())
 			return ctrl.Result{}, err
 		}
+
+		if patchErr := machineScope.PatchObject(); patchErr != nil {
+			machineScope.Error(patchErr, "failed to patch providerID")
+			return ctrl.Result{}, patchErr
+		}
 	}
 
 	// BYO Public IPv4 Pool feature: allocates and associates an EIP to machine when PublicIP and

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -174,6 +174,11 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			{infrav1.ELBAttachedCondition, corev1.ConditionTrue, "", ""},
 		})
 		g.Expect(ms.AWSMachine.Finalizers).Should(ContainElement(infrav1.MachineFinalizer))
+
+		persisted := &infrav1.AWSMachine{}
+		g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(ms.AWSMachine), persisted)).To(Succeed())
+		g.Expect(persisted.Spec.ProviderID).ToNot(BeNil())
+		g.Expect(persisted.Spec.InstanceID).ToNot(BeNil())
 	})
 	t.Run("Should successfully reconcile control plane machine deletion", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After `createInstance` returns, ProviderID and InstanceID are stored only in memory. They are persisted to the API server by the deferred `Close()` at end-of-reconcile. If that patch fails (e.g. optimistic locking conflict), the next reconcile sees an empty ProviderID, falls back to `GetRunningInstanceByTags`, and — because the EC2 `DescribeInstances` API [follows an eventual consistency model](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) — may not find the instance yet, creating a duplicate.

This adds an explicit `PatchObject()` call immediately after `createInstance` returns, following the same pattern already used for the finalizer and condition patches earlier in `reconcileNormal`.

**Which issue(s) this PR fixes**:
Fixes #6131

**Special notes for your reviewer**:

The deferred `PatchObject` can fail because `reconcileNormal` already calls `PatchObject` explicitly twice before instance creation (for the finalizer and for the `InstanceProvisionStarted` condition). Each call bumps the `ResourceVersion` on the API server. Any external modification to the AWSMachine between the last explicit `PatchObject` and the deferred `Close()` causes a conflict.

**AI Usage**:

Claude Code was used for codebase exploration, root cause analysis, reproduction, and drafting the fix.

**Checklist**:

- [X] squashed commits
- [ ] includes documentation
- [X] includes AI generated content
- [X] includes emoji in title
- [X] adds unit tests
- [ ] adds or updates e2e tests

```release-note
Fix duplicate EC2 instance creation caused by deferred ProviderID persistence combined with EC2 API eventual consistency
```