### PR TITLE
🐛 fix: authenticate GitHub API calls in auto-publish-ami workflow

### DIFF
--- a/.github/workflows/auto-publish-ami.yml
+++ b/.github/workflows/auto-publish-ami.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Determine target K8s versions
         id: versions
         env:
+          # Used by find-missing-ami to query the Kubernetes release API;
+          # unauthenticated requests share a per-IP rate limit across all
+          # jobs on the runner and get throttled with 403s.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MANUAL_VERSIONS: ${{ inputs.versions }}
           OWNER_ID: '819546954734'
           REGION: us-east-2
@@ -86,8 +90,8 @@ jobs:
           else
             # Pipe published AMIs directly into find-missing-ami to compute
             # which (k8s version × OS × region) combinations are absent.
-            # GITHUB_TOKEN is injected automatically by the Actions runner and
-            # is used by find-missing-ami to query the Kubernetes release API.
+            # find-missing-ami authenticates to the Kubernetes release API
+            # with the GITHUB_TOKEN set in this step's env.
             ./bin/clusterawsadm ami list \
               --owner-id "${OWNER_ID}" \
               --region "${CHECK_REGION}" \
@@ -113,6 +117,10 @@ jobs:
       - name: Build matrix from packer inputs
         id: matrix
         if: steps.versions.outputs.count != '0'
+        env:
+          # find-ami-publishing-inputs.sh uses this to authenticate its
+          # GitHub API lookup of crictl release tags.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 

--- a/scripts/find-ami-publishing-inputs.sh
+++ b/scripts/find-ami-publishing-inputs.sh
@@ -189,7 +189,13 @@ CNI_SEMVER="v$(echo "$CNI_DEB_VERSION" | cut -d'-' -f1)"
 # --- Determine CRICTL Version ---
 # Always based on the K8S_RELEASE_SERIES (vX.Y)
 echo "INFO: Fetching crictl release tags from GitHub API for series ${K8S_RELEASE_SERIES}..."
-CRICTL_RAW_TAG=$(curl -s https://api.github.com/repos/kubernetes-sigs/cri-tools/releases \
+# Authenticate when GITHUB_TOKEN is set (e.g. in CI) to avoid the shared
+# per-IP rate limit on unauthenticated GitHub API requests.
+GITHUB_AUTH_HEADER=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  GITHUB_AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+CRICTL_RAW_TAG=$(curl -s ${GITHUB_AUTH_HEADER[@]+"${GITHUB_AUTH_HEADER[@]}"} https://api.github.com/repos/kubernetes-sigs/cri-tools/releases \
   | grep '"tag_name":' \
   | grep "\"${K8S_RELEASE_SERIES}." \
   | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \


### PR DESCRIPTION
**What type of PR is this?**

/kind support

**What this PR does / why we need it**:

The 'Determine target K8s versions' step runs find-missing-ami without GITHUB_TOKEN in its environment, so the kubernetes/kubernetes tag listing is unauthenticated and hits the shared per-IP rate limit on hosted runners, failing the workflow with a 403. The inline comment claiming the token is injected automatically by the Actions runner was incorrect; it is only available via the secrets context.

Set GITHUB_TOKEN from secrets on that step and on the matrix step, and make find-ami-publishing-inputs.sh send an Authorization header for its crictl release lookup when the token is present, avoiding the same rate limit silently degrading crictl version detection.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

Claude Code with Fable helped investigate and make the change.

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
