### PR TITLE
🐛 fix: skip EKS public access CIDR reconciliation while the public endpoint is disabled

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -728,15 +728,23 @@ func (s *Service) reconcileVpcConfig(vpcConfig *ekstypes.VpcConfigResponse) (*ek
 	if err != nil {
 		return nil, err
 	}
+	// Public access CIDRs only restrict the public endpoint, so they are
+	// meaningless while it is disabled. EKS also retains the CIDRs last set on the
+	// cluster and rejects any update that repeats them, so comparing them here
+	// would request an update that can never converge.
+	publicAccess := tristate.WithDefault(true, updatedVpcConfig.EndpointPublicAccess)
 	needsUpdate := !tristate.EqualWithDefault(false, &vpcConfig.EndpointPrivateAccess, updatedVpcConfig.EndpointPrivateAccess) ||
 		!tristate.EqualWithDefault(true, &vpcConfig.EndpointPublicAccess, updatedVpcConfig.EndpointPublicAccess) ||
-		!publicAccessCIDRsEqual(vpcConfig.PublicAccessCidrs, updatedVpcConfig.PublicAccessCidrs)
+		(publicAccess && !publicAccessCIDRsEqual(vpcConfig.PublicAccessCidrs, updatedVpcConfig.PublicAccessCidrs))
 	if needsUpdate {
-		return &ekstypes.VpcConfigRequest{
+		updateRequest := &ekstypes.VpcConfigRequest{
 			EndpointPublicAccess:  updatedVpcConfig.EndpointPublicAccess,
 			EndpointPrivateAccess: updatedVpcConfig.EndpointPrivateAccess,
-			PublicAccessCidrs:     updatedVpcConfig.PublicAccessCidrs,
-		}, nil
+		}
+		if publicAccess {
+			updateRequest.PublicAccessCidrs = updatedVpcConfig.PublicAccessCidrs
+		}
+		return updateRequest, nil
 	}
 	return nil, nil
 }

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -321,6 +321,171 @@ func TestPublicAccessCIDRsEqual(t *testing.T) {
 	}
 }
 
+func TestReconcileVpcConfig(t *testing.T) {
+	subnets := infrav1.Subnets{
+		{
+			ID:               "subnet-1",
+			CidrBlock:        "10.0.10.0/24",
+			AvailabilityZone: "us-west-2a",
+		},
+		{
+			ID:               "subnet-2",
+			CidrBlock:        "10.0.11.0/24",
+			AvailabilityZone: "us-west-2b",
+		},
+	}
+	// The CIDRs EKS reports for a cluster whose public endpoint has since been disabled.
+	retainedCIDRs := []string{"1.2.3.4/32", "5.6.7.8/32"}
+
+	testCases := []struct {
+		name           string
+		current        *ekstypes.VpcConfigResponse
+		endpointAccess ekscontrolplanev1.EndpointAccess
+		expect         *ekstypes.VpcConfigRequest
+	}{
+		{
+			name: "public access disabled and EKS retains the previous CIDRs",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  false,
+				EndpointPrivateAccess: true,
+				PublicAccessCidrs:     retainedCIDRs,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{
+				Public:  aws.Bool(false),
+				Private: aws.Bool(true),
+			},
+			expect: nil,
+		},
+		{
+			name: "public access disabled and the spec still lists CIDRs",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  false,
+				EndpointPrivateAccess: true,
+				PublicAccessCidrs:     retainedCIDRs,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{
+				Public:      aws.Bool(false),
+				Private:     aws.Bool(true),
+				PublicCIDRs: []*string{aws.String("9.9.9.9/32")},
+			},
+			expect: nil,
+		},
+		{
+			name: "private access enabled while public access stays disabled",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  false,
+				EndpointPrivateAccess: false,
+				PublicAccessCidrs:     retainedCIDRs,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{
+				Public:  aws.Bool(false),
+				Private: aws.Bool(true),
+			},
+			expect: &ekstypes.VpcConfigRequest{
+				EndpointPublicAccess:  aws.Bool(false),
+				EndpointPrivateAccess: aws.Bool(true),
+			},
+		},
+		{
+			name: "public access being disabled",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  true,
+				EndpointPrivateAccess: true,
+				PublicAccessCidrs:     retainedCIDRs,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{
+				Public:  aws.Bool(false),
+				Private: aws.Bool(true),
+			},
+			expect: &ekstypes.VpcConfigRequest{
+				EndpointPublicAccess:  aws.Bool(false),
+				EndpointPrivateAccess: aws.Bool(true),
+			},
+		},
+		{
+			name: "public access being enabled with restricted CIDRs",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  false,
+				EndpointPrivateAccess: true,
+				PublicAccessCidrs:     retainedCIDRs,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{
+				Public:      aws.Bool(true),
+				Private:     aws.Bool(true),
+				PublicCIDRs: []*string{aws.String("9.9.9.9/32")},
+			},
+			expect: &ekstypes.VpcConfigRequest{
+				EndpointPublicAccess:  aws.Bool(true),
+				EndpointPrivateAccess: aws.Bool(true),
+				PublicAccessCidrs:     []string{"9.9.9.9/32"},
+			},
+		},
+		{
+			name: "public access enabled and the CIDRs differ",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  true,
+				EndpointPrivateAccess: true,
+				PublicAccessCidrs:     retainedCIDRs,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{
+				Public:      aws.Bool(true),
+				Private:     aws.Bool(true),
+				PublicCIDRs: []*string{aws.String("9.9.9.9/32")},
+			},
+			expect: &ekstypes.VpcConfigRequest{
+				EndpointPublicAccess:  aws.Bool(true),
+				EndpointPrivateAccess: aws.Bool(true),
+				PublicAccessCidrs:     []string{"9.9.9.9/32"},
+			},
+		},
+		{
+			name: "public access enabled and the CIDRs match",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  true,
+				EndpointPrivateAccess: true,
+				PublicAccessCidrs:     retainedCIDRs,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{
+				Public:      aws.Bool(true),
+				Private:     aws.Bool(true),
+				PublicCIDRs: []*string{aws.String("1.2.3.4/32"), aws.String("5.6.7.8/32")},
+			},
+			expect: nil,
+		},
+		{
+			name: "endpoint access left at its defaults",
+			current: &ekstypes.VpcConfigResponse{
+				EndpointPublicAccess:  true,
+				EndpointPrivateAccess: false,
+			},
+			endpointAccess: ekscontrolplanev1.EndpointAccess{},
+			expect:         nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			s := &Service{
+				scope: &scope.ManagedControlPlaneScope{
+					ControlPlane: &ekscontrolplanev1.AWSManagedControlPlane{
+						Spec: ekscontrolplanev1.AWSManagedControlPlaneSpec{
+							EndpointAccess: tc.endpointAccess,
+							NetworkSpec:    infrav1.NetworkSpec{Subnets: subnets},
+						},
+					},
+				},
+			}
+			got, err := s.reconcileVpcConfig(tc.current)
+			g.Expect(err).NotTo(HaveOccurred())
+			if tc.expect == nil {
+				g.Expect(got).To(BeNil())
+			} else {
+				g.Expect(got).To(Equal(tc.expect))
+			}
+		})
+	}
+}
+
 func TestMakeEKSLogging(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/pkg/internal/tristate/tristate.go
+++ b/pkg/internal/tristate/tristate.go
@@ -17,8 +17,8 @@ limitations under the License.
 // Package tristate provides a helper for working with bool pointers.
 package tristate
 
-// withDefault evaluates a pointer to a bool with a default value.
-func withDefault(def bool, b *bool) bool {
+// WithDefault evaluates a pointer to a bool with a default value.
+func WithDefault(def bool, b *bool) bool {
 	if b == nil {
 		return def
 	}
@@ -27,5 +27,5 @@ func withDefault(def bool, b *bool) bool {
 
 // EqualWithDefault compares two bool pointers using a default value.
 func EqualWithDefault(def bool, a *bool, b *bool) bool {
-	return withDefault(def, a) == withDefault(def, b)
+	return WithDefault(def, a) == WithDefault(def, b)
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

After you disable the public endpoint, EKS keeps the last `publicAccessCidrs` values. EKS then rejects an `UpdateClusterConfig` that repeats them:

```
InvalidParameterException: Cluster is already at the desired configuration with endpointPrivateAccess: true, endpointPublicAccess: false, and Public Endpoint Restrictions: [...]
```

`reconcileVpcConfig` compared the kept CIDRs with the desired CIDRs. An empty desired list expands to the `0.0.0.0/0` default. The two sets can never be equal. Each reconcile sent an update, received a 400 error, and left the control plane not ready. The loop only stops if you enable public access again.

Public access CIDRs only restrict the public endpoint. This PR skips the CIDR comparison while the desired public access is false. It also removes the CIDRs from the `UpdateClusterConfig` payload in that state. The second part matters for a public-to-private change with CIDRs still in the spec. Without it, the same loop starts.

Reproduction on CAPA v2.13.0: change an `AWSManagedControlPlane` from `endpointAccess: {public: true, publicCIDRs: [<some /32s>], private: true}` to `{public: false, private: true}`.

**Which issue(s) this PR fixes**:
Fixes #5441

**Special notes for your reviewer**:

- #5442 was an earlier attempt. It only changed the request payload and kept the comparison, so the update loop remained. The stale bot closed it.
- The new `TestReconcileVpcConfig` has 8 cases. Two cases fail without the fix. The other cases pin the current behavior for the public transitions.
- This PR exports `tristate.withDefault` as `tristate.WithDefault` to keep the default-true rule in one place. Tell me if you prefer an inline check and a single-file diff.
- A related case is out of scope. With public access enabled, a change of `publicCIDRs` back to an empty list also does not converge, because the request omits the empty list. A fix for that changes behavior and needs its own discussion.

**AI Usage**:

I used an AI coding assistant (Claude) for the implementation and the unit tests. I reviewed, tested, and adjusted the result. The reproduction and the root-cause analysis come from a live cluster that showed this fault.

**Checklist**:

- [x] squashed commits
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests

**Release note**:

```release-note
fix: infinite EKS UpdateClusterConfig loop for clusters that keep previously set public access CIDRs after you disable the public endpoint. CAPA now skips the CIDR comparison and the CIDR request field while public access is disabled.
```