### PR TITLE
🌱 chore: add raykrueger to reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,6 +17,7 @@ aliases:
   cluster-api-aws-reviewers:
     - faiq
     - fiunchinho
+    - raykrueger
   # -----------------------------------------------------------
   # OWNER_ALIASES for ROSA Work
   # -----------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds raykrueger to `cluster-api-aws-reviewers` in `OWNERS_ALIASES`.

Kubernetes org PR
https://github.com/kubernetes/org/pull/6557

Original application
https://github.com/kubernetes/org/issues/6554

**Which issue(s) this PR fixes**:
Fixes # None

**Special notes for your reviewer**:
Excited to help!

**AI Usage**:
None

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [ ] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
```
NONE
```