### PR TITLE
🌱 fix(ci): add delete-branch to detect-k8s-releases workflow

### DIFF
--- a/.github/workflows/detect-k8s-releases.yml
+++ b/.github/workflows/detect-k8s-releases.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: automation/update-k8s-supported-versions
+          delete-branch: true
           commit-message: "feat: update latest K8s version for CAPA AMIs build"
           title: "🤖 feat: Update latest K8s version for CAPA AMIs build"
           body: |


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The `detect-k8s-releases` workflow has been failing since June 2026 because `peter-evans/create-pull-request` cannot force-push to the existing `automation/update-k8s-supported-versions` branch, which is protected by the org-wide EasyCLA branch protection rule.

Adding `delete-branch: true` ensures the branch is cleaned up after the PR is merged, so subsequent runs create a fresh branch instead of attempting a force-push. This is the same approach used by other kubernetes-sigs repos (e.g. `provider-aws-test-infra`, `downloadkubernetes`).

**Note**: a one-time manual deletion of the stale `automation/update-k8s-supported-versions` branch is needed to unblock the next scheduled run.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

All 4 scheduled runs of `detect-k8s-releases` since June 1 have failed with:
```
remote: error: GH006: Protected branch update failed for refs/heads/automation/update-k8s-supported-versions.
remote: - Required status check "EasyCLA" is expected.
remote: - Cannot force-push to this branch
```

**AI Usage**:

Claude Code was used to research the root cause and identify the fix pattern used across other kubernetes-sigs repos.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
NONE
```