### PR TITLE
🐛 fix(webhook): validate AWSMachineTemplate gp3 throughput

### DIFF
--- a/webhooks/awsmachinetemplate_webhook.go
+++ b/webhooks/awsmachinetemplate_webhook.go
@@ -64,8 +64,9 @@ func (w *AWSMachineTemplate) validateRootVolume(r *infrav1.AWSMachineTemplate) f
 		if spec.RootVolume.Type != infrav1.VolumeTypeGP3 {
 			allErrs = append(allErrs, field.Required(field.NewPath("spec.template.spec.rootVolume.throughput"), "throughput is valid only for type 'gp3'"))
 		}
-		if *spec.RootVolume.Throughput < 0 {
-			allErrs = append(allErrs, field.Required(field.NewPath("spec.template.spec.rootVolume.throughput"), "throughput must be nonnegative"))
+		// See https://aws.amazon.com/ebs/general-purpose/ for gp3 limits.
+		if *spec.RootVolume.Throughput < 125 || *spec.RootVolume.Throughput > 2000 {
+			allErrs = append(allErrs, field.Required(field.NewPath("spec.template.spec.rootVolume.throughput"), "throughput must be between 125 MiB/s and 2000 MiB/s"))
 		}
 	}
 

--- a/webhooks/awsmachinetemplate_webhook_test.go
+++ b/webhooks/awsmachinetemplate_webhook_test.go
@@ -83,6 +83,78 @@ func TestAWSMachineTemplateValidateCreate(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name: "reject root volume gp3 throughput below the supported range",
+			inputTemplate: &infrav1.AWSMachineTemplate{
+				Spec: infrav1.AWSMachineTemplateSpec{
+					Template: infrav1.AWSMachineTemplateResource{
+						Spec: infrav1.AWSMachineSpec{
+							InstanceType: "test",
+							RootVolume: &infrav1.Volume{
+								Type:       infrav1.VolumeTypeGP3,
+								Size:       *aws.Int64(8),
+								Throughput: aws.Int64(124),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "accept root volume gp3 throughput at the supported range boundaries",
+			inputTemplate: &infrav1.AWSMachineTemplate{
+				Spec: infrav1.AWSMachineTemplateSpec{
+					Template: infrav1.AWSMachineTemplateResource{
+						Spec: infrav1.AWSMachineSpec{
+							InstanceType: "test",
+							RootVolume: &infrav1.Volume{
+								Type:       infrav1.VolumeTypeGP3,
+								Size:       *aws.Int64(8),
+								Throughput: aws.Int64(125),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "accept root volume gp3 throughput at the maximum supported value",
+			inputTemplate: &infrav1.AWSMachineTemplate{
+				Spec: infrav1.AWSMachineTemplateSpec{
+					Template: infrav1.AWSMachineTemplateResource{
+						Spec: infrav1.AWSMachineSpec{
+							InstanceType: "test",
+							RootVolume: &infrav1.Volume{
+								Type:       infrav1.VolumeTypeGP3,
+								Size:       *aws.Int64(8),
+								Throughput: aws.Int64(2000),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "reject root volume gp3 throughput above the supported range",
+			inputTemplate: &infrav1.AWSMachineTemplate{
+				Spec: infrav1.AWSMachineTemplateSpec{
+					Template: infrav1.AWSMachineTemplateResource{
+						Spec: infrav1.AWSMachineSpec{
+							InstanceType: "test",
+							RootVolume: &infrav1.Volume{
+								Type:       infrav1.VolumeTypeGP3,
+								Size:       *aws.Int64(8),
+								Throughput: aws.Int64(2001),
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
 			name: "hostID and dynamicHostAllocation are mutually exclusive",
 			inputTemplate: &infrav1.AWSMachineTemplate{
 				ObjectMeta: metav1.ObjectMeta{},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Validates AWS gp3 root-volume throughput in `AWSMachineTemplate` resources against AWS-supported limits of 125–2000 MiB/s.

Previously, CAPI accepted values below 125 MiB/s. AWS normalized those values to 125 MiB/s, while MAPI rejected them during CAPI-to-MAPI migration, causing synchronization failures.

Following up from https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5876
this change rejects invalid throughput values during admission and adds unit test coverage for both boundaries and out-of-range values.

**AI Usage**:

This change was implemented with AI assistance.

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [ ] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
fix(webhook): validate AWSMachineTemplate gp3 throughput against AWS-supported limits
```