### PR TITLE
🐛 fix(rosa): update predicates to nil ManagedFields before comparison

### DIFF
--- a/controlplane/rosa/controllers/rosacontrolplane_controller.go
+++ b/controlplane/rosa/controllers/rosacontrolplane_controller.go
@@ -139,6 +139,12 @@ func (r *ROSAControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr c
 					newCP.Status = rosacontrolplanev1.RosaControlPlaneStatus{}
 					oldCP.ObjectMeta.ResourceVersion = ""
 					newCP.ObjectMeta.ResourceVersion = ""
+
+					// A status write refreshes the timestamp of the writer's `managedFields` entry, so the metadata
+					// would otherwise always differ.
+					oldCP.ObjectMeta.ManagedFields = nil
+					newCP.ObjectMeta.ManagedFields = nil
+
 					return !cmp.Equal(oldCP, newCP)
 				},
 			},

--- a/exp/controllers/rosamachinepool_controller.go
+++ b/exp/controllers/rosamachinepool_controller.go
@@ -86,6 +86,12 @@ func (r *ROSAMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ct
 					newPool.Status = expinfrav1.RosaMachinePoolStatus{}
 					oldPool.ObjectMeta.ResourceVersion = ""
 					newPool.ObjectMeta.ResourceVersion = ""
+
+					// A status write refreshes the timestamp of the writer's `managedFields` entry, so the metadata
+					// would otherwise always differ.
+					oldPool.ObjectMeta.ManagedFields = nil
+					newPool.ObjectMeta.ManagedFields = nil
+
 					return !cmp.Equal(oldPool, newPool)
 				},
 			},

--- a/exp/controllers/rosanetwork_controller.go
+++ b/exp/controllers/rosanetwork_controller.go
@@ -349,6 +349,12 @@ func (r *ROSANetworkReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 					newNet.Status = expinfrav1.ROSANetworkStatus{}
 					oldNet.ObjectMeta.ResourceVersion = ""
 					newNet.ObjectMeta.ResourceVersion = ""
+
+					// A status write refreshes the timestamp of the writer's `managedFields` entry, so the metadata
+					// would otherwise always differ.
+					oldNet.ObjectMeta.ManagedFields = nil
+					newNet.ObjectMeta.ManagedFields = nil
+
 					return !cmp.Equal(oldNet, newNet)
 				},
 			},

--- a/exp/controllers/rosaocmroleconfig_controller.go
+++ b/exp/controllers/rosaocmroleconfig_controller.go
@@ -88,6 +88,12 @@ func (r *ROSAOCMRoleConfigReconciler) SetupWithManager(ctx context.Context, mgr 
 					newRC.Status = expinfrav1.ROSAOCMRoleConfigStatus{}
 					oldRC.ObjectMeta.ResourceVersion = ""
 					newRC.ObjectMeta.ResourceVersion = ""
+
+					// A status write refreshes the timestamp of the writer's `managedFields` entry, so the metadata
+					// would otherwise always differ.
+					oldRC.ObjectMeta.ManagedFields = nil
+					newRC.ObjectMeta.ManagedFields = nil
+
 					return !cmp.Equal(oldRC, newRC)
 				},
 			},

--- a/exp/controllers/rosaroleconfig_controller.go
+++ b/exp/controllers/rosaroleconfig_controller.go
@@ -101,6 +101,12 @@ func (r *ROSARoleConfigReconciler) SetupWithManager(ctx context.Context, mgr ctr
 					newRC.Status = expinfrav1.ROSARoleConfigStatus{}
 					oldRC.ObjectMeta.ResourceVersion = ""
 					newRC.ObjectMeta.ResourceVersion = ""
+
+					// A status write refreshes the timestamp of the writer's `managedFields` entry, so the metadata
+					// would otherwise always differ.
+					oldRC.ObjectMeta.ManagedFields = nil
+					newRC.ObjectMeta.ManagedFields = nil
+
 					return !cmp.Equal(oldRC, newRC)
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Five ROSA controllers (`ROSAControlPlane`, `ROSAMachinePool`, `ROSANetwork`, `ROSAOCMRoleConfig`, `ROSARoleConfig`) have update predicates that zero `Status` and `ResourceVersion` before comparing old and new objects with `cmp.Equal`, intending to skip reconciliation on status-only updates. However, a status-subresource write also refreshes the `lastTransitionTime` in the writer's `managedFields` entry, so the comparison always finds a difference and the predicate never filters anything out.

This PR nils `ManagedFields` on both copies before comparing, matching the fix already applied to `AWSMachine` and `AWSMachinePool` in #6198.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Special notes for your reviewer**:

The same two-line fix is applied identically in all five files. See `controllers/awsmachine_controller.go:301-304` for the reference pattern from #6198.

**AI Usage**:

Claude Code (Opus) was used to locate the affected files, apply the fix across all five controllers, and verify with lint and tests.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
fix(rosa): update predicates to nil ManagedFields before comparison, preventing unnecessary reconciliations on status-only updates
```