### PR TITLE
🐛 fix: incorrect region used build ami v2

### DIFF
--- a/.github/workflows/build-ami-v2.yml
+++ b/.github/workflows/build-ami-v2.yml
@@ -42,7 +42,7 @@ permissions:
   contents: read
 
 env:
-  DEFAULT_REGIONS: "us-southeast-2"
+  DEFAULT_REGIONS: "us-east-2"
   AWS_ACCOUNT_ID: "819546954734"
 
 jobs:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We are using the wrong version when getting the AWS credentials. Changed to us-east-2. As can be seen by this failed GHA run: https://github.com/kubernetes-sigs/cluster-api-provider-aws/actions/runs/30256416028/job/89947133508

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

NONE

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Set correct region when building AMIs automatically.
```
