### PR TITLE
🐛 fix: use image-builder v0.1.55

### DIFF
--- a/.github/workflows/build-ami-v2.yml
+++ b/.github/workflows/build-ami-v2.yml
@@ -10,11 +10,11 @@ on:
       image_builder_version:
         type: string
         required: false
-        default: "990737c79abb37fd56faca64f46e5a385dd1a982"
+        default: "7ffb9b7f1f26cd66891874463cc9411e3633325f" # v0.1.55
       regions:
         type: string
         required: false
-        default: 'ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2'
+        default: "ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2"
       k8s_semver:
         type: string
         required: true
@@ -49,7 +49,7 @@ jobs:
   buildandpublish:
     strategy:
       matrix:
-        target: ['ubuntu-2204', 'ubuntu-2404', 'flatcar']
+        target: ["ubuntu-2204", "ubuntu-2404", "flatcar"]
       max-parallel: 1
       fail-fast: false
     name: Build and publish CAPA AMIs

--- a/.github/workflows/build-ami-varsfile.yml
+++ b/.github/workflows/build-ami-varsfile.yml
@@ -6,19 +6,19 @@ on:
       image_builder_repo:
         description: "Image builder repository (format: user/repo-name)"
         required: true
-        default: 'kubernetes-sigs/image-builder'
+        default: "kubernetes-sigs/image-builder"
       image_builder_version:
         description: "Image builder version"
         required: true
-        default: 'v0.1.52'
+        default: "v0.1.55"
       target:
         description: "target os"
         required: true
         type: choice
         options:
-        - ubuntu-2204
-        - ubuntu-2404
-        - flatcar
+          - ubuntu-2204
+          - ubuntu-2404
+          - flatcar
       packer_vars:
         description: "Packer vars (json)"
         type: string
@@ -64,4 +64,3 @@ jobs:
         if: inputs.packer_vars == ''
         working-directory: ./images/capi
         run: make build-ami-${{ inputs.target }}
-

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -6,35 +6,35 @@ on:
       image_builder_repo:
         description: "Image builder repository (format: user/repo-name)"
         required: true
-        default: 'kubernetes-sigs/image-builder'
+        default: "kubernetes-sigs/image-builder"
       image_builder_version:
         description: "Image builder version"
         required: true
-        default: 'v0.1.52'
+        default: "v0.1.55"
       regions:
-        description: 'Publication regions'
+        description: "Publication regions"
         required: true
-        default: 'ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2'
+        default: "ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2"
       k8s_semver:
-        description: 'K8s Semver'
+        description: "K8s Semver"
         required: true
       k8s_series:
-        description: 'K8s Release Series (major.minor version)'
+        description: "K8s Release Series (major.minor version)"
         required: true
       k8s_rpm_version:
-        description: 'K8s rpm package version'
+        description: "K8s rpm package version"
         required: true
       k8s_deb_version:
-        description: 'K8s deb package version'
+        description: "K8s deb package version"
         required: true
       cni_semver:
-        description: 'CNI Semver'
+        description: "CNI Semver"
         required: true
       cni_deb_version:
-        description: 'CNI deb package version'
+        description: "CNI deb package version"
         required: true
       crictl_version:
-        description: 'Crictl version'
+        description: "Crictl version"
         required: true
 
 permissions:
@@ -45,7 +45,7 @@ jobs:
   buildandpublish:
     strategy:
       matrix:
-        target: ['ubuntu-2204', 'ubuntu-2404', 'flatcar']
+        target: ["ubuntu-2204", "ubuntu-2404", "flatcar"]
       max-parallel: 1
       fail-fast: false
     name: Build and publish CAPA AMIs
@@ -96,4 +96,3 @@ jobs:
       - name: Build AMI
         working-directory: ./images/capi
         run: PACKER_VAR_FILES=vars.json make build-ami-${{ matrix.target }}
-


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Update the version of image-builder used in the AMI build workflows to v0.1.55 so that we can take advantage of a fix to the flatcar image build that increases the disk size from 8GB to 15GB to ensure the snapshot fits into it.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

NONE

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [ ] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Bump image-builder version for AMI builds.
```
