### PR TITLE
🐛 fix: emit valid JSON/YAML from 'clusterawsadm ami list' when no AMIs …

### DIFF
--- a/cmd/clusterawsadm/cmd/ami/list/list.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list.go
@@ -19,12 +19,14 @@ package list
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/ami"
+	amiv1 "sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/api/ami/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/cmd/flags"
 	cmdout "sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/printers"
 )
@@ -60,11 +62,6 @@ func ListAMICmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			region, _ := flags.GetRegion(cmd)
 
-			printer, err := cmdout.New(outputPrinter, os.Stdout)
-			if err != nil {
-				return fmt.Errorf("failed creating output printer: %w", err)
-			}
-
 			listByVersion, err := ami.List(ami.ListInput{
 				Region:            region,
 				KubernetesVersion: kubernetesVersion,
@@ -74,19 +71,8 @@ func ListAMICmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(listByVersion.Items) == 0 {
-				fmt.Println("No AMIs found")
-				return nil
-			}
 
-			if outputPrinter == string(cmdout.PrinterTypeTable) {
-				table := listByVersion.ToTable()
-				printer.Print(table)
-			} else {
-				printer.Print(listByVersion)
-			}
-
-			return nil
+			return printAMIList(os.Stdout, outputPrinter, listByVersion)
 		},
 	}
 
@@ -96,6 +82,26 @@ func ListAMICmd() *cobra.Command {
 	addOutputFlag(newCmd)
 	addOwnerIDFlag(newCmd)
 	return newCmd
+}
+
+// printAMIList writes the AMI list to out in the requested format. The
+// human-friendly "No AMIs found" message is limited to table output so that
+// json/yaml output is always machine-parseable, even when the list is empty.
+func printAMIList(out io.Writer, format string, list *amiv1.AWSAMIList) error {
+	printer, err := cmdout.New(format, out)
+	if err != nil {
+		return fmt.Errorf("failed creating output printer: %w", err)
+	}
+
+	if format == string(cmdout.PrinterTypeTable) {
+		if len(list.Items) == 0 {
+			_, err := fmt.Fprintln(out, "No AMIs found")
+			return err
+		}
+		return printer.Print(list.ToTable())
+	}
+
+	return printer.Print(list)
 }
 
 func addOsFlag(c *cobra.Command) {

--- a/cmd/clusterawsadm/cmd/ami/list/list_test.go
+++ b/cmd/clusterawsadm/cmd/ami/list/list_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	amiv1 "sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/api/ami/v1beta1"
+)
+
+func newAMIList(items ...amiv1.AWSAMI) *amiv1.AWSAMIList {
+	return &amiv1.AWSAMIList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: amiv1.AWSAMIListKind,
+		},
+		Items: items,
+	}
+}
+
+func newAMI(kubernetesVersion, os, region, imageID string) amiv1.AWSAMI {
+	return amiv1.AWSAMI{
+		TypeMeta: metav1.TypeMeta{
+			Kind: amiv1.AWSAMIKind,
+		},
+		Spec: amiv1.AWSAMISpec{
+			KubernetesVersion: kubernetesVersion,
+			OS:                os,
+			Region:            region,
+			ImageID:           imageID,
+		},
+	}
+}
+
+func TestPrintAMIList(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		list      *amiv1.AWSAMIList
+		wantErr   bool
+		wantJSON  bool
+		wantItems int
+		wantText  string
+	}{
+		{
+			name:      "empty list with json output is valid JSON",
+			format:    "json",
+			list:      newAMIList(),
+			wantJSON:  true,
+			wantItems: 0,
+		},
+		{
+			name:     "empty list with table output prints message",
+			format:   "table",
+			list:     newAMIList(),
+			wantText: "No AMIs found",
+		},
+		{
+			name:      "non-empty list with json output round-trips items",
+			format:    "json",
+			list:      newAMIList(newAMI("v1.32.0", "ubuntu-24.04", "us-east-1", "ami-123")),
+			wantJSON:  true,
+			wantItems: 1,
+		},
+		{
+			name:     "non-empty list with table output prints rows",
+			format:   "table",
+			list:     newAMIList(newAMI("v1.32.0", "ubuntu-24.04", "us-east-1", "ami-123")),
+			wantText: "ami-123",
+		},
+		{
+			name:     "empty list with yaml output is not the table message",
+			format:   "yaml",
+			list:     newAMIList(),
+			wantText: "items:",
+		},
+		{
+			name:    "unknown format returns error",
+			format:  "xml",
+			list:    newAMIList(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := printAMIList(&out, tt.format, tt.list)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("printAMIList() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("printAMIList() unexpected error: %v", err)
+			}
+
+			if tt.wantJSON {
+				var got struct {
+					Items []struct {
+						Spec amiv1.AWSAMISpec `json:"spec"`
+					} `json:"items"`
+				}
+				if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+					t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out.String())
+				}
+				if len(got.Items) != tt.wantItems {
+					t.Errorf("got %d items, want %d", len(got.Items), tt.wantItems)
+				}
+			}
+
+			if tt.wantText != "" && !strings.Contains(out.String(), tt.wantText) {
+				t.Errorf("output %q does not contain %q", out.String(), tt.wantText)
+			}
+		})
+	}
+}

--- a/hack/tools/release-tools/cmd/ami/find_missing_ami_test.go
+++ b/hack/tools/release-tools/cmd/ami/find_missing_ami_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ami
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadPublishedAMIs(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name:      "empty input returns empty list",
+			input:     "",
+			wantCount: 0,
+		},
+		{
+			name:      "whitespace-only input returns empty list",
+			input:     "  \n\t",
+			wantCount: 0,
+		},
+		{
+			name:      "null items returns empty list",
+			input:     `{"kind":"AWSAMIList","items":null}`,
+			wantCount: 0,
+		},
+		{
+			name:      "empty items array returns empty list",
+			input:     `{"kind":"AWSAMIList","items":[]}`,
+			wantCount: 0,
+		},
+		{
+			name: "items are parsed",
+			input: `{"items":[
+				{"spec":{"kubernetesVersion":"v1.32.0","os":"ubuntu-24.04","region":"us-east-1"}},
+				{"spec":{"kubernetesVersion":"v1.31.4","os":"flatcar-stable","region":"ap-southeast-2"}}
+			]}`,
+			wantCount: 2,
+		},
+		{
+			name:    "plain text input returns parse error",
+			input:   "No AMIs found\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readPublishedAMIs(strings.NewReader(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("readPublishedAMIs() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readPublishedAMIs() unexpected error: %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("got %d published AMIs, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

When zero AMIs matched, 'clusterawsadm ami list' printed the plain-text message 'No AMIs found' regardless of the requested output format. In the auto-publish-ami workflow this output is piped into 'release-tool ami find-missing-ami', which failed to parse it:

  reading published AMIs from stdin: parsing AMI JSON: invalid character 'N'
  looking for beginning of value

An empty inventory is the expected state when no AMIs have been published yet in the check region, so the pipeline must handle it.

Limit the human-friendly message to table output and always print an (empty) AWSAMIList through the json/yaml printers so the output stays machine-parseable. Add unit tests for the new printAMIList helper and for find-missing-ami's stdin parsing of empty/null/invalid inventories.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

Claude code with Fable

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix(clusterawsadm): allow zero results in release-tool ami find-missing-ami
```
