### PR TITLE
📖 Remove hardcoded m5.xlarge from ROSA default machine pool spec

### DIFF
--- a/docs/book/src/topics/rosa/creating-a-cluster.md
+++ b/docs/book/src/topics/rosa/creating-a-cluster.md
@@ -267,7 +267,6 @@ The CAPA controller requires service account credentials to provision ROSA HCP c
         podCIDR: "10.128.0.0/14"
         serviceCIDR: "172.30.0.0/16"
       defaultMachinePoolSpec:
-        instanceType: "m5.xlarge"
         autoscaling:
           maxReplicas: 6
           minReplicas: 3
@@ -279,6 +278,8 @@ The CAPA controller requires service account credentials to provision ROSA HCP c
     ```shell
     kubectl apply -f rosa-cluster.yaml
     ```
+
+    **Note:** `instanceType` is omitted from `defaultMachinePoolSpec` so the ROSA service applies its flavour default. You can set it explicitly if you need a specific instance type.
 
     **Note:** If you are providing pre-created role ARNs directly on `ROSAControlPlane` (without `rosaRoleConfigRef`) and your roles require an STS external ID, set `trustPolicyExternalID` on the `ROSAControlPlane` spec. In this case, you are responsible for ensuring the roles' trust policies already include the `sts:ExternalId` condition; CAPA will only pass the value to OCM, not modify the trust policies.
 
@@ -334,10 +335,12 @@ The CAPA controller requires service account credentials to provision ROSA HCP c
     spec:
       nodePoolName: "workers-extra"
       version: "4.20.11"
-      instanceType: "m5.xlarge"
+      instanceType: "m7i.xlarge"
       autoRepair: true
     EOF
     ```
+
+    **Note:** `m7i.xlarge` is not available in all AWS regions. Choose an instance type available in your target region.
 
     ```shell
     kubectl apply -f rosa-machinepool-extra.yaml

--- a/docs/book/src/topics/rosa/creating-rosa-machinepools.md
+++ b/docs/book/src/topics/rosa/creating-rosa-machinepools.md
@@ -41,9 +41,11 @@ metadata:
   name: "${CLUSTER_NAME}-pool-0"
 spec:
   nodePoolName: "nodepool-0"
-  instanceType: "m5.xlarge"
+  instanceType: "m7i.xlarge"
   subnet: "${PRIVATE_SUBNET_ID}"
   version: "${OPENSHIFT_VERSION}"
 ```
+
+**Note:** `m7i.xlarge` is not available in all AWS regions. Choose an instance type available in your target region.
 
 see [ROSAMachinePool CRD Reference](https://cluster-api-aws.sigs.k8s.io/crd/#infrastructure.cluster.x-k8s.io/v1beta2.ROSAMachinePool) for all possible configurations.

--- a/templates/cluster-template-rosa-machinepool.yaml
+++ b/templates/cluster-template-rosa-machinepool.yaml
@@ -74,6 +74,6 @@ metadata:
   name: "${CLUSTER_NAME}-pool-0"
 spec:
   nodePoolName: "nodepool-0"
-  instanceType: "m5.xlarge"
+  instanceType: "m7i.xlarge"
   subnet: "${PRIVATE_SUBNET_ID}"
   version: "${OPENSHIFT_VERSION}"


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The shared OCM flavour is changing so new AWS ROSA clusters default to `m7i.xlarge` instead of `m5.xlarge`. Clients that read `/flavours` pick this up automatically, but CAPA's documentation and clusterctl template hardcoded `m5.xlarge` on `defaultMachinePoolSpec.instanceType`, overriding the flavour.

This PR removes the hardcoded `instanceType` from the `defaultMachinePoolSpec` example in the ROSA cluster creation docs so the ROSA service can apply its flavour default server-side. It also updates `ROSAMachinePool` examples (where `instanceType` is required) from `m5.xlarge` to `m7i.xlarge` with notes about limited regional availability.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
N/A

**Special notes for your reviewer**:

Day-1 (`defaultMachinePoolSpec`): `instanceType` is omitted so OCM auto-selects the default instance type. The field is already `+optional` in the API and the OCM library handles the empty case correctly.

Day-2 (`ROSAMachinePool`): `instanceType` is `+kubebuilder:validation:Required`. Examples are updated from `m5.xlarge` to `m7i.xlarge` with a note that `m7i` is not available in all regions.

**AI Usage**:

Claude was used to validate changes did not need to be made anywhere else.

**Checklist**:

- [x] squashed commits
- [x] includes documentation
- [ ] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
docs: remove hardcoded m5.xlarge instance type from ROSA defaultMachinePoolSpec in docs and templates so the ROSA service applies its OCM flavour default and update ROSAMachinePool examples to m7i.xlarge
```