### PR TITLE
🌱 fix(ci): goreleaser now needs go 1.26

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Set version info
         run: |
           echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
**What type of PR is this?**

/kind support

```release-note
NONE
```
