### PR TITLE
✨ support CPU options in machine pools

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -662,6 +662,40 @@ spec:
                       "None": The instance may not make use of any Capacity Reservations. This is to conserve open reservations for desired workloads
                       "CapacityReservationsOnly": The instance will only run if matched or targeted to a Capacity Reservation
                     type: string
+                  cpuOptions:
+                    description: |-
+                      CPUOptions defines CPU-related settings for the instance, including the confidential computing policy.
+                      When omitted, this means no opinion and the AWS platform is left to choose a reasonable default.
+                    minProperties: 1
+                    properties:
+                      confidentialCompute:
+                        description: |-
+                          ConfidentialCompute specifies whether confidential computing should be enabled for the instance,
+                          and, if so, which confidential computing technology to use.
+                          Valid values are: Disabled, AMDEncryptedVirtualizationNestedPaging
+                          When set to Disabled, confidential computing will be disabled for the instance.
+                          When set to AMDEncryptedVirtualizationNestedPaging, AMD SEV-SNP will be used as the confidential computing technology for the instance.
+                          In this case, ensure the following conditions are met:
+                          1) The selected instance type supports AMD SEV-SNP.
+                          2) The selected AWS region supports AMD SEV-SNP.
+                          3) The selected AMI supports AMD SEV-SNP.
+                          More details can be checked at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html
+                          When omitted, this means no opinion and the AWS platform is left to choose a reasonable default,
+                          which is subject to change without notice. The current default is Disabled.
+                        enum:
+                        - Disabled
+                        - AMDEncryptedVirtualizationNestedPaging
+                        type: string
+                      nestedVirtualization:
+                        description: |-
+                          NestedVirtualization specifies whether to enable nested virtualization on the instance.
+                          Nested virtualization is supported on C8i, M8i, and R8i instance types.
+                          Valid values are: enabled, disabled
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
+                    type: object
                   enclaveOptions:
                     description: EnclaveOptions defines the options for Nitro Enclave
                       support on the instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -671,6 +671,40 @@ spec:
                       "None": The instance may not make use of any Capacity Reservations. This is to conserve open reservations for desired workloads
                       "CapacityReservationsOnly": The instance will only run if matched or targeted to a Capacity Reservation
                     type: string
+                  cpuOptions:
+                    description: |-
+                      CPUOptions defines CPU-related settings for the instance, including the confidential computing policy.
+                      When omitted, this means no opinion and the AWS platform is left to choose a reasonable default.
+                    minProperties: 1
+                    properties:
+                      confidentialCompute:
+                        description: |-
+                          ConfidentialCompute specifies whether confidential computing should be enabled for the instance,
+                          and, if so, which confidential computing technology to use.
+                          Valid values are: Disabled, AMDEncryptedVirtualizationNestedPaging
+                          When set to Disabled, confidential computing will be disabled for the instance.
+                          When set to AMDEncryptedVirtualizationNestedPaging, AMD SEV-SNP will be used as the confidential computing technology for the instance.
+                          In this case, ensure the following conditions are met:
+                          1) The selected instance type supports AMD SEV-SNP.
+                          2) The selected AWS region supports AMD SEV-SNP.
+                          3) The selected AMI supports AMD SEV-SNP.
+                          More details can be checked at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html
+                          When omitted, this means no opinion and the AWS platform is left to choose a reasonable default,
+                          which is subject to change without notice. The current default is Disabled.
+                        enum:
+                        - Disabled
+                        - AMDEncryptedVirtualizationNestedPaging
+                        type: string
+                      nestedVirtualization:
+                        description: |-
+                          NestedVirtualization specifies whether to enable nested virtualization on the instance.
+                          Nested virtualization is supported on C8i, M8i, and R8i instance types.
+                          Valid values are: enabled, disabled
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
+                    type: object
                   enclaveOptions:
                     description: EnclaveOptions defines the options for Nitro Enclave
                       support on the instance.

--- a/exp/api/v1beta1/conversion.go
+++ b/exp/api/v1beta1/conversion.go
@@ -76,6 +76,7 @@ func (src *AWSMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 	if preference := restored.Spec.AWSLaunchTemplate.CapacityReservationPreference; preference != "" {
 		dst.Spec.AWSLaunchTemplate.CapacityReservationPreference = preference
 	}
+	dst.Spec.AWSLaunchTemplate.CPUOptions = restored.Spec.AWSLaunchTemplate.CPUOptions
 
 	dst.Spec.DefaultInstanceWarmup = restored.Spec.DefaultInstanceWarmup
 	dst.Spec.AWSLaunchTemplate.NonRootVolumes = restored.Spec.AWSLaunchTemplate.NonRootVolumes
@@ -143,6 +144,8 @@ func (src *AWSManagedMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 		if preference := restored.Spec.AWSLaunchTemplate.CapacityReservationPreference; preference != "" {
 			dst.Spec.AWSLaunchTemplate.CapacityReservationPreference = preference
 		}
+
+		dst.Spec.AWSLaunchTemplate.CPUOptions = restored.Spec.AWSLaunchTemplate.CPUOptions
 	}
 	if restored.Spec.AvailabilityZoneSubnetType != nil {
 		dst.Spec.AvailabilityZoneSubnetType = restored.Spec.AvailabilityZoneSubnetType

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -404,6 +404,7 @@ func autoConvert_v1beta2_AWSLaunchTemplate_To_v1beta1_AWSLaunchTemplate(in *v1be
 	out.ImageLookupOrg = in.ImageLookupOrg
 	out.ImageLookupBaseOS = in.ImageLookupBaseOS
 	out.InstanceType = in.InstanceType
+	// WARNING: in.CPUOptions requires manual conversion: does not exist in peer-type
 	out.RootVolume = (*apiv1beta2.Volume)(unsafe.Pointer(in.RootVolume))
 	// WARNING: in.NonRootVolumes requires manual conversion: does not exist in peer-type
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -97,6 +97,11 @@ type AWSLaunchTemplate struct {
 	// InstanceType is the type of instance to create. Example: m4.xlarge
 	InstanceType string `json:"instanceType,omitempty"`
 
+	// CPUOptions defines CPU-related settings for the instance, including the confidential computing policy.
+	// When omitted, this means no opinion and the AWS platform is left to choose a reasonable default.
+	// +optional
+	CPUOptions infrav1.CPUOptions `json:"cpuOptions,omitempty,omitzero"`
+
 	// RootVolume encapsulates the configuration options for the root volume
 	// +optional
 	RootVolume *infrav1.Volume `json:"rootVolume,omitempty"`

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -93,6 +93,7 @@ func (in *AWSFargateProfileList) DeepCopyObject() runtime.Object {
 func (in *AWSLaunchTemplate) DeepCopyInto(out *AWSLaunchTemplate) {
 	*out = *in
 	in.AMI.DeepCopyInto(&out.AMI)
+	out.CPUOptions = in.CPUOptions
 	if in.RootVolume != nil {
 		in, out := &in.RootVolume, &out.RootVolume
 		*out = new(apiv1beta2.Volume)

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -626,6 +626,7 @@ func (s *Service) createLaunchTemplateData(scope scope.LaunchTemplateScope, imag
 
 	data := &types.RequestLaunchTemplateData{
 		InstanceType: types.InstanceType(lt.InstanceType),
+		CpuOptions:   getLaunchTemplateCPUOptionsRequest(lt.CPUOptions),
 		KeyName:      sshKeyNamePtr,
 		UserData:     ptr.To[string](base64.StdEncoding.EncodeToString(userDataForLaunchTemplate)),
 	}
@@ -710,6 +711,29 @@ func (s *Service) createLaunchTemplateData(scope scope.LaunchTemplateScope, imag
 	data.TagSpecifications = s.buildLaunchTemplateTagSpecificationRequest(scope, userDataSecretKey, bootstrapDataHash)
 
 	return data, nil
+}
+
+func getLaunchTemplateCPUOptionsRequest(cpuOptions infrav1.CPUOptions) *types.LaunchTemplateCpuOptionsRequest {
+	request := &types.LaunchTemplateCpuOptionsRequest{}
+	switch cpuOptions.ConfidentialCompute {
+	case infrav1.AWSConfidentialComputePolicySEVSNP:
+		request.AmdSevSnp = types.AmdSevSnpSpecificationEnabled
+	case infrav1.AWSConfidentialComputePolicyDisabled:
+		request.AmdSevSnp = types.AmdSevSnpSpecificationDisabled
+	}
+
+	switch cpuOptions.NestedVirtualization {
+	case infrav1.NestedVirtualizationPolicyEnabled:
+		request.NestedVirtualization = types.NestedVirtualizationSpecificationEnabled
+	case infrav1.NestedVirtualizationPolicyDisabled:
+		request.NestedVirtualization = types.NestedVirtualizationSpecificationDisabled
+	}
+
+	if *request == (types.LaunchTemplateCpuOptionsRequest{}) {
+		return nil
+	}
+
+	return request
 }
 
 func getLaunchTemplateCapacityReservationSpecification(awsLaunchTemplate *expinfrav1.AWSLaunchTemplate) *types.LaunchTemplateCapacityReservationSpecificationRequest {
@@ -916,6 +940,7 @@ func (s *Service) SDKToLaunchTemplate(d types.LaunchTemplateVersion) (*expinfrav
 			ID: v.ImageId,
 		},
 		InstanceType:      string(v.InstanceType),
+		CPUOptions:        launchTemplateCPUOptionsFromSDK(v.CpuOptions),
 		SSHKeyName:        v.KeyName,
 		SpotMarketOptions: SDKToSpotMarketOptions(v.InstanceMarketOptions),
 		VersionNumber:     d.VersionNumber,
@@ -1009,6 +1034,29 @@ func (s *Service) SDKToLaunchTemplate(d types.LaunchTemplateVersion) (*expinfrav
 	return i, decodedUserDataHash, launchTemplateUserDataSecretKey, bootstrapDataHash, nil
 }
 
+func launchTemplateCPUOptionsFromSDK(cpuOptions *types.LaunchTemplateCpuOptions) infrav1.CPUOptions {
+	if cpuOptions == nil {
+		return infrav1.CPUOptions{}
+	}
+
+	result := infrav1.CPUOptions{}
+	switch cpuOptions.AmdSevSnp {
+	case types.AmdSevSnpSpecificationEnabled:
+		result.ConfidentialCompute = infrav1.AWSConfidentialComputePolicySEVSNP
+	case types.AmdSevSnpSpecificationDisabled:
+		result.ConfidentialCompute = infrav1.AWSConfidentialComputePolicyDisabled
+	}
+
+	switch cpuOptions.NestedVirtualization {
+	case types.NestedVirtualizationSpecificationEnabled:
+		result.NestedVirtualization = infrav1.NestedVirtualizationPolicyEnabled
+	case types.NestedVirtualizationSpecificationDisabled:
+		result.NestedVirtualization = infrav1.NestedVirtualizationPolicyDisabled
+	}
+
+	return result
+}
+
 // LaunchTemplateNeedsUpdate checks if a new launch template version is needed.
 //
 // FIXME(dlipovetsky): This check should account for changed userdata, but does not yet do so.
@@ -1020,6 +1068,10 @@ func (s *Service) LaunchTemplateNeedsUpdate(scope scope.LaunchTemplateScope, inc
 
 	if incoming.InstanceType != existing.InstanceType {
 		return true, services.LaunchTemplateNeedsUpdateReasonInstanceType, nil
+	}
+
+	if !cmp.Equal(incoming.CPUOptions, existing.CPUOptions) {
+		return true, services.LaunchTemplateNeedsUpdateReasonCPUOptions, nil
 	}
 
 	if !cmp.Equal(incoming.InstanceMetadataOptions, existing.InstanceMetadataOptions) {

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -370,6 +370,26 @@ func TestServiceSDKToLaunchTemplate(t *testing.T) {
 			wantBootstrapDataHash: nil, // respective tag is not given
 		},
 		{
+			name: "CPU options",
+			input: ec2types.LaunchTemplateVersion{
+				LaunchTemplateName: aws.String("foo"),
+				LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+					CpuOptions: &ec2types.LaunchTemplateCpuOptions{
+						AmdSevSnp:            ec2types.AmdSevSnpSpecificationEnabled,
+						NestedVirtualization: ec2types.NestedVirtualizationSpecificationEnabled,
+					},
+				},
+			},
+			wantLT: &expinfrav1.AWSLaunchTemplate{
+				Name: "foo",
+				CPUOptions: infrav1.CPUOptions{
+					ConfidentialCompute:  infrav1.AWSConfidentialComputePolicySEVSNP,
+					NestedVirtualization: infrav1.NestedVirtualizationPolicyEnabled,
+				},
+			},
+			wantUserDataHash: userdata.ComputeHash(nil),
+		},
+		{
 			name: "spot market options",
 			input: ec2types.LaunchTemplateVersion{
 				LaunchTemplateId:   aws.String("lt-12345"),
@@ -722,6 +742,32 @@ func TestServiceLaunchTemplateNeedsUpdate(t *testing.T) {
 			},
 			want:                  true,
 			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonInstanceType,
+		},
+		{
+			name: "Should return true if incoming CPUOptions differ from existing CPUOptions",
+			incoming: &expinfrav1.AWSLaunchTemplate{
+				CPUOptions: infrav1.CPUOptions{
+					NestedVirtualization: infrav1.NestedVirtualizationPolicyEnabled,
+				},
+			},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				CPUOptions: infrav1.CPUOptions{
+					NestedVirtualization: infrav1.NestedVirtualizationPolicyDisabled,
+				},
+			},
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonCPUOptions,
+		},
+		{
+			name:     "Should return true if incoming CPUOptions remove existing CPUOptions",
+			incoming: &expinfrav1.AWSLaunchTemplate{},
+			existing: &expinfrav1.AWSLaunchTemplate{
+				CPUOptions: infrav1.CPUOptions{
+					NestedVirtualization: infrav1.NestedVirtualizationPolicyEnabled,
+				},
+			},
+			want:                  true,
+			wantNeedsUpdateReason: services.LaunchTemplateNeedsUpdateReasonCPUOptions,
 		},
 		{
 			name: "new additional security group with filters",
@@ -1529,11 +1575,61 @@ var LaunchTemplateVersionIgnoreUnexported = cmpopts.IgnoreUnexported(
 	ec2types.LaunchTemplateIamInstanceProfileSpecificationRequest{},
 	ec2types.LaunchTemplateSpotMarketOptionsRequest{},
 	ec2types.LaunchTemplateInstanceMarketOptionsRequest{},
+	ec2types.LaunchTemplateCpuOptionsRequest{},
 	ec2types.Tag{},
 	ec2types.LaunchTemplateTagSpecificationRequest{},
 	ec2types.RequestLaunchTemplateData{},
 	ec2.CreateLaunchTemplateVersionInput{},
 )
+
+func TestGetLaunchTemplateCPUOptionsRequest(t *testing.T) {
+	testCases := []struct {
+		name            string
+		cpuOptions      infrav1.CPUOptions
+		expectedRequest *ec2types.LaunchTemplateCpuOptionsRequest
+	}{
+		{
+			name:            "empty",
+			expectedRequest: nil,
+		},
+		{
+			name: "enabled nested virtualization",
+			cpuOptions: infrav1.CPUOptions{
+				NestedVirtualization: infrav1.NestedVirtualizationPolicyEnabled,
+			},
+			expectedRequest: &ec2types.LaunchTemplateCpuOptionsRequest{
+				NestedVirtualization: ec2types.NestedVirtualizationSpecificationEnabled,
+			},
+		},
+		{
+			name: "disabled nested virtualization",
+			cpuOptions: infrav1.CPUOptions{
+				NestedVirtualization: infrav1.NestedVirtualizationPolicyDisabled,
+			},
+			expectedRequest: &ec2types.LaunchTemplateCpuOptionsRequest{
+				NestedVirtualization: ec2types.NestedVirtualizationSpecificationDisabled,
+			},
+		},
+		{
+			name: "confidential compute and nested virtualization",
+			cpuOptions: infrav1.CPUOptions{
+				ConfidentialCompute:  infrav1.AWSConfidentialComputePolicySEVSNP,
+				NestedVirtualization: infrav1.NestedVirtualizationPolicyEnabled,
+			},
+			expectedRequest: &ec2types.LaunchTemplateCpuOptionsRequest{
+				AmdSevSnp:            ec2types.AmdSevSnpSpecificationEnabled,
+				NestedVirtualization: ec2types.NestedVirtualizationSpecificationEnabled,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(getLaunchTemplateCPUOptionsRequest(tc.cpuOptions)).To(Equal(tc.expectedRequest))
+		})
+	}
+}
 
 func TestCreateLaunchTemplateVersion(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
@@ -1559,8 +1655,15 @@ func TestCreateLaunchTemplateVersion(t *testing.T) {
 		marketType           ec2types.MarketType
 	}{
 		{
-			name:                 "Should successfully creates launch template version",
+			name:                 "Should successfully create launch template version with CPU options",
 			awsResourceReference: []infrav1.AWSResourceReference{{ID: aws.String("1")}},
+			mpScopeUpdater: func(mps *scope.MachinePoolScope) {
+				spec := mps.AWSMachinePool.Spec
+				spec.AWSLaunchTemplate.CPUOptions = infrav1.CPUOptions{
+					NestedVirtualization: infrav1.NestedVirtualizationPolicyEnabled,
+				}
+				mps.AWSMachinePool.Spec = spec
+			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
 				sgMap := make(map[infrav1.SecurityGroupRole]infrav1.SecurityGroup)
 				sgMap[infrav1.SecurityGroupNode] = infrav1.SecurityGroup{ID: "1"}
@@ -1569,6 +1672,9 @@ func TestCreateLaunchTemplateVersion(t *testing.T) {
 				expectedInput := &ec2.CreateLaunchTemplateVersionInput{
 					LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
 						InstanceType: ec2types.InstanceTypeT3Large,
+						CpuOptions: &ec2types.LaunchTemplateCpuOptionsRequest{
+							NestedVirtualization: ec2types.NestedVirtualizationSpecificationEnabled,
+						},
 						IamInstanceProfile: &ec2types.LaunchTemplateIamInstanceProfileSpecificationRequest{
 							Name: aws.String("instance-profile"),
 						},

--- a/pkg/cloud/services/interfaces.go
+++ b/pkg/cloud/services/interfaces.go
@@ -52,6 +52,8 @@ const (
 	LaunchTemplateNeedsUpdateReasonIamInstanceProfile LaunchTemplateNeedsUpdateReason = "IamInstanceProfile"
 	// LaunchTemplateNeedsUpdateReasonInstanceType means a difference in the instance type was found.
 	LaunchTemplateNeedsUpdateReasonInstanceType LaunchTemplateNeedsUpdateReason = "InstanceType"
+	// LaunchTemplateNeedsUpdateReasonCPUOptions means a difference in the CPU options was found.
+	LaunchTemplateNeedsUpdateReasonCPUOptions LaunchTemplateNeedsUpdateReason = "CPUOptions"
 	// LaunchTemplateNeedsUpdateReasonInstanceMetadataOptions means a difference in the instance metadata options was found.
 	LaunchTemplateNeedsUpdateReasonInstanceMetadataOptions LaunchTemplateNeedsUpdateReason = "InstanceMetadataOptions"
 	// LaunchTemplateNeedsUpdateReasonSpotMarketOptions means a difference in the spot market options was found.


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

Expose CPU options on AWS launch templates so machine pools can configure nested virtualization and confidential compute. `CPUOptions` was already added to `AWSMachine.spec.cpuOptions` in #5874.

**AI Usage**:
Yes, GPT 5.6-Sol XHigh was used to write some of the code.

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [X] squashed commits
- [ ] includes documentation
- [X] includes AI generated content
- [X] includes emoji in title
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Add CPUOptions support to AWSMachinePool and AWSManagedMachinePool launch templates, enabling nested virtualization and AMD SEV-SNP configuration
```
