### PR TITLE
🐛 fix: update PlantUML builder image

### DIFF
--- a/hack/tools/plantuml.Dockerfile
+++ b/hack/tools/plantuml.Dockerfile
@@ -27,7 +27,9 @@
 # 	${IMAGE_TAG} \
 # 	-v /figures/*.plantuml
 
-FROM maven:3-openjdk-18-slim
+# Use the maintained Eclipse Temurin image instead of the retired OpenJDK 18
+# image, whose Debian Bullseye repositories can contain expired metadata.
+FROM maven:3.9-eclipse-temurin-17
 ARG PLANTUML_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget graphviz fonts-symbola fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates the PlantUML builder image from the retired OpenJDK 18 image to the
maintained Eclipse Temurin 17 Maven image.

This avoids verify-job failures caused by expired Debian Bullseye repository
metadata when installing PlantUML build dependencies.

**AI Usage**:

This PR was prepared with AI assistance.

**Checklist**:

- [ ] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [ ] includes emoji in title
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

<!-- No user-facing release note is required. -->

```release-note
NONE
```
