### PR TITLE
:seedling: Bump Go to 1.26

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: '1.25'
+        go-version: '1.26'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 10m
-  go: "1.25"
+  go: "1.26"
   allow-parallel-runners: true
 
 linters:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 # https://suva.sh/posts/well-documented-makefiles
 
 # Go
-GO_VERSION ?=1.25.12
-GO_DIRECTIVE_VERSION ?= 1.25.0
+GO_VERSION ?=1.26.5
+GO_DIRECTIVE_VERSION ?= 1.26.0
 GO_CONTAINER_IMAGE ?= golang:$(GO_VERSION)
 
 # Directories.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/v2
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/alessio/shellescape v1.4.2

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -45,7 +45,7 @@ ifeq ($(OS), windows)
 	MDBOOK_EXTRACT_COMMAND := unzip -d /tmp
 endif
 
-# Use a golangci-lint built with Go >= 1.25 to match repo go.mod
+# Use a golangci-lint built with Go >= 1.26 to match repo go.mod
 GOLANGCI_LINT_VERSION := v2.12.2
 ## --------------------------------------
 ## Tooling Binaries

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/hack/tools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/a8m/envsubst v1.4.3

--- a/hack/tools/release-tools/go.mod
+++ b/hack/tools/release-tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/hack/tools/release-tools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.25.12"
+    GO_VERSION = "1.26.5"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What type of PR is this?**

/kind support

**What this PR does / why we need it**:

Bumps Go from 1.25.12 to 1.26.5 across the project:
- `go.mod`, `hack/tools/go.mod`, `hack/tools/release-tools/go.mod`: go directive → `1.26.0`
- `Makefile`: `GO_VERSION` → `1.26.5`, `GO_DIRECTIVE_VERSION` → `1.26.0`
- `.golangci-kal.yml`: `go:` → `"1.26"`
- `hack/tools/Makefile`: comment update for Go >= 1.26
- `.github/workflows/dependabot.yml`, `.github/workflows/release.yaml`: `go-version` → `'1.26'`
- `netlify.toml`: `GO_VERSION` → `"1.26.5"`

No golangci-lint version change needed — v2.12.2 pre-built binary is already built with Go 1.26.2.
No cloudbuild changes needed — GCB digest already matches upstream CAPI v1.13.4.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

Claude Code (Opus) was used to automate the Go version bump following the project's `docs/book/src/development/bump-go.md` guide via the `/bump-go` skill.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
chore(bump): bump Go to 1.26
```