### PR TITLE
[release-2.11] 🐛 fix reconciler loop at status patch update for ROSA controllers

### DIFF
--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -56,7 +56,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
@@ -116,6 +118,30 @@ func (r *ROSAControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr c
 		For(rosaControlPlane).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(
+			predicate.Funcs{
+				// Drop Update events that are status-only changes on ROSAControlPlane objects.
+				// Without this, Close() patching a condition re-enqueues the item immediately via
+				// the watch, bypassing the exponential backoff that an error return is supposed to engage.
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldCP, ok := e.ObjectOld.(*rosacontrolplanev1.ROSAControlPlane)
+					if !ok {
+						return true
+					}
+					newCP, ok := e.ObjectNew.(*rosacontrolplanev1.ROSAControlPlane)
+					if !ok {
+						return true
+					}
+					oldCP = oldCP.DeepCopy()
+					newCP = newCP.DeepCopy()
+					oldCP.Status = rosacontrolplanev1.RosaControlPlaneStatus{}
+					newCP.Status = rosacontrolplanev1.RosaControlPlaneStatus{}
+					oldCP.ObjectMeta.ResourceVersion = ""
+					newCP.ObjectMeta.ResourceVersion = ""
+					return !cmp.Equal(oldCP, newCP)
+				},
+			},
+		).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("failed setting up the ROSAControlPlane controller manager: %w", err)

--- a/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller_test.go
@@ -33,6 +33,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	rosaaws "github.com/openshift/rosa/pkg/aws"
@@ -44,6 +45,8 @@ import (
 	restclient "k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
@@ -1867,6 +1870,111 @@ func TestNeedsCredentialRefresh(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(needsCredentialRefresh(tt.secret)).To(Equal(tt.want))
+		})
+	}
+}
+
+// TestROSAControlPlaneUpdatePredicate verifies that the WithEventFilter predicate in
+// SetupWithManager drops Update events whose only differences are in .Status or
+// .ResourceVersion, and passes through events that carry real spec changes.
+func TestROSAControlPlaneUpdatePredicate(t *testing.T) {
+	pred := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCP, ok := e.ObjectOld.(*rosacontrolplanev1.ROSAControlPlane)
+			if !ok {
+				return true
+			}
+			newCP, ok := e.ObjectNew.(*rosacontrolplanev1.ROSAControlPlane)
+			if !ok {
+				return true
+			}
+			oldCP = oldCP.DeepCopy()
+			newCP = newCP.DeepCopy()
+			oldCP.Status = rosacontrolplanev1.RosaControlPlaneStatus{}
+			newCP.Status = rosacontrolplanev1.RosaControlPlaneStatus{}
+			oldCP.ObjectMeta.ResourceVersion = ""
+			newCP.ObjectMeta.ResourceVersion = ""
+			return !cmp.Equal(oldCP, newCP)
+		},
+	}
+
+	base := func() *rosacontrolplanev1.ROSAControlPlane {
+		return &rosacontrolplanev1.ROSAControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-rosa-cp",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+			Spec: rosacontrolplanev1.RosaControlPlaneSpec{
+				RosaClusterName: "test-cluster",
+				Region:          "us-east-1",
+				Version:         "4.15.20",
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		old         *rosacontrolplanev1.ROSAControlPlane
+		new         *rosacontrolplanev1.ROSAControlPlane
+		wantProcess bool
+	}{
+		{
+			name: "status-only change is filtered out",
+			old:  base(),
+			new: func() *rosacontrolplanev1.ROSAControlPlane {
+				p := base()
+				p.Status.Ready = true
+				p.Status.ID = "cluster-id-123"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "resource-version-only change is filtered out",
+			old:  base(),
+			new: func() *rosacontrolplanev1.ROSAControlPlane {
+				p := base()
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "spec change passes through",
+			old:  base(),
+			new: func() *rosacontrolplanev1.ROSAControlPlane {
+				p := base()
+				p.Spec.Region = "us-west-2"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+		{
+			name: "spec change with simultaneous status change passes through",
+			old:  base(),
+			new: func() *rosacontrolplanev1.ROSAControlPlane {
+				p := base()
+				p.Spec.Region = "us-west-2"
+				p.Status.Ready = true
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := pred.Update(event.UpdateEvent{
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
+			})
+			g.Expect(got).To(Equal(tc.wantProcess),
+				"predicate.Update() = %v, want %v", got, tc.wantProcess)
 		})
 	}
 }

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -23,7 +23,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
@@ -64,6 +66,30 @@ func (r *ROSAMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ct
 		For(&expinfrav1.ROSAMachinePool{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(
+			predicate.Funcs{
+				// Drop Update events that are status-only changes on ROSAMachinePool objects.
+				// Without this, Close() patching a condition re-enqueues the item immediately via
+				// the watch, bypassing the exponential backoff that an error return is supposed to engage.
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldPool, ok := e.ObjectOld.(*expinfrav1.ROSAMachinePool)
+					if !ok {
+						return true
+					}
+					newPool, ok := e.ObjectNew.(*expinfrav1.ROSAMachinePool)
+					if !ok {
+						return true
+					}
+					oldPool = oldPool.DeepCopy()
+					newPool = newPool.DeepCopy()
+					oldPool.Status = expinfrav1.RosaMachinePoolStatus{}
+					newPool.Status = expinfrav1.RosaMachinePoolStatus{}
+					oldPool.ObjectMeta.ResourceVersion = ""
+					newPool.ObjectMeta.ResourceVersion = ""
+					return !cmp.Equal(oldPool, newPool)
+				},
+			},
+		).
 		Watches(
 			&clusterv1.MachinePool{},
 			handler.EnqueueRequestsFromMapFunc(machinePoolToInfrastructureMapFunc(gvk)),

--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +18,8 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -754,6 +757,112 @@ func TestVolumeSizeZeroedBeforeUpdate(t *testing.T) {
 
 	g.Expect(nodePoolSpec.AWSNodePool()).ToNot(BeNil())
 	g.Expect(nodePoolSpec.AWSNodePool().RootVolume()).To(BeNil(), "RootVolume should not be set when volumeSize is 0")
+}
+
+// TestROSAMachinePoolUpdatePredicate verifies that the WithEventFilter predicate
+// used in SetupWithManager drops Update events whose only differences are in
+// .Status or .ResourceVersion, and passes through events that carry real spec changes.
+func TestROSAMachinePoolUpdatePredicate(t *testing.T) {
+	// Mirror the predicate registered in SetupWithManager exactly so the test
+	// proves the production logic rather than a reimagined version.
+	pred := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPool, ok := e.ObjectOld.(*expinfrav1.ROSAMachinePool)
+			if !ok {
+				return true
+			}
+			newPool, ok := e.ObjectNew.(*expinfrav1.ROSAMachinePool)
+			if !ok {
+				return true
+			}
+			oldPool = oldPool.DeepCopy()
+			newPool = newPool.DeepCopy()
+			oldPool.Status = expinfrav1.RosaMachinePoolStatus{}
+			newPool.Status = expinfrav1.RosaMachinePoolStatus{}
+			oldPool.ObjectMeta.ResourceVersion = ""
+			newPool.ObjectMeta.ResourceVersion = ""
+			return !cmp.Equal(oldPool, newPool)
+		},
+	}
+
+	base := func() *expinfrav1.ROSAMachinePool {
+		return &expinfrav1.ROSAMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-pool",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+			Spec: expinfrav1.RosaMachinePoolSpec{
+				NodePoolName: "test-nodepool",
+				InstanceType: "m5.large",
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		old         *expinfrav1.ROSAMachinePool
+		new         *expinfrav1.ROSAMachinePool
+		wantProcess bool // true = controller should reconcile, false = event dropped
+	}{
+		{
+			name: "status-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSAMachinePool {
+				p := base()
+				p.Status.Ready = true
+				p.Status.Replicas = 3
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "resource-version-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSAMachinePool {
+				p := base()
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "spec change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSAMachinePool {
+				p := base()
+				p.Spec.InstanceType = "m5.xlarge"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+		{
+			name: "spec change with simultaneous status change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSAMachinePool {
+				p := base()
+				p.Spec.InstanceType = "m5.xlarge"
+				p.Status.Ready = true
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := pred.Update(event.UpdateEvent{
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
+			})
+			g.Expect(got).To(Equal(tc.wantProcess),
+				"predicate.Update() = %v, want %v", got, tc.wantProcess)
+		})
+	}
 }
 
 func createObject(g *WithT, obj client.Object, namespace string) {

--- a/exp/controllers/rosanetwork_controller.go
+++ b/exp/controllers/rosanetwork_controller.go
@@ -30,6 +30,7 @@ import (
 	cloudformationtypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
 	rosaCFNetwork "github.com/openshift/rosa/cmd/create/network"
 	rosaAWSClient "github.com/openshift/rosa/pkg/aws"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
@@ -321,6 +324,30 @@ func (r *ROSANetworkReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(
+			predicate.Funcs{
+				// Drop Update events that are status-only changes on ROSANetwork objects.
+				// Without this, PatchObject() patching a condition re-enqueues the item immediately via
+				// the watch, bypassing the exponential backoff that an error return is supposed to engage.
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldNet, ok := e.ObjectOld.(*expinfrav1.ROSANetwork)
+					if !ok {
+						return true
+					}
+					newNet, ok := e.ObjectNew.(*expinfrav1.ROSANetwork)
+					if !ok {
+						return true
+					}
+					oldNet = oldNet.DeepCopy()
+					newNet = newNet.DeepCopy()
+					oldNet.Status = expinfrav1.ROSANetworkStatus{}
+					newNet.Status = expinfrav1.ROSANetworkStatus{}
+					oldNet.ObjectMeta.ResourceVersion = ""
+					newNet.ObjectMeta.ResourceVersion = ""
+					return !cmp.Equal(oldNet, newNet)
+				},
+			},
+		).
 		For(&expinfrav1.ROSANetwork{}).
 		Complete(r)
 }

--- a/exp/controllers/rosanetwork_controller_test.go
+++ b/exp/controllers/rosanetwork_controller_test.go
@@ -28,6 +28,7 @@ import (
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	rosaAWSClient "github.com/openshift/rosa/pkg/aws"
 	rosaMocks "github.com/openshift/rosa/pkg/aws/mocks"
@@ -38,6 +39,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
@@ -941,4 +944,107 @@ func TestROSANetworkReconcilerWithRoleIdentityNamespaceNotAllowed(t *testing.T) 
 		g.Expect(errReconcile.Error()).To(ContainSubstring("failed to create rosanetwork scope"))
 		g.Expect(awsClientCalled).To(BeFalse())
 	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
+// TestROSANetworkUpdatePredicate verifies that the WithEventFilter predicate in
+// SetupWithManager drops Update events whose only differences are in .Status or
+// .ResourceVersion, and passes through events that carry real spec changes.
+func TestROSANetworkUpdatePredicate(t *testing.T) {
+	pred := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNet, ok := e.ObjectOld.(*expinfrav1.ROSANetwork)
+			if !ok {
+				return true
+			}
+			newNet, ok := e.ObjectNew.(*expinfrav1.ROSANetwork)
+			if !ok {
+				return true
+			}
+			oldNet = oldNet.DeepCopy()
+			newNet = newNet.DeepCopy()
+			oldNet.Status = expinfrav1.ROSANetworkStatus{}
+			newNet.Status = expinfrav1.ROSANetworkStatus{}
+			oldNet.ObjectMeta.ResourceVersion = ""
+			newNet.ObjectMeta.ResourceVersion = ""
+			return !cmp.Equal(oldNet, newNet)
+		},
+	}
+
+	base := func() *expinfrav1.ROSANetwork {
+		return &expinfrav1.ROSANetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-rosa-network",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+			Spec: expinfrav1.ROSANetworkSpec{
+				CIDRBlock: "10.0.0.0/8",
+				Region:    "us-east-1",
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		old         *expinfrav1.ROSANetwork
+		new         *expinfrav1.ROSANetwork
+		wantProcess bool
+	}{
+		{
+			name: "status-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSANetwork {
+				p := base()
+				p.Status.Subnets = []expinfrav1.ROSANetworkSubnet{{PrivateSubnet: "subnet-123"}}
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "resource-version-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSANetwork {
+				p := base()
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "spec change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSANetwork {
+				p := base()
+				p.Spec.CIDRBlock = "192.168.0.0/16"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+		{
+			name: "spec change with simultaneous status change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSANetwork {
+				p := base()
+				p.Spec.CIDRBlock = "192.168.0.0/16"
+				p.Status.Subnets = []expinfrav1.ROSANetworkSubnet{{PrivateSubnet: "subnet-123"}}
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := pred.Update(event.UpdateEvent{
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
+			})
+			g.Expect(got).To(Equal(tc.wantProcess),
+				"predicate.Update() = %v, want %v", got, tc.wantProcess)
+		})
+	}
 }

--- a/exp/controllers/rosaocmroleconfig_controller.go
+++ b/exp/controllers/rosaocmroleconfig_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/google/go-cmp/cmp"
 	rosaaws "github.com/openshift/rosa/pkg/aws"
 	rosalogging "github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/reporter"
@@ -33,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
@@ -65,6 +68,30 @@ func (r *ROSAOCMRoleConfigReconciler) SetupWithManager(ctx context.Context, mgr 
 		For(&expinfrav1.ROSAOCMRoleConfig{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(
+			predicate.Funcs{
+				// Drop Update events that are status-only changes on ROSAOCMRoleConfig objects.
+				// Without this, PatchObject() patching a condition re-enqueues the item immediately via
+				// the watch, bypassing the exponential backoff that an error return is supposed to engage.
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldRC, ok := e.ObjectOld.(*expinfrav1.ROSAOCMRoleConfig)
+					if !ok {
+						return true
+					}
+					newRC, ok := e.ObjectNew.(*expinfrav1.ROSAOCMRoleConfig)
+					if !ok {
+						return true
+					}
+					oldRC = oldRC.DeepCopy()
+					newRC = newRC.DeepCopy()
+					oldRC.Status = expinfrav1.ROSAOCMRoleConfigStatus{}
+					newRC.Status = expinfrav1.ROSAOCMRoleConfigStatus{}
+					oldRC.ObjectMeta.ResourceVersion = ""
+					newRC.ObjectMeta.ResourceVersion = ""
+					return !cmp.Equal(oldRC, newRC)
+				},
+			},
+		).
 		Complete(r)
 }
 

--- a/exp/controllers/rosaocmroleconfig_controller_test.go
+++ b/exp/controllers/rosaocmroleconfig_controller_test.go
@@ -27,6 +27,7 @@ import (
 	iamv2 "github.com/aws/aws-sdk-go-v2/service/iam"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -43,6 +44,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
@@ -1069,4 +1072,106 @@ func TestROSAOCMRoleConfigDeleteWithRetainPolicy(t *testing.T) {
 	// Verify unlink was not called (DeletionPolicy=Retain)
 	h.g.Expect(unlinkCalled).To(BeFalse(), "Should skip unlink when DeletionPolicy is Retain")
 	h.g.Expect(deleteRoleCalled).To(BeFalse(), "Should skip IAM role deletion when DeletionPolicy is Retain")
+}
+
+// TestROSAOCMRoleConfigUpdatePredicate verifies that the WithEventFilter predicate in
+// SetupWithManager drops Update events whose only differences are in .Status or
+// .ResourceVersion, and passes through events that carry real spec changes.
+func TestROSAOCMRoleConfigUpdatePredicate(t *testing.T) {
+	pred := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldRC, ok := e.ObjectOld.(*expinfrav1.ROSAOCMRoleConfig)
+			if !ok {
+				return true
+			}
+			newRC, ok := e.ObjectNew.(*expinfrav1.ROSAOCMRoleConfig)
+			if !ok {
+				return true
+			}
+			oldRC = oldRC.DeepCopy()
+			newRC = newRC.DeepCopy()
+			oldRC.Status = expinfrav1.ROSAOCMRoleConfigStatus{}
+			newRC.Status = expinfrav1.ROSAOCMRoleConfigStatus{}
+			oldRC.ObjectMeta.ResourceVersion = ""
+			newRC.ObjectMeta.ResourceVersion = ""
+			return !cmp.Equal(oldRC, newRC)
+		},
+	}
+
+	base := func() *expinfrav1.ROSAOCMRoleConfig {
+		return &expinfrav1.ROSAOCMRoleConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-ocm-role-config",
+				ResourceVersion: "1",
+			},
+			Spec: expinfrav1.ROSAOCMRoleConfigSpec{
+				RolePrefix: "test",
+				Profile:    expinfrav1.ROSAOCMRoleProfileStandard,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		old         *expinfrav1.ROSAOCMRoleConfig
+		new         *expinfrav1.ROSAOCMRoleConfig
+		wantProcess bool
+	}{
+		{
+			name: "status-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSAOCMRoleConfig {
+				p := base()
+				p.Status.RoleARN = "arn:aws:iam::123:role/test"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "resource-version-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSAOCMRoleConfig {
+				p := base()
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "spec change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSAOCMRoleConfig {
+				p := base()
+				p.Spec.RolePrefix = "updated"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+		{
+			name: "spec change with simultaneous status change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSAOCMRoleConfig {
+				p := base()
+				p.Spec.RolePrefix = "updated"
+				p.Status.RoleARN = "arn:aws:iam::123:role/test"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := pred.Update(event.UpdateEvent{
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
+			})
+			g.Expect(got).To(Equal(tc.wantProcess),
+				"predicate.Update() = %v, want %v", got, tc.wantProcess)
+		})
+	}
 }

--- a/exp/controllers/rosaroleconfig_controller.go
+++ b/exp/controllers/rosaroleconfig_controller.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/google/go-cmp/cmp"
 	accountroles "github.com/openshift/rosa/cmd/create/accountroles"
 	oidcconfig "github.com/openshift/rosa/cmd/create/oidcconfig"
 	oidcprovider "github.com/openshift/rosa/cmd/create/oidcprovider"
@@ -43,6 +44,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2"
@@ -78,6 +81,30 @@ func (r *ROSARoleConfigReconciler) SetupWithManager(ctx context.Context, mgr ctr
 		For(&expinfrav1.ROSARoleConfig{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(
+			predicate.Funcs{
+				// Drop Update events that are status-only changes on ROSARoleConfig objects.
+				// Without this, PatchObject() patching a condition re-enqueues the item immediately via
+				// the watch, bypassing the exponential backoff that an error return is supposed to engage.
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldRC, ok := e.ObjectOld.(*expinfrav1.ROSARoleConfig)
+					if !ok {
+						return true
+					}
+					newRC, ok := e.ObjectNew.(*expinfrav1.ROSARoleConfig)
+					if !ok {
+						return true
+					}
+					oldRC = oldRC.DeepCopy()
+					newRC = newRC.DeepCopy()
+					oldRC.Status = expinfrav1.ROSARoleConfigStatus{}
+					newRC.Status = expinfrav1.ROSARoleConfigStatus{}
+					oldRC.ObjectMeta.ResourceVersion = ""
+					newRC.ObjectMeta.ResourceVersion = ""
+					return !cmp.Equal(oldRC, newRC)
+				},
+			},
+		).
 		Complete(r)
 }
 

--- a/exp/controllers/rosaroleconfig_controller_test.go
+++ b/exp/controllers/rosaroleconfig_controller_test.go
@@ -30,6 +30,7 @@ import (
 	iamv2 "github.com/aws/aws-sdk-go-v2/service/iam"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	ocmlogging "github.com/openshift-online/ocm-sdk-go/logging"
@@ -44,6 +45,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	rosacontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/rosa/api/v1beta2"
@@ -1153,4 +1156,109 @@ func TestROSARoleConfigReconcilerWithRoleIdentityNamespaceNotAllowed(t *testing.
 	g.Expect(errReconcile).To(HaveOccurred())
 	g.Expect(errReconcile.Error()).To(ContainSubstring("failed to create rosaroleconfig scope"))
 	g.Expect(runtimeCalled).To(BeFalse())
+}
+
+// TestROSARoleConfigUpdatePredicate verifies that the WithEventFilter predicate in
+// SetupWithManager drops Update events whose only differences are in .Status or
+// .ResourceVersion, and passes through events that carry real spec changes.
+func TestROSARoleConfigUpdatePredicate(t *testing.T) {
+	pred := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldRC, ok := e.ObjectOld.(*expinfrav1.ROSARoleConfig)
+			if !ok {
+				return true
+			}
+			newRC, ok := e.ObjectNew.(*expinfrav1.ROSARoleConfig)
+			if !ok {
+				return true
+			}
+			oldRC = oldRC.DeepCopy()
+			newRC = newRC.DeepCopy()
+			oldRC.Status = expinfrav1.ROSARoleConfigStatus{}
+			newRC.Status = expinfrav1.ROSARoleConfigStatus{}
+			oldRC.ObjectMeta.ResourceVersion = ""
+			newRC.ObjectMeta.ResourceVersion = ""
+			return !cmp.Equal(oldRC, newRC)
+		},
+	}
+
+	base := func() *expinfrav1.ROSARoleConfig {
+		return &expinfrav1.ROSARoleConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-role-config",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+			Spec: expinfrav1.ROSARoleConfigSpec{
+				AccountRoleConfig: expinfrav1.AccountRoleConfig{
+					Prefix:  "test",
+					Version: "4.15.0",
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		old         *expinfrav1.ROSARoleConfig
+		new         *expinfrav1.ROSARoleConfig
+		wantProcess bool
+	}{
+		{
+			name: "status-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSARoleConfig {
+				p := base()
+				p.Status.OIDCID = "test-oidc-id"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "resource-version-only change is filtered out",
+			old:  base(),
+			new: func() *expinfrav1.ROSARoleConfig {
+				p := base()
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: false,
+		},
+		{
+			name: "spec change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSARoleConfig {
+				p := base()
+				p.Spec.AccountRoleConfig.Prefix = "updated"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+		{
+			name: "spec change with simultaneous status change passes through",
+			old:  base(),
+			new: func() *expinfrav1.ROSARoleConfig {
+				p := base()
+				p.Spec.AccountRoleConfig.Prefix = "updated"
+				p.Status.OIDCID = "test-oidc-id"
+				p.ResourceVersion = "2"
+				return p
+			}(),
+			wantProcess: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := pred.Update(event.UpdateEvent{
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
+			})
+			g.Expect(got).To(Equal(tc.wantProcess),
+				"predicate.Update() = %v, want %v", got, tc.wantProcess)
+		})
+	}
 }


### PR DESCRIPTION
(cherry picked from commit 5cab58e5c1fcc0c3bd867876d6687fce922bb960)

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
This is an cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/6128

/assign serngawy

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fix ROSA infinite OCM API request loop when failed with a persistent error.
```
