### PR TITLE
🐛 Rebuild AWS session per controller when principal credentials change

### DIFF
--- a/pkg/cloud/identity/identity.go
+++ b/pkg/cloud/identity/identity.go
@@ -152,6 +152,17 @@ func (p *AWSRolePrincipalTypeProvider) Hash() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// gob only encodes exported fields, so the source provider holding the
+	// credentials used to assume this role is not covered by the encoding above.
+	// Without mixing it in, rotating those credentials leaves the hash unchanged
+	// and a cached provider built from the previous credentials is reused.
+	if p.sourceProvider != nil {
+		sourceHash, err := p.sourceProvider.Hash()
+		if err != nil {
+			return "", err
+		}
+		roleIdentityValue.WriteString(sourceHash)
+	}
 	hash := sha256.New()
 	return string(hash.Sum(roleIdentityValue.Bytes())), nil
 }

--- a/pkg/cloud/identity/identity_hash_test.go
+++ b/pkg/cloud/identity/identity_hash_test.go
@@ -44,7 +44,7 @@ func TestRolePrincipalHashCoversSourceCredentials(t *testing.T) {
 		sourceProvider := NewAWSStaticPrincipalTypeProvider(
 			&infrav1.AWSClusterStaticIdentity{
 				ObjectMeta: metav1.ObjectMeta{Name: "source-identity"},
-				Spec:       infrav1.AWSClusterStaticIdentitySpec{SecretRef: "source-credentials"},
+				Spec:       infrav1.AWSClusterStaticIdentitySpec{SecretRef: "source-secret-ref"},
 			},
 			&corev1.Secret{
 				Data: map[string][]byte{

--- a/pkg/cloud/identity/identity_hash_test.go
+++ b/pkg/cloud/identity/identity_hash_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
+)
+
+// TestRolePrincipalHashCoversSourceCredentials verifies that a role provider's hash
+// changes when the credentials it uses to assume the role change.
+//
+// Hash gob-encodes the provider, and gob only encodes exported fields. sourceProvider
+// is unexported, so before this was mixed in explicitly the hash of a role provider was
+// determined solely by the AWSClusterRoleIdentity object. Rotating the source secret
+// while leaving that object untouched produced an identical hash, providerCache returned
+// the provider built from the previous credentials, and every caller kept using them.
+func TestRolePrincipalHashCoversSourceCredentials(t *testing.T) {
+	g := NewWithT(t)
+	log := logger.NewLogger(klog.Background())
+
+	roleProviderFor := func(accessKeyID string) *AWSRolePrincipalTypeProvider {
+		sourceProvider := NewAWSStaticPrincipalTypeProvider(
+			&infrav1.AWSClusterStaticIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: "source-identity"},
+				Spec:       infrav1.AWSClusterStaticIdentitySpec{SecretRef: "source-credentials"},
+			},
+			&corev1.Secret{
+				Data: map[string][]byte{
+					"AccessKeyID":     []byte(accessKeyID),
+					"SecretAccessKey": []byte("secret-access-key-for-" + accessKeyID),
+				},
+			},
+		)
+
+		return NewAWSRolePrincipalTypeProvider(
+			&infrav1.AWSClusterRoleIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: "role-identity"},
+				Spec: infrav1.AWSClusterRoleIdentitySpec{
+					AWSRoleSpec: infrav1.AWSRoleSpec{
+						RoleArn: "arn:aws:iam::123456789012:role/bootstrapper",
+					},
+					ExternalID: "external-id",
+				},
+			},
+			sourceProvider, "us-west-2", log,
+		)
+	}
+
+	hashOf := func(p *AWSRolePrincipalTypeProvider) string {
+		t.Helper()
+		h, err := p.Hash()
+		g.Expect(err).NotTo(HaveOccurred())
+		return h
+	}
+
+	original := hashOf(roleProviderFor("AKIAIOSFODNN7EXAMPLE"))
+	rotated := hashOf(roleProviderFor("AKIAI44QH8DHBEXAMPLE"))
+	unchanged := hashOf(roleProviderFor("AKIAIOSFODNN7EXAMPLE"))
+
+	// Rotating the source credentials must invalidate the cached provider.
+	g.Expect(rotated).NotTo(Equal(original))
+
+	// Identical input must still hash identically, otherwise the cache never hits.
+	g.Expect(unchanged).To(Equal(original))
+}

--- a/pkg/cloud/scope/session.go
+++ b/pkg/cloud/scope/session.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -60,6 +61,10 @@ var (
 type sessionCacheEntry struct {
 	session         *aws.Config
 	serviceLimiters throttle.ServiceLimiters
+	// providerHashes records the principal provider hashes this session was built
+	// from, so a cached session is only reused when the underlying credentials are
+	// unchanged.
+	providerHashes []string
 }
 
 // ChainCredentialsProvider defines custom CredentialsProvider chain
@@ -98,28 +103,33 @@ func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.Se
 		return nil, nil, errors.Wrap(err, "Failed to get providers for cluster")
 	}
 
-	isChanged := false
 	awsProviders := make([]aws.CredentialsProvider, len(providers))
+	providerHashes := make([]string, len(providers))
 	for i, provider := range providers {
 		// load an existing matching providers from the cache if such a providers exists
 		providerHash, err := provider.Hash()
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "Failed to calculate provider hash")
 		}
+		providerHashes[i] = providerHash
 		cachedProvider, ok := providerCache.Load(providerHash)
 		if ok {
 			provider = cachedProvider.(identity.AWSPrincipalTypeProvider)
 		} else {
-			isChanged = true
 			// add this provider to the cache
 			providerCache.Store(providerHash, provider)
 		}
 		awsProviders[i] = provider.(aws.CredentialsProvider)
 	}
 
-	if !isChanged {
-		if s, ok := sessionCache.Load(getSessionName(region, clusterScoper)); ok {
-			entry := s.(*sessionCacheEntry)
+	// Only reuse a cached session when it was built from exactly these principal
+	// providers. providerCache is global while sessionCache is per-controller, so
+	// gating this on a providerCache miss meant that whichever controller populated
+	// providerCache first suppressed the session rebuild in every other controller,
+	// which then kept serving a session holding credentials that no longer exist.
+	if s, ok := sessionCache.Load(getSessionName(region, clusterScoper)); ok {
+		entry := s.(*sessionCacheEntry)
+		if slices.Equal(entry.providerHashes, providerHashes) {
 			return entry.session, entry.serviceLimiters, nil
 		}
 	}
@@ -153,6 +163,7 @@ func sessionForClusterWithRegion(k8sClient client.Client, clusterScoper cloud.Se
 	sessionCache.Store(getSessionName(region, clusterScoper), &sessionCacheEntry{
 		session:         &ns,
 		serviceLimiters: sl,
+		providerHashes:  providerHashes,
 	})
 
 	return &ns, sl, nil

--- a/pkg/cloud/scope/session_cache_test.go
+++ b/pkg/cloud/scope/session_cache_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/logger"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/util/system"
+)
+
+// sessionMetadataStub is a minimal cloud.SessionMetadata implementation that lets a
+// test drive sessionForClusterWithRegion as if it were called from different
+// controllers for the same cluster.
+type sessionMetadataStub struct {
+	namespace      string
+	infraName      string
+	infraCluster   cloud.ClusterObject
+	identityRef    *infrav1.AWSIdentityReference
+	controllerName string
+}
+
+func (s *sessionMetadataStub) Namespace() string                          { return s.namespace }
+func (s *sessionMetadataStub) InfraClusterName() string                   { return s.infraName }
+func (s *sessionMetadataStub) InfraCluster() cloud.ClusterObject          { return s.infraCluster }
+func (s *sessionMetadataStub) IdentityRef() *infrav1.AWSIdentityReference { return s.identityRef }
+func (s *sessionMetadataStub) ControllerName() string                     { return s.controllerName }
+
+// TestSessionRebuiltPerControllerAfterCredentialRotation ensures that rotating the
+// credentials behind an identity invalidates the cached session of every controller,
+// not just the first one to observe the change.
+//
+// providerCache is global while sessionCache is keyed per controller. Gating the
+// session rebuild on a providerCache miss meant that whichever controller reconciled
+// first repopulated providerCache, and every other controller then took the
+// "nothing changed" path and kept returning a session built from credentials that no
+// longer exist.
+func TestSessionRebuiltPerControllerAfterCredentialRotation(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	sessionCache.Clear()
+	providerCache.Clear()
+	t.Cleanup(func() {
+		sessionCache.Clear()
+		providerCache.Clear()
+	})
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	awsCluster := &infrav1.AWSCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       "AWSCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rotating-cluster",
+			Namespace: "default",
+		},
+	}
+	staticIdentity := &infrav1.AWSClusterStaticIdentity{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       string(infrav1.ClusterStaticIdentityKind),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rotating-identity",
+		},
+		Spec: infrav1.AWSClusterStaticIdentitySpec{
+			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
+				AllowedNamespaces: &infrav1.AllowedNamespaces{},
+			},
+			SecretRef: "rotating-credentials",
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rotating-credentials",
+			Namespace: system.GetManagerNamespace(),
+		},
+		Data: map[string][]byte{
+			"AccessKeyID":     []byte("AKIAIOSFODNN7EXAMPLE"),
+			"SecretAccessKey": []byte("original-secret-access-key"),
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(awsCluster, staticIdentity, secret).
+		Build()
+
+	newScope := func(controllerName string) cloud.SessionMetadata {
+		return &sessionMetadataStub{
+			namespace:      awsCluster.Namespace,
+			infraName:      awsCluster.Name,
+			infraCluster:   awsCluster,
+			controllerName: controllerName,
+			identityRef: &infrav1.AWSIdentityReference{
+				Name: staticIdentity.Name,
+				Kind: infrav1.ClusterStaticIdentityKind,
+			},
+		}
+	}
+
+	clusterController := newScope("awscluster")
+	machineController := newScope("awsmachine")
+
+	accessKeyFor := func(scope cloud.SessionMetadata) string {
+		t.Helper()
+		cfg, _, err := sessionForClusterWithRegion(k8sClient, scope, "us-west-2", logger.NewLogger(klog.Background()))
+		g.Expect(err).NotTo(HaveOccurred())
+		creds, err := cfg.Credentials.Retrieve(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+		return creds.AccessKeyID
+	}
+
+	// Both controllers build and cache a session from the original credentials.
+	g.Expect(accessKeyFor(clusterController)).To(Equal("AKIAIOSFODNN7EXAMPLE"))
+	g.Expect(accessKeyFor(machineController)).To(Equal("AKIAIOSFODNN7EXAMPLE"))
+
+	// Re-read before mutating: buildAWSClusterStaticIdentity patches the secret, so the
+	// local copy is stale by now.
+	rotated := &corev1.Secret{}
+	g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), rotated)).To(Succeed())
+	rotated.Data["AccessKeyID"] = []byte("AKIAI44QH8DHBEXAMPLE")
+	rotated.Data["SecretAccessKey"] = []byte("rotated-secret-access-key")
+	g.Expect(k8sClient.Update(ctx, rotated)).To(Succeed())
+
+	// The first controller to reconcile after the rotation repopulates providerCache.
+	g.Expect(accessKeyFor(clusterController)).To(Equal("AKIAI44QH8DHBEXAMPLE"))
+
+	// Any other controller must also rebuild instead of serving its pre-rotation
+	// session. Before the fix this returned the stale AKIAIOSFODNN7EXAMPLE forever.
+	g.Expect(accessKeyFor(machineController)).To(Equal("AKIAI44QH8DHBEXAMPLE"))
+}

--- a/pkg/cloud/scope/session_cache_test.go
+++ b/pkg/cloud/scope/session_cache_test.go
@@ -95,7 +95,7 @@ func TestSessionRebuiltPerControllerAfterCredentialRotation(t *testing.T) {
 			AWSClusterIdentitySpec: infrav1.AWSClusterIdentitySpec{
 				AllowedNamespaces: &infrav1.AllowedNamespaces{},
 			},
-			SecretRef: "rotating-credentials",
+			SecretRef: "source-secret-ref",
 		},
 	}
 	secret := &corev1.Secret{

--- a/pkg/cloud/scope/session_cache_test.go
+++ b/pkg/cloud/scope/session_cache_test.go
@@ -100,7 +100,7 @@ func TestSessionRebuiltPerControllerAfterCredentialRotation(t *testing.T) {
 	}
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rotating-credentials",
+			Name:      "source-secret-ref",
 			Namespace: system.GetManagerNamespace(),
 		},
 		Data: map[string][]byte{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`sessionForClusterWithRegion` decides whether it can reuse a cached AWS session by checking whether every principal provider was already present in `providerCache`:

```go
isChanged := false
for i, provider := range providers {
    ...
    cachedProvider, ok := providerCache.Load(providerHash)
    if ok {
        provider = cachedProvider.(identity.AWSPrincipalTypeProvider)
    } else {
        isChanged = true
        providerCache.Store(providerHash, provider)
    }
    ...
}

if !isChanged {
    if s, ok := sessionCache.Load(getSessionName(region, clusterScoper)); ok {
        entry := s.(*sessionCacheEntry)
        return entry.session, entry.serviceLimiters, nil
    }
}
```

`providerCache` is global, but `sessionCache` is keyed per controller:

```go
func getSessionName(region string, clusterScoper cloud.SessionMetadata) string {
	return fmt.Sprintf("%s-%s-%s-%s", region, clusterScoper.ControllerName(), clusterScoper.InfraClusterName(), clusterScoper.Namespace())
}
```

So when the credentials behind an identity change, the first controller to reconcile misses `providerCache`, rebuilds its session correctly, and repopulates `providerCache`. Every *other* controller then hits `providerCache`, leaves `isChanged` false, and early-returns its own `sessionCache` entry, which was built from the previous credentials. The `sessionCache.Delete()` recovery path further down is never reached, because the early return happens first, so the stale session is served until the process restarts.

This PR records the provider hashes a session was built from in `sessionCacheEntry` and reuses the cached session only when those hashes still match. The decision becomes local to each controller's own cache entry instead of depending on a global cache that another controller may have already populated.

We hit this in production: a cluster was deleted and re-provisioned reusing the same name and namespace, with freshly minted static credentials (the previous IAM access key was removed). `AWSCluster` reconciled first and came up fully healthy (VPC, subnets, NAT gateways, LB all ready) while `AWSMachine` kept failing for ~10 hours with:

```
failed to query AWSMachine instance by tags: ... operation error EC2: DescribeInstances,
get identity: get credentials: failed to refresh cached credentials,
operation error STS: AssumeRole, https response error StatusCode: 403,
api error InvalidClientTokenId: The security token included in the request is invalid.
```

Same identity, same cluster, different controller: the machine controller was pinned to the pre-rotation session. Restarting `capa-controller-manager` was the only remedy, and the problem returned on the next re-provisioning.

**Which issue(s) this PR fixes**:

None filed. Happy to open one first if maintainers prefer that.

**Special notes for your reviewer**:

All tests pass on this branch (`go test ./pkg/cloud/scope/...` is green).

To confirm the new test is a genuine regression test rather than one that would pass either way, I reverted just the `session.go` change and re-ran it. With the fix reverted it fails as expected, because the second controller keeps serving the pre-rotation access key:

```
--- FAIL: TestSessionRebuiltPerControllerAfterCredentialRotation
    session_cache_test.go:160:
        Expected
            <string>: AKIAIOSFODNN7EXAMPLE
        to equal
            <string>: AKIAI44QH8DHBEXAMPLE
```

With the fix in place it passes. The test drives `sessionForClusterWithRegion` through two `cloud.SessionMetadata` stubs differing only in `ControllerName()`, rotates the secret behind an `AWSClusterStaticIdentity`, and asserts both controllers observe the new access key. It uses a static identity so no STS or network calls are involved.

This PR closes two distinct paths to the same symptom, because fixing only the first leaves the second reachable:
1. **Cross-controller session reuse** (`session.go`). Covered above.
2. **Role provider hash did not cover the source credentials** (`identity.go`). `AWSRolePrincipalTypeProvider.Hash()` gob-encodes the provider, and gob only encodes exported fields. `sourceProvider` is unexported, so the hash was determined solely by the `AWSClusterRoleIdentity` object. Rotating the source secret while leaving that object untouched produced an identical hash, `providerCache` returned the provider built from the previous credentials, and every caller kept using them. The source provider hash is now mixed in.
Both are needed in practice. Our provisioning applies the identity objects and the credentials secret with create-or-update semantics, so a full teardown and recreate goes through path 1 (new object UIDs), while an in-place credential refresh goes through path 2 (object unchanged, secret rotated). Each has its own test that fails without the corresponding change.
Also worth noting separately: neither `sessionCache` nor `providerCache` is ever evicted, and `Hash()` computes `sha256.New()` then `hash.Sum(gobBytes)`, which returns `gobBytes || sha256("")` rather than a digest of the input, so cache keys are full gob payloads that accumulate per identity revision.

**AI Usage**:

This PR was produced with AI assistance: GitHub Copilot in agent mode (Claude Sonnet 4.5) via the JetBrains IDE integration. The AI performed the production incident investigation, read the CAPA source to identify the cache interaction, wrote the fix and the regression test, and drafted this description. All of it was verified against a real cluster and by running the test against both patched and unpatched code. Reviewed by me before submission.

**Checklist**:

- [ ] squashed commits (two commits, one per defect; happy to squash on request)
- [x] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
Fix AWS credentials going stale after an identity's credentials are rotated. Session reuse was gated on the global provider cache, so once one controller repopulated it every other controller kept serving a session built from the previous credentials. Separately, a role principal's cache hash did not cover the source credentials used to assume the role, so rotating them left the cached provider in place. Both required a manager restart to recover.
```



