### PR TITLE
🐛 Stop recreating EKS access entries when username is unset

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -2470,7 +2470,9 @@ spec:
                       - hyperpod_linux
                       type: string
                     username:
-                      description: Username is the username for the access entry
+                      description: |-
+                        Username is the username for the access entry
+                        If left empty, EKS generates one and it is left unmanaged
                       type: string
                   required:
                   - principalARN

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanetemplates.yaml
@@ -149,8 +149,9 @@ spec:
                               - hyperpod_linux
                               type: string
                             username:
-                              description: Username is the username for the access
-                                entry
+                              description: |-
+                                Username is the username for the access entry
+                                If left empty, EKS generates one and it is left unmanaged
                               type: string
                           required:
                           - principalARN

--- a/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
+++ b/controlplane/eks/api/v1beta2/awsmanagedcontrolplane_types.go
@@ -306,6 +306,7 @@ type AccessEntry struct {
 	KubernetesGroups []string `json:"kubernetesGroups,omitempty"`
 
 	// Username is the username for the access entry
+	// If left empty, EKS generates one and it is left unmanaged
 	// +optional
 	Username string `json:"username,omitempty"`
 

--- a/pkg/cloud/services/eks/accessentry.go
+++ b/pkg/cloud/services/eks/accessentry.go
@@ -167,13 +167,9 @@ func (s *Service) updateAccessEntry(ctx context.Context, accessEntry ekscontrolp
 		return errors.Wrapf(err, "failed to describe access entry for principal %s", accessEntry.PrincipalARN)
 	}
 
-	// EKS requires recreate when changing type or removing username
-	existingUsername := ""
-	if describeOutput.AccessEntry.Username != nil {
-		existingUsername = *describeOutput.AccessEntry.Username
-	}
-
-	if *accessEntry.Type.APIValue() != *describeOutput.AccessEntry.Type || accessEntry.Username != existingUsername {
+	// Type is the only immutable field, so it is the only one requiring a recreate.
+	// UpdateAccessEntry accepts username and Kubernetes groups.
+	if *accessEntry.Type.APIValue() != *describeOutput.AccessEntry.Type {
 		if err = s.deleteAccessEntry(ctx, accessEntry.PrincipalARN); err != nil {
 			return errors.Wrapf(err, "failed to delete access entry for principal %s during recreation", accessEntry.PrincipalARN)
 		}
@@ -191,9 +187,25 @@ func (s *Service) updateAccessEntry(ctx context.Context, accessEntry ekscontrolp
 		ClusterName:  &clusterName,
 		PrincipalArn: &accessEntry.PrincipalARN,
 	}
+	needsUpdate := false
 
 	if !slices.Equal(accessEntry.KubernetesGroups, describeOutput.AccessEntry.KubernetesGroups) {
 		updateInput.KubernetesGroups = accessEntry.KubernetesGroups
+		needsUpdate = true
+	}
+
+	// An unset username means EKS generates one, so the generated value is not drift.
+	existingUsername := ""
+	if describeOutput.AccessEntry.Username != nil {
+		existingUsername = *describeOutput.AccessEntry.Username
+	}
+
+	if accessEntry.Username != "" && accessEntry.Username != existingUsername {
+		updateInput.Username = &accessEntry.Username
+		needsUpdate = true
+	}
+
+	if needsUpdate {
 		if _, err := s.EKSClient.UpdateAccessEntry(ctx, updateInput); err != nil {
 			return errors.Wrapf(err, "failed to update access entry for principal %s", accessEntry.PrincipalARN)
 		}

--- a/pkg/cloud/services/eks/accessentry_test.go
+++ b/pkg/cloud/services/eks/accessentry_test.go
@@ -761,7 +761,7 @@ func TestUpdateAccessEntry(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "username change requires recreate",
+			name: "username change is applied in place",
 			accessEntry: ekscontrolplanev1.AccessEntry{
 				PrincipalARN:     principalARN,
 				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
@@ -778,9 +778,11 @@ func TestUpdateAccessEntry(t *testing.T) {
 					},
 				}, nil)
 
-				m.DeleteAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DeleteAccessEntryOutput{}, nil)
-
-				m.CreateAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.CreateAccessEntryOutput{}, nil)
+				m.UpdateAccessEntry(gomock.Any(), &eks.UpdateAccessEntryInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+					Username:     aws.String("new-admin"),
+				}).Return(&eks.UpdateAccessEntryOutput{}, nil)
 
 				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
 					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},
@@ -819,7 +821,7 @@ func TestUpdateAccessEntry(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "username cleared requires recreate",
+			name: "empty username in spec does not trigger a recreate",
 			accessEntry: ekscontrolplanev1.AccessEntry{
 				PrincipalARN:     principalARN,
 				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
@@ -836,10 +838,6 @@ func TestUpdateAccessEntry(t *testing.T) {
 					},
 				}, nil)
 
-				m.DeleteAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DeleteAccessEntryOutput{}, nil)
-
-				m.CreateAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.CreateAccessEntryOutput{}, nil)
-
 				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
 					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},
 				}, nil)
@@ -847,7 +845,7 @@ func TestUpdateAccessEntry(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "username added requires recreate",
+			name: "username added is applied in place",
 			accessEntry: ekscontrolplanev1.AccessEntry{
 				PrincipalARN:     principalARN,
 				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
@@ -864,9 +862,42 @@ func TestUpdateAccessEntry(t *testing.T) {
 					},
 				}, nil)
 
-				m.DeleteAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DeleteAccessEntryOutput{}, nil)
+				m.UpdateAccessEntry(gomock.Any(), &eks.UpdateAccessEntryInput{
+					ClusterName:  aws.String(clusterName),
+					PrincipalArn: aws.String(principalARN),
+					Username:     aws.String("admin"),
+				}).Return(&eks.UpdateAccessEntryOutput{}, nil)
 
-				m.CreateAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.CreateAccessEntryOutput{}, nil)
+				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
+					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},
+				}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "username and groups change in a single update",
+			accessEntry: ekscontrolplanev1.AccessEntry{
+				PrincipalARN:     principalARN,
+				Type:             ekscontrolplanev1.AccessEntryTypeStandard,
+				Username:         "new-admin",
+				KubernetesGroups: []string{"developers"},
+			},
+			expect: func(m *mock_eksiface.MockEKSAPIMockRecorder) {
+				m.DescribeAccessEntry(gomock.Any(), gomock.Any()).Return(&eks.DescribeAccessEntryOutput{
+					AccessEntry: &ekstypes.AccessEntry{
+						PrincipalArn:     aws.String(principalARN),
+						Type:             ekscontrolplanev1.AccessEntryTypeStandard.APIValue(),
+						Username:         aws.String("admin"),
+						KubernetesGroups: []string{"system:masters"},
+					},
+				}, nil)
+
+				m.UpdateAccessEntry(gomock.Any(), &eks.UpdateAccessEntryInput{
+					ClusterName:      aws.String(clusterName),
+					PrincipalArn:     aws.String(principalARN),
+					KubernetesGroups: []string{"developers"},
+					Username:         aws.String("new-admin"),
+				}).Return(&eks.UpdateAccessEntryOutput{}, nil)
 
 				m.ListAssociatedAccessPolicies(gomock.Any(), gomock.Any()).Return(&eks.ListAssociatedAccessPoliciesOutput{
 					AssociatedAccessPolicies: []ekstypes.AssociatedAccessPolicy{},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

An access entry whose spec omits `username` is deleted and recreated on every reconcile.

`updateAccessEntry` compares the spec username against the value reported by AWS. When `username` is omitted, `accessEntry.Username` is `""` (a plain `string` with `omitempty` and no defaulting, and `createAccessEntry` skips setting it), while EKS generates a username server-side. The comparison therefore never holds and the entry is torn down and rebuilt on every cycle. Each `DeleteAccessEntry` drops the associated access policies, so principals authorized via `accessPolicies` intermittently lose access — this is how the bug becomes user-visible as sporadic `Forbidden` errors.

`UpdateAccessEntryInput` accepts `Username` and has no `Type` field, so `type` is the only genuinely immutable attribute. This PR:

1. Narrows the recreate path to a `type` change, and corrects the comment claiming a recreate is required to change the username.
2. Moves `username` to the update path, treating an empty spec value as unmanaged so the EKS generated username is not seen as drift.
3. Gates `UpdateAccessEntry` on a flag. Previously only a `KubernetesGroups` difference triggered the call, so a username-only change would have been silently dropped.

Beyond stopping the loop, this removes the delete/create window for username changes entirely.

**Which issue(s) this PR fixes**:

Fixes #6003

**Special notes for your reviewer**:

This overlaps with #6007, which fixes the same issue from the `Type` side by normalizing an empty `Type` to `STANDARD`. That PR leaves `accessEntry.Username != existingUsername` untouched, so entries that set `type` explicitly and omit `username` keep looping. Both PRs modify the same condition and will conflict textually; I am happy to rebase whichever lands second, or to fold this into #6007 if the author prefers.

Since this narrows the recreate condition to `type` only, it also subsumes the `Type` half of #6007 for the recreate decision, though not the redundant `AssociateAccessPolicy` calls that #6007 also addresses.

Three existing test cases changed expectations from delete+create to an in-place update. One of them, `username cleared requires recreate`, asserted that emptying `username` in the spec resets the entry. That behaviour is dropped here: EKS offers no way to clear a username and revert to a generated one, so the only mechanism was the recreate that causes this bug, and it is not documented anywhere. Losing an undocumented reset seemed clearly preferable to an endless loop that breaks authorization.

On verification: I observed the delete/create loop and the resulting `Forbidden` errors on a live EKS cluster, which is what led me here. The fix itself is verified by unit tests only — I have not run a patched controller against a real cluster. `make lint` and the `pkg/cloud/services/eks` and `controlplane/eks/...` suites pass.

Not included: `test/e2e/data/eks/cluster-template-eks-control-plane-only-with-accessentries.yaml` already contains an entry that omits `username` and carries `accessPolicies`, so the e2e suite exercises the affected configuration but has no assertion on entry stability. Adding one seems worthwhile but felt out of scope, and I cannot run the EKS e2e suite locally.

**AI Usage**:

Claude Code (Claude Opus) was used throughout. I investigated the production symptom and directed the work; the model read the upstream source to identify the faulty comparison, confirmed via `go doc` that `UpdateAccessEntryInput` carries `Username` but not `Type` (which is what shifted the fix from suppressing the comparison to moving username into the update path), and drafted the code, tests, and this description. I reviewed every change, and verified the tests fail without the fix and pass with it.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] tested manually
- [x] includes unit tests
- [ ] adds or updates e2e tests

```release-note
Fix EKS access entries being deleted and recreated on every reconcile when `username` is not set in the spec, which intermittently removed associated access policies. Username changes are now applied in place; only a `type` change recreates the entry. Note that clearing `username` in the spec no longer resets the entry to an EKS generated username.
```
