### PR TITLE
✨ feat: add support for controlplane egress mode

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2569,6 +2569,16 @@ spec:
                   bare EKS cluster without EKS default networking addons
                   If you set this value to false when creating a cluster, the default networking add-ons will not be installed
                 type: boolean
+              controlPlaneEgressMode:
+                default: aws-managed
+                description: |-
+                  ControlPlaneEgressMode specifies how traffic should leave the control plane. It defaults to aws-managed.
+                  You can change the mode from aws-managed to customer-routed. But once set to customer-routed it cannot
+                  be changed at a later date.
+                enum:
+                - aws-managed
+                - customer-routed
+                type: string
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
                   communicate with the control plane.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
@@ -251,6 +251,16 @@ spec:
                           bare EKS cluster without EKS default networking addons
                           If you set this value to false when creating a cluster, the default networking add-ons will not be installed
                         type: boolean
+                      controlPlaneEgressMode:
+                        default: aws-managed
+                        description: |-
+                          ControlPlaneEgressMode specifies how traffic should leave the control plane. It defaults to aws-managed.
+                          You can change the mode from aws-managed to customer-routed. But once set to customer-routed it cannot
+                          be changed at a later date.
+                        enum:
+                        - aws-managed
+                        - customer-routed
+                        type: string
                       controlPlaneEndpoint:
                         description: ControlPlaneEndpoint represents the endpoint
                           used to communicate with the control plane.

--- a/controlplane/eks/api/v1beta1/conversion.go
+++ b/controlplane/eks/api/v1beta1/conversion.go
@@ -122,6 +122,7 @@ func (r *AWSManagedControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Status.Version = restored.Status.Version
 	dst.Spec.BootstrapSelfManagedAddons = restored.Spec.BootstrapSelfManagedAddons
 	dst.Spec.UpgradePolicy = restored.Spec.UpgradePolicy
+	dst.Spec.ControlPlaneEgressMode = restored.Spec.ControlPlaneEgressMode
 	return nil
 }
 

--- a/controlplane/eks/api/v1beta1/zz_generated.conversion.go
+++ b/controlplane/eks/api/v1beta1/zz_generated.conversion.go
@@ -382,6 +382,7 @@ func autoConvert_v1beta2_AWSManagedControlPlaneSpec_To_v1beta1_AWSManagedControl
 		return err
 	}
 	// WARNING: in.UpgradePolicy requires manual conversion: does not exist in peer-type
+	// WARNING: in.ControlPlaneEgressMode requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
@@ -226,6 +226,13 @@ type AWSManagedControlPlaneSpec struct { //nolint: maligned
 	// +kubebuilder:validation:Enum=extended;standard
 	// +optional
 	UpgradePolicy UpgradePolicy `json:"upgradePolicy,omitempty"`
+
+	// ControlPlaneEgressMode specifies how traffic should leave the control plane. It defaults to aws-managed.
+	// You can change the mode from aws-managed to customer-routed. But once set to customer-routed it cannot
+	// be changed at a later date.
+	// +kubebuilder:default=aws-managed
+	// +kubebuilder:validation:Enum=aws-managed;customer-routed
+	ControlPlaneEgressMode ControlPlaneEgressMode `json:"controlPlaneEgressMode,omitempty"`
 }
 
 // KubeProxy specifies how the kube-proxy daemonset is managed.

--- a/controlplane/eks/api/v1beta2/types.go
+++ b/controlplane/eks/api/v1beta2/types.go
@@ -360,3 +360,15 @@ type OIDCIdentityProviderConfig struct {
 	// +optional
 	Tags infrav1.Tags `json:"tags,omitempty"`
 }
+
+// ControlPlaneEgressMode represents the different ways traffic can leave the control plane.
+type ControlPlaneEgressMode string
+
+var (
+	// ControlPlaneEgressModeAwsManaged specifies that the control plane routes customer-controllable traffic
+	// (such as admission webhooks) through AWS managed networking.
+	ControlPlaneEgressModeAwsManaged = ControlPlaneEgressMode("aws-managed")
+	// ControlPlaneEgressModeCustomerRouted specifies that the control plane routes customer-controllable traffic
+	// (such as admission webhooks) through your VPC instead of AWS managed networking.
+	ControlPlaneEgressModeCustomerRouted = ControlPlaneEgressMode("customer-routed")
+)

--- a/controlplane/eks/webhooks/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/webhooks/awsmanagedcontrolplane_webhook.go
@@ -69,8 +69,10 @@ func (w *AWSManagedControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error
 // +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-awsmanagedcontrolplane,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=awsmanagedcontrolplanes,versions=v1beta2,name=validation.awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-awsmanagedcontrolplane,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=awsmanagedcontrolplanes,versions=v1beta2,name=default.awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.CustomDefaulter = &AWSManagedControlPlane{}
-var _ webhook.CustomValidator = &AWSManagedControlPlane{}
+var (
+	_ webhook.CustomDefaulter = &AWSManagedControlPlane{}
+	_ webhook.CustomValidator = &AWSManagedControlPlane{}
+)
 
 func parseEKSVersion(raw string) (*version.Version, error) {
 	v, err := version.ParseGeneric(raw)
@@ -188,6 +190,12 @@ func (w *AWSManagedControlPlane) ValidateUpdate(ctx context.Context, oldObj, new
 	if oldAWSManagedControlplane.Spec.NetworkSpec.VPC.IsIPv6Enabled() != r.Spec.NetworkSpec.VPC.IsIPv6Enabled() {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "network", "vpc", "enableIPv6"), r.Spec.NetworkSpec.VPC.IsIPv6Enabled(), "changing IP family is not allowed after it has been set"))
+	}
+
+	if oldAWSManagedControlplane.Spec.ControlPlaneEgressMode == ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted &&
+		r.Spec.ControlPlaneEgressMode != ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "controlPlaneEgressMode"), r.Spec.ControlPlaneEgressMode, "cannot change egress mode from customer routed"))
 	}
 
 	if len(allErrs) == 0 {

--- a/controlplane/eks/webhooks/awsmanagedcontrolplane_webhook_test.go
+++ b/controlplane/eks/webhooks/awsmanagedcontrolplane_webhook_test.go
@@ -86,21 +86,21 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true, ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged},
 		},
 		{
 			name:         "less than 100 chars, dot in name",
 			resourceName: "team1.cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_team1_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_team1_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true, ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged},
 		},
 		{
 			name:         "more than 100 chars",
 			resourceName: "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde",
 			resourceNS:   "default",
 			expectHash:   true,
-			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "capi_", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "capi_", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true, ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged},
 		},
 		{
 			name:         "with patch",
@@ -108,7 +108,7 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceNS:   "default",
 			expectHash:   false,
 			spec:         ekscontrolplanev1.AWSManagedControlPlaneSpec{Version: &vV1_17_1},
-			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Version: &vV1_17_1, IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", Version: &vV1_17_1, IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true, ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged},
 		},
 		{
 			name:         "with allowed ip on bastion",
@@ -129,6 +129,7 @@ func TestDefaultingWebhook(t *testing.T) {
 				NetworkSpec:                defaultNetworkSpec,
 				TokenMethod:                &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator,
 				BootstrapSelfManagedAddons: true,
+				ControlPlaneEgressMode:     ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 			},
 		},
 		{
@@ -137,14 +138,14 @@ func TestDefaultingWebhook(t *testing.T) {
 			resourceNS:   "default",
 			expectHash:   false,
 			spec:         ekscontrolplanev1.AWSManagedControlPlaneSpec{NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}}},
-			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}, VPC: defaultVPCSpec}, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: infrav1.NetworkSpec{CNI: &infrav1.CNISpec{}, VPC: defaultVPCSpec}, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true, ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged},
 		},
 		{
 			name:         "secondary CIDR",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			expectHash:   false,
-			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, SecondaryCidrBlock: nil, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true},
+			expectSpec:   ekscontrolplanev1.AWSManagedControlPlaneSpec{EKSClusterName: "default_cluster1", IdentityRef: defaultIdentityRef, Bastion: defaultTestBastion, NetworkSpec: defaultNetworkSpec, SecondaryCidrBlock: nil, TokenMethod: &ekscontrolplanev1.EKSTokenMethodIAMAuthenticator, BootstrapSelfManagedAddons: true, ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged},
 		},
 	}
 
@@ -864,6 +865,64 @@ func TestWebhookUpdate(t *testing.T) {
 				},
 			},
 			expectError: true,
+		},
+		{
+			name: "egress mode customer-routed unchanged is allowed",
+			oldClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted,
+			},
+			newClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted,
+			},
+			expectError: false,
+		},
+		{
+			name: "changing egress mode from customer-routed to aws-managed is denied",
+			oldClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted,
+			},
+			newClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
+			},
+			expectError: true,
+		},
+		{
+			name: "changing egress mode from customer-routed to unset is denied",
+			oldClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted,
+			},
+			newClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+			},
+			expectError: true,
+		},
+		{
+			name: "changing egress mode from aws-managed to customer-routed is allowed",
+			oldClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
+			},
+			newClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted,
+			},
+			expectError: false,
+		},
+		{
+			name: "setting egress mode from unset to customer-routed is allowed",
+			oldClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName: "default_cluster1",
+			},
+			newClusterSpec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+				EKSClusterName:         "default_cluster1",
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted,
+			},
+			expectError: false,
 		},
 		{
 			name: "changing ipv6 enabled is not allowed after it has been set - true, false",

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.7/.schema/devbox.schema.json",
   "packages": [
-    "go@latest",
+    "go@1.24.0",
     "kind@latest",
     "docker@latest",
     "jq@latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -236,51 +236,51 @@
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "resolved": "github:NixOS/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a?lastModified=1741865919&narHash=sha256-4thdbnP6dlbdq%2BqZWTsm4ffAwoS8Tiq1YResB%2BRP6WE%3D"
     },
-    "go@latest": {
-      "last_modified": "2025-07-28T17:09:23Z",
-      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#go",
+    "go@1.24.0": {
+      "last_modified": "2025-02-23T09:42:26Z",
+      "resolved": "github:NixOS/nixpkgs/2d068ae5c6516b2d04562de50a58c682540de9bf#go_1_24",
       "source": "devbox-search",
-      "version": "1.24.5",
+      "version": "1.24.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/kw1vd98s15vj700m3gx2x2xca2z477i3-go-1.24.5",
+              "path": "/nix/store/v495d2fb3ffi08ri6jffvhzr08p104pk-go-1.24.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/kw1vd98s15vj700m3gx2x2xca2z477i3-go-1.24.5"
+          "store_path": "/nix/store/v495d2fb3ffi08ri6jffvhzr08p104pk-go-1.24.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/5bzlaj0c4mqw9p0zrcx5g9vz16vd45dl-go-1.24.5",
+              "path": "/nix/store/fy5xhvha2ha7jcyqp73haqrpg8npw63b-go-1.24.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/5bzlaj0c4mqw9p0zrcx5g9vz16vd45dl-go-1.24.5"
+          "store_path": "/nix/store/fy5xhvha2ha7jcyqp73haqrpg8npw63b-go-1.24.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/b72n20ixzl5ja9vciwahkr30bhmsn5jc-go-1.24.5",
+              "path": "/nix/store/gg6947k6wwxq7ld2f90i62fkcf3kdd55-go-1.24.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/b72n20ixzl5ja9vciwahkr30bhmsn5jc-go-1.24.5"
+          "store_path": "/nix/store/gg6947k6wwxq7ld2f90i62fkcf3kdd55-go-1.24.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/y4awwzp30ka130wmjrpaqjmjdf9p010w-go-1.24.5",
+              "path": "/nix/store/wk1vg9ksvmqwxhgj7cmvdv1g62v9kff0-go-1.24.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/y4awwzp30ka130wmjrpaqjmjdf9p010w-go-1.24.5"
+          "store_path": "/nix/store/wk1vg9ksvmqwxhgj7cmvdv1g62v9kff0-go-1.24.0"
         }
       }
     },

--- a/docs/book/src/topics/eks/controlplane-egress.md
+++ b/docs/book/src/topics/eks/controlplane-egress.md
@@ -1,0 +1,36 @@
+# Control Plane Egress Routing
+
+## Overview
+
+The default behaviour of EKS is to manage the routing of controlplane traffic to resources in your VPC, for example, when webhooks are called. This is called "AWS Managed".
+
+There may be situations where you want full control over how the traffic is routed. This is especially useful for highly regulated environments. This is called "customer routed".
+
+The table below summarizes the 2 modes:
+
+| Mode | Description | 
+| --- | --- | 
+|  `aws-managed`  | Default behavior. Amazon EKS manages the egress path from the control plane ENIs. You don’t need to configure NAT gateways or other routing infrastructure for control plane traffic. | 
+|  `customer-routed`  | You manage the egress path from the control plane in your VPC subnets. You are responsible for ensuring that the control plane can reach required endpoints (such as webhook servers, OIDC providers, and other resources). You provide an egress path, such as a NAT gateway, NAT instance, transit gateway, or firewall appliance. You also configure the route table, network ACL, and security group rules that allow this traffic. | 
+
+**Important**  
+In `customer-routed` mode, you’re responsible for ensuring proper network connectivity from the control plane. Misconfigurations in your VPC networking can cause control plane operations to fail. These misconfigurations include a missing egress path, restrictive network ACLs, or incorrect security groups. Affected operations include admission webhook calls and OIDC authentication.
+
+## How to use
+
+You can set the control plane egress mode using the `controlPlaneEgressMode` field of the `AWSManagedControlPlane`:
+
+```yaml
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "capi-managed-test-control-plane"
+spec:
+  ...
+  controlPlaneEgressMode: aws-managed
+```
+
+## Further information
+
+See the AWS documentation [here](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-egress.html).
+

--- a/docs/book/src/topics/eks/index.md
+++ b/docs/book/src/topics/eks/index.md
@@ -38,3 +38,4 @@ And a number of new templates are available in the templates folder for creating
 - [Enabling Encryption](encryption.md)
 - [Cluster Upgrades](cluster-upgrades.md)
 - [Using EKS Pod Identity for controller credentials](eks-pod-identity.md)
+- [Control Plane Egress Traffic](controlplane-egress.md)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-vpc-cni-k8s v1.15.5
 	github.com/aws/aws-lambda-go v1.41.0
-	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.31.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.19.12
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.288.0
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/efs v1.39.0
-	github.com/aws/aws-sdk-go-v2/service/eks v1.64.0
+	github.com/aws/aws-sdk-go-v2/service/eks v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.29.6
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.2
 	github.com/aws/aws-sdk-go-v2/service/iam v1.32.0
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.28.6
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.59.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.38.6
-	github.com/aws/smithy-go v1.24.2
+	github.com/aws/smithy-go v1.27.1
 	github.com/awslabs/goformation/v4 v4.19.5
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/ignition v0.35.0
@@ -122,8 +122,8 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.9 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.50.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/aws/amazon-vpc-cni-k8s v1.15.5 h1:/mqTXB4HoGYg4CiU4Gco9iEvZ+V/309Na4H
 github.com/aws/amazon-vpc-cni-k8s v1.15.5/go.mod h1:jV4wNtmgT2Ra1/oZU99DPOFsCUKnf0mYfIyzDyAUVAY=
 github.com/aws/aws-lambda-go v1.41.0 h1:l/5fyVb6Ud9uYd411xdHZzSf2n86TakxzpvIoz7l+3Y=
 github.com/aws/aws-lambda-go v1.41.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
-github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
-github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
+github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.31.12 h1:pYM1Qgy0dKZLHX2cXslNacbcEFMkDMl+Bcj5ROuS6p8=
@@ -54,10 +54,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.9 h1:Mv4Bc0mWmv6oDuSWTKnk+wg
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.9/go.mod h1:IKlKfRppK2a1y0gy1yH6zD+yX5uplJ6UuPlgd48dJiQ=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.19.12 h1:ofHawDLJTI6ytDIji+g4dXQ6u2idzTb04tDlN9AS614=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.19.12/go.mod h1:f5pL4iLDfbcxj1SZcdRdIokBB5eHbuYPS/Fs9DwUPRQ=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -76,8 +76,8 @@ github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.36.0 h1:8GcatvIKYx5WkwjwY4H+K7
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.36.0/go.mod h1:yz4NeCWotlbHoT41Vc9NofCbKEyiNlKYZFT4SiqVQCY=
 github.com/aws/aws-sdk-go-v2/service/efs v1.39.0 h1:nxn7P1nAd7ThB1B0WASAKvjddJQcvLzaOo9iN4tp3ZU=
 github.com/aws/aws-sdk-go-v2/service/efs v1.39.0/go.mod h1:8Ij4/TIExqfWWjcyQy82/V/aec2kQruuyndljE+Vuo0=
-github.com/aws/aws-sdk-go-v2/service/eks v1.64.0 h1:EYeOThTRysemFtC6J6h6b7dNg3jN03QuO5cg92ojIQE=
-github.com/aws/aws-sdk-go-v2/service/eks v1.64.0/go.mod h1:v1xXy6ea0PHtWkjFUvAUh6B/5wv7UF909Nru0dOIJDk=
+github.com/aws/aws-sdk-go-v2/service/eks v1.87.0 h1:bftLltXNWmNr9ed3CaQnVlzNPTNTFdHguNhIsZF6DxM=
+github.com/aws/aws-sdk-go-v2/service/eks v1.87.0/go.mod h1:rbIASs+SfCDUXx2EdfMkNpDGptlW8hvMZ9AawRiUBqE=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.29.6 h1:9grU/+HRwLXJV8XUjEPThJj/H+0oHkeNBFpSSfZekeg=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.29.6/go.mod h1:N4fs285CsnBHlAkzBpQapefR/noggTyF09fWs72EzB4=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.2 h1:vX70Z4lNSr7XsioU0uJq5yvxgI50sB66MvD+V/3buS4=
@@ -114,8 +114,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.1 h1:5fm5RTONng73/QA73LhCNR7U
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.1/go.mod h1:xBEjWD13h+6nq+z4AkqSfSvqRKFgDIQeaMguAJndOWo=
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.6 h1:p3jIvqYwUZgu/XYeI48bJxOhvm47hZb5HUQ0tn6Q9kA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.6/go.mod h1:WtKK+ppze5yKPkZ0XwqIVWD4beCwv056ZbPQNoeHqM8=
-github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
-github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/awslabs/goformation/v4 v4.19.5 h1:Y+Tzh01tWg8gf//AgGKUamaja7Wx9NPiJf1FpZu4/iU=
 github.com/awslabs/goformation/v4 v4.19.5/go.mod h1:JoNpnVCBOUtEz9bFxc9sjy8uBUCLF5c4D1L7RhRTVM8=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=

--- a/pkg/cloud/converters/eks.go
+++ b/pkg/cloud/converters/eks.go
@@ -36,6 +36,9 @@ var (
 
 	// ErrUnknownCapacityType is an error when a unknown CapacityType is used.
 	ErrUnknownCapacityType = errors.New("unknown capacity type")
+
+	// ErrUnknownEgressMode is an error when a unknown EgressMode is used.
+	ErrUnknownEgressMode = errors.New("unknown control plane egress mode")
 )
 
 // AddonSDKToAddonState is used to convert an AWS SDK Addon to a control plane AddonState.
@@ -167,6 +170,18 @@ func ConvertSDKToIdentityProvider(in *ekscontrolplanev1.OIDCIdentityProviderConf
 	}
 
 	return nil
+}
+
+// EgressModeToSDK is used to convert a EgressMode to the AWS SDK egress mode value.
+func EgressModeToSDK(egressMode ekscontrolplanev1.ControlPlaneEgressMode) (ekstypes.ControlPlaneEgressModeType, error) {
+	switch egressMode {
+	case ekscontrolplanev1.ControlPlaneEgressModeAwsManaged:
+		return ekstypes.ControlPlaneEgressModeTypeAwsManaged, nil
+	case ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted:
+		return ekstypes.ControlPlaneEgressModeTypeCustomerRouted, nil
+	default:
+		return "", ErrUnknownEgressMode
+	}
 }
 
 // CapacityTypeToSDK is used to convert a CapacityType to the AWS SDK capacity type value.

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -342,7 +342,11 @@ func makeKubernetesNetworkConfig(serviceCidrs *clusterv1.NetworkRanges) (*ekstyp
 	}, nil
 }
 
-func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.EndpointAccess, securityGroups map[infrav1.SecurityGroupRole]infrav1.SecurityGroup) (*ekstypes.VpcConfigRequest, error) {
+func makeVpcConfig(subnets infrav1.Subnets,
+	endpointAccess ekscontrolplanev1.EndpointAccess,
+	securityGroups map[infrav1.SecurityGroupRole]infrav1.SecurityGroup,
+	egressMode ekscontrolplanev1.ControlPlaneEgressMode,
+) (*ekstypes.VpcConfigRequest, error) {
 	// TODO: Do we need to just add the private subnets?
 	if len(subnets) < 2 {
 		return nil, awserrors.NewFailedDependency("at least 2 subnets is required")
@@ -359,6 +363,11 @@ func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.End
 		subnetIDs = append(subnetIDs, subnetID)
 	}
 
+	sdkEgressMode, err := converters.EgressModeToSDK(egressMode)
+	if err != nil {
+		return nil, fmt.Errorf("converting egress mode %s: %w", egressMode, err)
+	}
+
 	cidrs := make([]string, 0)
 	for _, cidr := range endpointAccess.PublicCIDRs {
 		_, ipNet, err := net.ParseCIDR(*cidr)
@@ -370,9 +379,10 @@ func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.End
 	}
 
 	vpcConfig := &ekstypes.VpcConfigRequest{
-		EndpointPublicAccess:  endpointAccess.Public,
-		EndpointPrivateAccess: endpointAccess.Private,
-		SubnetIds:             subnetIDs,
+		EndpointPublicAccess:   endpointAccess.Public,
+		EndpointPrivateAccess:  endpointAccess.Private,
+		SubnetIds:              subnetIDs,
+		ControlPlaneEgressMode: sdkEgressMode,
 	}
 
 	if len(cidrs) > 0 {
@@ -440,9 +450,9 @@ func (s *Service) createCluster(ctx context.Context, eksClusterName string) (*ek
 	encryptionConfigs := makeEksEncryptionConfigs(s.scope.ControlPlane.Spec.EncryptionConfig)
 	if s.scope.ControlPlane.Spec.RestrictPrivateSubnets {
 		s.scope.Info("Filtering private subnets")
-		vpcConfig, err = makeVpcConfig(s.scope.Subnets().FilterPrivate(), s.scope.ControlPlane.Spec.EndpointAccess, s.scope.SecurityGroups())
+		vpcConfig, err = makeVpcConfig(s.scope.Subnets().FilterPrivate(), s.scope.ControlPlane.Spec.EndpointAccess, s.scope.SecurityGroups(), s.scope.ControlPlane.Spec.ControlPlaneEgressMode)
 	} else {
-		vpcConfig, err = makeVpcConfig(s.scope.Subnets(), s.scope.ControlPlane.Spec.EndpointAccess, s.scope.SecurityGroups())
+		vpcConfig, err = makeVpcConfig(s.scope.Subnets(), s.scope.ControlPlane.Spec.EndpointAccess, s.scope.SecurityGroups(), s.scope.ControlPlane.Spec.ControlPlaneEgressMode)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't create vpc config for cluster")
@@ -713,9 +723,9 @@ func (s *Service) reconcileVpcConfig(vpcConfig *ekstypes.VpcConfigResponse) (*ek
 	)
 	endpointAccess := s.scope.ControlPlane.Spec.EndpointAccess
 	if s.scope.ControlPlane.Spec.RestrictPrivateSubnets {
-		updatedVpcConfig, err = makeVpcConfig(s.scope.Subnets().FilterPrivate(), endpointAccess, s.scope.SecurityGroups())
+		updatedVpcConfig, err = makeVpcConfig(s.scope.Subnets().FilterPrivate(), endpointAccess, s.scope.SecurityGroups(), s.scope.ControlPlane.Spec.ControlPlaneEgressMode)
 	} else {
-		updatedVpcConfig, err = makeVpcConfig(s.scope.Subnets(), endpointAccess, s.scope.SecurityGroups())
+		updatedVpcConfig, err = makeVpcConfig(s.scope.Subnets(), endpointAccess, s.scope.SecurityGroups(), s.scope.ControlPlane.Spec.ControlPlaneEgressMode)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -143,6 +143,7 @@ func TestMakeVPCConfig(t *testing.T) {
 		subnets        infrav1.Subnets
 		endpointAccess ekscontrolplanev1.EndpointAccess
 		securityGroups map[infrav1.SecurityGroupRole]infrav1.SecurityGroup
+		egressMode     ekscontrolplanev1.ControlPlaneEgressMode
 	}
 
 	idOne := "one"
@@ -180,9 +181,11 @@ func TestMakeVPCConfig(t *testing.T) {
 					},
 				},
 				endpointAccess: ekscontrolplanev1.EndpointAccess{},
+				egressMode:     ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 			},
 			expect: &ekstypes.VpcConfigRequest{
-				SubnetIds: []string{idOne, idTwo},
+				SubnetIds:              []string{idOne, idTwo},
+				ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
 			},
 		},
 		{
@@ -207,9 +210,11 @@ func TestMakeVPCConfig(t *testing.T) {
 					},
 				},
 				endpointAccess: ekscontrolplanev1.EndpointAccess{},
+				egressMode:     ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 			},
 			expect: &ekstypes.VpcConfigRequest{
-				SubnetIds: []string{idOne, idTwo},
+				SubnetIds:              []string{idOne, idTwo},
+				ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
 			},
 		},
 		{
@@ -235,10 +240,12 @@ func TestMakeVPCConfig(t *testing.T) {
 						ID: idOne,
 					},
 				},
+				egressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 			},
 			expect: &ekstypes.VpcConfigRequest{
-				SubnetIds:        []string{idOne, idTwo},
-				SecurityGroupIds: []string{idOne},
+				SubnetIds:              []string{idOne, idTwo},
+				SecurityGroupIds:       []string{idOne},
+				ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
 			},
 		},
 		{
@@ -261,17 +268,67 @@ func TestMakeVPCConfig(t *testing.T) {
 				endpointAccess: ekscontrolplanev1.EndpointAccess{
 					PublicCIDRs: []*string{aws.String("10.0.0.1/24")},
 				},
+				egressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 			},
 			expect: &ekstypes.VpcConfigRequest{
-				SubnetIds:         []string{idOne, idTwo},
-				PublicAccessCidrs: []string{"10.0.0.0/24"},
+				SubnetIds:              []string{idOne, idTwo},
+				PublicAccessCidrs:      []string{"10.0.0.0/24"},
+				ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
 			},
+		},
+		{
+			name: "customer-routed egress mode",
+			input: input{
+				subnets: []infrav1.SubnetSpec{
+					{
+						ID:               idOne,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2a",
+						IsPublic:         true,
+					},
+					{
+						ID:               idTwo,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2b",
+						IsPublic:         false,
+					},
+				},
+				endpointAccess: ekscontrolplanev1.EndpointAccess{},
+				egressMode:     ekscontrolplanev1.ControlPlaneEgressModeCustomerRouted,
+			},
+			expect: &ekstypes.VpcConfigRequest{
+				SubnetIds:              []string{idOne, idTwo},
+				ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeCustomerRouted,
+			},
+		},
+		{
+			name: "unknown egress mode",
+			input: input{
+				subnets: []infrav1.SubnetSpec{
+					{
+						ID:               idOne,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2a",
+						IsPublic:         true,
+					},
+					{
+						ID:               idTwo,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2b",
+						IsPublic:         false,
+					},
+				},
+				endpointAccess: ekscontrolplanev1.EndpointAccess{},
+				egressMode:     ekscontrolplanev1.ControlPlaneEgressMode("invalid"),
+			},
+			err:    true,
+			expect: nil,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			config, err := makeVpcConfig(tc.input.subnets, tc.input.endpointAccess, tc.input.securityGroups)
+			config, err := makeVpcConfig(tc.input.subnets, tc.input.endpointAccess, tc.input.securityGroups, tc.input.egressMode)
 			if tc.err {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -653,6 +710,7 @@ func TestCreateCluster(t *testing.T) {
 						NetworkSpec:                infrav1.NetworkSpec{Subnets: tc.subnets},
 						BootstrapSelfManagedAddons: false,
 						UpgradePolicy:              ekscontrolplanev1.UpgradePolicyStandard,
+						ControlPlaneEgressMode:     ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 					},
 				},
 			})
@@ -669,7 +727,8 @@ func TestCreateCluster(t *testing.T) {
 					Name:             aws.String(clusterName),
 					EncryptionConfig: []ekstypes.EncryptionConfig{},
 					ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
-						SubnetIds: subnetIDs,
+						SubnetIds:              subnetIDs,
+						ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
 					},
 					RoleArn:                    tc.role,
 					Tags:                       tc.tags,
@@ -951,6 +1010,7 @@ func TestCreateIPv6Cluster(t *testing.T) {
 				},
 				EncryptionConfig:           encryptionConfig,
 				BootstrapSelfManagedAddons: false,
+				ControlPlaneEgressMode:     ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 			},
 		},
 	})
@@ -968,7 +1028,8 @@ func TestCreateIPv6Cluster(t *testing.T) {
 			},
 		},
 		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
-			SubnetIds: []string{"sub-1", "sub-2"},
+			SubnetIds:              []string{"sub-1", "sub-2"},
+			ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
 		},
 		KubernetesNetworkConfig: &ekstypes.KubernetesNetworkConfigRequest{
 			IpFamily: ekstypes.IpFamilyIpv6,
@@ -1031,6 +1092,7 @@ func TestCreateClusterWithBootstrapClusterCreatorAdminPermissions(t *testing.T) 
 				AccessConfig: &ekscontrolplanev1.AccessConfig{
 					BootstrapClusterCreatorAdminPermissions: ptr.To(false),
 				},
+				ControlPlaneEgressMode: ekscontrolplanev1.ControlPlaneEgressModeAwsManaged,
 			},
 		},
 	})
@@ -1040,7 +1102,8 @@ func TestCreateClusterWithBootstrapClusterCreatorAdminPermissions(t *testing.T) 
 		Name:    aws.String(clusterName),
 		Version: aws.String("1.24"),
 		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
-			SubnetIds: []string{"1", "2"},
+			SubnetIds:              []string{"1", "2"},
+			ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
 		},
 		RoleArn: aws.String("arn:role"),
 		Tags: map[string]string{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add support for specifying the mode for the control plane egress traffic. The default is to let AWS manage this. It can be changed to "customer routed" which gives greater control to the routing at the cost of you having to manage the routing.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

**AI Usage**:

None

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [x] includes documentation
- [ ] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Add support for EKS control plane egress mode
```
