### PR TITLE
🐛 Exclude CNI (secondary) subnets from EKS control plane VPC config

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -344,6 +344,7 @@ func makeKubernetesNetworkConfig(serviceCidrs *clusterv1.NetworkRanges) (*ekstyp
 
 func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.EndpointAccess, securityGroups map[infrav1.SecurityGroupRole]infrav1.SecurityGroup) (*ekstypes.VpcConfigRequest, error) {
 	// TODO: Do we need to just add the private subnets?
+	subnets = subnets.FilterNonCni()
 	if len(subnets) < 2 {
 		return nil, awserrors.NewFailedDependency("at least 2 subnets is required")
 	}

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -267,6 +267,35 @@ func TestMakeVPCConfig(t *testing.T) {
 				PublicAccessCidrs: []string{"10.0.0.0/24"},
 			},
 		},
+		{
+			name: "cni subnets are excluded",
+			input: input{
+				subnets: []infrav1.SubnetSpec{
+					{
+						ID:               idOne,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2a",
+					},
+					{
+						ID:               idTwo,
+						CidrBlock:        "10.0.11.0/24",
+						AvailabilityZone: "us-west-2b",
+					},
+					{
+						ID:               "cni-subnet",
+						CidrBlock:        "100.64.0.0/18",
+						AvailabilityZone: "us-west-2a",
+						Tags: infrav1.Tags{
+							infrav1.NameAWSSubnetAssociation: infrav1.SecondarySubnetTagValue,
+						},
+					},
+				},
+				endpointAccess: ekscontrolplanev1.EndpointAccess{},
+			},
+			expect: &ekstypes.VpcConfigRequest{
+				SubnetIds: []string{idOne, idTwo},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

EKS control plane ENIs could be placed in subnets tagged with
`sigs.k8s.io/cluster-api-provider-aws/association=secondary`, because
`makeVpcConfig` passes all subnets from the spec to EKS `CreateCluster`.
When the secondary CIDR is a non-routable range (common CGNAT pattern,
e.g. 100.64.0.0/16), this makes the private endpoint unreachable from
outside the VPC — including from the CAPA management cluster, which then
fails all workload-cluster reconciliation with connection timeouts.

This PR applies `FilterNonCni()` in `makeVpcConfig`, consistent with
nodegroup and EC2 instance placement (see #4800, which introduced the
helper for exactly this purpose but left the control plane path
unfiltered).

No effect on existing clusters — this only affects `CreateCluster` input;
`reconcileVpcConfig` does not reconcile SubnetIds.

**Which issue(s) this PR fixes:**
Fixes #6172 

**Special notes for your reviewer:**
Added test cases to `TestMakeVPCConfig` covering CNI subnet exclusion.

**Checklist:**
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

```release-note
fix(eks): control plane ENIs are no longer placed in subnets tagged for CNI/pod networking
```