### PR TITLE
🌱 chore(e2e): bump workload cluster Kubernetes to v1.34.10

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -188,9 +188,9 @@ variables:
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
   KUBERNETES_VERSION_MANAGEMENT: "v1.34.3" # Kind bootstrap
-  KUBERNETES_VERSION: "v1.33.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.4"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.32.0"
+  KUBERNETES_VERSION: "v1.34.10"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.34.10"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.33.4"
   CNI: "../../data/cni/calico.yaml"
   KUBETEST_CONFIGURATION: "../../data/kubetest/conformance.yaml"
   EVENT_BRIDGE_INSTANCE_STATE: "true"
@@ -198,11 +198,11 @@ variables:
   AWS_NODE_MACHINE_TYPE: t3.large
   AWS_MACHINE_TYPE_VCPU_USAGE: 2
   AWS_SSH_KEY_NAME: "cluster-api-provider-aws-sigs-k8s-io"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.33.4"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.34.10"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "3"
-  ETCD_VERSION_UPGRADE_TO: "3.5.21-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.12.0"
+  ETCD_VERSION_UPGRADE_TO: "3.6.5-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.12.1"
   MULTI_TENANCY_ROLE_NAME: "multi-tenancy-role"
   MULTI_TENANCY_NESTED_ROLE_NAME: "multi-tenancy-nested-role"
   IP_FAMILY: "IPv4"
@@ -215,7 +215,7 @@ variables:
   INIT_WITH_BINARY_V1BETA1: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/clusterctl-{OS}-{ARCH}"
   # INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_KUBERNETES_VERSION: "v1.34.3"
+  INIT_WITH_KUBERNETES_VERSION: "v1.34.10"
   EXP_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   GC_WORKLOAD: "../../data/gcworkload.yaml"

--- a/test/e2e/data/e2e_eks_conf.yaml
+++ b/test/e2e/data/e2e_eks_conf.yaml
@@ -132,10 +132,10 @@ providers:
         targetName: "cluster-template-eks-nitro-enclave-managedmachinepool.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.34.8"
+  KUBERNETES_VERSION: "v1.34.10"
   KUBERNETES_VERSION_MANAGEMENT: "v1.34.3" # Kind bootstrap
-  UPGRADE_TO_VERSION: "v1.34.8"
-  UPGRADE_FROM_VERSION: "v1.33.4"
+  UPGRADE_TO_VERSION: "v1.34.10"
+  UPGRADE_FROM_VERSION: "v1.34.8"
   EXP_MACHINE_POOL: "true"
   EXP_MACHINE_POOL_MACHINES: "true"
   EXP_CLUSTER_RESOURCE_SET: "true"
@@ -148,7 +148,7 @@ variables:
   EXP_EKS_ADD_ROLES: "false"
   VPC_ADDON_VERSION: "v1.21.1-eksbuild.7"
   KUBE_PROXY_ADDON_VERSION: "v1.34.6-eksbuild.2"
-  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.34.8"
+  CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION: "v1.34.10"
   IP_FAMILY: "IPv4"
   CAPA_LOGLEVEL: "4"
   GC_WORKLOAD: "../../data/gcworkload.yaml"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps Kubernetes workload cluster versions in e2e test configurations to v1.34.10.

Changes in `test/e2e/data/e2e_conf.yaml` (unmanaged clusters):
- `KUBERNETES_VERSION`: v1.33.4 → v1.34.10
- `KUBERNETES_VERSION_UPGRADE_TO`: v1.33.4 → v1.34.10
- `KUBERNETES_VERSION_UPGRADE_FROM`: v1.32.0 → v1.33.4
- `CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION`: v1.33.4 → v1.34.10
- `INIT_WITH_KUBERNETES_VERSION`: v1.34.3 → v1.34.10
- `ETCD_VERSION_UPGRADE_TO`: 3.5.21-0 → 3.6.5-0 (matches kubeadm 1.34 default)
- `COREDNS_VERSION_UPGRADE_TO`: v1.12.0 → v1.12.1 (matches kubeadm 1.34 default)

Changes in `test/e2e/data/e2e_eks_conf.yaml` (EKS clusters):
- `KUBERNETES_VERSION`: v1.34.8 → v1.34.10
- `UPGRADE_TO_VERSION`: v1.34.8 → v1.34.10
- `UPGRADE_FROM_VERSION`: v1.33.4 → v1.34.8
- `CONFORMANCE_CI_ARTIFACTS_KUBERNETES_VERSION`: v1.34.8 → v1.34.10

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

- Kind bootstrap (`KUBERNETES_VERSION_MANAGEMENT`) left unchanged at v1.34.3 in both configs.
- `KUBE_PROXY_ADDON_VERSION` left at v1.34.6-eksbuild.2 (latest kube-proxy for k8s 1.34 is still v1.34.6, only the eksbuild number has changed).
- etcd and CoreDNS versions updated to match [kubeadm 1.34 defaults](https://github.com/kubernetes/kubernetes/blob/release-1.34/cmd/kubeadm/app/constants/constants.go).

**AI Usage**:

Claude Code was used to search for version references across the codebase, look up kubeadm default component versions, and apply the edits.

**Checklist**:

- [X] squashed commits
- [ ] includes documentation
- [X] includes AI generated content
- [X] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
chore(e2e): bump workload cluster Kubernetes to v1.34.10
```