### PR TITLE
🐛 fix(ci/actions): use canonical Flatcar AMI OS slug

### DIFF
--- a/.github/workflows/auto-publish-ami.yml
+++ b/.github/workflows/auto-publish-ami.yml
@@ -71,7 +71,7 @@ jobs:
           # image-builder uses hyphenated ones (ubuntu-2204, ubuntu-2404).
           # flatcar is identical in both conventions.
           # Keep this list aligned with the target matrix in build-ami-v2.yml.
-          OS_LIST: "ubuntu-22.04,ubuntu-24.04,flatcar"
+          OS_LIST: "ubuntu-22.04,ubuntu-24.04,flatcar-stable"
           # Region used to query already-published AMIs. image-builder publishes
           # to every region in REGION_LIST atomically, so checking a single
           # region is sufficient to determine whether an AMI was ever built.


### PR DESCRIPTION
 /kind bug

 **What this PR does / why we need it**:

 Changes the AMI publishing workflow to use the canonical `flatcar-stable` OS
 slug expected by `clusterawsadm`.

 The workflow previously used `flatcar`, causing published Flatcar AMIs to be
 unmatched by `find-missing-ami`. This could prevent missing Flatcar AMIs from
 being detected and rebuilt.

 **Evidence**:

 - `clusterawsadm` defines `flatcar-stable` as the supported inventory OS slug
   in `cmd/clusterawsadm/ami/helper.go`.
 - Querying `clusterawsadm ami list` with `flatcar-stable` returns the published
   `v1.36.0` AMI in `us-west-2`.
 - The equivalent query using `flatcar` returns no items.
 - The image-builder target remains `flatcar`; only the inventory/query slug is
   changed.


 **AI Usage**:

 This PR was prepared with AI assistance for investigation and implementation.

 **Checklist**:

 - [ ] squashed commits
 - [ ] includes documentation
 - [x] includes AI generated content
 - [x] includes emoji in title
 - [ ] adds unit tests
 - [ ] adds or updates e2e tests

 **Release note**:

 ```release-note
 NONE
 ```