### PR TITLE
🌱 Bump Go to 1.25

### DIFF
--- a/.agents/skills/bump-go/SKILL.md
+++ b/.agents/skills/bump-go/SKILL.md
@@ -1,0 +1,15 @@
+description
+Bump Go to a new minor or patch version across the entire project. Use when upgrading Go (e.g. from 1.24 to 1.25). Handles go.mod, Makefile, golangci-lint, GitHub Actions, netlify.toml, and cloudbuild.
+
+argument-hint
+<go-minor-version> (e.g. 1.26)
+
+allowed-tools
+Bash(go *) Bash(git *) Bash(grep *) Bash(find *) Bash(docker *) Bash(gh *) Bash(make *)
+
+Bump Go Version
+===============
+
+Target Go minor version: **$ARGUMENTS**
+
+Follow the instructions in docs/book/src/development/bump-go.md exactly, using `$ARGUMENTS` as the target Go minor version.

--- a/.claude/skills/bump-go
+++ b/.claude/skills/bump-go
@@ -1,0 +1,1 @@
+../../.agents/skills/bump-go

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: '1.24'
+        go-version: '1.25'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # tag=v9.2.1
         with:
-          version: v2.7.0
+          version: v2.12.2
           working-directory: ${{matrix.working-directory}}
       - name: Lint API
         run: make lint-api

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26'
+          go-version: '1.25'
       - name: Set version info
         run: |
           echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 10m
-  go: "1.24"
+  go: "1.25"
   allow-parallel-runners: true
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -339,6 +339,9 @@ linters:
       - path: _test\.go
         text: cyclomatic complexity
       - linters:
+          - prealloc
+        text: "Consider preallocating allErrs"
+      - linters:
           - unparam
         text: (.+) - g is unused
       - path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -360,6 +360,34 @@ linters:
           - goconst
         path: (.+)_test\.go
       - linters:
+          - goconst
+        path: cmd/clusterawsadm/
+      - linters:
+          - goconst
+        path: pkg/cloud/services/network/enis.go
+      - linters:
+          - goconst
+        path: pkg/cloud/services/securitygroup/securitygroups.go
+      - linters:
+          - goconst
+        path: test/helpers/kubernetesversions/template.go
+      - linters:
+          - gosec
+        path: cmd/clusterawsadm/cloudformation/bootstrap/
+        text: "G101: Potential hardcoded credentials"
+      - linters:
+          - prealloc
+        path: _test\.go
+      - linters:
+          - prealloc
+        path: cmd/clusterawsadm/
+      - linters:
+          - prealloc
+        path: pkg/cloud/services/ec2/dedicatedhosts.go
+      - linters:
+          - prealloc
+        path: pkg/cloud/services/eks/cluster.go
+      - linters:
           - staticcheck
         text: 'SA1019: "sigs.k8s.io/cluster-api/(.*)" is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
       - linters:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 # https://suva.sh/posts/well-documented-makefiles
 
 # Go
-GO_VERSION ?=1.24.7
-GO_DIRECTIVE_VERSION ?= 1.24.0
+GO_VERSION ?=1.25.12
+GO_DIRECTIVE_VERSION ?= 1.25.0
 GO_CONTAINER_IMAGE ?= golang:$(GO_VERSION)
 
 # Directories.

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -43,7 +43,7 @@ func AWSMachineFuzzer(obj *AWSMachine, c randfill.Continue) {
 	if obj.Spec.Subnet != nil {
 		obj.Spec.Subnet.ARN = nil
 	}
-	restored := make([]AWSResourceReference, len(obj.Spec.AdditionalSecurityGroups))
+	restored := make([]AWSResourceReference, 0, len(obj.Spec.AdditionalSecurityGroups))
 	for _, sg := range obj.Spec.AdditionalSecurityGroups {
 		sg.ARN = nil
 		restored = append(restored, sg)
@@ -59,7 +59,7 @@ func AWSMachineTemplateFuzzer(obj *AWSMachineTemplate, c randfill.Continue) {
 	if obj.Spec.Template.Spec.Subnet != nil {
 		obj.Spec.Template.Spec.Subnet.ARN = nil
 	}
-	restored := make([]AWSResourceReference, len(obj.Spec.Template.Spec.AdditionalSecurityGroups))
+	restored := make([]AWSResourceReference, 0, len(obj.Spec.Template.Spec.AdditionalSecurityGroups))
 	for _, sg := range obj.Spec.Template.Spec.AdditionalSecurityGroups {
 		sg.ARN = nil
 		restored = append(restored, sg)

--- a/api/v1beta1/network_types.go
+++ b/api/v1beta1/network_types.go
@@ -295,7 +295,7 @@ func (s Subnets) ToMap() map[string]*SubnetSpec {
 
 // IDs returns a slice of the subnet ids.
 func (s Subnets) IDs() []string {
-	res := []string{}
+	res := make([]string, 0, len(s))
 	for _, subnet := range s {
 		res = append(res, subnet.ID)
 	}

--- a/api/v1beta2/defaults.go
+++ b/api/v1beta2/defaults.go
@@ -22,11 +22,16 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 )
 
+const (
+	defaultIPv4ZeroCIDR = "0.0.0.0/0"
+	defaultIPv6ZeroCIDR = "::/0"
+)
+
 // SetDefaults_Bastion is used by defaulter-gen.
 func SetDefaults_Bastion(obj *Bastion) { //nolint:golint,stylecheck
 	// Default to allow open access to the bastion host if no CIDR Blocks have been set
 	if len(obj.AllowedCIDRBlocks) == 0 && !obj.DisableIngressRules {
-		obj.AllowedCIDRBlocks = []string{"0.0.0.0/0", "::/0"}
+		obj.AllowedCIDRBlocks = []string{defaultIPv4ZeroCIDR, defaultIPv6ZeroCIDR}
 	}
 }
 

--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -803,7 +803,7 @@ func (s Subnets) IDs() []string {
 
 // IDsWithEdge returns a slice of the subnet ids.
 func (s Subnets) IDsWithEdge() []string {
-	res := []string{}
+	res := make([]string, 0, len(s))
 	for _, subnet := range s {
 		res = append(res, subnet.GetResourceID())
 	}

--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -50,7 +50,11 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
-const eksConfigKind = "EKSConfig"
+const (
+	eksConfigKind              = "EKSConfig"
+	kindMachine                = "Machine"
+	kindAWSManagedControlPlane = "AWSManagedControlPlane"
+)
 
 // EKSConfigReconciler reconciles a EKSConfig object.
 type EKSConfigReconciler struct {
@@ -151,7 +155,7 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 	log := logger.FromContext(ctx)
 
 	// only need to reconcile the secret for Machine kinds once, but MachinePools need updates for new launch templates
-	if config.Status.DataSecretName != nil && configOwner.GetKind() == "Machine" {
+	if config.Status.DataSecretName != nil && configOwner.GetKind() == kindMachine {
 		secretKey := client.ObjectKey{Namespace: config.Namespace, Name: *config.Status.DataSecretName}
 		log = log.WithValues("data-secret-name", secretKey.Name)
 		existingSecret := &corev1.Secret{}
@@ -168,7 +172,7 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 		}
 	}
 
-	if !cluster.Spec.ControlPlaneRef.IsDefined() || cluster.Spec.ControlPlaneRef.Kind != "AWSManagedControlPlane" {
+	if !cluster.Spec.ControlPlaneRef.IsDefined() || cluster.Spec.ControlPlaneRef.Kind != kindAWSManagedControlPlane {
 		return errors.New("Cluster's controlPlaneRef needs to be an AWSManagedControlPlane in order to use the EKS bootstrap provider")
 	}
 

--- a/bootstrap/eks/controllers/nodeadmconfig_controller.go
+++ b/bootstrap/eks/controllers/nodeadmconfig_controller.go
@@ -152,7 +152,7 @@ func (r *NodeadmConfigReconciler) joinWorker(ctx context.Context, cluster *clust
 	log := logger.FromContext(ctx)
 
 	// only need to reconcile the secret for Machine kinds once, but MachinePools need updates for new launch templates
-	if config.Status.DataSecretName != nil && configOwner.GetKind() == "Machine" {
+	if config.Status.DataSecretName != nil && configOwner.GetKind() == kindMachine {
 		secretKey := client.ObjectKey{Namespace: config.Namespace, Name: *config.Status.DataSecretName}
 		log = log.WithValues("data-secret-name", secretKey.Name)
 		existingSecret := &corev1.Secret{}
@@ -168,7 +168,7 @@ func (r *NodeadmConfigReconciler) joinWorker(ctx context.Context, cluster *clust
 		}
 	}
 
-	if cluster.Spec.ControlPlaneRef.Kind != "AWSManagedControlPlane" {
+	if cluster.Spec.ControlPlaneRef.Kind != kindAWSManagedControlPlane {
 		return ctrl.Result{}, errors.New("Cluster's controlPlaneRef needs to be an AWSManagedControlPlane in order to use the EKS bootstrap provider")
 	}
 

--- a/bootstrap/eks/internal/userdata/nodeadm.go
+++ b/bootstrap/eks/internal/userdata/nodeadm.go
@@ -172,7 +172,7 @@ func NewNodeadmUserdata(input *NodeadmInput) ([]byte, error) {
 	var buf bytes.Buffer
 
 	// Write MIME header
-	if _, err := buf.WriteString(fmt.Sprintf("MIME-Version: 1.0\nContent-Type: multipart/mixed; boundary=%q\n\n", input.Boundary)); err != nil {
+	if _, err := fmt.Fprintf(&buf, "MIME-Version: 1.0\nContent-Type: multipart/mixed; boundary=%q\n\n", input.Boundary); err != nil {
 		return nil, fmt.Errorf("failed to write MIME header: %v", err)
 	}
 

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -61,6 +61,10 @@ import (
 
 const (
 	deleteRequeueAfter = 20 * time.Second
+
+	kindAWSCluster = "AWSCluster"
+	kindAWSMachine = "AWSMachine"
+	kindCluster    = "Cluster"
 )
 
 var defaultAWSSecurityGroupRoles = []infrav1.SecurityGroupRole{
@@ -438,7 +442,7 @@ func (r *AWSClusterReconciler) requeueAWSClusterForUnpausedCluster(_ context.Con
 			return nil
 		}
 
-		if c.Spec.InfrastructureRef.Kind != "AWSCluster" {
+		if c.Spec.InfrastructureRef.Kind != kindAWSCluster {
 			log.Trace("Cluster has an InfrastructureRef for a different type, skipping mapping.")
 			return nil
 		}

--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -258,7 +258,7 @@ func (r *AWSMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 		For(&infrav1.AWSMachine{}).
 		Watches(
 			&clusterv1.Machine{},
-			handler.EnqueueRequestsFromMapFunc(util.MachineToInfrastructureMapFunc(infrav1.GroupVersion.WithKind("AWSMachine"))),
+			handler.EnqueueRequestsFromMapFunc(util.MachineToInfrastructureMapFunc(infrav1.GroupVersion.WithKind(kindAWSMachine))),
 		).
 		Watches(
 			&infrav1.AWSCluster{},
@@ -270,7 +270,7 @@ func (r *AWSMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 				// Avoid reconciling if the event triggering the reconciliation is related to incremental status updates
 				// for AWSMachine resources only
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					if e.ObjectOld.GetObjectKind().GroupVersionKind().Kind != "AWSMachine" {
+					if e.ObjectOld.GetObjectKind().GroupVersionKind().Kind != kindAWSMachine {
 						return true
 					}
 
@@ -1209,7 +1209,7 @@ func (r *AWSMachineReconciler) requestsForCluster(log logger.Wrapper, namespace,
 	result := make([]ctrl.Request, 0, len(machineList.Items))
 	for _, m := range machineList.Items {
 		log.WithValues("machine", klog.KObj(&m))
-		if m.Spec.InfrastructureRef.Kind != "AWSMachine" {
+		if m.Spec.InfrastructureRef.Kind != kindAWSMachine {
 			log.Trace("Machine has an InfrastructureRef for a different type, will not add to reconciliation request.")
 			continue
 		}
@@ -1229,7 +1229,7 @@ func (r *AWSMachineReconciler) getInfraCluster(ctx context.Context, log *logger.
 	var managedControlPlaneScope *scope.ManagedControlPlaneScope
 	var err error
 
-	if cluster.Spec.ControlPlaneRef.IsDefined() && cluster.Spec.ControlPlaneRef.Kind == "AWSManagedControlPlane" {
+	if cluster.Spec.ControlPlaneRef.IsDefined() && cluster.Spec.ControlPlaneRef.Kind == AWSManagedControlPlaneRefKind {
 		controlPlane := &ekscontrolplanev1.AWSManagedControlPlane{}
 		controlPlaneName := client.ObjectKey{
 			Namespace: awsMachine.Namespace,

--- a/controllers/awsmachinetemplate_controller.go
+++ b/controllers/awsmachinetemplate_controller.go
@@ -54,6 +54,8 @@ import (
 const (
 	// awsMachineTemplateKind is the Kind name for AWSMachineTemplate resources.
 	awsMachineTemplateKind = "AWSMachineTemplate"
+
+	kindKubeadmControlPlane = "KubeadmControlPlane"
 )
 
 // AWSMachineTemplateReconciler reconciles AWSMachineTemplate objects.
@@ -89,7 +91,7 @@ func (r *AWSMachineTemplateReconciler) SetupWithManager(ctx context.Context, mgr
 		)
 
 	// Watch KubeadmControlPlane if they exist.
-	if _, err := mgr.GetRESTMapper().RESTMapping(schema.GroupKind{Group: controlplanev1.GroupVersion.Group, Kind: "KubeadmControlPlane"}, controlplanev1.GroupVersion.Version); err == nil {
+	if _, err := mgr.GetRESTMapper().RESTMapping(schema.GroupKind{Group: controlplanev1.GroupVersion.Group, Kind: kindKubeadmControlPlane}, controlplanev1.GroupVersion.Version); err == nil {
 		b = b.Watches(&controlplanev1.KubeadmControlPlane{},
 			handler.EnqueueRequestsFromMapFunc(r.kubeadmControlPlaneToAWSMachineTemplate),
 			// Only emit events for creation to reconcile in case the KubeadmControlPlane got created after the AWSMachineTemplate was reconciled.
@@ -212,7 +214,7 @@ func (r *AWSMachineTemplateReconciler) getRegion(ctx context.Context, cluster *c
 	}
 
 	// Get region from AWSCluster (standard EC2-based cluster)
-	if cluster.Spec.InfrastructureRef.IsDefined() && cluster.Spec.InfrastructureRef.Kind == "AWSCluster" {
+	if cluster.Spec.InfrastructureRef.IsDefined() && cluster.Spec.InfrastructureRef.Kind == kindAWSCluster {
 		awsCluster := &infrav1.AWSCluster{}
 		if err := r.Get(ctx, client.ObjectKey{
 			Namespace: cluster.Namespace,
@@ -227,7 +229,7 @@ func (r *AWSMachineTemplateReconciler) getRegion(ctx context.Context, cluster *c
 	}
 
 	// Get region from AWSManagedControlPlane (EKS cluster)
-	if cluster.Spec.ControlPlaneRef.IsDefined() && cluster.Spec.ControlPlaneRef.Kind == "AWSManagedControlPlane" {
+	if cluster.Spec.ControlPlaneRef.IsDefined() && cluster.Spec.ControlPlaneRef.Kind == AWSManagedControlPlaneRefKind {
 		awsManagedCP := &ekscontrolplanev1.AWSManagedControlPlane{}
 		if err := r.Get(ctx, client.ObjectKey{
 			Namespace: cluster.Namespace,
@@ -455,7 +457,7 @@ func getParentListOptions(obj metav1.ObjectMeta) ([]client.ListOption, error) {
 	}
 
 	for _, ref := range obj.GetOwnerReferences() {
-		if ref.Kind != "Cluster" {
+		if ref.Kind != kindCluster {
 			continue
 		}
 		gv, err := schema.ParseGroupVersion(ref.APIVersion)

--- a/controllers/rosacluster_controller.go
+++ b/controllers/rosacluster_controller.go
@@ -50,6 +50,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
+const kindROSACluster = "ROSACluster"
+
 // ROSAClusterReconciler reconciles ROSACluster.
 type ROSAClusterReconciler struct {
 	client.Client
@@ -166,7 +168,7 @@ func (r *ROSAClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	// Add a watch for clusterv1.Cluster unpaise
 	if err = controller.Watch(
 		source.Kind[client.Object](mgr.GetCache(), &clusterv1.Cluster{},
-			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("ROSACluster"), mgr.GetClient(), &expinfrav1.ROSACluster{})),
+			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind(kindROSACluster), mgr.GetClient(), &expinfrav1.ROSACluster{})),
 			predicates.ClusterPausedTransitions(mgr.GetScheme(), log.GetLogger())),
 	); err != nil {
 		return fmt.Errorf("failed adding a watch for ready clusters: %w", err)
@@ -214,7 +216,7 @@ func (r *ROSAClusterReconciler) rosaControlPlaneToManagedCluster(log *logger.Log
 		}
 
 		rosaClusterRef := cluster.Spec.InfrastructureRef
-		if !rosaClusterRef.IsDefined() || rosaClusterRef.Kind != "ROSACluster" {
+		if !rosaClusterRef.IsDefined() || rosaClusterRef.Kind != kindROSACluster {
 			log.Info("InfrastructureRef is not defined or not ROSACluster, skipping mapping")
 			return nil
 		}

--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller_test.go
@@ -337,7 +337,7 @@ func mockedCallsForMissingEverything(ec2Rec *mocks.MockEC2APIMockRecorder, subne
 		Subnets: []ec2types.Subnet{},
 	}, nil)
 
-	zones := []ec2types.AvailabilityZone{}
+	zones := make([]ec2types.AvailabilityZone, 0, len(subnets))
 	for _, subnet := range subnets {
 		zones = append(zones, ec2types.AvailabilityZone{
 			ZoneName: aws.String(subnet.AvailabilityZone),

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -77,6 +77,7 @@ import (
 )
 
 const (
+	kubeSystemNamespace  = "kube-system"
 	rosaControlPlaneKind = "ROSAControlPlane"
 	// ROSAControlPlaneFinalizer allows the controller to clean up resources on delete.
 	ROSAControlPlaneFinalizer = "rosacontrolplane.controlplane.cluster.x-k8s.io"
@@ -629,7 +630,7 @@ func findExistingLogForwarders(ocmClient rosa.OCMClient, clusterID string) (cwLo
 
 // buildGroups converts a slice of group IDs into LogForwarderGroupBuilder objects.
 func buildGroups(ids []string) []*cmv1.LogForwarderGroupBuilder {
-	groups := make([]*cmv1.LogForwarderGroupBuilder, 0)
+	groups := make([]*cmv1.LogForwarderGroupBuilder, 0, len(ids))
 	for _, id := range ids {
 		groups = append(groups, cmv1.NewLogForwarderGroup().ID(id))
 	}
@@ -1404,22 +1405,22 @@ func operatorIAMRoles(rolesRef rosacontrolplanev1.AWSRolesRef) []ocm.OperatorIAM
 		},
 		{
 			Name:      "kube-controller-manager",
-			Namespace: "kube-system",
+			Namespace: kubeSystemNamespace,
 			RoleARN:   rolesRef.KubeCloudControllerARN,
 		},
 		{
 			Name:      "kms-provider",
-			Namespace: "kube-system",
+			Namespace: kubeSystemNamespace,
 			RoleARN:   rolesRef.KMSProviderARN,
 		},
 		{
 			Name:      "control-plane-operator",
-			Namespace: "kube-system",
+			Namespace: kubeSystemNamespace,
 			RoleARN:   rolesRef.ControlPlaneOperatorARN,
 		},
 		{
 			Name:      "capa-controller-manager",
-			Namespace: "kube-system",
+			Namespace: kubeSystemNamespace,
 			RoleARN:   rolesRef.NodePoolManagementARN,
 		},
 	}

--- a/docs/book/src/SUMMARY_SUFFIX.md
+++ b/docs/book/src/SUMMARY_SUFFIX.md
@@ -4,6 +4,7 @@
   - [Coding Conventions](./development/conventions.md)
   - [Try unreleased changes with Nightly Builds](./development/nightlies.md)
   - [Publishing AMIs](./development/amis.md)
+  - [Bumping Go](./development/bump-go.md)
 - [CRD Reference](./crd/index.md)
 - [Reference](./topics/reference/reference.md)
   - [Glossary](./topics/reference/glossary.md)

--- a/docs/book/src/development/bump-go.md
+++ b/docs/book/src/development/bump-go.md
@@ -1,0 +1,194 @@
+# Bumping Go
+
+This document describes how to bump the Go version across the project. It is
+primarily intended to be consumed by an AI coding agent (e.g. via
+`/bump-go 1.26`), but the steps can also be followed manually.
+
+## Convention
+
+- `go` directive in `go.mod`: use `X.Y.0` (the minor version with patch `0`)
+- `GO_VERSION` in Makefile: use `X.Y.Z` where Z is the **latest available
+  patch** (e.g. `1.26.4`)
+
+## Step 1: Research
+
+Perform these lookups before making any changes.
+
+### 1a. Latest patch version
+
+Find the latest Go `X.Y.x` patch release at <https://go.dev/doc/devel/release>.
+Determine the full version string (e.g. `1.26.4`). Call this `FULL_VERSION`.
+
+### 1b. Upstream cluster-api references
+
+Look up what `kubernetes-sigs/cluster-api` uses at the latest release tag on the
+main CAPI minor version this project depends on (check `go.mod` for
+`sigs.k8s.io/cluster-api` to find the CAPI minor, then find the latest tag for
+that minor):
+
+```bash
+# GCB image digest + tag comment
+curl -sL https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/<TAG>/cloudbuild.yaml
+
+# golangci-lint version
+curl -sL https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/<TAG>/.github/workflows/pr-golangci-lint.yaml \
+  | grep 'version:'
+```
+
+Call these `GCB_DIGEST`, `GCB_TAG_COMMENT`, and `CAPI_GOLANGCI_VER`.
+
+### 1c. golangci-lint compatibility
+
+The golangci-lint version must be **built with the target Go version** or newer.
+Versions built with an older Go will refuse to lint. Test candidate versions:
+
+```bash
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@<VERSION> version
+```
+
+Look for `built with goX.Y` in the output. Pick the latest stable version that
+reports the target Go minor or newer. Call this `GOLANGCI_VERSION` (e.g.
+`v2.12.2`).
+
+## Step 2: Update files
+
+### go.mod (root) and hack/tools/go.mod
+
+Update the `go` directive:
+
+```
+go X.Y.0
+```
+
+### Makefile
+
+```makefile
+GO_VERSION ?= FULL_VERSION
+GO_DIRECTIVE_VERSION ?= X.Y.0
+```
+
+### .golangci-kal.yml
+
+Update the `go:` field under `run:`:
+
+```yaml
+run:
+  go: "X.Y"
+```
+
+### hack/tools/Makefile
+
+Update `GOLANGCI_LINT_VERSION` and the comment:
+
+```makefile
+# Use a golangci-lint built with Go >= X.Y to match repo go.mod
+GOLANGCI_LINT_VERSION := GOLANGCI_VERSION
+```
+
+### hack/tools/.custom-gcl.yaml
+
+Update the `version:` field used to build the custom KAL linter:
+
+```yaml
+version: GOLANGCI_VERSION
+```
+
+### .github/workflows/pr-golangci-lint.yaml
+
+Update the golangci-lint `version:`:
+
+```yaml
+version: GOLANGCI_VERSION
+```
+
+(The `go-version` in this workflow is already derived dynamically via
+`make go-version`, so it does not need a manual update.)
+
+### .github/workflows/dependabot.yml
+
+Update the `go-version:` field:
+
+```yaml
+go-version: 'X.Y'
+```
+
+### .github/workflows/release.yaml
+
+Update the `go-version:` field:
+
+```yaml
+go-version: 'X.Y'
+```
+
+### netlify.toml
+
+```toml
+GO_VERSION = "FULL_VERSION"
+```
+
+### cloudbuild.yaml and cloudbuild-nightly.yaml
+
+Only update if the upstream CAPI release tag uses a **different** GCB image
+digest than what this repo already has. If they match, skip this file.
+
+```yaml
+- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:GCB_DIGEST' # GCB_TAG_COMMENT
+```
+
+## Step 3: go mod tidy
+
+Run in both module directories:
+
+```bash
+go mod tidy
+cd hack/tools && go mod tidy
+```
+
+## Step 4: Lint and test
+
+```bash
+make lint
+make lint-api
+make test
+```
+
+If `make lint` or `make lint-api` fails:
+- If the failure is `the Go language version used to build golangci-lint is
+  lower than the targeted Go version`, the chosen `GOLANGCI_VERSION` is wrong.
+  Go back to Step 1c. For `make lint-api`, also check
+  `hack/tools/.custom-gcl.yaml`.
+- If the failure shows new lint findings, fix them. These are pre-existing
+  issues surfaced by the newer linter version, not caused by the Go bump itself.
+- If a new linter version produces noisy false positives (e.g. `prealloc` on
+  idiomatic `var allErrs field.ErrorList` patterns), add targeted exclusion
+  rules in `.golangci.yml` rather than suppressing the linter entirely.
+
+## Step 5: Verify build
+
+```bash
+go build ./...
+```
+
+## Step 6: Commit
+
+Create **three separate commits** in this order:
+
+1. **Lint fixes** (if any): `fix(lint): resolve <linter-names> lint issues`
+   - Only the source files with lint fixes
+2. **Linter bump** (if version changed):
+   `chore(bump): bump golangci-lint from <old> to <new>`
+   - `hack/tools/Makefile`, `hack/tools/.custom-gcl.yaml`,
+     `.github/workflows/pr-golangci-lint.yaml`, and `.golangci.yml` if
+     exclusion rules were added
+3. **Go version bump**: `chore(bump): bump Go to FULL_VERSION`
+   - All remaining files: `go.mod`, `hack/tools/go.mod`, `Makefile`,
+     `.golangci-kal.yml`, `.github/workflows/dependabot.yml`,
+     `.github/workflows/release.yaml`, `netlify.toml`,
+     `cloudbuild.yaml`, `cloudbuild-nightly.yaml`
+
+If there are no lint fixes or no linter version change, skip that commit.
+
+All commits must be signed off (`git commit -s`).
+
+Do NOT push or create a PR unless the user asks. If a PR is created, use the
+pull request template defined in `.github/PULL_REQUEST_TEMPLATE.md`.

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -62,6 +62,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
+const kindMachinePool = "MachinePool"
+
 // AWSMachinePoolReconciler reconciles a AWSMachinePool object.
 type AWSMachinePoolReconciler struct {
 	client.Client
@@ -694,7 +696,7 @@ func diffASG(machinePoolScope *scope.MachinePoolScope, existingASG *expinfrav1.A
 // getOwnerMachinePool returns the MachinePool object owning the current resource.
 func getOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*clusterv1.MachinePool, error) {
 	for _, ref := range obj.OwnerReferences {
-		if ref.Kind != "MachinePool" {
+		if ref.Kind != kindMachinePool {
 			continue
 		}
 		gv, err := schema.ParseGroupVersion(ref.APIVersion)

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -472,7 +472,7 @@ func nodePoolBuilder(rosaMachinePoolSpec expinfrav1.RosaMachinePoolSpec, machine
 	}
 
 	if len(rosaMachinePoolSpec.Taints) > 0 {
-		taintBuilders := []*cmv1.TaintBuilder{}
+		taintBuilders := make([]*cmv1.TaintBuilder, 0, len(rosaMachinePoolSpec.Taints))
 		for _, taint := range rosaMachinePoolSpec.Taints {
 			newTaintBuilder := cmv1.NewTaint().Key(taint.Key).Value(taint.Value).Effect(string(taint.Effect))
 			taintBuilders = append(taintBuilders, newTaintBuilder)
@@ -574,7 +574,7 @@ func (r *ROSAMachinePoolReconciler) reconcileProviderIDList(ctx context.Context,
 }
 
 func buildEC2FiltersFromTags(tags map[string]string) []ec2types.Filter {
-	filters := make([]ec2types.Filter, len(tags)+1)
+	filters := make([]ec2types.Filter, 0, len(tags)+1)
 	for key, value := range tags {
 		filters = append(filters, ec2types.Filter{
 			Name: ptr.To(fmt.Sprintf("tag:%s", key)),

--- a/exp/controllers/rosanetwork_controller.go
+++ b/exp/controllers/rosanetwork_controller.go
@@ -48,6 +48,11 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
+const (
+	cfnResourceTypeSubnet = "AWS::EC2::Subnet"
+	validationError       = "ValidationError"
+)
+
 // ROSANetworkReconciler reconciles a ROSANetwork object.
 type ROSANetworkReconciler struct {
 	client.Client
@@ -96,7 +101,7 @@ func (r *ROSANetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	cfStack, err := awsClient.GetCFStack(ctx, rosaNetworkScope.ROSANetwork.Spec.StackName)
 	if err != nil {
 		var apiErr smithy.APIError // in case the stack does not exist, AWS returns ValidationError
-		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "ValidationError" {
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == validationError {
 			cfStack = nil
 		} else {
 			return ctrl.Result{}, fmt.Errorf("error fetching CF stack details: %w", err)
@@ -275,7 +280,7 @@ func (r *ROSANetworkReconciler) parseSubnets(rosaNet *expinfrav1.ROSANetwork, aw
 	subnets := make(map[string]expinfrav1.ROSANetworkSubnet)
 
 	for _, resource := range rosaNet.Status.Resources {
-		if resource.ResourceType != "AWS::EC2::Subnet" {
+		if resource.ResourceType != cfnResourceTypeSubnet {
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/v2
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/alessio/shellescape v1.4.2

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -1,4 +1,4 @@
-version: v2.7.0
+version: v2.12.2
 name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -45,8 +45,8 @@ ifeq ($(OS), windows)
 	MDBOOK_EXTRACT_COMMAND := unzip -d /tmp
 endif
 
-# Use a golangci-lint built with Go >= 1.24 to match repo go.mod
-GOLANGCI_LINT_VERSION := v1.60.3
+# Use a golangci-lint built with Go >= 1.25 to match repo go.mod
+GOLANGCI_LINT_VERSION := v2.12.2
 ## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/hack/tools
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/a8m/envsubst v1.4.3

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.23.7"
+    GO_VERSION = "1.25.12"
 
 # Standard Netlify redirects
 [[redirects]]

--- a/pkg/cloud/converters/eks.go
+++ b/pkg/cloud/converters/eks.go
@@ -65,7 +65,7 @@ func AddonSDKToAddonState(eksAddon *ekstypes.Addon) *ekscontrolplanev1.AddonStat
 
 // FromAWSStringSlice will converts an AWS string pointer slice.
 func FromAWSStringSlice(from []*string) []string {
-	converted := []string{}
+	converted := make([]string, 0, len(from))
 	for _, s := range from {
 		converted = append(converted, *s)
 	}
@@ -189,11 +189,11 @@ func NodegroupUpdateconfigToSDK(updateConfig *expinfrav1.UpdateConfig) (*ekstype
 
 	converted := &ekstypes.NodegroupUpdateConfig{}
 	if updateConfig.MaxUnavailable != nil {
-		//nolint:G115 // Added golint exception as there is a kubebuilder validation configured
+		//nolint:gosec // G115: value is bounded by kubebuilder validation on the CRD field
 		converted.MaxUnavailable = aws.Int32(int32(*updateConfig.MaxUnavailable))
 	}
 	if updateConfig.MaxUnavailablePercentage != nil {
-		//nolint:G115 // Added golint exception as there is a kubebuilder validation configured
+		//nolint:gosec // G115: value is bounded by kubebuilder validation on the CRD field
 		converted.MaxUnavailablePercentage = aws.Int32(int32(*updateConfig.MaxUnavailablePercentage))
 	}
 

--- a/pkg/cloud/scope/session_test.go
+++ b/pkg/cloud/scope/session_test.go
@@ -365,7 +365,7 @@ func TestPrincipalParsing(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "static-identity",
 					},
-					Spec: infrav1.AWSClusterStaticIdentitySpec{
+					Spec: infrav1.AWSClusterStaticIdentitySpec{ //nolint:gosec // G101: test fixture, not real credentials
 						SecretRef: "static-credentials-secret",
 						AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
 							AllowedNamespaces: &infrav1.AllowedNamespaces{},
@@ -440,7 +440,7 @@ func TestPrincipalParsing(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "static-identity",
 					},
-					Spec: infrav1.AWSClusterStaticIdentitySpec{
+					Spec: infrav1.AWSClusterStaticIdentitySpec{ //nolint:gosec // G101: test fixture, not real credentials
 						SecretRef: "static-credentials-secret",
 						AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
 							AllowedNamespaces: &infrav1.AllowedNamespaces{},

--- a/pkg/cloud/scope/test_helpers.go
+++ b/pkg/cloud/scope/test_helpers.go
@@ -21,46 +21,53 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	infrastructureGroupName    = "infrastructure.cluster.x-k8s.io"
+	versionV1Beta2             = "v1beta2"
+	kindAWSCluster             = "AWSCluster"
+	kindAWSClusterRoleIdentity = "AWSClusterRoleIdentity"
+)
+
 // newTestRESTMapper creates a RESTMapper for tests that knows about CAPA resource types.
 func newTestRESTMapper() meta.RESTMapper {
 	rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{
-		{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2"},
+		{Group: infrastructureGroupName, Version: versionV1Beta2},
 		{Group: "", Version: "v1"},
 	})
 
 	rm.Add(schema.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
-		Kind:    "AWSCluster",
+		Group:   infrastructureGroupName,
+		Version: versionV1Beta2,
+		Kind:    kindAWSCluster,
 	}, meta.RESTScopeNamespace)
 
 	rm.Add(schema.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
+		Group:   infrastructureGroupName,
+		Version: versionV1Beta2,
 		Kind:    "ROSANetwork",
 	}, meta.RESTScopeNamespace)
 
 	rm.Add(schema.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
-		Kind:    "AWSClusterRoleIdentity",
+		Group:   infrastructureGroupName,
+		Version: versionV1Beta2,
+		Kind:    kindAWSClusterRoleIdentity,
 	}, meta.RESTScopeRoot)
 
 	rm.Add(schema.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
+		Group:   infrastructureGroupName,
+		Version: versionV1Beta2,
 		Kind:    "AWSClusterStaticIdentity",
 	}, meta.RESTScopeRoot)
 
 	rm.Add(schema.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
+		Group:   infrastructureGroupName,
+		Version: versionV1Beta2,
 		Kind:    "AWSClusterControllerIdentity",
 	}, meta.RESTScopeRoot)
 
 	rm.Add(schema.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
+		Group:   infrastructureGroupName,
+		Version: versionV1Beta2,
 		Kind:    "ROSAOCMRoleConfig",
 	}, meta.RESTScopeRoot)
 

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -503,7 +503,7 @@ func (s *Service) ResumeProcesses(name string, processes []string) error {
 }
 
 func mapToTags(input map[string]string, resourceID *string) []autoscalingtypes.Tag {
-	tags := make([]autoscalingtypes.Tag, 0)
+	tags := make([]autoscalingtypes.Tag, 0, len(input))
 	for k, v := range input {
 		tags = append(tags, autoscalingtypes.Tag{
 			Key:               aws.String(k),

--- a/pkg/cloud/services/ec2/ami.go
+++ b/pkg/cloud/services/ec2/ami.go
@@ -76,6 +76,12 @@ const (
 	// 4. a `-` followed by any additional characters.
 	DefaultAmiNameFormat = "capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*"
 
+	// amiStateAvailable is the state value for available AMIs.
+	amiStateAvailable = "available"
+
+	// virtualizationTypeHVM is the virtualization type for HVM AMIs.
+	virtualizationTypeHVM = "hvm"
+
 	// Amazon's AMI timestamp format.
 	createDateTimestampFormat = "2006-01-02T15:04:05.000Z"
 
@@ -219,11 +225,11 @@ func DefaultAMILookup(ec2Client common.EC2API, ownerID, baseOS, kubernetesVersio
 			},
 			{
 				Name:   aws.String("state"),
-				Values: []string{"available"},
+				Values: []string{amiStateAvailable},
 			},
 			{
 				Name:   aws.String("virtualization-type"),
-				Values: []string{"hvm"},
+				Values: []string{virtualizationTypeHVM},
 			},
 		},
 	}
@@ -293,15 +299,15 @@ func (s *Service) defaultBastionAMILookup() (string, error) {
 		Filters: []ec2types.Filter{
 			{
 				Name:   aws.String("architecture"),
-				Values: []string{"x86_64"},
+				Values: []string{Amd64ArchitectureTag},
 			},
 			{
 				Name:   aws.String("state"),
-				Values: []string{"available"},
+				Values: []string{amiStateAvailable},
 			},
 			{
 				Name:   aws.String("virtualization-type"),
-				Values: []string{"hvm"},
+				Values: []string{virtualizationTypeHVM},
 			},
 			{
 				Name:   aws.String("description"),

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -44,6 +44,11 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 )
 
+const (
+	defaultRegion = "us-east-1"
+	nodeRole      = "node"
+)
+
 // GetRunningInstanceByTags returns the existing instance or nothing if it doesn't exist.
 func (s *Service) GetRunningInstanceByTags(scope *scope.MachineScope) (*infrav1.Instance, error) {
 	s.scope.Debug("Looking for existing machine instance by tags")
@@ -490,7 +495,7 @@ func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, er
 	}
 
 	switch scope.Role() {
-	case "node":
+	case nodeRole:
 		// Just the common security groups above
 		if scope.IsEKSManaged() {
 			sgRoles = append(sgRoles, infrav1.SecurityGroupEKSNodeAdditional)
@@ -1228,8 +1233,8 @@ func (s *Service) GetDHCPOptionSetDomainName(ec2client common.EC2API, vpcID *str
 			}
 			domainName := dhcpConfig.Values[0].Value
 			// default domainName is 'ec2.internal' in us-east-1 and 'region.compute.internal' in the other regions.
-			if (s.scope.Region() == "us-east-1" && aws.ToString(domainName) == "ec2.internal") ||
-				(s.scope.Region() != "us-east-1" && aws.ToString(domainName) == fmt.Sprintf("%s.compute.internal", s.scope.Region())) {
+			if (s.scope.Region() == defaultRegion && aws.ToString(domainName) == "ec2.internal") ||
+				(s.scope.Region() != defaultRegion && aws.ToString(domainName) == fmt.Sprintf("%s.compute.internal", s.scope.Region())) {
 				return nil
 			}
 

--- a/pkg/cloud/services/eks/addons.go
+++ b/pkg/cloud/services/eks/addons.go
@@ -180,19 +180,19 @@ func (s *Service) listAddons(ctx context.Context, eksClusterName string) ([]stri
 		ClusterName: &eksClusterName,
 	}
 
-	addons := []string{}
 	output, err := s.EKSClient.ListAddons(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("listing eks addons: %w", err)
 	}
 
+	addons := make([]string, 0, len(output.Addons))
 	addons = append(addons, output.Addons...)
 
 	return addons, nil
 }
 
 func (s *Service) translateAPIToAddon(addons []ekscontrolplanev1.Addon) []*eksaddons.EKSAddon {
-	converted := []*eksaddons.EKSAddon{}
+	converted := make([]*eksaddons.EKSAddon, 0, len(addons))
 
 	for i := range addons {
 		addon := addons[i]

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -670,9 +670,14 @@ func (s *Service) reconcileLogging(ctx context.Context, logging *ekstypes.Loggin
 	return nil
 }
 
+const (
+	defaultIPv4ZeroCIDR = "0.0.0.0/0"
+	defaultIPv6ZeroCIDR = "::/0"
+)
+
 func publicAccessCIDRsEqual(as []string, bs []string) bool {
-	allV4 := "0.0.0.0/0"
-	allV6 := "::/0"
+	allV4 := defaultIPv4ZeroCIDR
+	allV6 := defaultIPv6ZeroCIDR
 	asDefault := false
 	bsDefault := false
 

--- a/pkg/cloud/services/eks/iam/iam.go
+++ b/pkg/cloud/services/eks/iam/iam.go
@@ -44,6 +44,10 @@ import (
 const (
 	// EKSFargateService is the service to trust for fargate pod execution roles.
 	EKSFargateService = "eks-fargate-pods.amazonaws.com"
+
+	iamPolicyVersion    = "2012-10-17"
+	iamEffectAllow      = "Allow"
+	iamActionAssumeRole = "sts:AssumeRole"
 )
 
 // IAMService defines the specs for an IAM service.
@@ -173,7 +177,7 @@ func (s *IAMService) EnsurePoliciesAttached(ctx context.Context, role *iamtypes.
 // RoleTags returns the tags for the given role.
 func RoleTags(key string, additionalTags infrav1.Tags) []iamtypes.Tag {
 	additionalTags[infrav1.ClusterAWSCloudProviderTagKey(key)] = string(infrav1.ResourceLifecycleOwned)
-	tags := []iamtypes.Tag{}
+	tags := make([]iamtypes.Tag, 0, len(additionalTags))
 	for k, v := range additionalTags {
 		tags = append(tags, iamtypes.Tag{
 			Key:   aws.String(k),
@@ -363,12 +367,12 @@ func ControlPlaneTrustRelationship(enableFargate bool) *iamv1.PolicyDocument {
 	}
 
 	policy := &iamv1.PolicyDocument{
-		Version: "2012-10-17",
+		Version: iamPolicyVersion,
 		Statement: []iamv1.StatementEntry{
 			{
-				Effect: "Allow",
+				Effect: iamEffectAllow,
 				Action: []string{
-					"sts:AssumeRole",
+					iamActionAssumeRole,
 				},
 				Principal: identity,
 			},
@@ -384,12 +388,12 @@ func FargateTrustRelationship() *iamv1.PolicyDocument {
 	identity["Service"] = []string{EKSFargateService}
 
 	policy := &iamv1.PolicyDocument{
-		Version: "2012-10-17",
+		Version: iamPolicyVersion,
 		Statement: []iamv1.StatementEntry{
 			{
-				Effect: "Allow",
+				Effect: iamEffectAllow,
 				Action: []string{
-					"sts:AssumeRole",
+					iamActionAssumeRole,
 				},
 				Principal: identity,
 			},
@@ -405,12 +409,12 @@ func NodegroupTrustRelationship() *iamv1.PolicyDocument {
 	identity["Service"] = []string{"ec2.amazonaws.com"}
 
 	policy := &iamv1.PolicyDocument{
-		Version: "2012-10-17",
+		Version: iamPolicyVersion,
 		Statement: []iamv1.StatementEntry{
 			{
-				Effect: "Allow",
+				Effect: iamEffectAllow,
 				Action: []string{
-					"sts:AssumeRole",
+					iamActionAssumeRole,
 				},
 				Principal: identity,
 			},

--- a/pkg/cloud/services/eks/oidc_test.go
+++ b/pkg/cloud/services/eks/oidc_test.go
@@ -204,7 +204,7 @@ func createTestServer(g *GomegaWithT) *httptest.Server {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Create custom TLS config
-	tlsConfig := &tls.Config{ //nolint:gosec
+	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 	}
 

--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -1357,7 +1357,7 @@ func (s *Service) configureAttributes(ctx context.Context, name string, attribut
 }
 
 func (s *Service) configureLBAttributes(ctx context.Context, arn string, attributes map[string]*string) error {
-	attrs := make([]elbv2types.LoadBalancerAttribute, 0)
+	attrs := make([]elbv2types.LoadBalancerAttribute, 0, len(attributes))
 	for k, v := range attributes {
 		attrs = append(attrs, elbv2types.LoadBalancerAttribute{
 			Key:   aws.String(k),

--- a/pkg/cloud/services/iamauth/configmap_test.go
+++ b/pkg/cloud/services/iamauth/configmap_test.go
@@ -63,7 +63,7 @@ func TestAddRoleMappingCM(t *testing.T) {
 				RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 				KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 					UserName: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			expectedRoleMaps: []ekscontrolplanev1.RoleMapping{
@@ -71,7 +71,7 @@ func TestAddRoleMappingCM(t *testing.T) {
 					RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 						UserName: "system:node:{{EC2PrivateDNSName}}",
-						Groups:   []string{"system:bootstrappers", "system:nodes"},
+						Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 					},
 				},
 			},
@@ -91,7 +91,7 @@ func TestAddRoleMappingCM(t *testing.T) {
 					RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 						UserName: "system:node:{{EC2PrivateDNSName}}",
-						Groups:   []string{"system:bootstrappers", "system:nodes"},
+						Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 					},
 				},
 				{
@@ -111,7 +111,7 @@ func TestAddRoleMappingCM(t *testing.T) {
 				RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 				KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 					UserName: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			expectedRoleMaps: []ekscontrolplanev1.RoleMapping{
@@ -119,7 +119,7 @@ func TestAddRoleMappingCM(t *testing.T) {
 					RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 						UserName: "system:node:{{EC2PrivateDNSName}}",
-						Groups:   []string{"system:bootstrappers", "system:nodes"},
+						Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 					},
 				},
 			},

--- a/pkg/cloud/services/iamauth/crd_test.go
+++ b/pkg/cloud/services/iamauth/crd_test.go
@@ -46,14 +46,14 @@ func TestAddRoleMappingCRD(t *testing.T) {
 				RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 				KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 					UserName: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			expectedRoleMapSpecs: []iamauthv1.IAMIdentityMappingSpec{
 				{
 					ARN:      "arn:aws:iam::000000000000:role/KubernetesNode",
 					Username: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			expectError: false,
@@ -64,7 +64,7 @@ func TestAddRoleMappingCRD(t *testing.T) {
 				RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 				KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 					UserName: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			existingRoleMapping: createIAMAuthMapping("arn:aws:iam::000000000000:role/KubernetesAdmin", "admin:{{SessionName}}", []string{"system:masters"}),
@@ -77,7 +77,7 @@ func TestAddRoleMappingCRD(t *testing.T) {
 				{
 					ARN:      "arn:aws:iam::000000000000:role/KubernetesNode",
 					Username: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			expectError: false,
@@ -88,15 +88,15 @@ func TestAddRoleMappingCRD(t *testing.T) {
 				RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
 				KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 					UserName: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
-			existingRoleMapping: createIAMAuthMapping("arn:aws:iam::000000000000:role/KubernetesNode", "system:node:{{EC2PrivateDNSName}}", []string{"system:bootstrappers", "system:nodes"}),
+			existingRoleMapping: createIAMAuthMapping("arn:aws:iam::000000000000:role/KubernetesNode", "system:node:{{EC2PrivateDNSName}}", []string{systemBootstrappersGroup, systemNodesGroup}),
 			expectedRoleMapSpecs: []iamauthv1.IAMIdentityMappingSpec{
 				{
 					ARN:      "arn:aws:iam::000000000000:role/KubernetesNode",
 					Username: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			expectError: false,
@@ -107,7 +107,7 @@ func TestAddRoleMappingCRD(t *testing.T) {
 				RoleARN: "arn:aws:iam::000000000000:user/Alice",
 				KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 					UserName: "system:node:{{EC2PrivateDNSName}}",
-					Groups:   []string{"system:bootstrappers", "system:nodes"},
+					Groups:   []string{systemBootstrappersGroup, systemNodesGroup},
 				},
 			},
 			expectedRoleMapSpecs: []iamauthv1.IAMIdentityMappingSpec{},

--- a/pkg/cloud/services/iamauth/iamauth.go
+++ b/pkg/cloud/services/iamauth/iamauth.go
@@ -25,11 +25,15 @@ import (
 const (
 	// EC2NodeUserName is the username required for EC2 nodes.
 	EC2NodeUserName = "system:node:{{EC2PrivateDNSName}}"
+
+	// systemBootstrappersGroup is the Kubernetes group for node bootstrappers.
+	systemBootstrappersGroup = "system:bootstrappers"
+	systemNodesGroup         = "system:nodes"
 )
 
 var (
 	// NodeGroups is the groups that are required for a node.
-	NodeGroups = []string{"system:bootstrappers", "system:nodes"}
+	NodeGroups = []string{systemBootstrappersGroup, systemNodesGroup}
 )
 
 // AuthenticatorBackend is the interface that represents an aws-iam-authenticator backend.

--- a/pkg/cloud/services/instancestate/rule.go
+++ b/pkg/cloud/services/instancestate/rule.go
@@ -32,8 +32,13 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
 )
 
-// Ec2StateChangeNotification defines the EC2 instance's state change notification.
-const Ec2StateChangeNotification = "EC2 Instance State-change Notification"
+const (
+	// Ec2StateChangeNotification defines the EC2 instance's state change notification.
+	Ec2StateChangeNotification = "EC2 Instance State-change Notification"
+
+	// ec2EventSource is the EventBridge source for EC2 events.
+	ec2EventSource = "aws.ec2"
+)
 
 // reconcileRules creates rules and attaches the queue as a target.
 func (s Service) reconcileRules(ctx context.Context) error {
@@ -131,7 +136,7 @@ func (s Service) reconcileRules(ctx context.Context) error {
 
 func (s Service) createRule(ctx context.Context) error {
 	eventPattern := eventPattern{
-		Source:     []string{"aws.ec2"},
+		Source:     []string{ec2EventSource},
 		DetailType: []string{Ec2StateChangeNotification},
 		EventDetail: &eventDetail{
 			States: []infrav1.InstanceState{infrav1.InstanceStateShuttingDown, infrav1.InstanceStateTerminated},

--- a/pkg/cloud/services/instancestate/rule_test.go
+++ b/pkg/cloud/services/instancestate/rule_test.go
@@ -55,7 +55,7 @@ func TestReconcileRules(t *testing.T) {
 					Name: aws.String(ruleName),
 				})).Return(nil, &eventbridgetypes.ResourceNotFoundException{})
 				e := &eventPattern{
-					Source:     []string{"aws.ec2"},
+					Source:     []string{ec2EventSource},
 					DetailType: []string{Ec2StateChangeNotification},
 					EventDetail: &eventDetail{
 						States: []infrav1.InstanceState{infrav1.InstanceStateShuttingDown, infrav1.InstanceStateTerminated},
@@ -258,7 +258,7 @@ func TestAddInstanceToRule(t *testing.T) {
 	defer mockCtrl.Finish()
 	pattern := eventPattern{
 		DetailType: []string{Ec2StateChangeNotification},
-		Source:     []string{"aws.ec2"},
+		Source:     []string{ec2EventSource},
 		EventDetail: &eventDetail{
 			InstanceIDs: []string{"instance-a"},
 		},
@@ -339,7 +339,7 @@ func TestRemoveInstanceStateFromEventPattern(t *testing.T) {
 	defer mockCtrl.Finish()
 	pattern := eventPattern{
 		DetailType: []string{Ec2StateChangeNotification},
-		Source:     []string{"aws.ec2"},
+		Source:     []string{ec2EventSource},
 		EventDetail: &eventDetail{
 			InstanceIDs: []string{"instance-a", "instance-b", "instance-c"},
 		},

--- a/pkg/cloud/services/network/eips.go
+++ b/pkg/cloud/services/network/eips.go
@@ -170,8 +170,10 @@ func (s *Service) releaseAddressesWithFilter(filters []types.Filter) error {
 // releaseAddresses is default cluster release flow, discoverying and releasing all
 // addresses associated and owned by the cluster tag.
 func (s *Service) releaseAddresses() error {
-	filters := []types.Filter{filter.EC2.Cluster(s.scope.Name())}
-	filters = append(filters, filter.EC2.ClusterOwned(s.scope.Name()))
+	filters := []types.Filter{
+		filter.EC2.Cluster(s.scope.Name()),
+		filter.EC2.ClusterOwned(s.scope.Name()),
+	}
 	return s.releaseAddressesWithFilter(filters)
 }
 

--- a/pkg/cloud/services/s3/s3.go
+++ b/pkg/cloud/services/s3/s3.go
@@ -43,8 +43,13 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/userdata"
 )
 
-// AWSDefaultRegion is the default AWS region.
-const AWSDefaultRegion string = "us-east-1"
+const (
+	// AWSDefaultRegion is the default AWS region.
+	AWSDefaultRegion string = "us-east-1"
+
+	// s3ActionGetObject is the S3 IAM action for retrieving objects.
+	s3ActionGetObject = "s3:GetObject"
+)
 
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
@@ -545,7 +550,7 @@ func (s *Service) bucketPolicy(bucketName string) (string, error) {
 				Principal: map[iam.PrincipalType]iam.PrincipalID{
 					iam.PrincipalAWS: []string{fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, *accountID.Account, bucket.ControlPlaneIAMInstanceProfile)},
 				},
-				Action:   []string{"s3:GetObject"},
+				Action:   []string{s3ActionGetObject},
 				Resource: []string{fmt.Sprintf("arn:%s:s3:::%s/control-plane/*", partition, bucketName)},
 			})
 		}
@@ -559,7 +564,7 @@ func (s *Service) bucketPolicy(bucketName string) (string, error) {
 					Principal: map[iam.PrincipalType]iam.PrincipalID{
 						iam.PrincipalAWS: []string{fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, *accountID.Account, iamInstanceProfile)},
 					},
-					Action:   []string{"s3:GetObject"},
+					Action:   []string{s3ActionGetObject},
 					Resource: []string{fmt.Sprintf("arn:%s:s3:::%s/node/*", partition, bucketName)},
 				},
 				iam.StatementEntry{
@@ -568,7 +573,7 @@ func (s *Service) bucketPolicy(bucketName string) (string, error) {
 					Principal: map[iam.PrincipalType]iam.PrincipalID{
 						iam.PrincipalAWS: []string{fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, *accountID.Account, iamInstanceProfile)},
 					},
-					Action:   []string{"s3:GetObject"},
+					Action:   []string{s3ActionGetObject},
 					Resource: []string{fmt.Sprintf("arn:%s:s3:::%s/machine-pool/*", partition, bucketName)},
 				})
 		}
@@ -584,7 +589,7 @@ func (s *Service) bucketPolicy(bucketName string) (string, error) {
 							partition, *accountID.Account, additionalRole.Name),
 					},
 				},
-				Action: []string{"s3:GetObject"},
+				Action: []string{s3ActionGetObject},
 				Resource: []string{
 					fmt.Sprintf("arn:%s:s3:::%s/%s",
 						partition, bucketName, additionalRole.Prefix),

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -1042,8 +1042,8 @@ func (s *Service) processIngressRulesSGs(ingressRules []infrav1.IngressRule) (in
 
 	for _, rule := range ingressRules {
 		if rule.NatGatewaysIPsSource { // if the rule has NatGatewaysIPsSource set to true, use the NAT Gateway IPs as the source
-			natGatewaysCidrs := []string{}
 			natGatewaysIPs := s.scope.GetNatGatewaysIPs()
+			natGatewaysCidrs := make([]string, 0, len(natGatewaysIPs))
 			for _, ip := range natGatewaysIPs {
 				natGatewaysCidrs = append(natGatewaysCidrs, fmt.Sprintf("%s/32", ip))
 			}

--- a/pkg/internal/mime/mime.go
+++ b/pkg/internal/mime/mime.go
@@ -61,7 +61,7 @@ func GenerateInitDocument(secretPrefix string, chunks int32, region string, secr
 
 	var buf bytes.Buffer
 	mpWriter := multipart.NewWriter(&buf)
-	buf.WriteString(fmt.Sprintf(multipartHeader, mpWriter.Boundary()))
+	fmt.Fprintf(&buf, multipartHeader, mpWriter.Boundary())
 	scriptWriter, err := mpWriter.CreatePart(boothookType)
 	if err != nil {
 		return []byte{}, err

--- a/test/e2e/shared/aws.go
+++ b/test/e2e/shared/aws.go
@@ -994,11 +994,11 @@ func conformanceImageID(e2eCtx *E2EContext) string {
 			Name:   aws.String("name"),
 			Values: []string{amiName},
 		},
+		{
+			Name:   aws.String("owner-id"),
+			Values: []string{DefaultImageLookupOrg},
+		},
 	}
-	filters = append(filters, ec2types.Filter{
-		Name:   aws.String("owner-id"),
-		Values: []string{DefaultImageLookupOrg},
-	})
 	resp, err := ec2Svc.DescribeImages(context.TODO(), &ec2.DescribeImagesInput{
 		Filters: filters,
 	})

--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -371,7 +371,7 @@ func postProcessBase64LogData(dir, src, dst string) error {
 	}
 
 	// Write the destination file
-	if err := os.WriteFile(destinationFile, outputData, 0600); err != nil {
+	if err := os.WriteFile(destinationFile, outputData, 0600); err != nil { //nolint:gosec // G703: path comes from trusted test helper
 		return errors.Wrapf(err, "unable to write destination file at %q", destinationFile)
 	}
 

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -148,39 +148,46 @@ func (m MultitenancyRole) RoleARN(ctx context.Context, cfg *aws.Config) (string,
 	return roleARN, nil
 }
 
+const (
+	// serviceCodeVPC is the AWS service code for VPC quotas.
+	serviceCodeVPC = "vpc"
+	// serviceCodeEC2 is the AWS service code for EC2 quotas.
+	serviceCodeEC2 = "ec2"
+)
+
 // Service codes and quotas can be found under: https://us-west-1.console.aws.amazon.com/servicequotas/home/services
 func getLimitedResources() map[string]*ServiceQuota {
 	serviceQuotas := map[string]*ServiceQuota{}
 	serviceQuotas["igw"] = &ServiceQuota{
-		ServiceCode:         "vpc",
+		ServiceCode:         serviceCodeVPC,
 		QuotaName:           "Internet gateways per Region",
 		QuotaCode:           "L-A4707A72",
 		DesiredMinimumValue: 20,
 	}
 
 	serviceQuotas["ngw"] = &ServiceQuota{
-		ServiceCode:         "vpc",
+		ServiceCode:         serviceCodeVPC,
 		QuotaName:           "NAT gateways per Availability Zone",
 		QuotaCode:           "L-FE5A380F",
 		DesiredMinimumValue: 20,
 	}
 
 	serviceQuotas["vpc"] = &ServiceQuota{
-		ServiceCode:         "vpc",
+		ServiceCode:         serviceCodeVPC,
 		QuotaName:           "VPCs per Region",
 		QuotaCode:           "L-F678F1CE",
 		DesiredMinimumValue: 25,
 	}
 
 	serviceQuotas["ec2-normal"] = &ServiceQuota{
-		ServiceCode:         "ec2",
+		ServiceCode:         serviceCodeEC2,
 		QuotaName:           "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances",
 		QuotaCode:           "L-1216C47A",
 		DesiredMinimumValue: 128,
 	}
 
 	serviceQuotas["eip"] = &ServiceQuota{
-		ServiceCode:         "ec2",
+		ServiceCode:         serviceCodeEC2,
 		QuotaName:           "EC2-VPC Elastic IPs",
 		QuotaCode:           "L-0263D0A3",
 		DesiredMinimumValue: 100,
@@ -194,7 +201,7 @@ func getLimitedResources() map[string]*ServiceQuota {
 	}
 
 	serviceQuotas["ec2-GPU"] = &ServiceQuota{
-		ServiceCode:         "ec2",
+		ServiceCode:         serviceCodeEC2,
 		QuotaName:           "Running On-Demand G and VT instances",
 		QuotaCode:           "L-DB2E81BA",
 		DesiredMinimumValue: 8,

--- a/test/e2e/shared/gpu.go
+++ b/test/e2e/shared/gpu.go
@@ -138,9 +138,9 @@ func WaitForJobComplete(ctx context.Context, input WaitForJobCompleteInput, inte
 func DescribeFailedJob(ctx context.Context, input WaitForJobCompleteInput) string {
 	namespace, name := input.Job.GetNamespace(), input.Job.GetName()
 	b := strings.Builder{}
-	b.WriteString(fmt.Sprintf("Job %s/%s failed",
-		namespace, name))
-	b.WriteString(fmt.Sprintf("\nJob:\n%s\n", prettyPrint(input.Job)))
+	fmt.Fprintf(&b, "Job %s/%s failed",
+		namespace, name)
+	fmt.Fprintf(&b, "\nJob:\n%s\n", prettyPrint(input.Job))
 	b.WriteString(describeEvents(ctx, input.Clientset, namespace, name))
 	return b.String()
 }

--- a/test/e2e/shared/resource.go
+++ b/test/e2e/shared/resource.go
@@ -108,7 +108,7 @@ func (r *TestResource) WriteRequestedResources(e2eCtx *E2EContext, testName stri
 	err := fileLock.Lock()
 	Expect(err).NotTo(HaveOccurred())
 
-	requestedResources, err := os.ReadFile(requestedResourceFilePath)
+	requestedResources, err := os.ReadFile(requestedResourceFilePath) //nolint:gosec // G304: path comes from trusted test configuration
 	Expect(err).NotTo(HaveOccurred())
 
 	resources := struct {

--- a/test/e2e/shared/workload.go
+++ b/test/e2e/shared/workload.go
@@ -83,12 +83,12 @@ func WaitForDeploymentsAvailable(ctx context.Context, input WaitForDeploymentsAv
 // DescribeFailedDeployment returns detailed output to help debug a deployment failure in e2e.
 func DescribeFailedDeployment(input WaitForDeploymentsAvailableInput, deployment *appsv1.Deployment) string {
 	b := strings.Builder{}
-	b.WriteString(fmt.Sprintf("Deployment %s/%s failed to get status.Available = True condition",
-		input.Namespace, input.Name))
+	fmt.Fprintf(&b, "Deployment %s/%s failed to get status.Available = True condition",
+		input.Namespace, input.Name)
 	if deployment == nil {
 		b.WriteString("\nDeployment: nil\n")
 	} else {
-		b.WriteString(fmt.Sprintf("\nDeployment:\n%s\n", framework.PrettyPrint(deployment)))
+		fmt.Fprintf(&b, "\nDeployment:\n%s\n", framework.PrettyPrint(deployment))
 	}
 	return b.String()
 }

--- a/test/e2e/suites/managed/aws_node_env.go
+++ b/test/e2e/suites/managed/aws_node_env.go
@@ -36,6 +36,11 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
 
+const (
+	// awsNodeName is the name of the aws-node DaemonSet.
+	awsNodeName = "aws-node"
+)
+
 type UpdateAwsNodeVersionSpecInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 	BootstrapClusterProxy framework.ClusterProxy
@@ -71,12 +76,12 @@ func CheckAwsNodeEnvVarsSet(ctx context.Context, inputGetter func() UpdateAwsNod
 	clusterClient := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName).GetClient()
 
 	Eventually(func() error {
-		if err := clusterClient.Get(ctx, crclient.ObjectKey{Namespace: "kube-system", Name: "aws-node"}, daemonSet); err != nil {
+		if err := clusterClient.Get(ctx, crclient.ObjectKey{Namespace: "kube-system", Name: awsNodeName}, daemonSet); err != nil {
 			return fmt.Errorf("unable to get aws-node: %w", err)
 		}
 
 		for _, container := range daemonSet.Spec.Template.Spec.Containers {
-			if container.Name == "aws-node" {
+			if container.Name == awsNodeName {
 				if matchEnvVar(container.Env, corev1.EnvVar{Name: "FOO", Value: "BAR"}) &&
 					matchEnvVar(container.Env, corev1.EnvVar{Name: "ENABLE_PREFIX_DELEGATION", Value: "true"}) {
 					return nil

--- a/test/helpers/external/cluster.go
+++ b/test/helpers/external/cluster.go
@@ -28,6 +28,9 @@ import (
 const (
 	clusterAPIGroup       = "cluster.x-k8s.io"
 	clusterAPITestVersion = "v1beta1"
+
+	// jsonSchemaTypeObject is the JSON Schema type for objects.
+	jsonSchemaTypeObject = "object"
 )
 
 var (
@@ -64,14 +67,14 @@ func generateTestClusterAPICRD(kind, pluralKind string) *apiextensionsv1.CustomR
 					},
 					Schema: &apiextensionsv1.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							Type: "object",
+							Type: jsonSchemaTypeObject,
 							Properties: map[string]apiextensionsv1.JSONSchemaProps{
 								"spec": {
-									Type:                   "object",
+									Type:                   jsonSchemaTypeObject,
 									XPreserveUnknownFields: ptr.To[bool](true),
 								},
 								"status": {
-									Type:                   "object",
+									Type:                   jsonSchemaTypeObject,
 									XPreserveUnknownFields: ptr.To[bool](true),
 								},
 							},

--- a/webhooks/awsmachine_webhook_test.go
+++ b/webhooks/awsmachine_webhook_test.go
@@ -1011,9 +1011,9 @@ func TestAWSMachineSecretsBackend(t *testing.T) {
 			cloudInit:              infrav1.CloudInit{InsecureSkipSecretsManager: false},
 			expectedSecretsBackend: "secrets-manager",
 		},
-		{
+		{ //nolint:gosec // G101: test fixture, not real credentials
 			name:                   "with insecure skip secrets manager unset and secrets backend set",
-			cloudInit:              infrav1.CloudInit{InsecureSkipSecretsManager: false, SecureSecretsBackend: "ssm-parameter-store"},
+			cloudInit:              infrav1.CloudInit{InsecureSkipSecretsManager: false, SecureSecretsBackend: "ssm-parameter-store"}, //nolint:gosec // G101: test fixture, not real credentials
 			expectedSecretsBackend: "ssm-parameter-store",
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps Go from 1.24.7 to 1.25.12 and golangci-lint from v1.60.3 to v2.12.2 (including the custom KAL linter config).

The golangci-lint v2 upgrade was required because v2.7.0 (used previously in CI) is built with Go 1.24 and refuses to lint a Go 1.25 codebase. v2.12.2 is the latest stable release, built with Go 1.25.12.

Pre-existing lint issues surfaced by the newer linter (goconst, prealloc, gosec, staticcheck, nolintlint) are fixed in a separate commit.

**Commits**:

- `49b3e10ff` feat: add bump-go Claude skill and developer guide - adds a Claude Code skill for automating Go version bumps and a developer guide (`docs/book/src/development/bump-go.md`) documenting the process step by step.
- `922401f7b` fix(lint): resolve goconst, prealloc, gosec, staticcheck, nolintlint issues - fixes pre-existing lint violations surfaced by the golangci-lint v2 upgrade and adds targeted exclusions where extracting constants or preallocating would hurt readability.
- `f34816915` chore(bump): bump golangci-lint from v1.60.3 to v2.12.2 - upgrades golangci-lint in `hack/tools/Makefile`, `.custom-gcl.yaml`, and the CI workflow.
- `c7c8899c6` chore(bump): bump Go to 1.25.12 - updates `go.mod` (root and hack/tools), `Makefile`, `.golangci-kal.yml`, `netlify.toml`, `dependabot.yml`, and `release.yaml`.

**AI Usage**:

This PR was authored with Claude Code (Opus). All changes were reviewed and approved by a human.

**Release Note**
```release-note
chore(bump): bump Go to 1.25
```