### PR TITLE
🐛 Add ROSAOCMRoleConfig CRD to kustomization

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -64,3 +64,6 @@ resources:
 - group: infrastructure
   kind: ROSANetwork
   version: v1beta2
+- group: infrastructure
+  kind: ROSAOCMRoleConfig
+  version: v1beta2

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
 - bases/infrastructure.cluster.x-k8s.io_rosaclusters.yaml
 - bases/infrastructure.cluster.x-k8s.io_rosamachinepools.yaml
 - bases/infrastructure.cluster.x-k8s.io_rosaroleconfigs.yaml
+- bases/infrastructure.cluster.x-k8s.io_rosaocmroleconfigs.yaml
 - bases/infrastructure.cluster.x-k8s.io_rosanetworks.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 


### PR DESCRIPTION
**What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:

The `ROSAOCMRoleConfig` CRD file exists in `config/crd/bases/` and the controller is registered in `main.go` under the ROSA feature gate, but the CRD was never added to `config/crd/kustomization.yaml`. This means deployments via `clusterctl init` with `ROSA=true` (e.g. v2.12.1) don't install the CRD, and the controller logs errors every 10 seconds:

"if kind is a CRD, it should be installed before calling Start" kind="ROSAOCMRoleConfig.infrastructure.cluster.x-k8s.io"
So users cannot create `ROSAOCMRoleConfig` resources.

This was not caught because both unit tests (envtest) and manual e2e tests load CRDs directly from `config/crd/bases/`, bypassing the kustomization.

  **Which issue(s) this PR fixes**:

  Fixes #6140

  **Special notes for your reviewer**:

  Reproduced on a kind cluster with `clusterctl init --infrastructure aws:v2.12.1` and `EXP_ROSA=true`.

  **AI Usage**:

  None

  **Checklist**:

  - [x] squashed commits
  - [ ] includes documentation
  - [ ] includes AI generated content
  - [x] includes emoji in title
  - [ ] adds unit tests
  - [ ] adds or updates e2e tests

```release-note
 fix(ROSA): ROSAOCMRoleConfig CRD not being deployed when using clusterctl with ROSA=true
```