### PR TITLE
🐛 fix(bump): bump release-tools go.mod to 1.25 and update bump-go docs

### DIFF
--- a/.github/workflows/detect-k8s-releases.yml
+++ b/.github/workflows/detect-k8s-releases.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version-file: hack/tools/release-tools/go.mod
+          go-version-file: go.mod
           cache-dependency-path: hack/tools/release-tools/go.sum
 
       - name: Build release-tool

--- a/docs/book/src/development/bump-go.md
+++ b/docs/book/src/development/bump-go.md
@@ -52,7 +52,7 @@ reports the target Go minor or newer. Call this `GOLANGCI_VERSION` (e.g.
 
 ## Step 2: Update files
 
-### go.mod (root) and hack/tools/go.mod
+### go.mod (root), hack/tools/go.mod, and hack/tools/release-tools/go.mod
 
 Update the `go` directive:
 
@@ -137,11 +137,12 @@ digest than what this repo already has. If they match, skip this file.
 
 ## Step 3: go mod tidy
 
-Run in both module directories:
+Run in all module directories:
 
 ```bash
 go mod tidy
 cd hack/tools && go mod tidy
+cd release-tools && go mod tidy
 ```
 
 ## Step 4: Lint and test
@@ -181,7 +182,8 @@ Create **three separate commits** in this order:
      `.github/workflows/pr-golangci-lint.yaml`, and `.golangci.yml` if
      exclusion rules were added
 3. **Go version bump**: `chore(bump): bump Go to FULL_VERSION`
-   - All remaining files: `go.mod`, `hack/tools/go.mod`, `Makefile`,
+   - All remaining files: `go.mod`, `hack/tools/go.mod`,
+     `hack/tools/release-tools/go.mod`, `Makefile`,
      `.golangci-kal.yml`, `.github/workflows/dependabot.yml`,
      `.github/workflows/release.yaml`, `netlify.toml`,
      `cloudbuild.yaml`, `cloudbuild-nightly.yaml`

--- a/hack/tools/release-tools/go.mod
+++ b/hack/tools/release-tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/hack/tools/release-tools
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The Go 1.25 bump (#6135) missed `hack/tools/release-tools/go.mod`, which stayed at `go 1.24.0`. This caused the `detect-k8s-releases` workflow to [fail](https://github.com/kubernetes-sigs/cluster-api-provider-aws/actions/runs/30086486770/job/89459766239) because `setup-go` installed Go 1.24 (from the release-tools go.mod) but `generate-ami-inventory-report.sh` builds `clusterawsadm` from the root `go.mod` which requires Go 1.25:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.0; GOTOOLCHAIN=local)
```

This PR:
- Bumps `hack/tools/release-tools/go.mod` from `go 1.24.0` to `go 1.25.0`
- Changes `detect-k8s-releases.yml` to use `go-version-file: go.mod` (the main module) instead of `hack/tools/release-tools/go.mod`, since the workflow also builds binaries from the root module
- Updates the bump-go developer guide to include `hack/tools/release-tools/go.mod` so it won't be missed in future Go bumps

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

Claude Code was used to investigate the workflow failure and prepare this fix.

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
NONE
```