### PR TITLE
✨ v1beta2 contract: define v1beta2 condition type and reason const

### DIFF
--- a/api/v1beta2/v1beta2_condition_consts.go
+++ b/api/v1beta2/v1beta2_condition_consts.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+// AWSCluster v1beta2 condition types.
+const (
+	// AWSClusterReadyCondition defines the Ready condition type that summarizes the operational state of an AWSCluster.
+	AWSClusterReadyCondition = clusterv1.ReadyCondition
+
+	// AWSClusterVpcReadyCondition reports on the successful reconciliation of a VPC.
+	AWSClusterVpcReadyCondition = "VpcReady"
+
+	// AWSClusterSubnetsReadyCondition reports on the successful reconciliation of subnets.
+	AWSClusterSubnetsReadyCondition = "SubnetsReady"
+
+	// AWSClusterInternetGatewayReadyCondition reports on the successful reconciliation of internet gateways.
+	// Only applicable to managed clusters.
+	AWSClusterInternetGatewayReadyCondition = "InternetGatewayReady"
+
+	// AWSClusterEgressOnlyInternetGatewayReadyCondition reports on the successful reconciliation of egress only internet gateways.
+	// Only applicable to managed clusters.
+	AWSClusterEgressOnlyInternetGatewayReadyCondition = "EgressOnlyInternetGatewayReady"
+
+	// AWSClusterCarrierGatewayReadyCondition reports on the successful reconciliation of carrier gateways.
+	// Only applicable to managed clusters.
+	AWSClusterCarrierGatewayReadyCondition = "CarrierGatewayReady"
+
+	// AWSClusterNatGatewaysReadyCondition reports on the successful reconciliation of NAT gateways.
+	// Only applicable to managed clusters.
+	AWSClusterNatGatewaysReadyCondition = "NatGatewaysReady"
+
+	// AWSClusterRouteTablesReadyCondition reports on the successful reconciliation of route tables.
+	// Only applicable to managed clusters.
+	AWSClusterRouteTablesReadyCondition = "RouteTablesReady"
+
+	// AWSClusterVpcEndpointsReadyCondition reports on the successful reconciliation of VPC endpoints.
+	// Only applicable to managed clusters.
+	AWSClusterVpcEndpointsReadyCondition = "VpcEndpointsReady"
+
+	// AWSClusterSecondaryCidrsReadyCondition reports on the successful reconciliation of secondary CIDR blocks.
+	// Only applicable to managed clusters.
+	AWSClusterSecondaryCidrsReadyCondition = "SecondaryCidrsReady"
+
+	// AWSClusterSecurityGroupsReadyCondition reports on the successful reconciliation of cluster security groups.
+	AWSClusterSecurityGroupsReadyCondition = "ClusterSecurityGroupsReady"
+
+	// AWSClusterBastionHostReadyCondition reports whether a bastion host is ready. Depending on the configuration,
+	// a cluster may not require a bastion host and this condition will be skipped.
+	AWSClusterBastionHostReadyCondition = "BastionHostReady"
+
+	// AWSClusterLoadBalancerReadyCondition reports on whether a control plane load balancer was successfully reconciled.
+	AWSClusterLoadBalancerReadyCondition = "LoadBalancerReady"
+
+	// AWSClusterS3BucketReadyCondition reports on the successful reconciliation of an S3 bucket.
+	AWSClusterS3BucketReadyCondition = "S3BucketReady"
+
+	// AWSClusterPrincipalCredentialRetrievedCondition reports on whether principal credentials could be retrieved successfully.
+	// A possible scenario, where retrieval is unsuccessful, is when SourcePrincipal is not authorized for assume role.
+	AWSClusterPrincipalCredentialRetrievedCondition = "PrincipalCredentialRetrieved"
+
+	// AWSClusterPrincipalUsageAllowedCondition reports on whether the principal and all nested source identities
+	// are allowed to be used in the AWSCluster namespace.
+	AWSClusterPrincipalUsageAllowedCondition = "PrincipalUsageAllowed"
+)
+
+// AWSCluster v1beta2 reason constants.
+const (
+	// AWSClusterReadyReason indicates the AWSCluster infrastructure is ready.
+	AWSClusterReadyReason = clusterv1.ReadyReason
+
+	// AWSClusterNotReadyReason indicates the AWSCluster infrastructure is not ready.
+	AWSClusterNotReadyReason = clusterv1.NotReadyReason
+
+	// AWSClusterDeletingReason indicates the AWSCluster is being deleted.
+	AWSClusterDeletingReason = clusterv1.DeletingReason
+
+	// AWSClusterVpcReconciliationFailedReason used when errors occur during VPC reconciliation.
+	AWSClusterVpcReconciliationFailedReason = "VpcReconciliationFailed"
+
+	// AWSClusterVpcCreationStartedReason used when attempting to create a VPC for a managed cluster.
+	// Will not be applied to unmanaged clusters.
+	AWSClusterVpcCreationStartedReason = "VpcCreationStarted"
+
+	// AWSClusterSubnetsReconciliationFailedReason used to report failures while reconciling subnets.
+	AWSClusterSubnetsReconciliationFailedReason = "SubnetsReconciliationFailed"
+
+	// AWSClusterInternetGatewayFailedReason used when errors occur during internet gateway reconciliation.
+	AWSClusterInternetGatewayFailedReason = "InternetGatewayFailed"
+
+	// AWSClusterEgressOnlyInternetGatewayFailedReason used when errors occur during egress only internet gateway reconciliation.
+	AWSClusterEgressOnlyInternetGatewayFailedReason = "EgressOnlyInternetGatewayFailed"
+
+	// AWSClusterCarrierGatewayFailedReason used when errors occur during carrier gateway reconciliation.
+	AWSClusterCarrierGatewayFailedReason = "CarrierGatewayFailed"
+
+	// AWSClusterNatGatewaysReconciliationFailedReason used when any errors occur during reconciliation of NAT gateways.
+	AWSClusterNatGatewaysReconciliationFailedReason = "NatGatewaysReconciliationFailed"
+
+	// AWSClusterNatGatewaysCreationStartedReason set once when creating new NAT gateways.
+	AWSClusterNatGatewaysCreationStartedReason = "NatGatewaysCreationStarted"
+
+	// AWSClusterRouteTableReconciliationFailedReason used when any errors occur during reconciliation of route tables.
+	AWSClusterRouteTableReconciliationFailedReason = "RouteTableReconciliationFailed"
+
+	// AWSClusterVpcEndpointsReconciliationFailedReason used when any errors occur during reconciliation of VPC endpoints.
+	AWSClusterVpcEndpointsReconciliationFailedReason = "VpcEndpointsReconciliationFailed"
+
+	// AWSClusterSecondaryCidrReconciliationFailedReason used when any errors occur during reconciliation of secondary CIDR blocks.
+	AWSClusterSecondaryCidrReconciliationFailedReason = "SecondaryCidrReconciliationFailed"
+
+	// AWSClusterSecurityGroupReconciliationFailedReason used when any errors occur during reconciliation of security groups.
+	AWSClusterSecurityGroupReconciliationFailedReason = "SecurityGroupReconciliationFailed"
+
+	// AWSClusterBastionHostFailedReason used when an error occurs during the creation of a bastion host.
+	AWSClusterBastionHostFailedReason = "BastionHostFailed"
+
+	// AWSClusterBastionCreationStartedReason used when creating a new bastion host.
+	AWSClusterBastionCreationStartedReason = "BastionCreationStarted"
+
+	// AWSClusterLoadBalancerFailedReason used when an error occurs during load balancer reconciliation.
+	AWSClusterLoadBalancerFailedReason = "LoadBalancerFailed"
+
+	// AWSClusterWaitForDNSNameReason used while waiting for a DNS name for the API server to be populated.
+	AWSClusterWaitForDNSNameReason = "WaitForDNSName"
+
+	// AWSClusterWaitForExternalControlPlaneEndpointReason is set when the AWSCluster is waiting for an externally managed
+	// load balancer, such as an external control plane provider.
+	AWSClusterWaitForExternalControlPlaneEndpointReason = "WaitForExternalControlPlaneEndpoint"
+
+	// AWSClusterWaitForDNSNameResolveReason used while waiting for DNS name to resolve.
+	AWSClusterWaitForDNSNameResolveReason = "WaitForDNSNameResolve"
+
+	// AWSClusterS3BucketFailedReason used when any errors occur during reconciliation of an S3 bucket.
+	AWSClusterS3BucketFailedReason = "S3BucketCreationFailed"
+
+	// AWSClusterPrincipalCredentialRetrievalFailedReason used when errors occur during identity credential retrieval.
+	AWSClusterPrincipalCredentialRetrievalFailedReason = "PrincipalCredentialRetrievalFailed"
+
+	// AWSClusterCredentialProviderBuildFailedReason used when errors occur during building providers before trying credential retrieval.
+	//nolint:gosec
+	AWSClusterCredentialProviderBuildFailedReason = "CredentialProviderBuildFailed"
+
+	// AWSClusterPrincipalUsageUnauthorizedReason used when AWSCluster namespace is not in the identity's allowed namespaces list.
+	AWSClusterPrincipalUsageUnauthorizedReason = "PrincipalUsageUnauthorized"
+
+	// AWSClusterSourcePrincipalUsageUnauthorizedReason used when AWSCluster namespace is not in the intersection
+	// of source identity allowed namespaces and allowed namespaces of the identities that source identity depends on.
+	AWSClusterSourcePrincipalUsageUnauthorizedReason = "SourcePrincipalUsageUnauthorized"
+)
+
+// AWSMachine v1beta2 condition types.
+const (
+	// AWSMachineReadyCondition defines the Ready condition type that summarizes the operational state of an AWSMachine.
+	AWSMachineReadyCondition = clusterv1.ReadyCondition
+
+	// AWSMachineInstanceReadyCondition reports on current status of the EC2 instance. Ready indicates the instance is in a Running state.
+	AWSMachineInstanceReadyCondition = "InstanceReady"
+
+	// AWSMachineSecurityGroupsReadyCondition indicates the security groups are up to date on the AWSMachine.
+	AWSMachineSecurityGroupsReadyCondition = "SecurityGroupsReady"
+
+	// AWSMachineELBAttachedCondition will report true when a control plane is successfully registered with an ELB.
+	// When set to false, the subnet may not be found or unavailable in the instance's AZ.
+	// Only applicable to control plane machines.
+	AWSMachineELBAttachedCondition = "ELBAttached"
+
+	// AWSMachineDedicatedHostReleaseCondition reports on the status of dedicated host release operations.
+	// This condition tracks whether the dedicated host has been successfully released or if there are failures.
+	AWSMachineDedicatedHostReleaseCondition = "DedicatedHostRelease"
+)
+
+// AWSMachine v1beta2 reason constants.
+const (
+	// AWSMachineReadyReason indicates the AWSMachine is ready.
+	AWSMachineReadyReason = clusterv1.ReadyReason
+
+	// AWSMachineNotReadyReason indicates the AWSMachine is not ready.
+	AWSMachineNotReadyReason = clusterv1.NotReadyReason
+
+	// AWSMachineDeletingReason indicates the AWSMachine is being deleted.
+	AWSMachineDeletingReason = clusterv1.DeletingReason
+
+	// AWSMachineInstanceNotFoundReason used when the instance couldn't be retrieved.
+	AWSMachineInstanceNotFoundReason = "InstanceNotFound"
+
+	// AWSMachineInstanceTerminatedReason used when the instance is in a terminated state.
+	AWSMachineInstanceTerminatedReason = "InstanceTerminated"
+
+	// AWSMachineInstanceStoppedReason used when the instance is in a stopped state.
+	AWSMachineInstanceStoppedReason = "InstanceStopped"
+
+	// AWSMachineInstanceNotReadyReason used when the instance is in a pending state.
+	AWSMachineInstanceNotReadyReason = "InstanceNotReady"
+
+	// AWSMachineInstanceProvisionStartedReason set when the provisioning of an instance started.
+	AWSMachineInstanceProvisionStartedReason = "InstanceProvisionStarted"
+
+	// AWSMachineInstanceProvisionFailedReason used for failures during instance provisioning.
+	AWSMachineInstanceProvisionFailedReason = "InstanceProvisionFailed"
+
+	// AWSMachineWaitingForClusterInfrastructureReason used when machine is waiting for cluster infrastructure to be ready before proceeding.
+	AWSMachineWaitingForClusterInfrastructureReason = clusterv1.WaitingForClusterInfrastructureReadyReason
+
+	// AWSMachineWaitingForBootstrapDataReason used when machine is waiting for bootstrap data to be ready before proceeding.
+	AWSMachineWaitingForBootstrapDataReason = clusterv1.WaitingForBootstrapDataReason
+
+	// AWSMachineSecurityGroupsFailedReason used when the security groups could not be synced.
+	AWSMachineSecurityGroupsFailedReason = "SecurityGroupsSyncFailed"
+
+	// AWSMachineELBAttachFailedReason used when a control plane node fails to attach to the ELB.
+	AWSMachineELBAttachFailedReason = "ELBAttachFailed"
+
+	// AWSMachineELBDetachFailedReason used when a control plane node fails to detach from an ELB.
+	AWSMachineELBDetachFailedReason = "ELBDetachFailed"
+
+	// AWSMachineDedicatedHostReleaseFailedReason used when the dedicated host release fails.
+	AWSMachineDedicatedHostReleaseFailedReason = "DedicatedHostReleaseFailed"
+)

--- a/bootstrap/eks/api/v1beta2/v1beta2_condition_consts.go
+++ b/bootstrap/eks/api/v1beta2/v1beta2_condition_consts.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+// EKSConfig v1beta2 condition types.
+const (
+	// EKSConfigReadyCondition defines the Ready condition type that summarizes the operational state of an EKSConfig.
+	EKSConfigReadyCondition = clusterv1.ReadyCondition
+
+	// EKSConfigDataSecretAvailableCondition reports on the status of the bootstrap secret generation process.
+	//
+	// NOTE: When the DataSecret generation starts the process completes immediately and within the
+	// same reconciliation, so the user will always see a transition from Wait to Generated without having
+	// evidence that BootstrapSecret generation is started/in progress.
+	EKSConfigDataSecretAvailableCondition = "DataSecretAvailable"
+)
+
+// EKSConfig v1beta2 reason constants.
+const (
+	// EKSConfigReadyReason indicates the EKSConfig is ready.
+	EKSConfigReadyReason = clusterv1.ReadyReason
+
+	// EKSConfigNotReadyReason indicates the EKSConfig is not ready.
+	EKSConfigNotReadyReason = clusterv1.NotReadyReason
+
+	// EKSConfigDeletingReason indicates the EKSConfig is being deleted.
+	EKSConfigDeletingReason = clusterv1.DeletingReason
+
+	// EKSConfigDataSecretGenerationFailedReason indicates an error while generating a data secret;
+	// those kind of errors are usually due to misconfigurations and user intervention is required to get them fixed.
+	EKSConfigDataSecretGenerationFailedReason = "DataSecretGenerationFailed"
+
+	// EKSConfigWaitingForClusterInfrastructureReason indicates waiting for cluster infrastructure to be ready.
+	//
+	// NOTE: Having the cluster infrastructure ready is a pre-condition for starting to create machines;
+	// the EKSConfig controller ensures this pre-condition is satisfied.
+	EKSConfigWaitingForClusterInfrastructureReason = clusterv1.WaitingForClusterInfrastructureReadyReason
+
+	// EKSConfigWaitingForControlPlaneInitializationReason indicates waiting for the control plane to be initialized.
+	//
+	// NOTE: This is a pre-condition for starting to create machines;
+	// the EKSConfig controller ensures this pre-condition is satisfied.
+	EKSConfigWaitingForControlPlaneInitializationReason = clusterv1.WaitingForControlPlaneInitializedReason
+)
+
+// NodeadmConfig v1beta2 condition types.
+const (
+	// NodeadmConfigReadyCondition defines the Ready condition type that summarizes the operational state of a NodeadmConfig.
+	NodeadmConfigReadyCondition = clusterv1.ReadyCondition
+
+	// NodeadmConfigDataSecretAvailableCondition reports on the status of the bootstrap secret generation process.
+	//
+	// NOTE: When the DataSecret generation starts the process completes immediately and within the
+	// same reconciliation, so the user will always see a transition from Wait to Generated without having
+	// evidence that BootstrapSecret generation is started/in progress.
+	NodeadmConfigDataSecretAvailableCondition = "DataSecretAvailable"
+)
+
+// NodeadmConfig v1beta2 reason constants.
+const (
+	// NodeadmConfigReadyReason indicates the NodeadmConfig is ready.
+	NodeadmConfigReadyReason = clusterv1.ReadyReason
+
+	// NodeadmConfigNotReadyReason indicates the NodeadmConfig is not ready.
+	NodeadmConfigNotReadyReason = clusterv1.NotReadyReason
+
+	// NodeadmConfigDeletingReason indicates the NodeadmConfig is being deleted.
+	NodeadmConfigDeletingReason = clusterv1.DeletingReason
+
+	// NodeadmConfigDataSecretGenerationFailedReason indicates an error while generating a data secret;
+	// those kind of errors are usually due to misconfigurations and user intervention is required to get them fixed.
+	NodeadmConfigDataSecretGenerationFailedReason = "DataSecretGenerationFailed"
+
+	// NodeadmConfigWaitingForClusterInfrastructureReason indicates waiting for cluster infrastructure to be ready.
+	//
+	// NOTE: Having the cluster infrastructure ready is a pre-condition for starting to create machines;
+	// the NodeadmConfig controller ensures this pre-condition is satisfied.
+	NodeadmConfigWaitingForClusterInfrastructureReason = clusterv1.WaitingForClusterInfrastructureReadyReason
+
+	// NodeadmConfigWaitingForControlPlaneInitializationReason indicates waiting for the control plane to be initialized.
+	//
+	// NOTE: This is a pre-condition for starting to create machines;
+	// the NodeadmConfig controller ensures this pre-condition is satisfied.
+	NodeadmConfigWaitingForControlPlaneInitializationReason = clusterv1.WaitingForControlPlaneInitializedReason
+)

--- a/controlplane/eks/api/v1beta2/v1beta2_condition_consts.go
+++ b/controlplane/eks/api/v1beta2/v1beta2_condition_consts.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+// AWSManagedControlPlane v1beta2 condition types.
+const (
+	// AWSManagedControlPlaneReadyCondition defines the Ready condition type that summarizes the operational state of an AWSManagedControlPlane.
+	AWSManagedControlPlaneReadyCondition = clusterv1.ReadyCondition
+
+	// AWSManagedControlPlaneEKSControlPlaneReadyCondition reports on the successful reconciliation of the EKS control plane.
+	AWSManagedControlPlaneEKSControlPlaneReadyCondition = "EKSControlPlaneReady"
+
+	// AWSManagedControlPlaneEKSControlPlaneCreatingCondition reports whether the EKS control plane is being created.
+	AWSManagedControlPlaneEKSControlPlaneCreatingCondition = "EKSControlPlaneCreating"
+
+	// AWSManagedControlPlaneEKSControlPlaneUpdatingCondition reports whether the EKS control plane is being updated.
+	AWSManagedControlPlaneEKSControlPlaneUpdatingCondition = "EKSControlPlaneUpdating"
+
+	// AWSManagedControlPlaneIAMControlPlaneRolesReadyCondition reports on the successful reconciliation of EKS control plane IAM roles.
+	AWSManagedControlPlaneIAMControlPlaneRolesReadyCondition = "IAMControlPlaneRolesReady"
+
+	// AWSManagedControlPlaneIAMAuthenticatorConfiguredCondition reports on the successful reconciliation of the aws-iam-authenticator config.
+	AWSManagedControlPlaneIAMAuthenticatorConfiguredCondition = "IAMAuthenticatorConfigured"
+
+	// AWSManagedControlPlaneEKSAddonsConfiguredCondition reports on the successful reconciliation of EKS addons.
+	AWSManagedControlPlaneEKSAddonsConfiguredCondition = "EKSAddonsConfigured"
+
+	// AWSManagedControlPlaneEKSIdentityProviderConfiguredCondition reports on the successful association of identity provider config.
+	AWSManagedControlPlaneEKSIdentityProviderConfiguredCondition = "EKSIdentityProviderConfigured"
+)
+
+// AWSManagedControlPlane v1beta2 reason constants.
+const (
+	// AWSManagedControlPlaneReadyReason indicates the AWSManagedControlPlane is ready.
+	AWSManagedControlPlaneReadyReason = clusterv1.ReadyReason
+
+	// AWSManagedControlPlaneNotReadyReason indicates the AWSManagedControlPlane is not ready.
+	AWSManagedControlPlaneNotReadyReason = clusterv1.NotReadyReason
+
+	// AWSManagedControlPlaneDeletingReason indicates the AWSManagedControlPlane is being deleted.
+	AWSManagedControlPlaneDeletingReason = clusterv1.DeletingReason
+
+	// AWSManagedControlPlaneEKSControlPlaneReconciliationFailedReason used to report failures while reconciling EKS control plane.
+	AWSManagedControlPlaneEKSControlPlaneReconciliationFailedReason = "EKSControlPlaneReconciliationFailed"
+
+	// AWSManagedControlPlaneIAMControlPlaneRolesReconciliationFailedReason used to report failures while reconciling EKS control plane IAM roles.
+	AWSManagedControlPlaneIAMControlPlaneRolesReconciliationFailedReason = "IAMControlPlaneRolesReconciliationFailed"
+
+	// AWSManagedControlPlaneIAMAuthenticatorConfigurationFailedReason used to report failures while reconciling the aws-iam-authenticator config.
+	AWSManagedControlPlaneIAMAuthenticatorConfigurationFailedReason = "IAMAuthenticatorConfigurationFailed"
+
+	// AWSManagedControlPlaneEKSAddonsConfiguredFailedReason used to report failures while reconciling the EKS addons.
+	AWSManagedControlPlaneEKSAddonsConfiguredFailedReason = "EKSAddonsConfiguredFailed"
+
+	// AWSManagedControlPlaneEKSIdentityProviderConfiguredFailedReason used to report failures while reconciling the identity provider config association.
+	AWSManagedControlPlaneEKSIdentityProviderConfiguredFailedReason = "EKSIdentityProviderConfiguredFailed"
+)

--- a/controlplane/rosa/api/v1beta2/conditions_consts.go
+++ b/controlplane/rosa/api/v1beta2/conditions_consts.go
@@ -19,14 +19,17 @@ package v1beta2
 import clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 
 const (
-	// ROSAControlPlaneReadyCondition condition reports on the successful reconciliation of ROSAControlPlane.
-	ROSAControlPlaneReadyCondition clusterv1beta1.ConditionType = "ROSAControlPlaneReady"
+	// ROSAControlPlaneReadyV1Beta1Condition condition reports on the successful reconciliation of ROSAControlPlane.
+	// Use ROSAControlPlaneReadyCondition from v1beta2_condition_consts.go instead.
+	ROSAControlPlaneReadyV1Beta1Condition clusterv1beta1.ConditionType = "ROSAControlPlaneReady"
 
-	// ROSAControlPlaneValidCondition condition reports whether ROSAControlPlane configuration is valid.
-	ROSAControlPlaneValidCondition clusterv1beta1.ConditionType = "ROSAControlPlaneValid"
+	// ROSAControlPlaneValidV1Beta1Condition condition reports whether ROSAControlPlane configuration is valid.
+	// Use ROSAControlPlaneValidCondition from v1beta2_condition_consts.go instead.
+	ROSAControlPlaneValidV1Beta1Condition clusterv1beta1.ConditionType = "ROSAControlPlaneValid"
 
-	// ROSAControlPlaneUpgradingCondition condition reports whether ROSAControlPlane is upgrading or not.
-	ROSAControlPlaneUpgradingCondition clusterv1beta1.ConditionType = "ROSAControlPlaneUpgrading"
+	// ROSAControlPlaneUpgradingV1Beta1Condition condition reports whether ROSAControlPlane is upgrading or not.
+	// Use ROSAControlPlaneUpgradingCondition from v1beta2_condition_consts.go instead.
+	ROSAControlPlaneUpgradingV1Beta1Condition clusterv1beta1.ConditionType = "ROSAControlPlaneUpgrading"
 
 	// ExternalAuthConfiguredCondition condition reports whether external auth has beed correctly configured.
 	ExternalAuthConfiguredCondition clusterv1beta1.ConditionType = "ExternalAuthConfigured"
@@ -37,11 +40,13 @@ const (
 	// ReconciliationFailedReason used to report reconciliation failures.
 	ReconciliationFailedReason = "ReconciliationFailed"
 
-	// ROSAControlPlaneDeletionFailedReason used to report failures while deleting ROSAControlPlane.
-	ROSAControlPlaneDeletionFailedReason = "DeletionFailed"
+	// ROSAControlPlaneDeletionFailedV1Beta1Reason used to report failures while deleting ROSAControlPlane.
+	// Use ROSAControlPlaneDeletionFailedReason from v1beta2_condition_consts.go instead.
+	ROSAControlPlaneDeletionFailedV1Beta1Reason = "DeletionFailed"
 
-	// ROSAControlPlaneInvalidConfigurationReason used to report invalid user input.
-	ROSAControlPlaneInvalidConfigurationReason = "InvalidConfiguration"
+	// ROSAControlPlaneInvalidConfigurationV1Beta1Reason used to report invalid user input.
+	// Use ROSAControlPlaneInvalidConfigurationReason from v1beta2_condition_consts.go instead.
+	ROSAControlPlaneInvalidConfigurationV1Beta1Reason = "InvalidConfiguration"
 
 	// ROSARoleConfigNotReadyReason used to report when referenced RosaRoleConfig is not ready.
 	ROSARoleConfigNotReadyReason = "ROSARoleConfigNotReady"

--- a/controlplane/rosa/api/v1beta2/v1beta2_condition_consts.go
+++ b/controlplane/rosa/api/v1beta2/v1beta2_condition_consts.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+// ROSAControlPlane v1beta2 condition types.
+const (
+	// ROSAControlPlaneReadyCondition defines the Ready condition type that summarizes the operational state of a ROSAControlPlane.
+	ROSAControlPlaneReadyCondition = clusterv1.ReadyCondition
+
+	// ROSAControlPlaneControlPlaneReadyCondition reports on the successful reconciliation of ROSAControlPlane.
+	ROSAControlPlaneControlPlaneReadyCondition = "ROSAControlPlaneReady"
+
+	// ROSAControlPlaneValidCondition reports whether ROSAControlPlane configuration is valid.
+	ROSAControlPlaneValidCondition = "ROSAControlPlaneValid"
+
+	// ROSAControlPlaneUpgradingCondition reports whether ROSAControlPlane is upgrading or not.
+	ROSAControlPlaneUpgradingCondition = "ROSAControlPlaneUpgrading"
+
+	// ROSAControlPlaneExternalAuthConfiguredCondition reports whether external auth has been correctly configured.
+	ROSAControlPlaneExternalAuthConfiguredCondition = "ExternalAuthConfigured"
+
+	// ROSAControlPlaneRoleConfigReadyCondition reports whether the referenced RosaRoleConfig is ready.
+	ROSAControlPlaneRoleConfigReadyCondition = "ROSARoleConfigReady"
+)
+
+// ROSAControlPlane v1beta2 reason constants.
+const (
+	// ROSAControlPlaneReadyReason indicates the ROSAControlPlane is ready.
+	ROSAControlPlaneReadyReason = clusterv1.ReadyReason
+
+	// ROSAControlPlaneNotReadyReason indicates the ROSAControlPlane is not ready.
+	ROSAControlPlaneNotReadyReason = clusterv1.NotReadyReason
+
+	// ROSAControlPlaneDeletingReason indicates the ROSAControlPlane is being deleted.
+	ROSAControlPlaneDeletingReason = clusterv1.DeletingReason
+
+	// ROSAControlPlaneReconciliationFailedReason used to report reconciliation failures.
+	ROSAControlPlaneReconciliationFailedReason = "ReconciliationFailed"
+
+	// ROSAControlPlaneDeletionFailedReason used to report failures while deleting ROSAControlPlane.
+	ROSAControlPlaneDeletionFailedReason = "DeletionFailed"
+
+	// ROSAControlPlaneInvalidConfigurationReason used to report invalid user input.
+	ROSAControlPlaneInvalidConfigurationReason = "InvalidConfiguration"
+
+	// ROSAControlPlaneRoleConfigNotReadyReason used to report when referenced RosaRoleConfig is not ready.
+	ROSAControlPlaneRoleConfigNotReadyReason = "ROSARoleConfigNotReady"
+
+	// ROSAControlPlaneRoleConfigNotFoundReason used to report when referenced RosaRoleConfig is not found.
+	ROSAControlPlaneRoleConfigNotFoundReason = "ROSARoleConfigNotFound"
+)

--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -261,11 +261,11 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 		return ctrl.Result{}, fmt.Errorf("failed to validate ROSAControlPlane.spec: %w", err)
 	}
 
-	v1beta1conditions.MarkTrue(rosaScope.ControlPlane, rosacontrolplanev1.ROSAControlPlaneValidCondition)
+	v1beta1conditions.MarkTrue(rosaScope.ControlPlane, rosacontrolplanev1.ROSAControlPlaneValidV1Beta1Condition)
 	if validationMessage != "" {
 		v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
-			rosacontrolplanev1.ROSAControlPlaneValidCondition,
-			rosacontrolplanev1.ROSAControlPlaneInvalidConfigurationReason,
+			rosacontrolplanev1.ROSAControlPlaneValidV1Beta1Condition,
+			rosacontrolplanev1.ROSAControlPlaneInvalidConfigurationV1Beta1Reason,
 			clusterv1beta1.ConditionSeverityError,
 			"%s",
 			validationMessage)
@@ -288,7 +288,7 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 
 		switch cluster.Status().State() {
 		case cmv1.ClusterStateReady:
-			v1beta1conditions.MarkTrue(rosaScope.ControlPlane, rosacontrolplanev1.ROSAControlPlaneReadyCondition)
+			v1beta1conditions.MarkTrue(rosaScope.ControlPlane, rosacontrolplanev1.ROSAControlPlaneReadyV1Beta1Condition)
 			rosaScope.ControlPlane.Status.Ready = true
 
 			apiEndpoint, err := buildAPIEndpoint(cluster)
@@ -326,7 +326,7 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 			rosaScope.ControlPlane.Status.FailureMessage = &errorMessage
 
 			v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
-				rosacontrolplanev1.ROSAControlPlaneReadyCondition,
+				rosacontrolplanev1.ROSAControlPlaneReadyV1Beta1Condition,
 				string(cluster.Status().State()),
 				clusterv1beta1.ConditionSeverityError,
 				"%s",
@@ -336,7 +336,7 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 		}
 
 		v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
-			rosacontrolplanev1.ROSAControlPlaneReadyCondition,
+			rosacontrolplanev1.ROSAControlPlaneReadyV1Beta1Condition,
 			string(cluster.Status().State()),
 			clusterv1beta1.ConditionSeverityInfo,
 			"%s",
@@ -361,7 +361,7 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 		}
 
 		// Is the referenced ROSANetwork ready yet?
-		if !v1beta1conditions.IsTrue(rosaNet, expinfrav1.ROSANetworkReadyCondition) {
+		if !v1beta1conditions.IsTrue(rosaNet, expinfrav1.ROSANetworkReadyV1Beta1Condition) {
 			rosaScope.Info(fmt.Sprintf("referenced ROSANetwork %s is not ready", rosaNet.Name))
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
@@ -375,7 +375,7 @@ func (r *ROSAControlPlaneReconciler) reconcileNormal(ctx context.Context, rosaSc
 	cluster, err = ocmClient.CreateCluster(ocmClusterSpec)
 	if err != nil {
 		v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
-			rosacontrolplanev1.ROSAControlPlaneReadyCondition,
+			rosacontrolplanev1.ROSAControlPlaneReadyV1Beta1Condition,
 			rosacontrolplanev1.ReconciliationFailedReason,
 			clusterv1beta1.ConditionSeverityError,
 			"%s",
@@ -470,8 +470,8 @@ func (r *ROSAControlPlaneReconciler) reconcileDelete(ctx context.Context, rosaSc
 	if cluster.Status().State() != cmv1.ClusterStateUninstalling {
 		if _, err := ocmClient.DeleteCluster(cluster.ID(), bestEffort, creator); err != nil {
 			v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
-				rosacontrolplanev1.ROSAControlPlaneReadyCondition,
-				rosacontrolplanev1.ROSAControlPlaneDeletionFailedReason,
+				rosacontrolplanev1.ROSAControlPlaneReadyV1Beta1Condition,
+				rosacontrolplanev1.ROSAControlPlaneDeletionFailedV1Beta1Reason,
 				clusterv1beta1.ConditionSeverityError,
 				"failed to delete ROSAControlPlane: %s; if the error can't be resolved, set '%s' annotation to force the deletion",
 				err.Error(),
@@ -481,7 +481,7 @@ func (r *ROSAControlPlaneReconciler) reconcileDelete(ctx context.Context, rosaSc
 	}
 
 	v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
-		rosacontrolplanev1.ROSAControlPlaneReadyCondition,
+		rosacontrolplanev1.ROSAControlPlaneReadyV1Beta1Condition,
 		string(cluster.Status().State()),
 		clusterv1beta1.ConditionSeverityInfo,
 		"deleting")
@@ -639,7 +639,7 @@ func buildGroups(ids []string) []*cmv1.LogForwarderGroupBuilder {
 func (r *ROSAControlPlaneReconciler) reconcileClusterVersion(rosaScope *scope.ROSAControlPlaneScope, ocmClient rosa.OCMClient, cluster *cmv1.Cluster) error {
 	version := rosaScope.ControlPlane.Spec.Version
 	if version == rosa.RawVersionID(cluster.Version()) {
-		v1beta1conditions.MarkFalse(rosaScope.ControlPlane, rosacontrolplanev1.ROSAControlPlaneUpgradingCondition, "upgraded", clusterv1beta1.ConditionSeverityInfo, "")
+		v1beta1conditions.MarkFalse(rosaScope.ControlPlane, rosacontrolplanev1.ROSAControlPlaneUpgradingV1Beta1Condition, "upgraded", clusterv1beta1.ConditionSeverityInfo, "")
 
 		if cluster.Version() != nil {
 			rosaScope.ControlPlane.Status.AvailableUpgrades = cluster.Version().AvailableUpgrades()
@@ -668,7 +668,7 @@ func (r *ROSAControlPlaneReconciler) reconcileClusterVersion(rosaScope *scope.RO
 		scheduledUpgrade, err = rosa.ScheduleControlPlaneUpgrade(ocmClient, cluster, version, time.Now(), ack)
 		if err != nil {
 			condition := &clusterv1beta1.Condition{
-				Type:    rosacontrolplanev1.ROSAControlPlaneUpgradingCondition,
+				Type:    rosacontrolplanev1.ROSAControlPlaneUpgradingV1Beta1Condition,
 				Status:  corev1.ConditionFalse,
 				Reason:  "failed",
 				Message: fmt.Sprintf("failed to schedule upgrade to version %s: %v", version, err),
@@ -680,7 +680,7 @@ func (r *ROSAControlPlaneReconciler) reconcileClusterVersion(rosaScope *scope.RO
 	}
 
 	condition := &clusterv1beta1.Condition{
-		Type:    rosacontrolplanev1.ROSAControlPlaneUpgradingCondition,
+		Type:    rosacontrolplanev1.ROSAControlPlaneUpgradingV1Beta1Condition,
 		Status:  corev1.ConditionTrue,
 		Reason:  string(scheduledUpgrade.State().Value()),
 		Message: fmt.Sprintf("Upgrading to version %s", scheduledUpgrade.Version()),
@@ -703,8 +703,8 @@ func (r *ROSAControlPlaneReconciler) updateOCMCluster(rosaScope *scope.ROSAContr
 		rosaScope.Info("Updating cluster")
 		if err := ocmClient.UpdateCluster(cluster.ID(), creator, ocmClusterSpec); err != nil {
 			v1beta1conditions.MarkFalse(rosaScope.ControlPlane,
-				rosacontrolplanev1.ROSAControlPlaneValidCondition,
-				rosacontrolplanev1.ROSAControlPlaneInvalidConfigurationReason,
+				rosacontrolplanev1.ROSAControlPlaneValidV1Beta1Condition,
+				rosacontrolplanev1.ROSAControlPlaneInvalidConfigurationV1Beta1Reason,
 				clusterv1beta1.ConditionSeverityError,
 				"%s",
 				err.Error())

--- a/exp/api/v1beta2/conditions_consts.go
+++ b/exp/api/v1beta2/conditions_consts.go
@@ -136,21 +136,27 @@ const (
 )
 
 const (
-	// ROSANetworkReadyCondition condition reports on the successful reconciliation of ROSANetwork.
-	ROSANetworkReadyCondition clusterv1beta1.ConditionType = "ROSANetworkReady"
+	// ROSANetworkReadyV1Beta1Condition condition reports on the successful reconciliation of ROSANetwork.
+	// Use ROSANetworkReadyCondition from v1beta2_condition_consts.go instead.
+	ROSANetworkReadyV1Beta1Condition clusterv1beta1.ConditionType = "ROSANetworkReady"
 
-	// ROSANetworkCreatingReason used when ROSANetwork is being created.
-	ROSANetworkCreatingReason = "Creating"
+	// ROSANetworkCreatingV1Beta1Reason used when ROSANetwork is being created.
+	// Use ROSANetworkCreatingReason from v1beta2_condition_consts.go instead.
+	ROSANetworkCreatingV1Beta1Reason = "Creating"
 
-	// ROSANetworkCreatedReason used when ROSANetwork is created.
-	ROSANetworkCreatedReason = "Created"
+	// ROSANetworkCreatedV1Beta1Reason used when ROSANetwork is created.
+	// Use ROSANetworkCreatedReason from v1beta2_condition_consts.go instead.
+	ROSANetworkCreatedV1Beta1Reason = "Created"
 
-	// ROSANetworkFailedReason used when rosaNetwork creation failed.
-	ROSANetworkFailedReason = "Failed"
+	// ROSANetworkFailedV1Beta1Reason used when rosaNetwork creation failed.
+	// Use ROSANetworkFailedReason from v1beta2_condition_consts.go instead.
+	ROSANetworkFailedV1Beta1Reason = "Failed"
 
-	// ROSANetworkDeletingReason used when ROSANetwork is being deleted.
-	ROSANetworkDeletingReason = "Deleting"
+	// ROSANetworkDeletingV1Beta1Reason used when ROSANetwork is being deleted.
+	// Use ROSANetworkDeletingReason from v1beta2_condition_consts.go instead.
+	ROSANetworkDeletingV1Beta1Reason = "Deleting"
 
-	// ROSANetworkDeletionFailedReason used to report failures while deleting ROSANetwork.
-	ROSANetworkDeletionFailedReason = "DeletionFailed"
+	// ROSANetworkDeletionFailedV1Beta1Reason used to report failures while deleting ROSANetwork.
+	// Use ROSANetworkDeletionFailedReason from v1beta2_condition_consts.go instead.
+	ROSANetworkDeletionFailedV1Beta1Reason = "DeletionFailed"
 )

--- a/exp/api/v1beta2/rosaocmroleconfig_types.go
+++ b/exp/api/v1beta2/rosaocmroleconfig_types.go
@@ -50,23 +50,29 @@ const (
 )
 
 const (
-	// ROSAOCMRoleConfigReadyCondition condition reports on the successful reconciliation of ROSAOCMRoleConfig.
-	ROSAOCMRoleConfigReadyCondition = "ROSAOCMRoleConfigReady"
+	// ROSAOCMRoleConfigReadyV1Beta1Condition condition reports on the successful reconciliation of ROSAOCMRoleConfig.
+	// Use ROSAOCMRoleConfigReadyCondition from v1beta2_condition_consts.go instead.
+	ROSAOCMRoleConfigReadyV1Beta1Condition = "ROSAOCMRoleConfigReady"
 
-	// ROSAOCMRoleConfigDeletionFailedReason used to report failures while deleting ROSAOCMRoleConfig.
-	ROSAOCMRoleConfigDeletionFailedReason = "DeletionFailed"
+	// ROSAOCMRoleConfigDeletionFailedV1Beta1Reason used to report failures while deleting ROSAOCMRoleConfig.
+	// Use ROSAOCMRoleConfigDeletionFailedReason from v1beta2_condition_consts.go instead.
+	ROSAOCMRoleConfigDeletionFailedV1Beta1Reason = "DeletionFailed"
 
-	// ROSAOCMRoleConfigReconciliationFailedReason used to report reconciliation failures.
-	ROSAOCMRoleConfigReconciliationFailedReason = "ReconciliationFailed"
+	// ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason used to report reconciliation failures.
+	// Use ROSAOCMRoleConfigReconciliationFailedReason from v1beta2_condition_consts.go instead.
+	ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason = "ReconciliationFailed"
 
-	// ROSAOCMRoleConfigDeletionStarted used to indicate that the deletion of ROSAOCMRoleConfig has started.
-	ROSAOCMRoleConfigDeletionStarted = "DeletionStarted"
+	// ROSAOCMRoleConfigDeletionStartedV1Beta1 used to indicate that the deletion of ROSAOCMRoleConfig has started.
+	// Use ROSAOCMRoleConfigDeletionStartedReason from v1beta2_condition_consts.go instead.
+	ROSAOCMRoleConfigDeletionStartedV1Beta1 = "DeletionStarted"
 
-	// ROSAOCMRoleConfigCreatedReason used to indicate that the ROSAOCMRoleConfig has been created.
-	ROSAOCMRoleConfigCreatedReason = "Created"
+	// ROSAOCMRoleConfigCreatedV1Beta1Reason used to indicate that the ROSAOCMRoleConfig has been created.
+	// Use ROSAOCMRoleConfigCreatedReason from v1beta2_condition_consts.go instead.
+	ROSAOCMRoleConfigCreatedV1Beta1Reason = "Created"
 
-	// ROSAOCMRoleConfigLinkedReason used to indicate that the OCM role has been linked to the organization.
-	ROSAOCMRoleConfigLinkedReason = "Linked"
+	// ROSAOCMRoleConfigLinkedV1Beta1Reason used to indicate that the OCM role has been linked to the organization.
+	// Use ROSAOCMRoleConfigLinkedReason from v1beta2_condition_consts.go instead.
+	ROSAOCMRoleConfigLinkedV1Beta1Reason = "Linked"
 )
 
 // ROSAOCMRoleConfigSpec defines the desired state of ROSAOCMRoleConfig

--- a/exp/api/v1beta2/v1beta2_condition_consts.go
+++ b/exp/api/v1beta2/v1beta2_condition_consts.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+// AWSMachinePool v1beta2 condition types.
+const (
+	// AWSMachinePoolReadyCondition defines the Ready condition type that summarizes the operational state of an AWSMachinePool.
+	AWSMachinePoolReadyCondition = clusterv1.ReadyCondition
+
+	// AWSMachinePoolASGReadyCondition reports on current status of the autoscaling group. Ready indicates the group is provisioned.
+	AWSMachinePoolASGReadyCondition = "ASGReady"
+
+	// AWSMachinePoolLaunchTemplateReadyCondition reports on the status of an AWSMachinePool's associated launch template.
+	AWSMachinePoolLaunchTemplateReadyCondition = "LaunchTemplateReady"
+
+	// AWSMachinePoolPreLaunchTemplateUpdateCheckCondition reports if all prerequisites are met for launch template update.
+	AWSMachinePoolPreLaunchTemplateUpdateCheckCondition = "PreLaunchTemplateUpdateCheckSuccess"
+
+	// AWSMachinePoolPostLaunchTemplateUpdateOperationCondition reports on successfully completed post launch template update operation.
+	AWSMachinePoolPostLaunchTemplateUpdateOperationCondition = "PostLaunchTemplateUpdateOperationSuccess"
+
+	// AWSMachinePoolInstanceRefreshStartedCondition reports on successfully starting instance refresh.
+	AWSMachinePoolInstanceRefreshStartedCondition = "InstanceRefreshStarted"
+
+	// AWSMachinePoolLifecycleHookReadyCondition reports on the status of the lifecycle hook.
+	AWSMachinePoolLifecycleHookReadyCondition = "LifecycleHookReady"
+)
+
+// AWSMachinePool v1beta2 reason constants.
+const (
+	// AWSMachinePoolReadyReason indicates the AWSMachinePool is ready.
+	AWSMachinePoolReadyReason = clusterv1.ReadyReason
+
+	// AWSMachinePoolNotReadyReason indicates the AWSMachinePool is not ready.
+	AWSMachinePoolNotReadyReason = clusterv1.NotReadyReason
+
+	// AWSMachinePoolDeletingReason indicates the AWSMachinePool is being deleted.
+	AWSMachinePoolDeletingReason = clusterv1.DeletingReason
+
+	// AWSMachinePoolASGNotFoundReason used when the autoscaling group couldn't be retrieved.
+	AWSMachinePoolASGNotFoundReason = "ASGNotFound"
+
+	// AWSMachinePoolASGProvisionFailedReason used for failures during autoscaling group provisioning.
+	AWSMachinePoolASGProvisionFailedReason = "ASGProvisionFailed"
+
+	// AWSMachinePoolASGDeletionInProgressReason used when the autoscaling group is in a deletion in progress state.
+	AWSMachinePoolASGDeletionInProgressReason = "ASGDeletionInProgress"
+
+	// AWSMachinePoolLaunchTemplateNotFoundReason used when an associated launch template can't be found.
+	AWSMachinePoolLaunchTemplateNotFoundReason = "LaunchTemplateNotFound"
+
+	// AWSMachinePoolLaunchTemplateCreateFailedReason used for failures during launch template creation.
+	AWSMachinePoolLaunchTemplateCreateFailedReason = "LaunchTemplateCreateFailed"
+
+	// AWSMachinePoolLaunchTemplateReconcileFailedReason used for failures during launch template reconciliation.
+	AWSMachinePoolLaunchTemplateReconcileFailedReason = "LaunchTemplateReconcileFailed"
+
+	// AWSMachinePoolLaunchTemplateNitroEnclaveEdgeZoneReason used when enclaveOptions is enabled but the pool
+	// targets a Local Zone or Wavelength Zone, which does not support Nitro Enclaves.
+	AWSMachinePoolLaunchTemplateNitroEnclaveEdgeZoneReason = "NitroEnclaveEdgeZoneUnsupported"
+
+	// AWSMachinePoolPreLaunchTemplateUpdateCheckFailedReason used to report when not all prerequisites are met for launch template update.
+	AWSMachinePoolPreLaunchTemplateUpdateCheckFailedReason = "PreLaunchTemplateUpdateCheckFailed"
+
+	// AWSMachinePoolPostLaunchTemplateUpdateOperationFailedReason used to report when post launch template update operation failed.
+	AWSMachinePoolPostLaunchTemplateUpdateOperationFailedReason = "PostLaunchTemplateUpdateOperationFailed"
+
+	// AWSMachinePoolInstanceRefreshNotReadyReason used to report instance refresh is not initiated.
+	// If there are instance refreshes that are in progress, then a new instance refresh request will fail.
+	AWSMachinePoolInstanceRefreshNotReadyReason = "InstanceRefreshNotReady"
+
+	// AWSMachinePoolInstanceRefreshFailedReason used to report when instance refresh is not initiated.
+	AWSMachinePoolInstanceRefreshFailedReason = "InstanceRefreshFailed"
+
+	// AWSMachinePoolMachineCreationFailedReason used to report when creating AWSMachines to represent ASG machines failed.
+	AWSMachinePoolMachineCreationFailedReason = "AWSMachineCreationFailed"
+
+	// AWSMachinePoolMachineDeletionFailedReason used to report when deleting AWSMachines failed.
+	AWSMachinePoolMachineDeletionFailedReason = "AWSMachineDeletionFailed"
+
+	// AWSMachinePoolLifecycleHookCreationFailedReason used for failures during lifecycle hook creation.
+	AWSMachinePoolLifecycleHookCreationFailedReason = "LifecycleHookCreationFailed"
+
+	// AWSMachinePoolLifecycleHookUpdateFailedReason used for failures during lifecycle hook update.
+	AWSMachinePoolLifecycleHookUpdateFailedReason = "LifecycleHookUpdateFailed"
+
+	// AWSMachinePoolLifecycleHookDeletionFailedReason used for failures during lifecycle hook deletion.
+	AWSMachinePoolLifecycleHookDeletionFailedReason = "LifecycleHookDeletionFailed"
+)
+
+// AWSManagedMachinePool v1beta2 condition types.
+const (
+	// AWSManagedMachinePoolReadyCondition defines the Ready condition type that summarizes the operational state of an AWSManagedMachinePool.
+	AWSManagedMachinePoolReadyCondition = clusterv1.ReadyCondition
+
+	// AWSManagedMachinePoolEKSNodegroupReadyCondition reports on the successful reconciliation of the EKS node group.
+	AWSManagedMachinePoolEKSNodegroupReadyCondition = "EKSNodegroupReady"
+
+	// AWSManagedMachinePoolIAMNodegroupRolesReadyCondition reports on the successful reconciliation of EKS node group IAM roles.
+	AWSManagedMachinePoolIAMNodegroupRolesReadyCondition = "IAMNodegroupRolesReady"
+
+	// AWSManagedMachinePoolLaunchTemplateReadyCondition reports on the status of the associated launch template.
+	AWSManagedMachinePoolLaunchTemplateReadyCondition = "LaunchTemplateReady"
+)
+
+// AWSManagedMachinePool v1beta2 reason constants.
+const (
+	// AWSManagedMachinePoolReadyReason indicates the AWSManagedMachinePool is ready.
+	AWSManagedMachinePoolReadyReason = clusterv1.ReadyReason
+
+	// AWSManagedMachinePoolNotReadyReason indicates the AWSManagedMachinePool is not ready.
+	AWSManagedMachinePoolNotReadyReason = clusterv1.NotReadyReason
+
+	// AWSManagedMachinePoolDeletingReason indicates the AWSManagedMachinePool is being deleted.
+	AWSManagedMachinePoolDeletingReason = clusterv1.DeletingReason
+
+	// AWSManagedMachinePoolEKSNodegroupReconciliationFailedReason used to report failures while reconciling EKS control plane.
+	AWSManagedMachinePoolEKSNodegroupReconciliationFailedReason = "EKSNodegroupReconciliationFailed"
+
+	// AWSManagedMachinePoolWaitingForEKSControlPlaneReason used when the machine pool is waiting for
+	// EKS control plane infrastructure to be ready before proceeding.
+	AWSManagedMachinePoolWaitingForEKSControlPlaneReason = "WaitingForEKSControlPlane"
+
+	// AWSManagedMachinePoolIAMNodegroupRolesReconciliationFailedReason used to report failures while reconciling EKS nodegroup IAM roles.
+	AWSManagedMachinePoolIAMNodegroupRolesReconciliationFailedReason = "IAMNodegroupRolesReconciliationFailed"
+
+	// AWSManagedMachinePoolLaunchTemplateNotFoundReason used when an associated launch template can't be found.
+	AWSManagedMachinePoolLaunchTemplateNotFoundReason = "LaunchTemplateNotFound"
+
+	// AWSManagedMachinePoolLaunchTemplateCreateFailedReason used for failures during launch template creation.
+	AWSManagedMachinePoolLaunchTemplateCreateFailedReason = "LaunchTemplateCreateFailed"
+
+	// AWSManagedMachinePoolLaunchTemplateReconcileFailedReason used for failures during launch template reconciliation.
+	AWSManagedMachinePoolLaunchTemplateReconcileFailedReason = "LaunchTemplateReconcileFailed"
+)
+
+// AWSFargateProfile v1beta2 condition types.
+const (
+	// AWSFargateProfileReadyCondition defines the Ready condition type that summarizes the operational state of an AWSFargateProfile.
+	AWSFargateProfileReadyCondition = clusterv1.ReadyCondition
+
+	// AWSFargateProfileEKSFargateProfileReadyCondition reports on the successful reconciliation of the EKS Fargate profile.
+	AWSFargateProfileEKSFargateProfileReadyCondition = "EKSFargateProfileReady"
+
+	// AWSFargateProfileEKSFargateCreatingCondition reports whether the Fargate profile is being created.
+	AWSFargateProfileEKSFargateCreatingCondition = "EKSFargateCreating"
+
+	// AWSFargateProfileEKSFargateDeletingCondition used to report that the profile is deleting.
+	AWSFargateProfileEKSFargateDeletingCondition = "EKSFargateDeleting"
+
+	// AWSFargateProfileIAMFargateRolesReadyCondition reports on the successful reconciliation of Fargate IAM roles.
+	AWSFargateProfileIAMFargateRolesReadyCondition = "IAMFargateRolesReady"
+)
+
+// AWSFargateProfile v1beta2 reason constants.
+const (
+	// AWSFargateProfileReadyReason indicates the AWSFargateProfile is ready.
+	AWSFargateProfileReadyReason = clusterv1.ReadyReason
+
+	// AWSFargateProfileNotReadyReason indicates the AWSFargateProfile is not ready.
+	AWSFargateProfileNotReadyReason = clusterv1.NotReadyReason
+
+	// AWSFargateProfileDeletingReason indicates the AWSFargateProfile is being deleted.
+	AWSFargateProfileDeletingReason = clusterv1.DeletingReason
+
+	// AWSFargateProfileReconciliationFailedReason used to report failures while reconciling EKS Fargate profile.
+	AWSFargateProfileReconciliationFailedReason = "EKSFargateReconciliationFailed"
+
+	// AWSFargateProfileCreatingReason used when the profile is creating.
+	AWSFargateProfileCreatingReason = "Creating"
+
+	// AWSFargateProfileCreatedReason used when the profile is created.
+	AWSFargateProfileCreatedReason = "Created"
+
+	// AWSFargateProfileFailedReason used when the profile failed.
+	AWSFargateProfileFailedReason = "Failed"
+
+	// AWSFargateProfileDeletedReason used when the profile is deleted.
+	AWSFargateProfileDeletedReason = "Deleted"
+
+	// AWSFargateProfileIAMFargateRolesReconciliationFailedReason used to report failures while reconciling Fargate IAM roles.
+	AWSFargateProfileIAMFargateRolesReconciliationFailedReason = "IAMFargateRolesReconciliationFailed"
+)
+
+// ROSAMachinePool v1beta2 condition types.
+const (
+	// ROSAMachinePoolReadyCondition defines the Ready condition type that summarizes the operational state of a ROSAMachinePool.
+	ROSAMachinePoolReadyCondition = clusterv1.ReadyCondition
+
+	// ROSAMachinePoolNodePoolReadyCondition reports on the successful reconciliation of rosa machinepool.
+	ROSAMachinePoolNodePoolReadyCondition = "RosaMachinePoolReady"
+
+	// ROSAMachinePoolUpgradingCondition reports whether ROSAMachinePool is upgrading or not.
+	ROSAMachinePoolUpgradingCondition = "RosaMachinePoolUpgrading"
+)
+
+// ROSAMachinePool v1beta2 reason constants.
+const (
+	// ROSAMachinePoolReadyReason indicates the ROSAMachinePool is ready.
+	ROSAMachinePoolReadyReason = clusterv1.ReadyReason
+
+	// ROSAMachinePoolNotReadyReason indicates the ROSAMachinePool is not ready.
+	ROSAMachinePoolNotReadyReason = clusterv1.NotReadyReason
+
+	// ROSAMachinePoolDeletingReason indicates the ROSAMachinePool is being deleted.
+	ROSAMachinePoolDeletingReason = clusterv1.DeletingReason
+
+	// ROSAMachinePoolWaitingForRosaControlPlaneReason used when the machine pool is waiting for
+	// ROSA control plane infrastructure to be ready before proceeding.
+	ROSAMachinePoolWaitingForRosaControlPlaneReason = "WaitingForRosaControlPlane"
+
+	// ROSAMachinePoolReconciliationFailedReason used to report failures while reconciling ROSAMachinePool.
+	ROSAMachinePoolReconciliationFailedReason = "ReconciliationFailed"
+)
+
+// ROSACluster v1beta2 condition types.
+const (
+	// ROSAClusterReadyCondition defines the Ready condition type that summarizes the operational state of a ROSACluster.
+	ROSAClusterReadyCondition = clusterv1.ReadyCondition
+)
+
+// ROSACluster v1beta2 reason constants.
+const (
+	// ROSAClusterReadyReason indicates the ROSACluster is ready.
+	ROSAClusterReadyReason = clusterv1.ReadyReason
+
+	// ROSAClusterNotReadyReason indicates the ROSACluster is not ready.
+	ROSAClusterNotReadyReason = clusterv1.NotReadyReason
+)
+
+// ROSANetwork v1beta2 condition types.
+const (
+	// ROSANetworkReadyCondition defines the Ready condition type that summarizes the operational state of a ROSANetwork.
+	ROSANetworkReadyCondition = clusterv1.ReadyCondition
+
+	// ROSANetworkNetworkReadyCondition reports on the successful reconciliation of ROSANetwork.
+	ROSANetworkNetworkReadyCondition = "ROSANetworkReady"
+)
+
+// ROSANetwork v1beta2 reason constants.
+const (
+	// ROSANetworkReadyReason indicates the ROSANetwork is ready.
+	ROSANetworkReadyReason = clusterv1.ReadyReason
+
+	// ROSANetworkNotReadyReason indicates the ROSANetwork is not ready.
+	ROSANetworkNotReadyReason = clusterv1.NotReadyReason
+
+	// ROSANetworkCreatingReason used when ROSANetwork is being created.
+	ROSANetworkCreatingReason = "Creating"
+
+	// ROSANetworkCreatedReason used when ROSANetwork is created.
+	ROSANetworkCreatedReason = "Created"
+
+	// ROSANetworkFailedReason used when ROSANetwork creation failed.
+	ROSANetworkFailedReason = "Failed"
+
+	// ROSANetworkDeletingReason indicates the ROSANetwork is being deleted.
+	ROSANetworkDeletingReason = clusterv1.DeletingReason
+
+	// ROSANetworkDeletionFailedReason used to report failures while deleting ROSANetwork.
+	ROSANetworkDeletionFailedReason = "DeletionFailed"
+)
+
+// ROSARoleConfig v1beta2 condition types.
+const (
+	// ROSARoleConfigReadyCondition defines the Ready condition type that summarizes the operational state of a ROSARoleConfig.
+	ROSARoleConfigReadyCondition = clusterv1.ReadyCondition
+
+	// ROSARoleConfigRoleConfigReadyCondition reports on the successful reconciliation of ROSARoleConfig.
+	ROSARoleConfigRoleConfigReadyCondition = "RosaRoleConfigReady"
+)
+
+// ROSARoleConfig v1beta2 reason constants.
+const (
+	// ROSARoleConfigReadyReason indicates the ROSARoleConfig is ready.
+	ROSARoleConfigReadyReason = clusterv1.ReadyReason
+
+	// ROSARoleConfigNotReadyReason indicates the ROSARoleConfig is not ready.
+	ROSARoleConfigNotReadyReason = clusterv1.NotReadyReason
+
+	// ROSARoleConfigDeletingReason indicates the ROSARoleConfig is being deleted.
+	ROSARoleConfigDeletingReason = clusterv1.DeletingReason
+
+	// ROSARoleConfigReconciliationFailedReason used to report reconciliation failures.
+	ROSARoleConfigReconciliationFailedReason = "ReconciliationFailed"
+
+	// ROSARoleConfigDeletionFailedReason used to report failures while deleting ROSARoleConfig.
+	ROSARoleConfigDeletionFailedReason = "DeletionFailed"
+
+	// ROSARoleConfigDeletionStartedReason used to indicate that the deletion of ROSARoleConfig has started.
+	ROSARoleConfigDeletionStartedReason = "DeletionStarted"
+
+	// ROSARoleConfigCreatedReason used to indicate that the ROSARoleConfig has been created.
+	ROSARoleConfigCreatedReason = "Created"
+)
+
+// ROSAOCMRoleConfig v1beta2 condition types.
+const (
+	// ROSAOCMRoleConfigReadyCondition defines the Ready condition type that summarizes the operational state of a ROSAOCMRoleConfig.
+	ROSAOCMRoleConfigReadyCondition = clusterv1.ReadyCondition
+
+	// ROSAOCMRoleConfigOCMRoleConfigReadyCondition reports on the successful reconciliation of ROSAOCMRoleConfig.
+	ROSAOCMRoleConfigOCMRoleConfigReadyCondition = "ROSAOCMRoleConfigReady"
+)
+
+// ROSAOCMRoleConfig v1beta2 reason constants.
+const (
+	// ROSAOCMRoleConfigReadyReason indicates the ROSAOCMRoleConfig is ready.
+	ROSAOCMRoleConfigReadyReason = clusterv1.ReadyReason
+
+	// ROSAOCMRoleConfigNotReadyReason indicates the ROSAOCMRoleConfig is not ready.
+	ROSAOCMRoleConfigNotReadyReason = clusterv1.NotReadyReason
+
+	// ROSAOCMRoleConfigDeletingReason indicates the ROSAOCMRoleConfig is being deleted.
+	ROSAOCMRoleConfigDeletingReason = clusterv1.DeletingReason
+
+	// ROSAOCMRoleConfigDeletionStartedReason used to indicate that the deletion of ROSAOCMRoleConfig has started.
+	ROSAOCMRoleConfigDeletionStartedReason = "DeletionStarted"
+
+	// ROSAOCMRoleConfigReconciliationFailedReason used to report reconciliation failures.
+	ROSAOCMRoleConfigReconciliationFailedReason = "ReconciliationFailed"
+
+	// ROSAOCMRoleConfigDeletionFailedReason used to report failures while deleting ROSAOCMRoleConfig.
+	ROSAOCMRoleConfigDeletionFailedReason = "DeletionFailed"
+
+	// ROSAOCMRoleConfigCreatedReason used to indicate that the ROSAOCMRoleConfig has been created.
+	ROSAOCMRoleConfigCreatedReason = "Created"
+
+	// ROSAOCMRoleConfigLinkedReason used to indicate that the OCM role has been linked to the organization.
+	ROSAOCMRoleConfigLinkedReason = "Linked"
+)

--- a/exp/controllers/rosanetwork_controller.go
+++ b/exp/controllers/rosanetwork_controller.go
@@ -150,16 +150,16 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 		_, err := awsClient.CreateStackWithParamsTags(ctx, templateBody, rosaNetScope.ROSANetwork.Spec.StackName, cfParams, rosaNetScope.ROSANetwork.Spec.StackTags)
 		if err != nil {
 			v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
-				expinfrav1.ROSANetworkReadyCondition,
-				expinfrav1.ROSANetworkFailedReason,
+				expinfrav1.ROSANetworkReadyV1Beta1Condition,
+				expinfrav1.ROSANetworkFailedV1Beta1Reason,
 				clusterv1beta1.ConditionSeverityError,
 				"%s",
 				err.Error())
 			return ctrl.Result{}, fmt.Errorf("failed to start CF stack creation: %w", err)
 		}
 		v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
-			expinfrav1.ROSANetworkReadyCondition,
-			expinfrav1.ROSANetworkCreatingReason,
+			expinfrav1.ROSANetworkReadyV1Beta1Condition,
+			expinfrav1.ROSANetworkCreatingV1Beta1Reason,
 			clusterv1beta1.ConditionSeverityInfo,
 			"")
 		return ctrl.Result{}, nil
@@ -172,10 +172,10 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 
 	switch cfStack.StackStatus {
 	case cloudformationtypes.StackStatusCreateInProgress: // Create in progress
-		// Set the reason of false ROSANetworkReadyCondition to Creating
+		// Set the reason of false ROSANetworkReadyV1Beta1Condition to Creating
 		v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
-			expinfrav1.ROSANetworkReadyCondition,
-			expinfrav1.ROSANetworkCreatingReason,
+			expinfrav1.ROSANetworkReadyV1Beta1Condition,
+			expinfrav1.ROSANetworkCreatingV1Beta1Reason,
 			clusterv1beta1.ConditionSeverityInfo,
 			"")
 		return ctrl.Result{RequeueAfter: time.Second * 60}, nil
@@ -184,21 +184,21 @@ func (r *ROSANetworkReconciler) reconcileNormal(ctx context.Context, rosaNetScop
 			return ctrl.Result{}, fmt.Errorf("parsing stack subnets failed: %w", err)
 		}
 
-		// Set the reason of true ROSANetworkReadyCondition to Created
+		// Set the reason of true ROSANetworkReadyV1Beta1Condition to Created
 		// We have to use v1beta1conditions.Set(), since v1beta1conditions.MarkTrue() does not support setting reason
 		v1beta1conditions.Set(rosaNetScope.ROSANetwork,
 			&clusterv1beta1.Condition{
-				Type:     expinfrav1.ROSANetworkReadyCondition,
+				Type:     expinfrav1.ROSANetworkReadyV1Beta1Condition,
 				Status:   corev1.ConditionTrue,
-				Reason:   expinfrav1.ROSANetworkCreatedReason,
+				Reason:   expinfrav1.ROSANetworkCreatedV1Beta1Reason,
 				Severity: clusterv1beta1.ConditionSeverityInfo,
 			})
 		return ctrl.Result{}, nil
 	case cloudformationtypes.StackStatusCreateFailed: // Create failed
-		// Set the reason of false ROSANetworkReadyCondition to Failed
+		// Set the reason of false ROSANetworkReadyV1Beta1Condition to Failed
 		v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
-			expinfrav1.ROSANetworkReadyCondition,
-			expinfrav1.ROSANetworkFailedReason,
+			expinfrav1.ROSANetworkReadyV1Beta1Condition,
+			expinfrav1.ROSANetworkFailedV1Beta1Reason,
 			clusterv1beta1.ConditionSeverityError,
 			"")
 		return ctrl.Result{}, fmt.Errorf("cloudformation stack %s creation failed, see the stack resources for more information", *cfStack.StackName)
@@ -221,8 +221,8 @@ func (r *ROSANetworkReconciler) reconcileDelete(ctx context.Context, rosaNetScop
 			return ctrl.Result{RequeueAfter: time.Second * 60}, nil
 		case cloudformationtypes.StackStatusDeleteFailed: // Deletion failed
 			v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
-				expinfrav1.ROSANetworkReadyCondition,
-				expinfrav1.ROSANetworkDeletionFailedReason,
+				expinfrav1.ROSANetworkReadyV1Beta1Condition,
+				expinfrav1.ROSANetworkDeletionFailedV1Beta1Reason,
 				clusterv1beta1.ConditionSeverityError,
 				"")
 			return ctrl.Result{}, fmt.Errorf("CF stack deletion failed")
@@ -230,16 +230,16 @@ func (r *ROSANetworkReconciler) reconcileDelete(ctx context.Context, rosaNetScop
 			err := awsClient.DeleteCFStack(ctx, rosaNetScope.ROSANetwork.Spec.StackName)
 			if err != nil {
 				v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
-					expinfrav1.ROSANetworkReadyCondition,
-					expinfrav1.ROSANetworkDeletionFailedReason,
+					expinfrav1.ROSANetworkReadyV1Beta1Condition,
+					expinfrav1.ROSANetworkDeletionFailedV1Beta1Reason,
 					clusterv1beta1.ConditionSeverityError,
 					"%s",
 					err.Error())
 				return ctrl.Result{}, fmt.Errorf("failed to start CF stack deletion: %w", err)
 			}
 			v1beta1conditions.MarkFalse(rosaNetScope.ROSANetwork,
-				expinfrav1.ROSANetworkReadyCondition,
-				expinfrav1.ROSANetworkDeletingReason,
+				expinfrav1.ROSANetworkReadyV1Beta1Condition,
+				expinfrav1.ROSANetworkDeletingV1Beta1Reason,
 				clusterv1beta1.ConditionSeverityInfo,
 				"")
 			return ctrl.Result{RequeueAfter: time.Second * 60}, nil

--- a/exp/controllers/rosanetwork_controller_test.go
+++ b/exp/controllers/rosanetwork_controller_test.go
@@ -162,10 +162,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).To(MatchError(ContainSubstring("failed to start CF stack creation:")))
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetwork)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetwork)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkFailedReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkFailedV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityError))
 			g.Expect(cnd.Message).To(Equal("test-error"))
 		}).Should(Succeed())
@@ -196,10 +196,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).ToNot(HaveOccurred())
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetwork)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetwork)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkCreatingReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkCreatingV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityInfo))
 		}).Should(Succeed())
 	})
@@ -231,10 +231,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).ToNot(HaveOccurred())
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetwork)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetwork)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkCreatingReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkCreatingV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityInfo))
 		}).Should(Succeed())
 	})
@@ -266,10 +266,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).ToNot(HaveOccurred())
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetwork)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetwork)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkCreatedReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkCreatedV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityInfo))
 		}).Should(Succeed())
 	})
@@ -301,10 +301,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).To(MatchError(ContainSubstring("creation failed")))
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetwork)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetwork)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkFailedReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkFailedV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityError))
 		}).Should(Succeed())
 	})
@@ -338,10 +338,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).To(MatchError(ContainSubstring("failed to start CF stack deletion:")))
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetworkDeleted)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetworkDeleted)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkDeletionFailedReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkDeletionFailedV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityError))
 		}).Should(Succeed())
 	})
@@ -375,10 +375,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).NotTo(HaveOccurred())
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetworkDeleted)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetworkDeleted)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkDeletingReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkDeletingV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityInfo))
 		}).Should(Succeed())
 	})
@@ -442,10 +442,10 @@ func TestROSANetworkReconciler_Reconcile(t *testing.T) {
 		g.Expect(errReconcile).To(MatchError(ContainSubstring("CF stack deletion failed")))
 
 		g.Eventually(func(g Gomega) {
-			cnd, err := getROSANetworkReadyCondition(reconciler, rosaNetworkDeleted)
+			cnd, err := getROSANetworkReadyV1Beta1Condition(reconciler, rosaNetworkDeleted)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cnd).ToNot(BeNil())
-			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkDeletionFailedReason))
+			g.Expect(cnd.Reason).To(Equal(expinfrav1.ROSANetworkDeletionFailedV1Beta1Reason))
 			g.Expect(cnd.Severity).To(Equal(clusterv1beta1.ConditionSeverityError))
 		}).Should(Succeed())
 	})
@@ -720,14 +720,14 @@ func deleteROSANetwork(ctx context.Context, rosaNetwork *expinfrav1.ROSANetwork)
 	return nil
 }
 
-func getROSANetworkReadyCondition(reconciler *ROSANetworkReconciler, rosaNet *expinfrav1.ROSANetwork) (*clusterv1beta1.Condition, error) {
+func getROSANetworkReadyV1Beta1Condition(reconciler *ROSANetworkReconciler, rosaNet *expinfrav1.ROSANetwork) (*clusterv1beta1.Condition, error) {
 	updatedROSANetwork := &expinfrav1.ROSANetwork{}
 
 	if err := reconciler.Client.Get(ctx, client.ObjectKeyFromObject(rosaNet), updatedROSANetwork); err != nil {
 		return nil, err
 	}
 
-	return v1beta1conditions.Get(updatedROSANetwork, expinfrav1.ROSANetworkReadyCondition), nil
+	return v1beta1conditions.Get(updatedROSANetwork, expinfrav1.ROSANetworkReadyV1Beta1Condition), nil
 }
 
 // TestROSANetworkReconcilerWithRoleIdentity verifies that ROSANetworkReconciler can create its

--- a/exp/controllers/rosaocmroleconfig_controller.go
+++ b/exp/controllers/rosaocmroleconfig_controller.go
@@ -100,7 +100,7 @@ func (r *ROSAOCMRoleConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Always close scope and set summary condition
 	defer func() {
 		v1beta1conditions.SetSummary(scope.ROSAOCMRoleConfig,
-			v1beta1conditions.WithConditions(expinfrav1.ROSAOCMRoleConfigReadyCondition),
+			v1beta1conditions.WithConditions(expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition),
 			v1beta1conditions.WithStepCounter())
 		if err := scope.PatchObject(); err != nil {
 			reterr = errors.Join(reterr, err)
@@ -114,11 +114,11 @@ func (r *ROSAOCMRoleConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if !scope.ROSAOCMRoleConfig.DeletionTimestamp.IsZero() {
 		scope.Info("Deleting ROSAOCMRoleConfig.")
-		v1beta1conditions.MarkFalse(scope.ROSAOCMRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition, expinfrav1.ROSAOCMRoleConfigDeletionStarted, clusterv1beta1.ConditionSeverityInfo, "Deletion of ROSAOCMRoleConfig started")
+		v1beta1conditions.MarkFalse(scope.ROSAOCMRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition, expinfrav1.ROSAOCMRoleConfigDeletionStartedV1Beta1, clusterv1beta1.ConditionSeverityInfo, "Deletion of ROSAOCMRoleConfig started")
 		err = r.reconcileDelete(ctx, scope, rt)
 		if err != nil {
-			v1beta1conditions.MarkFalse(scope.ROSAOCMRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-				expinfrav1.ROSAOCMRoleConfigDeletionFailedReason, clusterv1beta1.ConditionSeverityError,
+			v1beta1conditions.MarkFalse(scope.ROSAOCMRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+				expinfrav1.ROSAOCMRoleConfigDeletionFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 				"Failed to delete ROSAOCMRoleConfig: %s", err.Error())
 			return ctrl.Result{}, err
 		}
@@ -138,8 +138,8 @@ func (r *ROSAOCMRoleConfigReconciler) reconcileOCMRole(_ context.Context, scope 
 
 	orgID, externalID, err := rt.OCMClient.GetCurrentOrganization()
 	if err != nil {
-		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-			expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+			expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 			"Failed to get organization: %s", err.Error())
 		return ctrl.Result{}, fmt.Errorf("failed to get organization: %w", err)
 	}
@@ -147,8 +147,8 @@ func (r *ROSAOCMRoleConfigReconciler) reconcileOCMRole(_ context.Context, scope 
 	roleName := rosaaws.GetOCMRoleName(ocmRoleConfig.Spec.RolePrefix, rosaaws.OCMRole, externalID)
 	roleExists, existingRoleARN, err := rt.AWSClient.CheckRoleExists(roleName)
 	if err != nil {
-		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-			expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+			expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 			"Failed to check role existence: %s", err.Error())
 		return ctrl.Result{}, fmt.Errorf("failed to check role existence: %w", err)
 	}
@@ -161,8 +161,8 @@ func (r *ROSAOCMRoleConfigReconciler) reconcileOCMRole(_ context.Context, scope 
 		// Check if role is already linked to organization
 		existsOnOCM, _, linkedARN, err := rt.OCMClient.CheckIfAWSAccountExists(orgID, rt.Creator.AccountID)
 		if err != nil {
-			v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-				expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+			v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+				expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 				"Failed to check OCM link status: %s", err.Error())
 			return ctrl.Result{}, fmt.Errorf("failed to check OCM link status: %w", err)
 		}
@@ -172,22 +172,22 @@ func (r *ROSAOCMRoleConfigReconciler) reconcileOCMRole(_ context.Context, scope 
 			// Ensure the existing linked role's profile matches the requested profile
 			existingProfile, err := r.detectRoleProfile(rt.AWSClient, roleName)
 			if err != nil {
-				v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-					expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+				v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+					expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 					"Failed to detect role profile: %s", err.Error())
 				return ctrl.Result{}, fmt.Errorf("failed to detect role profile: %w", err)
 			}
 
 			requestedProfile := string(ocmRoleConfig.Spec.Profile)
 			if existingProfile != requestedProfile {
-				v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-					expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+				v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+					expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 					"Profile mismatch: role has %s profile but %s was requested", existingProfile, requestedProfile)
 				return ctrl.Result{}, fmt.Errorf("profile mismatch: role %s has %s profile but %s was requested",
 					roleName, existingProfile, requestedProfile)
 			}
 
-			v1beta1conditions.MarkTrue(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+			v1beta1conditions.MarkTrue(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 			return ctrl.Result{}, nil
 		}
 
@@ -198,8 +198,8 @@ func (r *ROSAOCMRoleConfigReconciler) reconcileOCMRole(_ context.Context, scope 
 	// Convert profile from CRD enum to extracted code enum
 	extractedProfile, err := r.convertProfile(ocmRoleConfig.Spec.Profile)
 	if err != nil {
-		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-			expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+			expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 			"Invalid profile: %s", err.Error())
 		return ctrl.Result{}, err
 	}
@@ -213,8 +213,8 @@ func (r *ROSAOCMRoleConfigReconciler) reconcileOCMRole(_ context.Context, scope 
 		ocmRoleConfig.Spec.Path,
 	)
 	if err != nil {
-		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-			expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+			expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 			"Failed to get or create OCM role: %s", err.Error())
 		return ctrl.Result{}, fmt.Errorf("failed to get or create OCM role: %w", err)
 	}
@@ -235,14 +235,14 @@ func (r *ROSAOCMRoleConfigReconciler) reconcileOCMRole(_ context.Context, scope 
 	// - Different role already linked: returns (false, error)
 	_, err = rt.OCMClient.LinkOrgToRole(orgID, roleARN)
 	if err != nil {
-		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition,
-			expinfrav1.ROSAOCMRoleConfigReconciliationFailedReason, clusterv1beta1.ConditionSeverityError,
+		v1beta1conditions.MarkFalse(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition,
+			expinfrav1.ROSAOCMRoleConfigReconciliationFailedV1Beta1Reason, clusterv1beta1.ConditionSeverityError,
 			"Failed to link OCM role: %s", err.Error())
 		return ctrl.Result{}, fmt.Errorf("failed to link OCM role to organization: %w", err)
 	}
 
 	// Set ready condition
-	v1beta1conditions.MarkTrue(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+	v1beta1conditions.MarkTrue(ocmRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 
 	return ctrl.Result{}, nil
 }

--- a/exp/controllers/rosaocmroleconfig_controller_test.go
+++ b/exp/controllers/rosaocmroleconfig_controller_test.go
@@ -411,7 +411,7 @@ func TestROSAOCMRoleConfigReconcileCreate(t *testing.T) {
 		g.Expect(updatedRoleConfig.Status.RoleARN).To(Equal(fmt.Sprintf("arn:aws:iam::%s:role/test-OCM-Role-%s", h.accountID, h.externalID)))
 		g.Expect(updatedRoleConfig.Status.OrganizationID).To(Equal(h.orgID))
 
-		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 		g.Expect(readyCondition).ToNot(BeNil())
 		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionTrue))
 	}).WithTimeout(30 * time.Second).Should(Succeed())
@@ -456,7 +456,7 @@ func TestROSAOCMRoleConfigReconcileExist(t *testing.T) {
 		g.Expect(updatedRoleConfig.Status.RoleARN).To(Equal(fmt.Sprintf("arn:aws:iam::%s:role/test-OCM-Role-%s", h.accountID, h.externalID)))
 		g.Expect(updatedRoleConfig.Status.OrganizationID).To(Equal(h.orgID))
 
-		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 		g.Expect(readyCondition).ToNot(BeNil())
 		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionTrue))
 	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
@@ -644,7 +644,7 @@ func TestROSAOCMRoleConfigRoleConflict(t *testing.T) {
 		updatedRoleConfig := &expinfrav1.ROSAOCMRoleConfig{}
 		g.Expect(reconciler.Client.Get(h.testCtx, req.NamespacedName, updatedRoleConfig)).ToNot(HaveOccurred())
 
-		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 		g.Expect(readyCondition).ToNot(BeNil())
 		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionFalse))
 		g.Expect(readyCondition.Message).To(ContainSubstring("Only one role can be linked per AWS account per organization"))
@@ -727,7 +727,7 @@ func TestROSAOCMRoleConfigNoConsoleTagPolicyMismatch(t *testing.T) {
 		updatedRoleConfig := &expinfrav1.ROSAOCMRoleConfig{}
 		g.Expect(reconciler.Client.Get(h.testCtx, req.NamespacedName, updatedRoleConfig)).ToNot(HaveOccurred())
 
-		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 		g.Expect(readyCondition).ToNot(BeNil())
 		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionTrue), "should be ready after self-healing policy")
 	}).WithTimeout(5 * time.Second).Should(Succeed())
@@ -773,7 +773,7 @@ func TestROSAOCMRoleConfigAdminProfile(t *testing.T) {
 		g.Expect(updatedRoleConfig.Status.RoleARN).To(Equal(fmt.Sprintf("arn:aws:iam::%s:role/test-OCM-Role-%s", h.accountID, h.externalID)))
 		g.Expect(updatedRoleConfig.Status.OrganizationID).To(Equal(h.orgID))
 
-		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 		g.Expect(readyCondition).ToNot(BeNil())
 		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionTrue))
 	}).WithTimeout(30 * time.Second).Should(Succeed())
@@ -823,7 +823,7 @@ func TestROSAOCMRoleConfigAdminTagSelfHealing(t *testing.T) {
 		g.Expect(updatedRoleConfig.Status.RoleARN).To(Equal(fmt.Sprintf("arn:aws:iam::%s:role/test-OCM-Role-%s", h.accountID, h.externalID)))
 		g.Expect(updatedRoleConfig.Status.OrganizationID).To(Equal(h.orgID))
 
-		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyCondition)
+		readyCondition := v1beta1conditions.Get(updatedRoleConfig, expinfrav1.ROSAOCMRoleConfigReadyV1Beta1Condition)
 		g.Expect(readyCondition).ToNot(BeNil())
 		g.Expect(readyCondition.Status).To(Equal(corev1.ConditionTrue))
 	}).WithTimeout(30 * time.Second).Should(Succeed())

--- a/pkg/cloud/scope/rosacontrolplane.go
+++ b/pkg/cloud/scope/rosacontrolplane.go
@@ -209,9 +209,9 @@ func (s *ROSAControlPlaneScope) PatchObject() error {
 		context.TODO(),
 		s.ControlPlane,
 		v1beta1patch.WithOwnedConditions{Conditions: []clusterv1beta1.ConditionType{
-			rosacontrolplanev1.ROSAControlPlaneReadyCondition,
-			rosacontrolplanev1.ROSAControlPlaneValidCondition,
-			rosacontrolplanev1.ROSAControlPlaneUpgradingCondition,
+			rosacontrolplanev1.ROSAControlPlaneReadyV1Beta1Condition,
+			rosacontrolplanev1.ROSAControlPlaneValidV1Beta1Condition,
+			rosacontrolplanev1.ROSAControlPlaneUpgradingV1Beta1Condition,
 		}})
 }
 

--- a/pkg/cloud/scope/rosanetwork.go
+++ b/pkg/cloud/scope/rosanetwork.go
@@ -131,6 +131,6 @@ func (s *ROSANetworkScope) PatchObject() error {
 		context.TODO(),
 		s.ROSANetwork,
 		v1beta1patch.WithOwnedConditions{Conditions: []clusterv1beta1.ConditionType{
-			expinfrav1.ROSANetworkReadyCondition,
+			expinfrav1.ROSANetworkReadyV1Beta1Condition,
 		}})
 }


### PR DESCRIPTION
 What type of PR is this?

  /kind feature

  What this PR does / why we need it:

  Defines new v1beta2 condition type and reason constants as plain string type (not `clusterv1beta1.ConditionType`) for use with `[]metav1.Condition`. This is part of CAPA's migration to the CAPI v1beta2 provider contract (Phase 1).

  New constants follow CAPV's naming convention:
  - Condition types: `{Resource}{ConditionName}Condition` — e.g. `AWSClusterVpcReadyCondition = "VpcReady"`
  - Summary/ready conditions: `{Resource}ReadyCondition = clusterv1.ReadyCondition`
  - Reason constants: reuse `clusterv1.ReadyReason`, `clusterv1.NotReadyReason`, `clusterv1.DeletingReason` where applicable; provider-specific reasons as {Resource}{Reason}Reason

New `v1beta2_condition_consts.go` files are added in each API package covering all resources: `AWSCluster`, `AWSMachine`, `AWSMachinePool`, `AWSManagedMachinePool`, `AWSFargateProfile`, `AWSManagedControlPlane`, `ROSAControlPlane`, `ROSAMachinePool`, `ROSACluster`, `ROSANetwork`, `ROSARoleConfig`, `ROSAOCMRoleConfig`, `EKSConfig`, and `NodeadmConfig`.

These constants are purely additive and sit alongside the existing `clusterv1beta1.ConditionType` constants. They will be consumed by controllers in a later sub-task (#6103: dual-write).

  Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
  Fixes #6101

  Special notes for your reviewer:

  - Constants are additive only, no controller or reconciliation logic changes.
  - Old constants with `VpcEndpointsReadyCondition` had the string value with the suffix `Condition` (`"VpcEndpointsReadyCondition"`). The new constant uses "VpcEndpointsReady".
  - Old `S3BucketReadyCondition` used value `"S3BucketCreated"`. The new constant uses `"S3BucketReady"`.

  AI Usage:

  Claude Code was used to assist with drafting the constant definitions and doc comments.

  Checklist:

  - [x] squashed commits
  - [ ] includes documentation
  - [x] includes AI generated content
  - [x] includes emoji in title
  - [ ] adds unit tests
  - [ ] adds or updates e2e tests

  Release note:

  release-note
  Define v1beta2 condition type and reason constants for all CAPA provider resources, following CAPV's naming convention, as part of the CAPI v1beta2 contract migration.