### PR TITLE
🐛 Fix wrong use of object kind in update predicates, leading to reconciliation when it could be skipped

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -279,18 +279,29 @@ func (r *AWSMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 				// Avoid reconciling if the event triggering the reconciliation is related to incremental status updates
 				// for AWSMachine resources only
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					if e.ObjectOld.GetObjectKind().GroupVersionKind().Kind != kindAWSMachine {
+					// Objects in watch events have no `TypeMeta`, so the kind can only be told from the Go type
+					oldAWSMachine, ok := e.ObjectOld.(*infrav1.AWSMachine)
+					if !ok {
+						return true
+					}
+					newAWSMachine, ok := e.ObjectNew.(*infrav1.AWSMachine)
+					if !ok {
 						return true
 					}
 
-					oldMachine := e.ObjectOld.(*infrav1.AWSMachine).DeepCopy()
-					newMachine := e.ObjectNew.(*infrav1.AWSMachine).DeepCopy()
+					oldMachine := oldAWSMachine.DeepCopy()
+					newMachine := newAWSMachine.DeepCopy()
 
 					oldMachine.Status = infrav1.AWSMachineStatus{}
 					newMachine.Status = infrav1.AWSMachineStatus{}
 
 					oldMachine.ObjectMeta.ResourceVersion = ""
 					newMachine.ObjectMeta.ResourceVersion = ""
+
+					// A status write refreshes the timestamp of the writer's `managedFields` entry, so the metadata
+					// would otherwise always differ.
+					oldMachine.ObjectMeta.ManagedFields = nil
+					newMachine.ObjectMeta.ManagedFields = nil
 
 					return !cmp.Equal(oldMachine, newMachine)
 				},

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -242,20 +242,31 @@ func (r *AWSMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctr
 				// Avoid reconciling if the event triggering the reconciliation is related to incremental status updates
 				// for AWSMachinePool resources only
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					if e.ObjectOld.GetObjectKind().GroupVersionKind().Kind != "AWSMachinePool" {
+					// Objects in watch events have no `TypeMeta`, so the kind can only be told from the Go type
+					oldAWSMachinePool, ok := e.ObjectOld.(*expinfrav1.AWSMachinePool)
+					if !ok {
+						return true
+					}
+					newAWSMachinePool, ok := e.ObjectNew.(*expinfrav1.AWSMachinePool)
+					if !ok {
 						return true
 					}
 
-					oldCluster := e.ObjectOld.(*expinfrav1.AWSMachinePool).DeepCopy()
-					newCluster := e.ObjectNew.(*expinfrav1.AWSMachinePool).DeepCopy()
+					oldPool := oldAWSMachinePool.DeepCopy()
+					newPool := newAWSMachinePool.DeepCopy()
 
-					oldCluster.Status = expinfrav1.AWSMachinePoolStatus{}
-					newCluster.Status = expinfrav1.AWSMachinePoolStatus{}
+					oldPool.Status = expinfrav1.AWSMachinePoolStatus{}
+					newPool.Status = expinfrav1.AWSMachinePoolStatus{}
 
-					oldCluster.ObjectMeta.ResourceVersion = ""
-					newCluster.ObjectMeta.ResourceVersion = ""
+					oldPool.ObjectMeta.ResourceVersion = ""
+					newPool.ObjectMeta.ResourceVersion = ""
 
-					return !cmp.Equal(oldCluster, newCluster)
+					// A status write refreshes the timestamp of the writer's `managedFields` entry, so the metadata
+					// would otherwise always differ.
+					oldPool.ObjectMeta.ManagedFields = nil
+					newPool.ObjectMeta.ManagedFields = nil
+
+					return !cmp.Equal(oldPool, newPool)
 				},
 			},
 		).


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The UPDATE request predicate didn't work as expected because the object kind might be empty. Use type check instead. This brings down reconciliation rate a little.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

n/a

**AI Usage**:

This was indeed a side effect finding from troubleshooting an unrelated issue using Claude Code. I manually deployed and tested this fix, ensuring the kind value is really empty, and also confirmed a reduction in a `workqueue_*` metric with this fix.

<!-- Declare if this PR has benefited from AI assistance in any way. Whether that's Cursor, Claude, Copilot, Codex, a local LLM, or another other AI assistant. If AI has been used please try to provide as much information as possible.

NOTE: basic autocompletion doesn't need to be declared.

If no AI assistance was used then used, write "None".

-->

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
-->

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: wrong use of object kind in update predicates leads to unnecessary reconciliation
```

(we could list the affected objects in the release note if you want – feel free to edit 😉)