### PR TITLE
🐛 fix: apply defaults in NodePoolToRosaMachinePoolSpec to prevent phantom diff

### DIFF
--- a/exp/controllers/rosamachinepool_controller_test.go
+++ b/exp/controllers/rosamachinepool_controller_test.go
@@ -714,14 +714,17 @@ func TestRosaMachinePoolReconcile(t *testing.T) {
 func TestVolumeSizeIgnoredInDiff(t *testing.T) {
 	g := NewWithT(t)
 
-	rosaMachinePoolSpec := expinfrav1.RosaMachinePoolSpec{
-		NodePoolName: "test-nodepool",
-		Version:      "4.14.5",
-		Subnet:       "subnet-id",
-		AutoRepair:   true,
-		InstanceType: "m5.large",
-		VolumeSize:   300,
+	rosaMachinePool := &expinfrav1.ROSAMachinePool{
+		Spec: expinfrav1.RosaMachinePoolSpec{
+			NodePoolName: "test-nodepool",
+			Version:      "4.14.5",
+			Subnet:       "subnet-id",
+			AutoRepair:   true,
+			InstanceType: "m5.large",
+			VolumeSize:   300,
+		},
 	}
+	rosaMachinePool.Default()
 
 	// Create a NodePool with different volumeSize
 	nodePool, err := cmv1.NewNodePool().
@@ -735,7 +738,7 @@ func TestVolumeSizeIgnoredInDiff(t *testing.T) {
 		Build()
 	g.Expect(err).ToNot(HaveOccurred())
 
-	diff := computeSpecDiff(rosaMachinePoolSpec, nodePool)
+	diff := computeSpecDiff(rosaMachinePool.Spec, nodePool)
 	g.Expect(diff).To(BeEmpty(), "volumeSize should be ignored in diff computation")
 }
 

--- a/exp/utils/rosa_helper.go
+++ b/exp/utils/rosa_helper.go
@@ -68,15 +68,18 @@ func NodePoolToRosaMachinePoolSpec(nodePool *cmv1.NodePool) expinfrav1.RosaMachi
 		}
 		spec.Taints = rosaTaints
 	}
+	spec.NodeDrainGracePeriod = &metav1.Duration{}
 	if nodePool.NodeDrainGracePeriod() != nil {
-		spec.NodeDrainGracePeriod = &metav1.Duration{
-			Duration: time.Minute * time.Duration(nodePool.NodeDrainGracePeriod().Value()),
-		}
+		spec.NodeDrainGracePeriod.Duration = time.Minute * time.Duration(nodePool.NodeDrainGracePeriod().Value())
+	}
+
+	spec.UpdateConfig = &expinfrav1.RosaUpdateConfig{
+		RollingUpdate: &expinfrav1.RollingUpdate{
+			MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+			MaxSurge:       ptr.To(intstr.FromInt32(1)),
+		},
 	}
 	if nodePool.ManagementUpgrade() != nil {
-		spec.UpdateConfig = &expinfrav1.RosaUpdateConfig{
-			RollingUpdate: &expinfrav1.RollingUpdate{},
-		}
 		if nodePool.ManagementUpgrade().MaxSurge() != "" {
 			spec.UpdateConfig.RollingUpdate.MaxSurge = ptr.To(intstr.Parse(nodePool.ManagementUpgrade().MaxSurge()))
 		}

--- a/exp/utils/rosa_helper_test.go
+++ b/exp/utils/rosa_helper_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +36,6 @@ import (
 func TestNodePoolToRosaMachinePoolSpec(t *testing.T) {
 	g := NewWithT(t)
 
-	// Build a NodePool with various fields populated
 	builder := cmv1.NewNodePool().
 		ID("test-nodepool").
 		Version(cmv1.NewVersion().ID("openshift-v4.15.0")).
@@ -70,7 +71,6 @@ func TestNodePoolToRosaMachinePoolSpec(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	actualSpec := NodePoolToRosaMachinePoolSpec(nodePool)
-	// Build the expected spec
 	expectedSpec := expinfrav1.RosaMachinePoolSpec{
 		NodePoolName:             "test-nodepool",
 		Version:                  "4.15.0",
@@ -103,4 +103,210 @@ func TestNodePoolToRosaMachinePoolSpec(t *testing.T) {
 	}
 
 	g.Expect(expectedSpec).To(Equal(actualSpec))
+}
+
+func TestNodePoolToRosaMachinePoolSpec_DefaultsWhenOCMFieldsAbsent(t *testing.T) {
+	tests := []struct {
+		name     string
+		builder  *cmv1.NodePoolBuilder
+		expected expinfrav1.RosaMachinePoolSpec
+	}{
+		{
+			name: "no NodeDrainGracePeriod or ManagementUpgrade from OCM",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")),
+			expected: expinfrav1.RosaMachinePoolSpec{
+				NodePoolName:         "test-nodepool",
+				AutoRepair:           true,
+				InstanceType:         "m5.large",
+				NodeDrainGracePeriod: &metav1.Duration{},
+				UpdateConfig: &expinfrav1.RosaUpdateConfig{
+					RollingUpdate: &expinfrav1.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
+					},
+				},
+			},
+		},
+		{
+			name: "ManagementUpgrade present but MaxSurge and MaxUnavailable empty",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				ManagementUpgrade(cmv1.NewNodePoolManagementUpgrade()),
+			expected: expinfrav1.RosaMachinePoolSpec{
+				NodePoolName:         "test-nodepool",
+				AutoRepair:           true,
+				InstanceType:         "m5.large",
+				NodeDrainGracePeriod: &metav1.Duration{},
+				UpdateConfig: &expinfrav1.RosaUpdateConfig{
+					RollingUpdate: &expinfrav1.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
+					},
+				},
+			},
+		},
+		{
+			name: "ManagementUpgrade with only MaxSurge set",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				ManagementUpgrade(
+					cmv1.NewNodePoolManagementUpgrade().MaxSurge("3"),
+				),
+			expected: expinfrav1.RosaMachinePoolSpec{
+				NodePoolName:         "test-nodepool",
+				AutoRepair:           true,
+				InstanceType:         "m5.large",
+				NodeDrainGracePeriod: &metav1.Duration{},
+				UpdateConfig: &expinfrav1.RosaUpdateConfig{
+					RollingUpdate: &expinfrav1.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						MaxSurge:       ptr.To(intstr.FromInt32(3)),
+					},
+				},
+			},
+		},
+		{
+			name: "ManagementUpgrade with only MaxUnavailable set",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				ManagementUpgrade(
+					cmv1.NewNodePoolManagementUpgrade().MaxUnavailable("2"),
+				),
+			expected: expinfrav1.RosaMachinePoolSpec{
+				NodePoolName:         "test-nodepool",
+				AutoRepair:           true,
+				InstanceType:         "m5.large",
+				NodeDrainGracePeriod: &metav1.Duration{},
+				UpdateConfig: &expinfrav1.RosaUpdateConfig{
+					RollingUpdate: &expinfrav1.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
+					},
+				},
+			},
+		},
+		{
+			name: "NodeDrainGracePeriod with zero value from OCM",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				NodeDrainGracePeriod(cmv1.NewValue().Value(0)),
+			expected: expinfrav1.RosaMachinePoolSpec{
+				NodePoolName:         "test-nodepool",
+				AutoRepair:           true,
+				InstanceType:         "m5.large",
+				NodeDrainGracePeriod: &metav1.Duration{},
+				UpdateConfig: &expinfrav1.RosaUpdateConfig{
+					RollingUpdate: &expinfrav1.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			nodePool, err := tt.builder.Build()
+			g.Expect(err).ToNot(HaveOccurred())
+
+			actualSpec := NodePoolToRosaMachinePoolSpec(nodePool)
+			g.Expect(actualSpec).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestNodePoolToRosaMachinePoolSpec_NoPhantomDiff(t *testing.T) {
+	tests := []struct {
+		name    string
+		builder *cmv1.NodePoolBuilder
+	}{
+		{
+			name: "OCM returns no NodeDrainGracePeriod or ManagementUpgrade",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")),
+		},
+		{
+			name: "OCM returns ManagementUpgrade with empty MaxSurge/MaxUnavailable",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				ManagementUpgrade(cmv1.NewNodePoolManagementUpgrade()),
+		},
+		{
+			name: "OCM returns NodeDrainGracePeriod with zero value",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				NodeDrainGracePeriod(cmv1.NewValue().Value(0)),
+		},
+		{
+			name: "OCM returns ManagementUpgrade with default values",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				ManagementUpgrade(
+					cmv1.NewNodePoolManagementUpgrade().MaxSurge("1").MaxUnavailable("0"),
+				),
+		},
+		{
+			name: "fully populated OCM response",
+			builder: cmv1.NewNodePool().
+				ID("test-nodepool").
+				AutoRepair(true).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.large")).
+				NodeDrainGracePeriod(cmv1.NewValue().Value(10)).
+				ManagementUpgrade(
+					cmv1.NewNodePoolManagementUpgrade().MaxSurge("3").MaxUnavailable("1"),
+				),
+		},
+	}
+
+	ignoredFields := []string{
+		"ProviderIDList",
+		"Version",
+		"AdditionalTags",
+		"AdditionalSecurityGroups",
+		"VolumeSize",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			nodePool, err := tt.builder.Build()
+			g.Expect(err).ToNot(HaveOccurred())
+
+			currentSpec := NodePoolToRosaMachinePoolSpec(nodePool)
+
+			desiredPool := &expinfrav1.ROSAMachinePool{
+				Spec: currentSpec,
+			}
+			desiredPool.Default()
+			desiredSpec := desiredPool.Spec
+
+			diff := cmp.Diff(desiredSpec, currentSpec,
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(currentSpec, ignoredFields...))
+			g.Expect(diff).To(BeEmpty(), "phantom diff detected between defaulted spec and OCM conversion: %s", diff)
+		})
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`NodePoolToRosaMachinePoolSpec` only set `NodeDrainGracePeriod` and `UpdateConfig` when OCM explicitly returned those fields. Since OCM uses bitmap-based field presence, default values are often absent from the JSON response. Meanwhile, `Default()` always sets these fields, so `computeSpecDiff` detected a phantom diff on every reconciliation, causing NO-OP PATCH requests to the OCM API.

This PR sets defaults unconditionally in the conversion and overrides with OCM values when present, matching what `Default()` produces.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The conversion output is used in two places:
1. `computeSpecDiff` — comparison only, never used to build PATCH payloads
2. `buildROSAMachinePool` — creates a K8s object that goes through webhook defaulting, which would set the same values anyway

The PATCH payload is always built from the desired spec (user's CR + `Default()`), so this change cannot alter what gets sent to OCM.

**AI Usage**:

Claude Code (claude-opus-4-6) was used implementation and test writing.

**Checklist**:

- [x] squashed commits
- [ ] includes documentation
- [x] includes AI generated content
- [x] includes emoji in title
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:

```release-note
fix(rosa): phantom spec diffs in ROSAMachinePool reconciliation caused by NodePoolToRosaMachinePoolSpec not applying defaults when OCM omits fields from the response
```